### PR TITLE
Add docker image with pgvector extension

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,0 +1,42 @@
+name: Build and publish Docker image for integration tests
+
+on:
+  push:
+    branches: [ 'main' ]
+    paths:
+      - 'docker/**'
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository }}/integration-test
+
+jobs:
+  build-and-push-image:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+      - name: Log in to the Container registry
+        uses: docker/login-action@65b78e6e13532edd9afa3aa52ac7964289d1a9c1
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Extract metadata (tags, labels) for Docker
+        id: meta
+        uses: docker/metadata-action@9ec57ed1fcdbf14dcef7dfbe97b2010124a938b7
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          tags: |
+            # set latest tag for default branch
+            # type=raw,value=latest,enable={{is_default_branch}}
+      - name: Build and push Docker image
+        uses: docker/build-push-action@f2a1d5e99d037542a71f64918e516c093c6f3fc4
+        with:
+          context: ./docker
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -2,7 +2,7 @@ name: Build and publish Docker image for integration tests
 
 on:
   push:
-    # branches: [ 'main' ]
+    branches: [ 'main' ]
     paths:
       - 'docker/**'
 

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -2,7 +2,7 @@ name: Build and publish Docker image for integration tests
 
 on:
   push:
-    branches: [ 'main' ]
+    # branches: [ 'main' ]
     paths:
       - 'docker/**'
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,0 +1,5 @@
+FROM postgis/postgis:14-3.3
+
+RUN apt-get update \
+    && apt-get install postgresql-$PG_MAJOR-pgvector \
+    && rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
Add docker image and CI build to include `pgvector` support in integration test image. Required for https://github.com/oyvindberg/typo/issues/58

Right now, this would build the image on `main`, and push it to `ghcr.io/oyvindberg/typo/integration-test:latest`. Once it's pushed, it can be used as db image in [docker-compose.yml](https://github.com/oyvindberg/typo/blob/main/docker-compose.yml). I haven't done that in this PR to avoid a bootstrapping problem.