### PR TITLE
Make view definition SQL optional

### DIFF
--- a/typo/src/scala/typo/db.scala
+++ b/typo/src/scala/typo/db.scala
@@ -104,7 +104,7 @@ object db {
   case class View(
       name: RelationName,
       cols: NonEmptyList[Col],
-      sql: String,
+      sql: Option[String],
       isMaterialized: Boolean,
       dependencies: Map[ColName, (RelationName, ColName)]
   ) extends Relation

--- a/typo/src/scala/typo/internal/metadb/load.scala
+++ b/typo/src/scala/typo/internal/metadb/load.scala
@@ -145,7 +145,7 @@ object load {
 
             for {
               mappedCols <- NonEmptyList.fromList(mappedCols)
-            } yield db.View(relationName, mappedCols, view.viewDefinition.get, isMaterialized = view.relkind == "m", deps)
+            } yield db.View(relationName, mappedCols, view.viewDefinition, isMaterialized = view.relkind == "m", deps)
 
           case None =>
             for {


### PR DESCRIPTION
It is not defined for the database I tested with typo, so definitely not safe to just run `.get` on this. Leaving it as Option doesn't do any harm either.