### PR TITLE
Don't crash in MetaDb.scala

### DIFF
--- a/typo/src/scala/typo/MetaDb.scala
+++ b/typo/src/scala/typo/MetaDb.scala
@@ -164,7 +164,7 @@ object MetaDb {
       input.tables.flatMap { relation =>
         val relationName = db.RelationName(schema = relation.tableSchema, name = relation.tableName.get)
 
-        NonEmptyList.fromList(columnsByTable(relationName).sortBy(_.ordinalPosition)) map { columns =>
+        NonEmptyList.fromList(columnsByTable.getOrElse(relationName, Nil).sortBy(_.ordinalPosition)) map { columns =>
           val lazyAnalysis = Lazy {
             val fks: List[db.ForeignKey] = foreignKeys.getOrElse(relationName, List.empty)
 


### PR DESCRIPTION
Hey there,

I wanted to play around with Typo and it crashed. The reason is probably that I'm using it with TimescaleDB, which is a modified version of PostgreSQL. I'm getting this error:
```
[error] java.util.NoSuchElementException: key not found: RelationName(Some(_timescaledb_cache),cache_inval_hypertable)
[error]         at scala.collection.immutable.BitmapIndexedMapNode.apply(HashMap.scala:670)
[error]         at scala.collection.immutable.BitmapIndexedMapNode.apply(HashMap.scala:672)
[error]         at scala.collection.immutable.HashMap.apply(HashMap.scala:132)
[error]         at typo.MetaDb$.$anonfun$fromDb$30(MetaDb.scala:167)
```

I'd love to try this fix, but I can't be bothered to figure out this newfangled bleep thing.