### PR TITLE
Add support for generating code into a build with multiple projects

### DIFF
--- a/.bleep/generated-sources/typo-tester-anorm@jvm212/scripts.GenHardcodedFiles/testdb/hardcoded/testInsert.scala
+++ b/.bleep/generated-sources/typo-tester-anorm@jvm212/scripts.GenHardcodedFiles/testdb/hardcoded/testInsert.scala
@@ -22,7 +22,7 @@ import testdb.hardcoded.myschema.marital_status.MaritalStatusRepoImpl
 import testdb.hardcoded.myschema.marital_status.MaritalStatusRow
 import testdb.hardcoded.myschema.person.PersonId
 
-class testInsert(random: Random) {
+class TestInsert(random: Random) {
   def compositepkPerson(name: Option[String] = if (random.nextBoolean()) None else Some(random.alphanumeric.take(20).mkString),
                         one: Defaulted[Long] = Defaulted.UseDefault,
                         two: Defaulted[Option[String]] = Defaulted.UseDefault

--- a/.bleep/generated-sources/typo-tester-anorm@jvm213/scripts.GenHardcodedFiles/testdb/hardcoded/testInsert.scala
+++ b/.bleep/generated-sources/typo-tester-anorm@jvm213/scripts.GenHardcodedFiles/testdb/hardcoded/testInsert.scala
@@ -22,7 +22,7 @@ import testdb.hardcoded.myschema.marital_status.MaritalStatusRepoImpl
 import testdb.hardcoded.myschema.marital_status.MaritalStatusRow
 import testdb.hardcoded.myschema.person.PersonId
 
-class testInsert(random: Random) {
+class TestInsert(random: Random) {
   def compositepkPerson(name: Option[String] = if (random.nextBoolean()) None else Some(random.alphanumeric.take(20).mkString),
                         one: Defaulted[Long] = Defaulted.UseDefault,
                         two: Defaulted[Option[String]] = Defaulted.UseDefault

--- a/.bleep/generated-sources/typo-tester-anorm@jvm3/scripts.GenHardcodedFiles/testdb/hardcoded/testInsert.scala
+++ b/.bleep/generated-sources/typo-tester-anorm@jvm3/scripts.GenHardcodedFiles/testdb/hardcoded/testInsert.scala
@@ -22,7 +22,7 @@ import testdb.hardcoded.myschema.marital_status.MaritalStatusRepoImpl
 import testdb.hardcoded.myschema.marital_status.MaritalStatusRow
 import testdb.hardcoded.myschema.person.PersonId
 
-class testInsert(random: Random) {
+class TestInsert(random: Random) {
   def compositepkPerson(name: Option[String] = if (random.nextBoolean()) None else Some(random.alphanumeric.take(20).mkString),
                         one: Defaulted[Long] = Defaulted.UseDefault,
                         two: Defaulted[Option[String]] = Defaulted.UseDefault

--- a/.bleep/generated-sources/typo-tester-doobie@jvm212/scripts.GenHardcodedFiles/testdb/hardcoded/testInsert.scala
+++ b/.bleep/generated-sources/typo-tester-doobie@jvm212/scripts.GenHardcodedFiles/testdb/hardcoded/testInsert.scala
@@ -22,7 +22,7 @@ import testdb.hardcoded.myschema.marital_status.MaritalStatusRepoImpl
 import testdb.hardcoded.myschema.marital_status.MaritalStatusRow
 import testdb.hardcoded.myschema.person.PersonId
 
-class testInsert(random: Random) {
+class TestInsert(random: Random) {
   def compositepkPerson(name: Option[String] = if (random.nextBoolean()) None else Some(random.alphanumeric.take(20).mkString),
                         one: Defaulted[Long] = Defaulted.UseDefault,
                         two: Defaulted[Option[String]] = Defaulted.UseDefault

--- a/.bleep/generated-sources/typo-tester-doobie@jvm213/scripts.GenHardcodedFiles/testdb/hardcoded/testInsert.scala
+++ b/.bleep/generated-sources/typo-tester-doobie@jvm213/scripts.GenHardcodedFiles/testdb/hardcoded/testInsert.scala
@@ -22,7 +22,7 @@ import testdb.hardcoded.myschema.marital_status.MaritalStatusRepoImpl
 import testdb.hardcoded.myschema.marital_status.MaritalStatusRow
 import testdb.hardcoded.myschema.person.PersonId
 
-class testInsert(random: Random) {
+class TestInsert(random: Random) {
   def compositepkPerson(name: Option[String] = if (random.nextBoolean()) None else Some(random.alphanumeric.take(20).mkString),
                         one: Defaulted[Long] = Defaulted.UseDefault,
                         two: Defaulted[Option[String]] = Defaulted.UseDefault

--- a/.bleep/generated-sources/typo-tester-doobie@jvm3/scripts.GenHardcodedFiles/testdb/hardcoded/testInsert.scala
+++ b/.bleep/generated-sources/typo-tester-doobie@jvm3/scripts.GenHardcodedFiles/testdb/hardcoded/testInsert.scala
@@ -22,7 +22,7 @@ import testdb.hardcoded.myschema.marital_status.MaritalStatusRepoImpl
 import testdb.hardcoded.myschema.marital_status.MaritalStatusRow
 import testdb.hardcoded.myschema.person.PersonId
 
-class testInsert(random: Random) {
+class TestInsert(random: Random) {
   def compositepkPerson(name: Option[String] = if (random.nextBoolean()) None else Some(random.alphanumeric.take(20).mkString),
                         one: Defaulted[Long] = Defaulted.UseDefault,
                         two: Defaulted[Option[String]] = Defaulted.UseDefault

--- a/.bleep/generated-sources/typo-tester-zio-jdbc@jvm212/scripts.GenHardcodedFiles/testdb/hardcoded/testInsert.scala
+++ b/.bleep/generated-sources/typo-tester-zio-jdbc@jvm212/scripts.GenHardcodedFiles/testdb/hardcoded/testInsert.scala
@@ -23,7 +23,7 @@ import testdb.hardcoded.myschema.person.PersonId
 import zio.ZIO
 import zio.jdbc.ZConnection
 
-class testInsert(random: Random) {
+class TestInsert(random: Random) {
   def compositepkPerson(name: Option[String] = if (random.nextBoolean()) None else Some(random.alphanumeric.take(20).mkString),
                         one: Defaulted[Long] = Defaulted.UseDefault,
                         two: Defaulted[Option[String]] = Defaulted.UseDefault

--- a/.bleep/generated-sources/typo-tester-zio-jdbc@jvm213/scripts.GenHardcodedFiles/testdb/hardcoded/testInsert.scala
+++ b/.bleep/generated-sources/typo-tester-zio-jdbc@jvm213/scripts.GenHardcodedFiles/testdb/hardcoded/testInsert.scala
@@ -23,7 +23,7 @@ import testdb.hardcoded.myschema.person.PersonId
 import zio.ZIO
 import zio.jdbc.ZConnection
 
-class testInsert(random: Random) {
+class TestInsert(random: Random) {
   def compositepkPerson(name: Option[String] = if (random.nextBoolean()) None else Some(random.alphanumeric.take(20).mkString),
                         one: Defaulted[Long] = Defaulted.UseDefault,
                         two: Defaulted[Option[String]] = Defaulted.UseDefault

--- a/.bleep/generated-sources/typo-tester-zio-jdbc@jvm3/scripts.GenHardcodedFiles/testdb/hardcoded/testInsert.scala
+++ b/.bleep/generated-sources/typo-tester-zio-jdbc@jvm3/scripts.GenHardcodedFiles/testdb/hardcoded/testInsert.scala
@@ -23,7 +23,7 @@ import testdb.hardcoded.myschema.person.PersonId
 import zio.ZIO
 import zio.jdbc.ZConnection
 
-class testInsert(random: Random) {
+class TestInsert(random: Random) {
   def compositepkPerson(name: Option[String] = if (random.nextBoolean()) None else Some(random.alphanumeric.take(20).mkString),
                         one: Defaulted[Long] = Defaulted.UseDefault,
                         two: Defaulted[Option[String]] = Defaulted.UseDefault

--- a/site-in/other-features/generate-into-multiple-projects.md
+++ b/site-in/other-features/generate-into-multiple-projects.md
@@ -1,0 +1,77 @@
+---
+title: Generate code into multiple projects
+---
+
+It's very common that you don't want to expose all the tables in one place in your system. 
+You also don't want duplication of generated code or more than one script to generate database code. 
+
+The solution is to pass a `ProjectGraph` structure to `generateFromDb` instead, 
+in which you encode the structure of the (relevant) projects in your build.
+
+Dependencies between projects are encoded by nesting in the tree you pass (each node has a `downstream` member), 
+with the root being the uppermost one. 
+
+If multiple downstream projects want to generate the same code, it'll be pulled up to the level necessary to become visible for all of them.
+
+sample:
+```scala mdoc:silent
+import typo.*
+import java.nio.file.Path
+import java.sql.Connection
+
+def generate(implicit c: Connection): String = {
+  val cwd: Path = Path.of(sys.props("user.dir"))
+
+  val generated = generateFromDb(
+    Options(
+      pkg = "org.mypkg",
+      jsonLibs = Nil,
+      dbLib = Some(DbLibName.ZioJdbc)
+    ),
+    // setup a project graph. this outer-most project is the root project.
+    // if multiple downstream projects need the same relation, it'll be pulled up until it's visible for all.
+    // in this simple example it means `a.bicycle` will be pulled up here
+    ProjectGraph(
+      name = "a",
+      target = cwd.resolve("a/src/main/typo"),
+      value = Selector.None,
+      scripts = Nil,
+      downstream = List(
+        ProjectGraph(
+          name = "b",
+          target = cwd.resolve("b/src/main/typo"),
+          value = Selector.fullRelationNames(
+            "a.bicycle",
+            "b.person"
+          ),
+          // where to find sql files
+          scripts = List(cwd.resolve("b/src/main/sql")),
+          downstream = Nil
+        ),
+        ProjectGraph(
+          name = "c",
+          target = cwd.resolve("b/src/main/typo"),
+          value = Selector.fullRelationNames(
+            "a.bicycle",
+            "c.animal"
+          ),
+          scripts = List(cwd.resolve("b/src/main/sql")),
+          downstream = Nil
+        )
+      )
+    )
+  )
+
+  generated.foreach(_.overwriteFolder())
+
+  import scala.sys.process.*
+
+  (List("git", "add") ++ generated.map(_.folder.toString)).!!
+}
+```
+
+### todo:
+
+- [ ] `testInsert` (we'll need one for each project)
+- [ ] docs
+- [ ] tests

--- a/site-in/other-features/testing-with-random-values.md
+++ b/site-in/other-features/testing-with-random-values.md
@@ -4,7 +4,7 @@ title: Testing with random values
 
 This covers a lot of interesting ground, test-wise.
 
-If you enable `enableTestInserts` in `typo.Options` you now get an `testInsert` class, with a method to insert a row for each table Typo knows about. 
+If you enable `enableTestInserts` in `typo.Options` you now get an `TestInsert` class, with a method to insert a row for each table Typo knows about. 
 All values except ids, foreign keys and so on are *randomly generated*, but you can override them with named parameters.
 
 The idea is that you:
@@ -13,7 +13,7 @@ The idea is that you:
 - will get random values for the rest
 - are still forced to follow FKs to setup the data graph correctly
 - it's easy to follow those FKs, because after inserting a row you get the persisted version back, including generated IDs
-- can get the same values each time by hard coding the seed `new testInsert(new scala.util.Random(0L))`, or you can run it multiple times with different seeds to see that the random values really do not matter
+- can get the same values each time by hard coding the seed `new TestInsert(new scala.util.Random(0L))`, or you can run it multiple times with different seeds to see that the random values really do not matter
 - do not need to write *any* code to get all this available to you, like the rest of Typo.
 
 In summary, this is a fantastic way of setting up complex test scenarios in the database!
@@ -30,11 +30,11 @@ c.setAutoCommit(false)
 ```scala mdoc
 import adventureworks.customtypes.{Defaulted, TypoXml}
 import adventureworks.production.unitmeasure.UnitmeasureId
-import adventureworks.testInsert
+import adventureworks.TestInsert
 
 import scala.util.Random
 
-val testInsert = new testInsert(new Random(0))
+val testInsert = new TestInsert(new Random(0))
 
 val unitmeasure = testInsert.productionUnitmeasure(UnitmeasureId("kgg"))
 val productCategory = testInsert.productionProductcategory()

--- a/site-in/patterns/multi-repo.md
+++ b/site-in/patterns/multi-repo.md
@@ -123,12 +123,12 @@ Here is example usage:
 
 Note that we can easily create a deep dependency graph with random data due to [testInsert](other-features/testing-with-random-values.md).
 ```scala mdoc:silent
-import adventureworks.{testInsert, withConnection}
+import adventureworks.{TestInsert, withConnection}
 import adventureworks.userdefined.FirstName
 import scala.util.Random
 
 // set a fixed seed to get consistent values
-val testInsert = new testInsert(new Random(1))
+val testInsert = new TestInsert(new Random(1))
 
 val businessentityRow = testInsert.personBusinessentity()
 val personRow = testInsert.personPerson(businessentityRow.businessentityid, FirstName("name"), persontype = "SC")

--- a/site-in/setup.md
+++ b/site-in/setup.md
@@ -65,8 +65,8 @@ val scriptsFolder = location.resolve("sql")
 // you can use this to customize which relations you want to generate code for, see below
 val selector = Selector.ExcludePostgresInternal
 
-generateFromDb(options, selector = selector, scriptsPaths = List(scriptsFolder))
-  .overwriteFolder(folder = targetDir)
+generateFromDb(options, folder = targetDir, selector = selector, scriptsPaths = List(scriptsFolder))
+  .overwriteFolder()
 
 // add changed files to git, so you can keep them under control
 //scala.sys.process.Process(List("git", "add", targetDir.toString)).!!
@@ -74,6 +74,9 @@ generateFromDb(options, selector = selector, scriptsPaths = List(scriptsFolder))
 
 ## `selector`
 You can customize which relations you generate code for, see [customize selected relations](customization/customize-selected-relations.md)
-## sbt plugin
 
+## `ProjectGraph`
+If you want to split the generated code across multiple projects in your build, have a look at [Generate code into multiple projects](other-features/generate-into-multiple-projects.md)
+
+## sbt plugin
 It's natural to think an sbt plugin would be a good match for Typo. This will likely be added in the future.

--- a/site/sidebars.js
+++ b/site/sidebars.js
@@ -51,6 +51,7 @@ const sidebars = {
             collapsed: false,
             items: [
                 {type: "doc", id: "other-features/streaming-inserts"},
+                {type: "doc", id: "other-features/generate-into-multiple-projects"},
                 {type: "doc", id: "other-features/json"},
                 {type: "doc", id: "other-features/faster-compilation"},
                 {type: "doc", id: "other-features/flexible"},

--- a/typo-scripts/src/scala/scripts/CompileBenchmark.scala
+++ b/typo-scripts/src/scala/scripts/CompileBenchmark.scala
@@ -63,9 +63,14 @@ object CompileBenchmark extends BleepScript("CompileBenchmark") {
               enableStreamingInserts = false
             ),
             metadb,
-            readSqlFileDirectories(TypoLogger.Noop, buildDir.resolve("adventureworks_sql")),
-            Selector.ExcludePostgresInternal // All
-          ).overwriteFolder(targetSources)
+            ProjectGraph(
+              name = "",
+              targetSources,
+              Selector.ExcludePostgresInternal, // All
+              readSqlFileDirectories(TypoLogger.Noop, buildDir.resolve("adventureworks_sql")),
+              Nil
+            )
+          ).foreach(_.overwriteFolder())
 
           crossIds.map { crossId =>
             started.projectPaths(CrossProjectName(ProjectName(projectName), Some(crossId))).sourcesDirs.fromSourceLayout.foreach { p =>

--- a/typo-scripts/src/scala/scripts/GenHardcodedFiles.scala
+++ b/typo-scripts/src/scala/scripts/GenHardcodedFiles.scala
@@ -143,7 +143,7 @@ object GenHardcodedFiles extends BleepCodegenScript("GenHardcodedFiles") {
         TypeMapperDb(enums, domains)
       )
 
-      val generated: Generated =
+      val generated: List[Generated] =
         generate(
           Options(
             pkg = "testdb.hardcoded",
@@ -160,14 +160,14 @@ object GenHardcodedFiles extends BleepCodegenScript("GenHardcodedFiles") {
             silentBanner = true
           ),
           metaDb,
-          sqlFiles = Nil,
-          Selector.All
+          ProjectGraph(name = "", target.sources, Selector.All, scripts = Nil, Nil)
         )
 
-      generated.overwriteFolder(
-        target.sources,
-        // todo: bleep should use something better than timestamps
-        softWrite = SoftWrite.No
+      generated.foreach(
+        _.overwriteFolder(
+          // todo: bleep should use something better than timestamps
+          softWrite = SoftWrite.No
+        )
       )
       cli("add to git", target.sources, List("git", "add", "-f", target.sources.toString), Logger.DevNull, cli.Out.Raw)
     }

--- a/typo-scripts/src/scala/scripts/GeneratedAdventureWorks.scala
+++ b/typo-scripts/src/scala/scripts/GeneratedAdventureWorks.scala
@@ -53,7 +53,7 @@ object GeneratedAdventureWorks {
             val targetSources = buildDir.resolve(s"$projectPath/generated-and-checked-in")
 
             val newFiles: Generated =
-              generate(options, metadb, newSqlScripts, Selector.ExcludePostgresInternal)
+              generate(options, metadb, ProjectGraph(name = "", targetSources, Selector.ExcludePostgresInternal, newSqlScripts, Nil)).head
 
             val knownUnchanged: Set[RelPath] = {
               val oldFiles = oldFilesRef.get()
@@ -62,7 +62,7 @@ object GeneratedAdventureWorks {
             oldFilesRef.set(newFiles.files)
 
             newFiles
-              .overwriteFolder(targetSources, softWrite = FileSync.SoftWrite.Yes(knownUnchanged))
+              .overwriteFolder(softWrite = FileSync.SoftWrite.Yes(knownUnchanged))
               .filter { case (_, synced) => synced != FileSync.Synced.Unchanged }
               .foreach { case (path, synced) => logger.withContext(path).warn(synced.toString) }
 

--- a/typo-scripts/src/scala/scripts/GeneratedSources.scala
+++ b/typo-scripts/src/scala/scripts/GeneratedSources.scala
@@ -38,6 +38,7 @@ object GeneratedSources {
         fileHeader = header,
         debugTypes = true
       ),
+      typoSources,
       Selector.relationNames(
         "columns",
         "key_column_usage",
@@ -51,7 +52,7 @@ object GeneratedSources {
       List(buildDir.resolve("sql"))
     )
 
-    files.overwriteFolder(typoSources)
+    files.overwriteFolder()
 
     import scala.sys.process.*
     List("git", "add", "-f", typoSources.toString).!!

--- a/typo-tester-anorm/generated-and-checked-in/adventureworks/testInsert.scala
+++ b/typo-tester-anorm/generated-and-checked-in/adventureworks/testInsert.scala
@@ -296,7 +296,7 @@ import java.time.LocalTime
 import java.time.ZoneOffset
 import scala.util.Random
 
-class testInsert(random: Random) {
+class TestInsert(random: Random) {
   def humanresourcesDepartment(name: Name = Name(random.alphanumeric.take(20).mkString),
                                groupname: Name = Name(random.alphanumeric.take(20).mkString),
                                departmentid: Defaulted[DepartmentId] = Defaulted.UseDefault,

--- a/typo-tester-anorm/src/scala/adventureworks/RecordTest.scala
+++ b/typo-tester-anorm/src/scala/adventureworks/RecordTest.scala
@@ -14,7 +14,7 @@ class RecordTest extends AnyFunSuite with TypeCheckedTripleEquals {
 
   test("works") {
     withConnection { implicit c =>
-      val testInsert = new testInsert(new Random(0))
+      val testInsert = new TestInsert(new Random(0))
       val businessentityRow = testInsert.personBusinessentity()
       val personRow = testInsert.personPerson(businessentityRow.businessentityid, FirstName("a"), persontype = "EM")
       testInsert.personEmailaddress(personRow.businessentityid, Some("a@b.c")): @nowarn

--- a/typo-tester-anorm/src/scala/adventureworks/person/MultiRepoTest.scala
+++ b/typo-tester-anorm/src/scala/adventureworks/person/MultiRepoTest.scala
@@ -1,6 +1,6 @@
 package adventureworks.person
 
-import adventureworks.{testInsert, withConnection}
+import adventureworks.{TestInsert, withConnection}
 import adventureworks.person.address.*
 import adventureworks.person.addresstype.*
 import adventureworks.person.businessentityaddress.*
@@ -89,7 +89,7 @@ class PersonWithAddressesTest extends AnyFunSuite with TypeCheckedTripleEquals {
   test("works") {
     withConnection { implicit c =>
       // insert randomly generated rows (with a fixed seed) we base the test on
-      val testInsert = new testInsert(new Random(1))
+      val testInsert = new TestInsert(new Random(1))
       val businessentityRow = testInsert.personBusinessentity()
       val personRow = testInsert.personPerson(businessentityRow.businessentityid, FirstName("name"), persontype = "SC")
       val countryregionRow = testInsert.personCountryregion(CountryregionId("NOR"))

--- a/typo-tester-anorm/src/scala/adventureworks/production/product/ProductTest.scala
+++ b/typo-tester-anorm/src/scala/adventureworks/production/product/ProductTest.scala
@@ -7,7 +7,7 @@ import adventureworks.production.productmodel.*
 import adventureworks.production.productsubcategory.*
 import adventureworks.production.unitmeasure.*
 import adventureworks.public.{Flag, Name}
-import adventureworks.{testInsert, withConnection}
+import adventureworks.{TestInsert, withConnection}
 import org.scalactic.TypeCheckedTripleEquals
 import org.scalatest.Assertion
 import org.scalatest.funsuite.AnyFunSuite
@@ -30,7 +30,7 @@ class ProductTest extends AnyFunSuite with TypeCheckedTripleEquals {
 
   test("foo") {
     withConnection { implicit c =>
-      val testInsert = new testInsert(new Random(0))
+      val testInsert = new TestInsert(new Random(0))
       val unitmeasure = testInsert.productionUnitmeasure(UnitmeasureId("kgg"))
       val productCategory = testInsert.productionProductcategory()
       val productSubcategory = testInsert.productionProductsubcategory(productCategory.productcategoryid)

--- a/typo-tester-doobie/generated-and-checked-in/adventureworks/testInsert.scala
+++ b/typo-tester-doobie/generated-and-checked-in/adventureworks/testInsert.scala
@@ -296,7 +296,7 @@ import java.time.LocalTime
 import java.time.ZoneOffset
 import scala.util.Random
 
-class testInsert(random: Random) {
+class TestInsert(random: Random) {
   def humanresourcesDepartment(name: Name = Name(random.alphanumeric.take(20).mkString),
                                groupname: Name = Name(random.alphanumeric.take(20).mkString),
                                departmentid: Defaulted[DepartmentId] = Defaulted.UseDefault,

--- a/typo-tester-zio-jdbc/generated-and-checked-in/adventureworks/testInsert.scala
+++ b/typo-tester-zio-jdbc/generated-and-checked-in/adventureworks/testInsert.scala
@@ -297,7 +297,7 @@ import scala.util.Random
 import zio.ZIO
 import zio.jdbc.ZConnection
 
-class testInsert(random: Random) {
+class TestInsert(random: Random) {
   def humanresourcesDepartment(name: Name = Name(random.alphanumeric.take(20).mkString),
                                groupname: Name = Name(random.alphanumeric.take(20).mkString),
                                departmentid: Defaulted[DepartmentId] = Defaulted.UseDefault,

--- a/typo/src/scala/typo/Generated.scala
+++ b/typo/src/scala/typo/Generated.scala
@@ -5,11 +5,11 @@ import typo.internal.FileSync.SoftWrite
 
 import java.nio.file.Path
 
-case class Generated(files: Map[RelPath, sc.Code]) {
+case class Generated(folder: Path, files: Map[RelPath, sc.Code]) {
   def mapFiles(f: Map[RelPath, sc.Code] => Map[RelPath, sc.Code]): Generated =
     copy(files = f(files))
 
-  def overwriteFolder(folder: Path, softWrite: SoftWrite = SoftWrite.Yes(Set.empty)): Map[Path, FileSync.Synced] =
+  def overwriteFolder(softWrite: SoftWrite = SoftWrite.Yes(Set.empty)): Map[Path, FileSync.Synced] =
     FileSync.syncStrings(
       folder = folder,
       fileRelMap = files.map { case (relPath, code) => (relPath, code.render.asString) },
@@ -17,8 +17,9 @@ case class Generated(files: Map[RelPath, sc.Code]) {
       softWrite = softWrite
     )
 }
+
 object Generated {
-  def apply(files: Iterator[sc.File]): Generated = {
+  def apply(folder: Path, files: Iterator[sc.File]): Generated = {
     val asRelativePaths: Map[RelPath, sc.Code] =
       files.map { case sc.File(sc.Type.Qualified(sc.QIdent(idents)), code, _) =>
         val path = idents.init
@@ -26,7 +27,7 @@ object Generated {
         val relPath = RelPath(path.map(_.value) :+ s"${name.value}.scala")
         relPath -> code
       }.toMap
-    new Generated(asRelativePaths)
-  }
 
+    new Generated(folder, asRelativePaths)
+  }
 }

--- a/typo/src/scala/typo/ProjectGraph.scala
+++ b/typo/src/scala/typo/ProjectGraph.scala
@@ -1,0 +1,26 @@
+package typo
+
+import java.nio.file.Path
+import typo.internal.compat.*
+
+/** this can be used to separate generated source in groups, typically because you want to put them in different projects in your build.
+  *
+  * Note that this is advanced functionality
+  *
+  * can be nice if have different "sub-graphs" of relations you want to put in different modules
+  */
+final case class ProjectGraph[T, S](name: String, target: Path, value: T, scripts: S, downstream: List[ProjectGraph[T, S]]) {
+  def toList: List[ProjectGraph[T, S]] =
+    (this :: downstream.flatMap(_.toList)).distinctByCompat(_.target)
+
+  def valueFromProject[TT, SS](f: ProjectGraph[T, S] => (TT, SS)): ProjectGraph[TT, SS] = {
+    val (tt, ss) = f(this)
+    ProjectGraph(name, target, tt, ss, downstream.map(_.valueFromProject(f)))
+  }
+
+  def mapValue[TT](f: T => TT): ProjectGraph[TT, S] =
+    ProjectGraph(name, target, f(value), scripts, downstream.map(_.mapValue(f)))
+
+  def mapScripts[SS](f: S => SS): ProjectGraph[T, SS] =
+    ProjectGraph(name, target, value, f(scripts), downstream.map(_.mapScripts(f)))
+}

--- a/typo/src/scala/typo/generateFromDb.scala
+++ b/typo/src/scala/typo/generateFromDb.scala
@@ -1,14 +1,21 @@
 package typo
 
-import typo.internal.*
 import typo.internal.sqlfiles.readSqlFileDirectories
 
 import java.nio.file.Path
 import java.sql.Connection
 
 object generateFromDb {
-  def apply(options: Options, selector: Selector = Selector.ExcludePostgresInternal, scriptsPaths: List[Path] = Nil)(implicit c: Connection): Generated = {
+  def apply(options: Options, folder: Path, selector: Selector = Selector.ExcludePostgresInternal, scriptsPaths: List[Path] = Nil)(implicit c: Connection): Generated = {
+    apply(options, ProjectGraph(name = "", folder, selector, scriptsPaths, Nil)).head
+  }
+
+  def apply(options: Options, graph: ProjectGraph[Selector, List[Path]])(implicit c: Connection): List[Generated] = {
     Banner.maybePrint(options)
-    generate(options, MetaDb.fromDb(options.logger), scriptsPaths.flatMap(p => readSqlFileDirectories(options.logger, p)), selector)
+    internal.generate(
+      options,
+      MetaDb.fromDb(options.logger),
+      graph.mapScripts(paths => paths.flatMap(p => readSqlFileDirectories(options.logger, p)))
+    )
   }
 }

--- a/typo/src/scala/typo/internal/ComputedTestInserts.scala
+++ b/typo/src/scala/typo/internal/ComputedTestInserts.scala
@@ -7,7 +7,7 @@ case class ComputedTestInserts(tpe: sc.Type.Qualified, methods: List[ComputedTes
 
 object ComputedTestInserts {
   val random: sc.Ident = sc.Ident("random")
-  def apply(options: InternalOptions, customTypes: CustomTypes, domains: List[ComputedDomain], enums: List[ComputedStringEnum], computedTables: Iterable[ComputedTable]) = {
+  def apply(projectName: String, options: InternalOptions, customTypes: CustomTypes, domains: List[ComputedDomain], enums: List[ComputedStringEnum], computedTables: Iterable[ComputedTable]) = {
     val domainsByName: Map[sc.Type, ComputedDomain] =
       domains.iterator.map(x => x.tpe -> x).toMap
     val enumsByName: Map[sc.Type, ComputedStringEnum] =
@@ -84,7 +84,7 @@ object ComputedTestInserts {
     }
 
     new ComputedTestInserts(
-      sc.Type.Qualified(options.pkg / sc.Ident("testInsert")),
+      sc.Type.Qualified(options.pkg / sc.Ident(s"${Naming.titleCase(projectName)}TestInsert")),
       computedTables.collect {
         case table if !options.readonlyRepo.include(table.dbTable.name) =>
           val cols: NonEmptyList[ComputedColumn] =

--- a/typo/src/scala/typo/internal/generate.scala
+++ b/typo/src/scala/typo/internal/generate.scala
@@ -4,11 +4,14 @@ package internal
 import typo.internal.codegen.*
 import typo.internal.sqlfiles.SqlFile
 
+import scala.collection.immutable
 import scala.collection.immutable.SortedMap
 
 object generate {
+  private type Files = Map[sc.Type.Qualified, sc.File]
+
   // use this constructor if you need to run `typo` multiple times with different options but same database/scripts
-  def apply(publicOptions: Options, metaDb: MetaDb, sqlFiles: List[SqlFile], selector: Selector): Generated = {
+  def apply(publicOptions: Options, metaDb: MetaDb, graph: ProjectGraph[Selector, List[SqlFile]]): List[Generated] = {
     Banner.maybePrint(publicOptions)
 
     val pkg = sc.Type.Qualified(publicOptions.pkg).value
@@ -50,78 +53,131 @@ object generate {
     val enums = metaDb.enums.map(ComputedStringEnum(naming))
     val domains = metaDb.domains.map(ComputedDomain(naming, scalaTypeMapper))
 
-    val computeds: SortedMap[db.RelationName, Lazy[HasSource]] =
-      rewriteDependentData(metaDb.relations).apply[HasSource] {
-        case (_, dbTable: db.Table, eval) =>
-          ComputedTable(options, default, dbTable, naming, scalaTypeMapper, eval)
-        case (_, dbView: db.View, eval) =>
-          ComputedView(dbView, naming, metaDb.typeMapperDb, scalaTypeMapper, eval, options.enableFieldValue.include(dbView.name), options.enableDsl)
+    val projectsWithFiles: ProjectGraph[Files, List[sc.File]] =
+      graph.valueFromProject { project =>
+        val isRoot = graph == project
+        val selector = project.value
+
+        // note, this will import *all* (dependent) relations for the given project. we'll deduplicate in the end
+        val computedLazyRelations: SortedMap[db.RelationName, Lazy[HasSource]] =
+          rewriteDependentData(metaDb.relations).apply[HasSource] {
+            case (_, dbTable: db.Table, eval) =>
+              ComputedTable(options, default, dbTable, naming, scalaTypeMapper, eval)
+            case (_, dbView: db.View, eval) =>
+              ComputedView(dbView, naming, metaDb.typeMapperDb, scalaTypeMapper, eval, options.enableFieldValue.include(dbView.name), options.enableDsl)
+          }
+
+        // note, these statements will force the evaluation of some of the lazy values
+        val computedSqlFiles: List[ComputedSqlFile] =
+          project.scripts.map { sqlScript =>
+            ComputedSqlFile(options.logger, sqlScript, options.pkg, naming, metaDb.typeMapperDb, scalaTypeMapper, computedLazyRelations.get)
+          }
+
+        computedLazyRelations.foreach { case (relName, lazyValue) =>
+          if (selector.include(relName)) lazyValue.get
+        }
+
+        // here we keep only the values which have been evaluated. this may very well be a bigger set than the sum of the
+        // relations chosen by the selector and the sql files
+        val computedRelations = computedLazyRelations.flatMap { case (_, lazyValue) => lazyValue.getIfEvaluated }
+
+        // yeah, sorry about the naming overload. this is a list of output files generated for each input sql file
+        val sqlFileFiles: List[sc.File] =
+          computedSqlFiles.flatMap(x => FilesSqlFile(x, naming, options).all)
+
+        val relationFilesByName = computedRelations.flatMap {
+          case viewComputed: ComputedView   => FilesView(viewComputed, options).all.map(x => (viewComputed.view.name, x))
+          case tableComputed: ComputedTable => FilesTable(tableComputed, options, genOrdering).all.map(x => (tableComputed.dbTable.name, x))
+          case _                            => Nil
+        }
+
+        val mostFiles: List[sc.File] =
+          List(
+            options.dbLib.toList.flatMap(_.additionalFiles),
+            List(FileDefault(default, options.jsonLibs, options.dbLib).file),
+            enums.map(enm => FileStringEnum(options, enm, genOrdering)),
+            domains.map(d => FileDomain(d, options, genOrdering)),
+            customTypes.All.values.map(FileCustomType(options, genOrdering)),
+            relationFilesByName.map { case (_, f) => f },
+            sqlFileFiles
+          ).flatten
+
+        val keptMostFiles: List[sc.File] = {
+          val keptRelations: immutable.Iterable[sc.File] =
+            if (options.keepDependencies) relationFilesByName.map { case (_, f) => f }
+            else relationFilesByName.collect { case (name, f) if selector.include(name) => f }
+
+          minimize(mostFiles, sqlFileFiles ++ keptRelations)
+        }
+
+        // package objects have weird scoping, so don't attempt to automatically write imports for them.
+        // this should be a stop-gap solution anyway
+        val pkgObject = if (isRoot) FilePackageObject.packageObject(options) else None
+
+        val testInsertsDataFile =
+          options.dbLib match {
+            case Some(dbLib) =>
+              val keptTypes = keptMostFiles.flatMap(x => x.tpe :: x.secondaryTypes).toSet
+              val keptTables =
+                computedRelations.collect { case x: ComputedTable if options.enableTestInserts.include(x.dbTable.name) && keptTypes(x.names.RepoImplName) => x }
+              if (keptTables.nonEmpty) {
+                val computed = ComputedTestInserts(project.name, options, customTypes, domains, enums, keptTables)
+                Some(FileTestInserts(computed, dbLib))
+              } else None
+            case _ => None
+          }
+
+        val allFiles: Iterator[sc.File] = {
+          val knownNamesByPkg: Map[sc.QIdent, Map[sc.Ident, sc.Type.Qualified]] =
+            keptMostFiles.groupBy(_.pkg).map { case (pkg, files) =>
+              (pkg, files.flatMap(f => (f.name, f.tpe) :: f.secondaryTypes.map(tpe => (tpe.value.name, tpe))).toMap)
+            }
+          val withImports = (testInsertsDataFile.iterator ++ keptMostFiles).map(file => addPackageAndImports(knownNamesByPkg, file))
+          val all = withImports ++ pkgObject.iterator
+          all.map(file => file.copy(contents = options.fileHeader.code ++ file.contents))
+        }
+
+        options.logger.info(s"Codegen complete for project ${project.target}")
+        // keep files generated for sql files separate, so we dont name clash later
+        val sqlTypes = sqlFileFiles.map(_.tpe).toSet
+        allFiles.toList.partition(file => sqlTypes.contains(file.tpe)) match {
+          case (sqlFiles, otherFiles) =>
+            (otherFiles.map(f => f.tpe -> f).toMap, sqlFiles)
+        }
       }
 
-    // note, these statements will force the evaluation of some of the lazy values
-    val computedSqlFiles = sqlFiles.map(sqlScript => ComputedSqlFile(options.logger, sqlScript, options.pkg, naming, metaDb.typeMapperDb, scalaTypeMapper, computeds.get))
-    computeds.foreach { case (relName, lazyValue) =>
-      if (selector.include(relName)) lazyValue.get
-    }
-    // here we keep only the values which have been evaluated. as such, the selector pattern should be safe
-    val computedRelations = computeds.flatMap { case (_, lazyValue) => lazyValue.getIfEvaluated }
+    val deduplicated = deduplicate(projectsWithFiles)
+    deduplicated.toList.map { p => Generated(p.target, p.value.valuesIterator ++ p.scripts) }
+  }
 
-    // yeah, sorry about the naming overload. this is a list of output files generated for each input sql file
-    val sqlFileFiles: List[sc.File] =
-      computedSqlFiles.flatMap(x => FilesSqlFile(x, naming, options).all)
+  // projects in graph will have duplicated files, this will pull the files up until they are no longer duplicated
+  def deduplicate[S](graph: ProjectGraph[Files, S]) = {
+    def go(current: ProjectGraph[Files, S]): (Files, ProjectGraph[Files, S]) = {
+      // start at leaves, so we can pull up files from the bottom up
+      val (downstreamAccFiles: List[Files], rewrittenDownstream: List[ProjectGraph[Files, S]]) =
+        current.downstream.map(go).unzip
 
-    val relationFilesByName = computedRelations.flatMap {
-      case viewComputed: ComputedView   => FilesView(viewComputed, options).all.map(x => (viewComputed.view.name, x))
-      case tableComputed: ComputedTable => FilesTable(tableComputed, options, genOrdering).all.map(x => (tableComputed.dbTable.name, x))
-      case _                            => Nil
-    }
+      // these are the files we'll pull up
+      val pullUp: Set[sc.Type.Qualified] = {
+        val existInMoreThanOneDownStream =
+          downstreamAccFiles.flatMap(_.keys).groupBy(identity).collect { case (k, v) if v.size > 1 => k }.toSet
 
-    val mostFiles: List[sc.File] =
-      List(
-        options.dbLib.toList.flatMap(_.additionalFiles),
-        List(FileDefault(default, options.jsonLibs, options.dbLib).file),
-        enums.map(enm => FileStringEnum(options, enm, genOrdering)),
-        domains.map(d => FileDomain(d, options, genOrdering)),
-        customTypes.All.values.map(FileCustomType(options, genOrdering)),
-        relationFilesByName.map { case (_, f) => f },
-        sqlFileFiles
-      ).flatten
-
-    val keptMostFiles: List[sc.File] = {
-      val entryPoints: Iterable[sc.File] =
-        sqlFileFiles.map { f => f } ++ relationFilesByName.collect { case (name, f) if options.keepDependencies || selector.include(name) => f }
-      internal.minimize(mostFiles, entryPoints)
-    }
-    lazy val keptTypes = keptMostFiles.flatMap(x => x.tpe :: x.secondaryTypes).toSet
-
-    val knownNamesByPkg: Map[sc.QIdent, Map[sc.Ident, sc.Type.Qualified]] =
-      keptMostFiles.groupBy(_.pkg).map { case (pkg, files) =>
-        (pkg, files.flatMap(f => (f.name, f.tpe) :: f.secondaryTypes.map(tpe => (tpe.value.name, tpe))).toMap)
+        existInMoreThanOneDownStream ++ current.value.keys
       }
 
-    // package objects have weird scoping, so don't attempt to automatically write imports for them.
-    // this should be a stop-gap solution anyway
-    val pkgObject = FilePackageObject.packageObject(options)
+      // compute the set of all types in this graph of projects
+      val currentAccFiles = downstreamAccFiles.foldLeft(current.value)(_ ++ _)
 
-    val testInsertsDataFile = options.dbLib match {
-      case Some(dbLib) =>
-        val keptTables =
-          computedRelations.collect { case x: ComputedTable if options.enableTestInserts.include(x.dbTable.name) && keptTypes(x.names.RepoImplName) => x }
-        if (keptTables.nonEmpty) {
-          val computed = ComputedTestInserts(options, customTypes, domains, enums, keptTables)
-          Some(FileTestInserts(computed, dbLib))
-        } else None
-      case _ => None
+      // compute deduplicated version of this project
+      val newGraph = current.copy(
+        // rewrite downstream projects a second time where we drop files. note that for each level we rewrite all downstream projects again
+        downstream = rewrittenDownstream.map(_.mapValue(_ -- pullUp)),
+        value = current.value ++ pullUp.map(tpe => (tpe, currentAccFiles(tpe)))
+      )
+
+      (currentAccFiles, newGraph)
     }
 
-    val allFiles: Iterator[sc.File] = {
-      val withImports = (testInsertsDataFile.iterator ++ keptMostFiles).map(file => addPackageAndImports(knownNamesByPkg, file))
-      val all = withImports ++ pkgObject.iterator
-      all.map(file => file.copy(contents = options.fileHeader.code ++ file.contents))
-    }
-
-    options.logger.info(s"Codegen complete")
-
-    Generated(allFiles)
+    go(graph)._2
   }
 }


### PR DESCRIPTION
It's very common that you don't want to expose all the tables in one place in your system. 
You also don't want duplication of generated code or more than one script to generate database code. 

The solution is to pass a `ProjectGraph` structure to `generateFromDb` instead, 
in which you encode the structure of the (relevant) projects in your build.

Dependencies between projects are encoded by nesting in the tree you pass (each node has a `downstream` member), 
with the root being the uppermost one. 

If multiple downstream projects want to generate the same code, it'll be pulled up to the level necessary to become visible for all of them.

sample:
```scala mdoc:silent
import typo.*
import java.nio.file.Path
import java.sql.Connection

def generate(implicit c: Connection): String = {
  val cwd: Path = Path.of(sys.props("user.dir"))

  val generated = generateFromDb(
    Options(
      pkg = "org.mypkg",
      jsonLibs = Nil,
      dbLib = Some(DbLibName.ZioJdbc)
    ),
    // setup a project graph. this outer-most project is the root project.
    // if multiple downstream projects need the same relation, it'll be pulled up until it's visible for all.
    // in this simple example it means `a.bicycle` will be pulled up here
    ProjectGraph(
      name = "a",
      target = cwd.resolve("a/src/main/typo"),
      value = Selector.None,
      scripts = Nil,
      downstream = List(
        ProjectGraph(
          name = "b",
          target = cwd.resolve("b/src/main/typo"),
          value = Selector.fullRelationNames(
            "a.bicycle",
            "b.person"
          ),
          // where to find sql files
          scripts = List(cwd.resolve("b/src/main/sql")),
          downstream = Nil
        ),
        ProjectGraph(
          name = "c",
          target = cwd.resolve("b/src/main/typo"),
          value = Selector.fullRelationNames(
            "a.bicycle",
            "c.animal"
          ),
          scripts = List(cwd.resolve("b/src/main/sql")),
          downstream = Nil
        )
      )
    )
  )

  generated.foreach(_.overwriteFolder())

  import scala.sys.process.*

  (List("git", "add") ++ generated.map(_.folder.toString)).!!
}
```

### todo:

- [x] `testInsert` (we'll need one for each project)
- [x] docs
- [ ] tests