### PR TITLE
Build Postgres images for multiple Postgres major versions via matrix

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     if: "!contains(github.event.head_commit.message, 'ci skip')"
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - uses: bleep-build/bleep-setup-action@0.0.1
       - uses: coursier/cache-action@v6
         with:
@@ -21,75 +21,43 @@ jobs:
       - name: Scalafmt Check
         run: bleep fmt --check
 
-  build-scala212:
-    timeout-minutes: 20
+  build-scala:
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     if: "!contains(github.event.head_commit.message, 'ci skip')"
+    strategy:
+      fail-fast: false
+      matrix:
+        scala-version: [212, 213, 3]
+        # TODO add other postgres versions we want to run tests against once we've pushed the images
+        postgres-version: [14]
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - uses: bleep-build/bleep-setup-action@0.0.1
       - uses: coursier/cache-action@v6
         with:
           extraFiles: bleep.yaml
 
       - name: Start up Postgres
+        env:
+          PG_MAJOR: ${{ matrix.postgres-version }}
         run: docker-compose up -d
 
       - name: Run tests
         env:
           CI: true
         run: |
-          bleep compile jvm212
-          bleep test jvm212
-
-  build-scala213:
-    timeout-minutes: 20
-    runs-on: ubuntu-latest
-    if: "!contains(github.event.head_commit.message, 'ci skip')"
-    steps:
-      - uses: actions/checkout@v2
-      - uses: bleep-build/bleep-setup-action@0.0.1
-      - uses: coursier/cache-action@v6
-        with:
-          extraFiles: bleep.yaml
-
-      - name: Start up Postgres
-        run: docker-compose up -d
-
-      - name: Run tests
-        env:
-          CI: true
-        run: |
-          bleep compile jvm213
-          bleep test jvm213
-
-  build-scala3:
-    timeout-minutes: 20
-    runs-on: ubuntu-latest
-    if: "!contains(github.event.head_commit.message, 'ci skip')"
-    steps:
-      - uses: actions/checkout@v2
-      - uses: bleep-build/bleep-setup-action@0.0.1
-      - uses: coursier/cache-action@v6
-        with:
-          extraFiles: bleep.yaml
-
-      - name: Start up Postgres
-        run: docker-compose up -d
-
-      - name: Run tests
-        env:
-          CI: true
-        run: |
-          bleep compile jvm3
-          bleep test jvm3
+          bleep compile jvm${{ matrix.scala-version }}
+          bleep test jvm${{ matrix.scala-version }}
 
   build-docs:
     timeout-minutes: 20
     runs-on: ubuntu-latest
     if: "!contains(github.event.head_commit.message, 'ci skip')"
+    env:
+      PG_MAJOR: 14
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - uses: bleep-build/bleep-setup-action@0.0.1
       - uses: coursier/cache-action@v6
         with:
@@ -105,10 +73,10 @@ jobs:
   release:
     timeout-minutes: 15
     runs-on: ubuntu-latest
-    needs: [ scalafmt, build-scala212, build-scala213, build-scala3 ]
+    needs: [ scalafmt, build-scala ]
     if: "startsWith(github.ref, 'refs/tags/v')"
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - uses: bleep-build/bleep-setup-action@0.0.1
       - uses: coursier/cache-action@v6
         with:

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -5,38 +5,57 @@ on:
     branches: [ 'main' ]
     paths:
       - 'docker/**'
+      - '.github/workflows/docker.yml'
+  pull_request:
+    branches: [ 'main' ]
+    paths:
+      - 'docker/**'
+      - '.github/workflows/docker.yml'
 
 env:
   REGISTRY: ghcr.io
-  IMAGE_NAME: ${{ github.repository }}/integration-test
+  IMAGE_NAME: ${{ github.repository }}/typo-postgres
 
 jobs:
-  build-and-push-image:
+  build-postgres-image:
+    timeout-minutes: 10
     runs-on: ubuntu-latest
+    if: "!contains(github.event.head_commit.message, 'ci skip')"
+    strategy:
+      fail-fast: false
+      matrix:
+        postgres-version: [12, 13, 14, 15, 16]
     permissions:
       contents: read
       packages: write
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
       - name: Log in to the Container registry
         uses: docker/login-action@65b78e6e13532edd9afa3aa52ac7964289d1a9c1
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
+
       - name: Extract metadata (tags, labels) for Docker
         id: meta
-        uses: docker/metadata-action@9ec57ed1fcdbf14dcef7dfbe97b2010124a938b7
+        uses: docker/metadata-action@v5
         with:
-          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
-          tags: |
-            # set latest tag for default branch
-            type=raw,value=latest,enable={{is_default_branch}}
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}${{ matrix.postgres-version }}
+          tags: type=raw,value=latest,enable=true
+
       - name: Build and push Docker image
-        uses: docker/build-push-action@f2a1d5e99d037542a71f64918e516c093c6f3fc4
+        uses: docker/build-push-action@v5
         with:
           context: ./docker
-          push: true
+          push: ${{ github.event_name != 'pull_request' }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
+          build-args: PG_MAJOR=${{ matrix.postgres-version }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,6 +4,8 @@ version: '3.1'
 services:
   db:
     image: ghcr.io/oyvindberg/typo/integration-test:main
+    # TODO switch to new images depending on PG_MAJOR once we've pushed them
+    # image: ghcr.io/oyvindberg/typo/typo-postgres${PG_MAJOR}:latest
     restart: always
     environment:
       POSTGRES_USER: postgres

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,4 +1,5 @@
-FROM postgis/postgis:14-3.3
+ARG PG_MAJOR
+FROM postgis/postgis:$PG_MAJOR-3.4
 
 RUN apt-get update \
     && apt-get install postgresql-$PG_MAJOR-pgvector \


### PR DESCRIPTION
We'd like to run generation and tests against multiple Postgres versions, so we need multiple images.

This is the first step, building and pushing multiple images. **Using** the new images needs to come in a subsequent step, but is already prepared in this PR as well.

We also use an additional matrix for Scala versions to avoid repeated job definitions.

@oyvindberg I played a bit with using dependent jobs to build the docker and then use the just built image to run tests, without having to push the image to a registry. But it was slow. We need to tar the image, upload it as artifact and then download in the next job. It's probably possible to improve it but it needs more effort. So I settled with keeping the two decoupled workflows for now, which is easier, but also means we need two different PRs (see TODOs).