### PR TITLE
Foreign keys in DSL

### DIFF
--- a/.bleep/generated-sources/typo-tester-anorm@jvm213/scripts.GenHardcodedFiles/testdb/hardcoded/myschema/person/PersonFields.scala
+++ b/.bleep/generated-sources/typo-tester-anorm@jvm213/scripts.GenHardcodedFiles/testdb/hardcoded/myschema/person/PersonFields.scala
@@ -10,8 +10,13 @@ package person
 
 import testdb.hardcoded.myschema.Number
 import testdb.hardcoded.myschema.Sector
+import testdb.hardcoded.myschema.football_club.FootballClubFields
 import testdb.hardcoded.myschema.football_club.FootballClubId
+import testdb.hardcoded.myschema.football_club.FootballClubRow
+import testdb.hardcoded.myschema.marital_status.MaritalStatusFields
 import testdb.hardcoded.myschema.marital_status.MaritalStatusId
+import testdb.hardcoded.myschema.marital_status.MaritalStatusRow
+import typo.dsl.ForeignKey
 import typo.dsl.Path
 import typo.dsl.SqlExpr.Field
 import typo.dsl.SqlExpr.FieldLikeNoHkt
@@ -32,6 +37,12 @@ trait PersonFields {
   def workEmail: OptField[/* max 254 chars */ String, PersonRow]
   def sector: Field[Sector, PersonRow]
   def favoriteNumber: Field[Number, PersonRow]
+  def fkFootballClub: ForeignKey[FootballClubFields, FootballClubRow] =
+    ForeignKey[FootballClubFields, FootballClubRow]("myschema.person_favourite_football_club_id_fkey", Nil)
+      .withColumnPair(favouriteFootballClubId, _.id)
+  def fkMaritalStatus: ForeignKey[MaritalStatusFields, MaritalStatusRow] =
+    ForeignKey[MaritalStatusFields, MaritalStatusRow]("myschema.person_marital_status_id_fkey", Nil)
+      .withColumnPair(maritalStatusId, _.id)
 }
 
 object PersonFields {

--- a/.bleep/generated-sources/typo-tester-anorm@jvm3/scripts.GenHardcodedFiles/testdb/hardcoded/myschema/person/PersonFields.scala
+++ b/.bleep/generated-sources/typo-tester-anorm@jvm3/scripts.GenHardcodedFiles/testdb/hardcoded/myschema/person/PersonFields.scala
@@ -10,8 +10,13 @@ package person
 
 import testdb.hardcoded.myschema.Number
 import testdb.hardcoded.myschema.Sector
+import testdb.hardcoded.myschema.football_club.FootballClubFields
 import testdb.hardcoded.myschema.football_club.FootballClubId
+import testdb.hardcoded.myschema.football_club.FootballClubRow
+import testdb.hardcoded.myschema.marital_status.MaritalStatusFields
 import testdb.hardcoded.myschema.marital_status.MaritalStatusId
+import testdb.hardcoded.myschema.marital_status.MaritalStatusRow
+import typo.dsl.ForeignKey
 import typo.dsl.Path
 import typo.dsl.SqlExpr.Field
 import typo.dsl.SqlExpr.FieldLikeNoHkt
@@ -32,6 +37,12 @@ trait PersonFields {
   def workEmail: OptField[/* max 254 chars */ String, PersonRow]
   def sector: Field[Sector, PersonRow]
   def favoriteNumber: Field[Number, PersonRow]
+  def fkFootballClub: ForeignKey[FootballClubFields, FootballClubRow] =
+    ForeignKey[FootballClubFields, FootballClubRow]("myschema.person_favourite_football_club_id_fkey", Nil)
+      .withColumnPair(favouriteFootballClubId, _.id)
+  def fkMaritalStatus: ForeignKey[MaritalStatusFields, MaritalStatusRow] =
+    ForeignKey[MaritalStatusFields, MaritalStatusRow]("myschema.person_marital_status_id_fkey", Nil)
+      .withColumnPair(maritalStatusId, _.id)
 }
 
 object PersonFields {

--- a/.bleep/generated-sources/typo-tester-doobie@jvm213/scripts.GenHardcodedFiles/testdb/hardcoded/myschema/person/PersonFields.scala
+++ b/.bleep/generated-sources/typo-tester-doobie@jvm213/scripts.GenHardcodedFiles/testdb/hardcoded/myschema/person/PersonFields.scala
@@ -10,8 +10,13 @@ package person
 
 import testdb.hardcoded.myschema.Number
 import testdb.hardcoded.myschema.Sector
+import testdb.hardcoded.myschema.football_club.FootballClubFields
 import testdb.hardcoded.myschema.football_club.FootballClubId
+import testdb.hardcoded.myschema.football_club.FootballClubRow
+import testdb.hardcoded.myschema.marital_status.MaritalStatusFields
 import testdb.hardcoded.myschema.marital_status.MaritalStatusId
+import testdb.hardcoded.myschema.marital_status.MaritalStatusRow
+import typo.dsl.ForeignKey
 import typo.dsl.Path
 import typo.dsl.SqlExpr.Field
 import typo.dsl.SqlExpr.FieldLikeNoHkt
@@ -32,6 +37,12 @@ trait PersonFields {
   def workEmail: OptField[/* max 254 chars */ String, PersonRow]
   def sector: Field[Sector, PersonRow]
   def favoriteNumber: Field[Number, PersonRow]
+  def fkFootballClub: ForeignKey[FootballClubFields, FootballClubRow] =
+    ForeignKey[FootballClubFields, FootballClubRow]("myschema.person_favourite_football_club_id_fkey", Nil)
+      .withColumnPair(favouriteFootballClubId, _.id)
+  def fkMaritalStatus: ForeignKey[MaritalStatusFields, MaritalStatusRow] =
+    ForeignKey[MaritalStatusFields, MaritalStatusRow]("myschema.person_marital_status_id_fkey", Nil)
+      .withColumnPair(maritalStatusId, _.id)
 }
 
 object PersonFields {

--- a/.bleep/generated-sources/typo-tester-doobie@jvm3/scripts.GenHardcodedFiles/testdb/hardcoded/myschema/person/PersonFields.scala
+++ b/.bleep/generated-sources/typo-tester-doobie@jvm3/scripts.GenHardcodedFiles/testdb/hardcoded/myschema/person/PersonFields.scala
@@ -10,8 +10,13 @@ package person
 
 import testdb.hardcoded.myschema.Number
 import testdb.hardcoded.myschema.Sector
+import testdb.hardcoded.myschema.football_club.FootballClubFields
 import testdb.hardcoded.myschema.football_club.FootballClubId
+import testdb.hardcoded.myschema.football_club.FootballClubRow
+import testdb.hardcoded.myschema.marital_status.MaritalStatusFields
 import testdb.hardcoded.myschema.marital_status.MaritalStatusId
+import testdb.hardcoded.myschema.marital_status.MaritalStatusRow
+import typo.dsl.ForeignKey
 import typo.dsl.Path
 import typo.dsl.SqlExpr.Field
 import typo.dsl.SqlExpr.FieldLikeNoHkt
@@ -32,6 +37,12 @@ trait PersonFields {
   def workEmail: OptField[/* max 254 chars */ String, PersonRow]
   def sector: Field[Sector, PersonRow]
   def favoriteNumber: Field[Number, PersonRow]
+  def fkFootballClub: ForeignKey[FootballClubFields, FootballClubRow] =
+    ForeignKey[FootballClubFields, FootballClubRow]("myschema.person_favourite_football_club_id_fkey", Nil)
+      .withColumnPair(favouriteFootballClubId, _.id)
+  def fkMaritalStatus: ForeignKey[MaritalStatusFields, MaritalStatusRow] =
+    ForeignKey[MaritalStatusFields, MaritalStatusRow]("myschema.person_marital_status_id_fkey", Nil)
+      .withColumnPair(maritalStatusId, _.id)
 }
 
 object PersonFields {

--- a/.bleep/generated-sources/typo-tester-zio-jdbc@jvm213/scripts.GenHardcodedFiles/testdb/hardcoded/myschema/person/PersonFields.scala
+++ b/.bleep/generated-sources/typo-tester-zio-jdbc@jvm213/scripts.GenHardcodedFiles/testdb/hardcoded/myschema/person/PersonFields.scala
@@ -10,8 +10,13 @@ package person
 
 import testdb.hardcoded.myschema.Number
 import testdb.hardcoded.myschema.Sector
+import testdb.hardcoded.myschema.football_club.FootballClubFields
 import testdb.hardcoded.myschema.football_club.FootballClubId
+import testdb.hardcoded.myschema.football_club.FootballClubRow
+import testdb.hardcoded.myschema.marital_status.MaritalStatusFields
 import testdb.hardcoded.myschema.marital_status.MaritalStatusId
+import testdb.hardcoded.myschema.marital_status.MaritalStatusRow
+import typo.dsl.ForeignKey
 import typo.dsl.Path
 import typo.dsl.SqlExpr.Field
 import typo.dsl.SqlExpr.FieldLikeNoHkt
@@ -32,6 +37,12 @@ trait PersonFields {
   def workEmail: OptField[/* max 254 chars */ String, PersonRow]
   def sector: Field[Sector, PersonRow]
   def favoriteNumber: Field[Number, PersonRow]
+  def fkFootballClub: ForeignKey[FootballClubFields, FootballClubRow] =
+    ForeignKey[FootballClubFields, FootballClubRow]("myschema.person_favourite_football_club_id_fkey", Nil)
+      .withColumnPair(favouriteFootballClubId, _.id)
+  def fkMaritalStatus: ForeignKey[MaritalStatusFields, MaritalStatusRow] =
+    ForeignKey[MaritalStatusFields, MaritalStatusRow]("myschema.person_marital_status_id_fkey", Nil)
+      .withColumnPair(maritalStatusId, _.id)
 }
 
 object PersonFields {

--- a/.bleep/generated-sources/typo-tester-zio-jdbc@jvm3/scripts.GenHardcodedFiles/testdb/hardcoded/myschema/person/PersonFields.scala
+++ b/.bleep/generated-sources/typo-tester-zio-jdbc@jvm3/scripts.GenHardcodedFiles/testdb/hardcoded/myschema/person/PersonFields.scala
@@ -10,8 +10,13 @@ package person
 
 import testdb.hardcoded.myschema.Number
 import testdb.hardcoded.myschema.Sector
+import testdb.hardcoded.myschema.football_club.FootballClubFields
 import testdb.hardcoded.myschema.football_club.FootballClubId
+import testdb.hardcoded.myschema.football_club.FootballClubRow
+import testdb.hardcoded.myschema.marital_status.MaritalStatusFields
 import testdb.hardcoded.myschema.marital_status.MaritalStatusId
+import testdb.hardcoded.myschema.marital_status.MaritalStatusRow
+import typo.dsl.ForeignKey
 import typo.dsl.Path
 import typo.dsl.SqlExpr.Field
 import typo.dsl.SqlExpr.FieldLikeNoHkt
@@ -32,6 +37,12 @@ trait PersonFields {
   def workEmail: OptField[/* max 254 chars */ String, PersonRow]
   def sector: Field[Sector, PersonRow]
   def favoriteNumber: Field[Number, PersonRow]
+  def fkFootballClub: ForeignKey[FootballClubFields, FootballClubRow] =
+    ForeignKey[FootballClubFields, FootballClubRow]("myschema.person_favourite_football_club_id_fkey", Nil)
+      .withColumnPair(favouriteFootballClubId, _.id)
+  def fkMaritalStatus: ForeignKey[MaritalStatusFields, MaritalStatusRow] =
+    ForeignKey[MaritalStatusFields, MaritalStatusRow]("myschema.person_marital_status_id_fkey", Nil)
+      .withColumnPair(maritalStatusId, _.id)
 }
 
 object PersonFields {

--- a/typo-dsl-doobie/src/scala/typo/dsl/SelectBuilder.scala
+++ b/typo-dsl-doobie/src/scala/typo/dsl/SelectBuilder.scala
@@ -68,11 +68,27 @@ trait SelectBuilder[Fields, Row] {
   /** Return sql for debugging. [[None]] if backed by a mock repository */
   def sql: Option[Fragment]
 
+  final def joinFk[Fields2, Row2](f: Fields => ForeignKey[Fields2, Row2])(other: SelectBuilder[Fields2, Row2]): SelectBuilder[Joined[Fields, Fields2], (Row, Row2)] =
+    joinOn[Fields2, Option, Row2](other) { case (thisFields, thatFields) =>
+      val fk: ForeignKey[Fields2, Row2] = f(thisFields)
+
+      fk.columnPairs
+        .map { case columnPair: ForeignKey.ColumnPair[t, Fields2] =>
+          implicit val ord: Ordering[t] = columnPair.ordering
+          val left: SqlExpr[t, Option] = columnPair.thisField
+          val right: SqlExpr[t, Option] = columnPair.thatField(thatFields)
+          left === right
+        }
+        .reduce(_.and(_))
+    }
+
   /** start constructing a join */
   final def join[F2, Row2](other: SelectBuilder[F2, Row2]): PartialJoin[F2, Row2] =
     new PartialJoin[F2, Row2](other)
 
   final class PartialJoin[Fields2, Row2](other: SelectBuilder[Fields2, Row2]) {
+    def onFk(f: Fields => ForeignKey[Fields2, Row2]): SelectBuilder[Joined[Fields, Fields2], (Row, Row2)] =
+      joinFk(f)(other)
 
     /** inner join with the given predicate
       * {{{

--- a/typo-dsl-doobie/src/scala/typo/dsl/SqlExpr.scala
+++ b/typo-dsl-doobie/src/scala/typo/dsl/SqlExpr.scala
@@ -113,7 +113,7 @@ object SqlExpr {
 
   sealed trait FieldLikeNotIdNoHkt[NT, R] extends FieldLikeNoHkt[NT, R]
 
-  sealed trait FieldLike[T, N[_], R] extends SqlExpr[T, N] with FieldLikeNoHkt[N[T], R] with Product {
+  sealed trait FieldLike[T, N[_], R] extends SqlExpr[T, N] with FieldLikeNoHkt[N[T], R] {
     val path: List[Path]
     val name: String
     val sqlReadCast: Option[String]

--- a/typo-dsl-shared/typo/dsl/ForeignKey.scala
+++ b/typo-dsl-shared/typo/dsl/ForeignKey.scala
@@ -1,0 +1,24 @@
+package typo.dsl
+
+case class ForeignKey[Fields2, Row2](
+    name: String,
+    columnPairs: List[ForeignKey.ColumnPair[?, Fields2]]
+) {
+
+  def withColumnPair[T, ThisN[_]: Nullability, ThatN[_]: Nullability](
+      field: SqlExpr.FieldLike[T, ThisN, ?],
+      thatField: Fields2 => SqlExpr.FieldLike[T, ThatN, Row2]
+  )(implicit O: Ordering[T]): ForeignKey[Fields2, Row2] =
+    new ForeignKey[Fields2, Row2](
+      name,
+      columnPairs :+ ForeignKey.ColumnPair[T, Fields2](field.?, f => thatField(f).?, O)
+    )
+}
+
+object ForeignKey {
+  case class ColumnPair[T, Fields2](
+      thisField: SqlExpr[T, Option],
+      thatField: Fields2 => SqlExpr[T, Option],
+      ordering: Ordering[T]
+  )
+}

--- a/typo-dsl-zio-jdbc/src/scala/typo/dsl/SelectBuilder.scala
+++ b/typo-dsl-zio-jdbc/src/scala/typo/dsl/SelectBuilder.scala
@@ -68,11 +68,27 @@ trait SelectBuilder[Fields, Row] {
   /** Return sql for debugging. [[None]] if backed by a mock repository */
   def sql: Option[SqlFragment]
 
+  final def joinFk[Fields2, Row2](f: Fields => ForeignKey[Fields2, Row2])(other: SelectBuilder[Fields2, Row2]): SelectBuilder[Joined[Fields, Fields2], (Row, Row2)] =
+    joinOn[Fields2, Option, Row2](other) { case (thisFields, thatFields) =>
+      val fk: ForeignKey[Fields2, Row2] = f(thisFields)
+
+      fk.columnPairs
+        .map { case columnPair: ForeignKey.ColumnPair[t, Fields2] =>
+          implicit val ord: Ordering[t] = columnPair.ordering
+          val left: SqlExpr[t, Option] = columnPair.thisField
+          val right: SqlExpr[t, Option] = columnPair.thatField(thatFields)
+          left === right
+        }
+        .reduce(_.and(_))
+    }
+
   /** start constructing a join */
   final def join[F2, Row2](other: SelectBuilder[F2, Row2]): PartialJoin[F2, Row2] =
     new PartialJoin[F2, Row2](other)
 
   final class PartialJoin[Fields2, Row2](other: SelectBuilder[Fields2, Row2]) {
+    def onFk(f: Fields => ForeignKey[Fields2, Row2]): SelectBuilder[Joined[Fields, Fields2], (Row, Row2)] =
+      joinFk(f)(other)
 
     /** inner join with the given predicate
       * {{{

--- a/typo-tester-anorm/generated-and-checked-in/adventureworks/humanresources/employee/EmployeeFields.scala
+++ b/typo-tester-anorm/generated-and-checked-in/adventureworks/humanresources/employee/EmployeeFields.scala
@@ -12,7 +12,10 @@ import adventureworks.customtypes.TypoLocalDateTime
 import adventureworks.customtypes.TypoShort
 import adventureworks.customtypes.TypoUUID
 import adventureworks.person.businessentity.BusinessentityId
+import adventureworks.person.person.PersonFields
+import adventureworks.person.person.PersonRow
 import adventureworks.public.Flag
+import typo.dsl.ForeignKey
 import typo.dsl.Path
 import typo.dsl.SqlExpr.Field
 import typo.dsl.SqlExpr.FieldLikeNoHkt
@@ -36,6 +39,9 @@ trait EmployeeFields {
   def rowguid: Field[TypoUUID, EmployeeRow]
   def modifieddate: Field[TypoLocalDateTime, EmployeeRow]
   def organizationnode: OptField[String, EmployeeRow]
+  def fkPersonPerson: ForeignKey[PersonFields, PersonRow] =
+    ForeignKey[PersonFields, PersonRow]("humanresources.FK_Employee_Person_BusinessEntityID", Nil)
+      .withColumnPair(businessentityid, _.businessentityid)
 }
 
 object EmployeeFields {

--- a/typo-tester-anorm/generated-and-checked-in/adventureworks/humanresources/employeedepartmenthistory/EmployeedepartmenthistoryFields.scala
+++ b/typo-tester-anorm/generated-and-checked-in/adventureworks/humanresources/employeedepartmenthistory/EmployeedepartmenthistoryFields.scala
@@ -9,9 +9,16 @@ package employeedepartmenthistory
 
 import adventureworks.customtypes.TypoLocalDate
 import adventureworks.customtypes.TypoLocalDateTime
+import adventureworks.humanresources.department.DepartmentFields
 import adventureworks.humanresources.department.DepartmentId
+import adventureworks.humanresources.department.DepartmentRow
+import adventureworks.humanresources.employee.EmployeeFields
+import adventureworks.humanresources.employee.EmployeeRow
+import adventureworks.humanresources.shift.ShiftFields
 import adventureworks.humanresources.shift.ShiftId
+import adventureworks.humanresources.shift.ShiftRow
 import adventureworks.person.businessentity.BusinessentityId
+import typo.dsl.ForeignKey
 import typo.dsl.Path
 import typo.dsl.SqlExpr.Field
 import typo.dsl.SqlExpr.FieldLikeNoHkt
@@ -26,6 +33,15 @@ trait EmployeedepartmenthistoryFields {
   def startdate: IdField[TypoLocalDate, EmployeedepartmenthistoryRow]
   def enddate: OptField[TypoLocalDate, EmployeedepartmenthistoryRow]
   def modifieddate: Field[TypoLocalDateTime, EmployeedepartmenthistoryRow]
+  def fkDepartment: ForeignKey[DepartmentFields, DepartmentRow] =
+    ForeignKey[DepartmentFields, DepartmentRow]("humanresources.FK_EmployeeDepartmentHistory_Department_DepartmentID", Nil)
+      .withColumnPair(departmentid, _.departmentid)
+  def fkEmployee: ForeignKey[EmployeeFields, EmployeeRow] =
+    ForeignKey[EmployeeFields, EmployeeRow]("humanresources.FK_EmployeeDepartmentHistory_Employee_BusinessEntityID", Nil)
+      .withColumnPair(businessentityid, _.businessentityid)
+  def fkShift: ForeignKey[ShiftFields, ShiftRow] =
+    ForeignKey[ShiftFields, ShiftRow]("humanresources.FK_EmployeeDepartmentHistory_Shift_ShiftID", Nil)
+      .withColumnPair(shiftid, _.shiftid)
 }
 
 object EmployeedepartmenthistoryFields {

--- a/typo-tester-anorm/generated-and-checked-in/adventureworks/humanresources/employeepayhistory/EmployeepayhistoryFields.scala
+++ b/typo-tester-anorm/generated-and-checked-in/adventureworks/humanresources/employeepayhistory/EmployeepayhistoryFields.scala
@@ -9,7 +9,10 @@ package employeepayhistory
 
 import adventureworks.customtypes.TypoLocalDateTime
 import adventureworks.customtypes.TypoShort
+import adventureworks.humanresources.employee.EmployeeFields
+import adventureworks.humanresources.employee.EmployeeRow
 import adventureworks.person.businessentity.BusinessentityId
+import typo.dsl.ForeignKey
 import typo.dsl.Path
 import typo.dsl.SqlExpr.Field
 import typo.dsl.SqlExpr.FieldLikeNoHkt
@@ -22,6 +25,9 @@ trait EmployeepayhistoryFields {
   def rate: Field[BigDecimal, EmployeepayhistoryRow]
   def payfrequency: Field[TypoShort, EmployeepayhistoryRow]
   def modifieddate: Field[TypoLocalDateTime, EmployeepayhistoryRow]
+  def fkEmployee: ForeignKey[EmployeeFields, EmployeeRow] =
+    ForeignKey[EmployeeFields, EmployeeRow]("humanresources.FK_EmployeePayHistory_Employee_BusinessEntityID", Nil)
+      .withColumnPair(businessentityid, _.businessentityid)
 }
 
 object EmployeepayhistoryFields {

--- a/typo-tester-anorm/generated-and-checked-in/adventureworks/humanresources/jobcandidate/JobcandidateFields.scala
+++ b/typo-tester-anorm/generated-and-checked-in/adventureworks/humanresources/jobcandidate/JobcandidateFields.scala
@@ -9,7 +9,10 @@ package jobcandidate
 
 import adventureworks.customtypes.TypoLocalDateTime
 import adventureworks.customtypes.TypoXml
+import adventureworks.humanresources.employee.EmployeeFields
+import adventureworks.humanresources.employee.EmployeeRow
 import adventureworks.person.businessentity.BusinessentityId
+import typo.dsl.ForeignKey
 import typo.dsl.Path
 import typo.dsl.SqlExpr.Field
 import typo.dsl.SqlExpr.FieldLikeNoHkt
@@ -22,6 +25,9 @@ trait JobcandidateFields {
   def businessentityid: OptField[BusinessentityId, JobcandidateRow]
   def resume: OptField[TypoXml, JobcandidateRow]
   def modifieddate: Field[TypoLocalDateTime, JobcandidateRow]
+  def fkEmployee: ForeignKey[EmployeeFields, EmployeeRow] =
+    ForeignKey[EmployeeFields, EmployeeRow]("humanresources.FK_JobCandidate_Employee_BusinessEntityID", Nil)
+      .withColumnPair(businessentityid, _.businessentityid)
 }
 
 object JobcandidateFields {

--- a/typo-tester-anorm/generated-and-checked-in/adventureworks/person/address/AddressFields.scala
+++ b/typo-tester-anorm/generated-and-checked-in/adventureworks/person/address/AddressFields.scala
@@ -10,7 +10,10 @@ package address
 import adventureworks.customtypes.TypoBytea
 import adventureworks.customtypes.TypoLocalDateTime
 import adventureworks.customtypes.TypoUUID
+import adventureworks.person.stateprovince.StateprovinceFields
 import adventureworks.person.stateprovince.StateprovinceId
+import adventureworks.person.stateprovince.StateprovinceRow
+import typo.dsl.ForeignKey
 import typo.dsl.Path
 import typo.dsl.SqlExpr.Field
 import typo.dsl.SqlExpr.FieldLikeNoHkt
@@ -28,6 +31,9 @@ trait AddressFields {
   def spatiallocation: OptField[TypoBytea, AddressRow]
   def rowguid: Field[TypoUUID, AddressRow]
   def modifieddate: Field[TypoLocalDateTime, AddressRow]
+  def fkStateprovince: ForeignKey[StateprovinceFields, StateprovinceRow] =
+    ForeignKey[StateprovinceFields, StateprovinceRow]("person.FK_Address_StateProvince_StateProvinceID", Nil)
+      .withColumnPair(stateprovinceid, _.stateprovinceid)
 }
 
 object AddressFields {

--- a/typo-tester-anorm/generated-and-checked-in/adventureworks/person/businessentityaddress/BusinessentityaddressFields.scala
+++ b/typo-tester-anorm/generated-and-checked-in/adventureworks/person/businessentityaddress/BusinessentityaddressFields.scala
@@ -9,9 +9,16 @@ package businessentityaddress
 
 import adventureworks.customtypes.TypoLocalDateTime
 import adventureworks.customtypes.TypoUUID
+import adventureworks.person.address.AddressFields
 import adventureworks.person.address.AddressId
+import adventureworks.person.address.AddressRow
+import adventureworks.person.addresstype.AddresstypeFields
 import adventureworks.person.addresstype.AddresstypeId
+import adventureworks.person.addresstype.AddresstypeRow
+import adventureworks.person.businessentity.BusinessentityFields
 import adventureworks.person.businessentity.BusinessentityId
+import adventureworks.person.businessentity.BusinessentityRow
+import typo.dsl.ForeignKey
 import typo.dsl.Path
 import typo.dsl.SqlExpr.Field
 import typo.dsl.SqlExpr.FieldLikeNoHkt
@@ -24,6 +31,15 @@ trait BusinessentityaddressFields {
   def addresstypeid: IdField[AddresstypeId, BusinessentityaddressRow]
   def rowguid: Field[TypoUUID, BusinessentityaddressRow]
   def modifieddate: Field[TypoLocalDateTime, BusinessentityaddressRow]
+  def fkAddress: ForeignKey[AddressFields, AddressRow] =
+    ForeignKey[AddressFields, AddressRow]("person.FK_BusinessEntityAddress_Address_AddressID", Nil)
+      .withColumnPair(addressid, _.addressid)
+  def fkAddresstype: ForeignKey[AddresstypeFields, AddresstypeRow] =
+    ForeignKey[AddresstypeFields, AddresstypeRow]("person.FK_BusinessEntityAddress_AddressType_AddressTypeID", Nil)
+      .withColumnPair(addresstypeid, _.addresstypeid)
+  def fkBusinessentity: ForeignKey[BusinessentityFields, BusinessentityRow] =
+    ForeignKey[BusinessentityFields, BusinessentityRow]("person.FK_BusinessEntityAddress_BusinessEntity_BusinessEntityID", Nil)
+      .withColumnPair(businessentityid, _.businessentityid)
 }
 
 object BusinessentityaddressFields {

--- a/typo-tester-anorm/generated-and-checked-in/adventureworks/person/businessentitycontact/BusinessentitycontactFields.scala
+++ b/typo-tester-anorm/generated-and-checked-in/adventureworks/person/businessentitycontact/BusinessentitycontactFields.scala
@@ -9,8 +9,15 @@ package businessentitycontact
 
 import adventureworks.customtypes.TypoLocalDateTime
 import adventureworks.customtypes.TypoUUID
+import adventureworks.person.businessentity.BusinessentityFields
 import adventureworks.person.businessentity.BusinessentityId
+import adventureworks.person.businessentity.BusinessentityRow
+import adventureworks.person.contacttype.ContacttypeFields
 import adventureworks.person.contacttype.ContacttypeId
+import adventureworks.person.contacttype.ContacttypeRow
+import adventureworks.person.person.PersonFields
+import adventureworks.person.person.PersonRow
+import typo.dsl.ForeignKey
 import typo.dsl.Path
 import typo.dsl.SqlExpr.Field
 import typo.dsl.SqlExpr.FieldLikeNoHkt
@@ -23,6 +30,15 @@ trait BusinessentitycontactFields {
   def contacttypeid: IdField[ContacttypeId, BusinessentitycontactRow]
   def rowguid: Field[TypoUUID, BusinessentitycontactRow]
   def modifieddate: Field[TypoLocalDateTime, BusinessentitycontactRow]
+  def fkPerson: ForeignKey[PersonFields, PersonRow] =
+    ForeignKey[PersonFields, PersonRow]("person.FK_BusinessEntityContact_Person_PersonID", Nil)
+      .withColumnPair(personid, _.businessentityid)
+  def fkContacttype: ForeignKey[ContacttypeFields, ContacttypeRow] =
+    ForeignKey[ContacttypeFields, ContacttypeRow]("person.FK_BusinessEntityContact_ContactType_ContactTypeID", Nil)
+      .withColumnPair(contacttypeid, _.contacttypeid)
+  def fkBusinessentity: ForeignKey[BusinessentityFields, BusinessentityRow] =
+    ForeignKey[BusinessentityFields, BusinessentityRow]("person.FK_BusinessEntityContact_BusinessEntity_BusinessEntityID", Nil)
+      .withColumnPair(businessentityid, _.businessentityid)
 }
 
 object BusinessentitycontactFields {

--- a/typo-tester-anorm/generated-and-checked-in/adventureworks/person/emailaddress/EmailaddressFields.scala
+++ b/typo-tester-anorm/generated-and-checked-in/adventureworks/person/emailaddress/EmailaddressFields.scala
@@ -10,6 +10,9 @@ package emailaddress
 import adventureworks.customtypes.TypoLocalDateTime
 import adventureworks.customtypes.TypoUUID
 import adventureworks.person.businessentity.BusinessentityId
+import adventureworks.person.person.PersonFields
+import adventureworks.person.person.PersonRow
+import typo.dsl.ForeignKey
 import typo.dsl.Path
 import typo.dsl.SqlExpr.Field
 import typo.dsl.SqlExpr.FieldLikeNoHkt
@@ -23,6 +26,9 @@ trait EmailaddressFields {
   def emailaddress: OptField[/* max 50 chars */ String, EmailaddressRow]
   def rowguid: Field[TypoUUID, EmailaddressRow]
   def modifieddate: Field[TypoLocalDateTime, EmailaddressRow]
+  def fkPerson: ForeignKey[PersonFields, PersonRow] =
+    ForeignKey[PersonFields, PersonRow]("person.FK_EmailAddress_Person_BusinessEntityID", Nil)
+      .withColumnPair(businessentityid, _.businessentityid)
 }
 
 object EmailaddressFields {

--- a/typo-tester-anorm/generated-and-checked-in/adventureworks/person/password/PasswordFields.scala
+++ b/typo-tester-anorm/generated-and-checked-in/adventureworks/person/password/PasswordFields.scala
@@ -10,6 +10,9 @@ package password
 import adventureworks.customtypes.TypoLocalDateTime
 import adventureworks.customtypes.TypoUUID
 import adventureworks.person.businessentity.BusinessentityId
+import adventureworks.person.person.PersonFields
+import adventureworks.person.person.PersonRow
+import typo.dsl.ForeignKey
 import typo.dsl.Path
 import typo.dsl.SqlExpr.Field
 import typo.dsl.SqlExpr.FieldLikeNoHkt
@@ -22,6 +25,9 @@ trait PasswordFields {
   def passwordsalt: Field[/* max 10 chars */ String, PasswordRow]
   def rowguid: Field[TypoUUID, PasswordRow]
   def modifieddate: Field[TypoLocalDateTime, PasswordRow]
+  def fkPerson: ForeignKey[PersonFields, PersonRow] =
+    ForeignKey[PersonFields, PersonRow]("person.FK_Password_Person_BusinessEntityID", Nil)
+      .withColumnPair(businessentityid, _.businessentityid)
 }
 
 object PasswordFields {

--- a/typo-tester-anorm/generated-and-checked-in/adventureworks/person/person/PersonFields.scala
+++ b/typo-tester-anorm/generated-and-checked-in/adventureworks/person/person/PersonFields.scala
@@ -10,10 +10,13 @@ package person
 import adventureworks.customtypes.TypoLocalDateTime
 import adventureworks.customtypes.TypoUUID
 import adventureworks.customtypes.TypoXml
+import adventureworks.person.businessentity.BusinessentityFields
 import adventureworks.person.businessentity.BusinessentityId
+import adventureworks.person.businessentity.BusinessentityRow
 import adventureworks.public.Name
 import adventureworks.public.NameStyle
 import adventureworks.userdefined.FirstName
+import typo.dsl.ForeignKey
 import typo.dsl.Path
 import typo.dsl.SqlExpr.Field
 import typo.dsl.SqlExpr.FieldLikeNoHkt
@@ -35,6 +38,9 @@ trait PersonFields {
   def demographics: OptField[TypoXml, PersonRow]
   def rowguid: Field[TypoUUID, PersonRow]
   def modifieddate: Field[TypoLocalDateTime, PersonRow]
+  def fkBusinessentity: ForeignKey[BusinessentityFields, BusinessentityRow] =
+    ForeignKey[BusinessentityFields, BusinessentityRow]("person.FK_Person_BusinessEntity_BusinessEntityID", Nil)
+      .withColumnPair(businessentityid, _.businessentityid)
 }
 
 object PersonFields {

--- a/typo-tester-anorm/generated-and-checked-in/adventureworks/person/personphone/PersonphoneFields.scala
+++ b/typo-tester-anorm/generated-and-checked-in/adventureworks/person/personphone/PersonphoneFields.scala
@@ -9,8 +9,13 @@ package personphone
 
 import adventureworks.customtypes.TypoLocalDateTime
 import adventureworks.person.businessentity.BusinessentityId
+import adventureworks.person.person.PersonFields
+import adventureworks.person.person.PersonRow
+import adventureworks.person.phonenumbertype.PhonenumbertypeFields
 import adventureworks.person.phonenumbertype.PhonenumbertypeId
+import adventureworks.person.phonenumbertype.PhonenumbertypeRow
 import adventureworks.public.Phone
+import typo.dsl.ForeignKey
 import typo.dsl.Path
 import typo.dsl.SqlExpr.Field
 import typo.dsl.SqlExpr.FieldLikeNoHkt
@@ -22,6 +27,12 @@ trait PersonphoneFields {
   def phonenumber: IdField[Phone, PersonphoneRow]
   def phonenumbertypeid: IdField[PhonenumbertypeId, PersonphoneRow]
   def modifieddate: Field[TypoLocalDateTime, PersonphoneRow]
+  def fkPerson: ForeignKey[PersonFields, PersonRow] =
+    ForeignKey[PersonFields, PersonRow]("person.FK_PersonPhone_Person_BusinessEntityID", Nil)
+      .withColumnPair(businessentityid, _.businessentityid)
+  def fkPhonenumbertype: ForeignKey[PhonenumbertypeFields, PhonenumbertypeRow] =
+    ForeignKey[PhonenumbertypeFields, PhonenumbertypeRow]("person.FK_PersonPhone_PhoneNumberType_PhoneNumberTypeID", Nil)
+      .withColumnPair(phonenumbertypeid, _.phonenumbertypeid)
 }
 
 object PersonphoneFields {

--- a/typo-tester-anorm/generated-and-checked-in/adventureworks/person/stateprovince/StateprovinceFields.scala
+++ b/typo-tester-anorm/generated-and-checked-in/adventureworks/person/stateprovince/StateprovinceFields.scala
@@ -9,10 +9,15 @@ package stateprovince
 
 import adventureworks.customtypes.TypoLocalDateTime
 import adventureworks.customtypes.TypoUUID
+import adventureworks.person.countryregion.CountryregionFields
 import adventureworks.person.countryregion.CountryregionId
+import adventureworks.person.countryregion.CountryregionRow
 import adventureworks.public.Flag
 import adventureworks.public.Name
+import adventureworks.sales.salesterritory.SalesterritoryFields
 import adventureworks.sales.salesterritory.SalesterritoryId
+import adventureworks.sales.salesterritory.SalesterritoryRow
+import typo.dsl.ForeignKey
 import typo.dsl.Path
 import typo.dsl.SqlExpr.Field
 import typo.dsl.SqlExpr.FieldLikeNoHkt
@@ -28,6 +33,12 @@ trait StateprovinceFields {
   def territoryid: Field[SalesterritoryId, StateprovinceRow]
   def rowguid: Field[TypoUUID, StateprovinceRow]
   def modifieddate: Field[TypoLocalDateTime, StateprovinceRow]
+  def fkCountryregion: ForeignKey[CountryregionFields, CountryregionRow] =
+    ForeignKey[CountryregionFields, CountryregionRow]("person.FK_StateProvince_CountryRegion_CountryRegionCode", Nil)
+      .withColumnPair(countryregioncode, _.countryregioncode)
+  def fkSalesSalesterritory: ForeignKey[SalesterritoryFields, SalesterritoryRow] =
+    ForeignKey[SalesterritoryFields, SalesterritoryRow]("person.FK_StateProvince_SalesTerritory_TerritoryID", Nil)
+      .withColumnPair(territoryid, _.territoryid)
 }
 
 object StateprovinceFields {

--- a/typo-tester-anorm/generated-and-checked-in/adventureworks/production/billofmaterials/BillofmaterialsFields.scala
+++ b/typo-tester-anorm/generated-and-checked-in/adventureworks/production/billofmaterials/BillofmaterialsFields.scala
@@ -9,8 +9,13 @@ package billofmaterials
 
 import adventureworks.customtypes.TypoLocalDateTime
 import adventureworks.customtypes.TypoShort
+import adventureworks.production.product.ProductFields
 import adventureworks.production.product.ProductId
+import adventureworks.production.product.ProductRow
+import adventureworks.production.unitmeasure.UnitmeasureFields
 import adventureworks.production.unitmeasure.UnitmeasureId
+import adventureworks.production.unitmeasure.UnitmeasureRow
+import typo.dsl.ForeignKey
 import typo.dsl.Path
 import typo.dsl.SqlExpr.Field
 import typo.dsl.SqlExpr.FieldLikeNoHkt
@@ -28,6 +33,15 @@ trait BillofmaterialsFields {
   def bomlevel: Field[TypoShort, BillofmaterialsRow]
   def perassemblyqty: Field[BigDecimal, BillofmaterialsRow]
   def modifieddate: Field[TypoLocalDateTime, BillofmaterialsRow]
+  def fkProductProductassemblyid: ForeignKey[ProductFields, ProductRow] =
+    ForeignKey[ProductFields, ProductRow]("production.FK_BillOfMaterials_Product_ProductAssemblyID", Nil)
+      .withColumnPair(productassemblyid, _.productid)
+  def fkProductComponentid: ForeignKey[ProductFields, ProductRow] =
+    ForeignKey[ProductFields, ProductRow]("production.FK_BillOfMaterials_Product_ComponentID", Nil)
+      .withColumnPair(componentid, _.productid)
+  def fkUnitmeasure: ForeignKey[UnitmeasureFields, UnitmeasureRow] =
+    ForeignKey[UnitmeasureFields, UnitmeasureRow]("production.FK_BillOfMaterials_UnitMeasure_UnitMeasureCode", Nil)
+      .withColumnPair(unitmeasurecode, _.unitmeasurecode)
 }
 
 object BillofmaterialsFields {

--- a/typo-tester-anorm/generated-and-checked-in/adventureworks/production/document/DocumentFields.scala
+++ b/typo-tester-anorm/generated-and-checked-in/adventureworks/production/document/DocumentFields.scala
@@ -11,8 +11,11 @@ import adventureworks.customtypes.TypoBytea
 import adventureworks.customtypes.TypoLocalDateTime
 import adventureworks.customtypes.TypoShort
 import adventureworks.customtypes.TypoUUID
+import adventureworks.humanresources.employee.EmployeeFields
+import adventureworks.humanresources.employee.EmployeeRow
 import adventureworks.person.businessentity.BusinessentityId
 import adventureworks.public.Flag
+import typo.dsl.ForeignKey
 import typo.dsl.Path
 import typo.dsl.SqlExpr.Field
 import typo.dsl.SqlExpr.FieldLikeNoHkt
@@ -34,6 +37,9 @@ trait DocumentFields {
   def rowguid: Field[TypoUUID, DocumentRow]
   def modifieddate: Field[TypoLocalDateTime, DocumentRow]
   def documentnode: IdField[DocumentId, DocumentRow]
+  def fkHumanresourcesEmployee: ForeignKey[EmployeeFields, EmployeeRow] =
+    ForeignKey[EmployeeFields, EmployeeRow]("production.FK_Document_Employee_Owner", Nil)
+      .withColumnPair(owner, _.businessentityid)
 }
 
 object DocumentFields {

--- a/typo-tester-anorm/generated-and-checked-in/adventureworks/production/product/ProductFields.scala
+++ b/typo-tester-anorm/generated-and-checked-in/adventureworks/production/product/ProductFields.scala
@@ -10,11 +10,18 @@ package product
 import adventureworks.customtypes.TypoLocalDateTime
 import adventureworks.customtypes.TypoShort
 import adventureworks.customtypes.TypoUUID
+import adventureworks.production.productmodel.ProductmodelFields
 import adventureworks.production.productmodel.ProductmodelId
+import adventureworks.production.productmodel.ProductmodelRow
+import adventureworks.production.productsubcategory.ProductsubcategoryFields
 import adventureworks.production.productsubcategory.ProductsubcategoryId
+import adventureworks.production.productsubcategory.ProductsubcategoryRow
+import adventureworks.production.unitmeasure.UnitmeasureFields
 import adventureworks.production.unitmeasure.UnitmeasureId
+import adventureworks.production.unitmeasure.UnitmeasureRow
 import adventureworks.public.Flag
 import adventureworks.public.Name
+import typo.dsl.ForeignKey
 import typo.dsl.Path
 import typo.dsl.SqlExpr.Field
 import typo.dsl.SqlExpr.FieldLikeNoHkt
@@ -48,6 +55,18 @@ trait ProductFields {
   def discontinueddate: OptField[TypoLocalDateTime, ProductRow]
   def rowguid: Field[TypoUUID, ProductRow]
   def modifieddate: Field[TypoLocalDateTime, ProductRow]
+  def fkUnitmeasureSizeunitmeasurecode: ForeignKey[UnitmeasureFields, UnitmeasureRow] =
+    ForeignKey[UnitmeasureFields, UnitmeasureRow]("production.FK_Product_UnitMeasure_SizeUnitMeasureCode", Nil)
+      .withColumnPair(sizeunitmeasurecode, _.unitmeasurecode)
+  def fkUnitmeasureWeightunitmeasurecode: ForeignKey[UnitmeasureFields, UnitmeasureRow] =
+    ForeignKey[UnitmeasureFields, UnitmeasureRow]("production.FK_Product_UnitMeasure_WeightUnitMeasureCode", Nil)
+      .withColumnPair(weightunitmeasurecode, _.unitmeasurecode)
+  def fkProductmodel: ForeignKey[ProductmodelFields, ProductmodelRow] =
+    ForeignKey[ProductmodelFields, ProductmodelRow]("production.FK_Product_ProductModel_ProductModelID", Nil)
+      .withColumnPair(productmodelid, _.productmodelid)
+  def fkProductsubcategory: ForeignKey[ProductsubcategoryFields, ProductsubcategoryRow] =
+    ForeignKey[ProductsubcategoryFields, ProductsubcategoryRow]("production.FK_Product_ProductSubcategory_ProductSubcategoryID", Nil)
+      .withColumnPair(productsubcategoryid, _.productsubcategoryid)
 }
 
 object ProductFields {

--- a/typo-tester-anorm/generated-and-checked-in/adventureworks/production/productcosthistory/ProductcosthistoryFields.scala
+++ b/typo-tester-anorm/generated-and-checked-in/adventureworks/production/productcosthistory/ProductcosthistoryFields.scala
@@ -8,7 +8,10 @@ package production
 package productcosthistory
 
 import adventureworks.customtypes.TypoLocalDateTime
+import adventureworks.production.product.ProductFields
 import adventureworks.production.product.ProductId
+import adventureworks.production.product.ProductRow
+import typo.dsl.ForeignKey
 import typo.dsl.Path
 import typo.dsl.SqlExpr.Field
 import typo.dsl.SqlExpr.FieldLikeNoHkt
@@ -22,6 +25,9 @@ trait ProductcosthistoryFields {
   def enddate: OptField[TypoLocalDateTime, ProductcosthistoryRow]
   def standardcost: Field[BigDecimal, ProductcosthistoryRow]
   def modifieddate: Field[TypoLocalDateTime, ProductcosthistoryRow]
+  def fkProduct: ForeignKey[ProductFields, ProductRow] =
+    ForeignKey[ProductFields, ProductRow]("production.FK_ProductCostHistory_Product_ProductID", Nil)
+      .withColumnPair(productid, _.productid)
 }
 
 object ProductcosthistoryFields {

--- a/typo-tester-anorm/generated-and-checked-in/adventureworks/production/productdocument/ProductdocumentFields.scala
+++ b/typo-tester-anorm/generated-and-checked-in/adventureworks/production/productdocument/ProductdocumentFields.scala
@@ -8,8 +8,13 @@ package production
 package productdocument
 
 import adventureworks.customtypes.TypoLocalDateTime
+import adventureworks.production.document.DocumentFields
 import adventureworks.production.document.DocumentId
+import adventureworks.production.document.DocumentRow
+import adventureworks.production.product.ProductFields
 import adventureworks.production.product.ProductId
+import adventureworks.production.product.ProductRow
+import typo.dsl.ForeignKey
 import typo.dsl.Path
 import typo.dsl.SqlExpr.Field
 import typo.dsl.SqlExpr.FieldLikeNoHkt
@@ -20,6 +25,12 @@ trait ProductdocumentFields {
   def productid: IdField[ProductId, ProductdocumentRow]
   def modifieddate: Field[TypoLocalDateTime, ProductdocumentRow]
   def documentnode: IdField[DocumentId, ProductdocumentRow]
+  def fkProduct: ForeignKey[ProductFields, ProductRow] =
+    ForeignKey[ProductFields, ProductRow]("production.FK_ProductDocument_Product_ProductID", Nil)
+      .withColumnPair(productid, _.productid)
+  def fkDocument: ForeignKey[DocumentFields, DocumentRow] =
+    ForeignKey[DocumentFields, DocumentRow]("production.FK_ProductDocument_Document_DocumentNode", Nil)
+      .withColumnPair(documentnode, _.documentnode)
 }
 
 object ProductdocumentFields {

--- a/typo-tester-anorm/generated-and-checked-in/adventureworks/production/productinventory/ProductinventoryFields.scala
+++ b/typo-tester-anorm/generated-and-checked-in/adventureworks/production/productinventory/ProductinventoryFields.scala
@@ -10,8 +10,13 @@ package productinventory
 import adventureworks.customtypes.TypoLocalDateTime
 import adventureworks.customtypes.TypoShort
 import adventureworks.customtypes.TypoUUID
+import adventureworks.production.location.LocationFields
 import adventureworks.production.location.LocationId
+import adventureworks.production.location.LocationRow
+import adventureworks.production.product.ProductFields
 import adventureworks.production.product.ProductId
+import adventureworks.production.product.ProductRow
+import typo.dsl.ForeignKey
 import typo.dsl.Path
 import typo.dsl.SqlExpr.Field
 import typo.dsl.SqlExpr.FieldLikeNoHkt
@@ -26,6 +31,12 @@ trait ProductinventoryFields {
   def quantity: Field[TypoShort, ProductinventoryRow]
   def rowguid: Field[TypoUUID, ProductinventoryRow]
   def modifieddate: Field[TypoLocalDateTime, ProductinventoryRow]
+  def fkLocation: ForeignKey[LocationFields, LocationRow] =
+    ForeignKey[LocationFields, LocationRow]("production.FK_ProductInventory_Location_LocationID", Nil)
+      .withColumnPair(locationid, _.locationid)
+  def fkProduct: ForeignKey[ProductFields, ProductRow] =
+    ForeignKey[ProductFields, ProductRow]("production.FK_ProductInventory_Product_ProductID", Nil)
+      .withColumnPair(productid, _.productid)
 }
 
 object ProductinventoryFields {

--- a/typo-tester-anorm/generated-and-checked-in/adventureworks/production/productlistpricehistory/ProductlistpricehistoryFields.scala
+++ b/typo-tester-anorm/generated-and-checked-in/adventureworks/production/productlistpricehistory/ProductlistpricehistoryFields.scala
@@ -8,7 +8,10 @@ package production
 package productlistpricehistory
 
 import adventureworks.customtypes.TypoLocalDateTime
+import adventureworks.production.product.ProductFields
 import adventureworks.production.product.ProductId
+import adventureworks.production.product.ProductRow
+import typo.dsl.ForeignKey
 import typo.dsl.Path
 import typo.dsl.SqlExpr.Field
 import typo.dsl.SqlExpr.FieldLikeNoHkt
@@ -22,6 +25,9 @@ trait ProductlistpricehistoryFields {
   def enddate: OptField[TypoLocalDateTime, ProductlistpricehistoryRow]
   def listprice: Field[BigDecimal, ProductlistpricehistoryRow]
   def modifieddate: Field[TypoLocalDateTime, ProductlistpricehistoryRow]
+  def fkProduct: ForeignKey[ProductFields, ProductRow] =
+    ForeignKey[ProductFields, ProductRow]("production.FK_ProductListPriceHistory_Product_ProductID", Nil)
+      .withColumnPair(productid, _.productid)
 }
 
 object ProductlistpricehistoryFields {

--- a/typo-tester-anorm/generated-and-checked-in/adventureworks/production/productmodelillustration/ProductmodelillustrationFields.scala
+++ b/typo-tester-anorm/generated-and-checked-in/adventureworks/production/productmodelillustration/ProductmodelillustrationFields.scala
@@ -8,8 +8,13 @@ package production
 package productmodelillustration
 
 import adventureworks.customtypes.TypoLocalDateTime
+import adventureworks.production.illustration.IllustrationFields
 import adventureworks.production.illustration.IllustrationId
+import adventureworks.production.illustration.IllustrationRow
+import adventureworks.production.productmodel.ProductmodelFields
 import adventureworks.production.productmodel.ProductmodelId
+import adventureworks.production.productmodel.ProductmodelRow
+import typo.dsl.ForeignKey
 import typo.dsl.Path
 import typo.dsl.SqlExpr.Field
 import typo.dsl.SqlExpr.FieldLikeNoHkt
@@ -20,6 +25,12 @@ trait ProductmodelillustrationFields {
   def productmodelid: IdField[ProductmodelId, ProductmodelillustrationRow]
   def illustrationid: IdField[IllustrationId, ProductmodelillustrationRow]
   def modifieddate: Field[TypoLocalDateTime, ProductmodelillustrationRow]
+  def fkProductmodel: ForeignKey[ProductmodelFields, ProductmodelRow] =
+    ForeignKey[ProductmodelFields, ProductmodelRow]("production.FK_ProductModelIllustration_ProductModel_ProductModelID", Nil)
+      .withColumnPair(productmodelid, _.productmodelid)
+  def fkIllustration: ForeignKey[IllustrationFields, IllustrationRow] =
+    ForeignKey[IllustrationFields, IllustrationRow]("production.FK_ProductModelIllustration_Illustration_IllustrationID", Nil)
+      .withColumnPair(illustrationid, _.illustrationid)
 }
 
 object ProductmodelillustrationFields {

--- a/typo-tester-anorm/generated-and-checked-in/adventureworks/production/productmodelproductdescriptionculture/ProductmodelproductdescriptioncultureFields.scala
+++ b/typo-tester-anorm/generated-and-checked-in/adventureworks/production/productmodelproductdescriptionculture/ProductmodelproductdescriptioncultureFields.scala
@@ -8,9 +8,16 @@ package production
 package productmodelproductdescriptionculture
 
 import adventureworks.customtypes.TypoLocalDateTime
+import adventureworks.production.culture.CultureFields
 import adventureworks.production.culture.CultureId
+import adventureworks.production.culture.CultureRow
+import adventureworks.production.productdescription.ProductdescriptionFields
 import adventureworks.production.productdescription.ProductdescriptionId
+import adventureworks.production.productdescription.ProductdescriptionRow
+import adventureworks.production.productmodel.ProductmodelFields
 import adventureworks.production.productmodel.ProductmodelId
+import adventureworks.production.productmodel.ProductmodelRow
+import typo.dsl.ForeignKey
 import typo.dsl.Path
 import typo.dsl.SqlExpr.Field
 import typo.dsl.SqlExpr.FieldLikeNoHkt
@@ -22,6 +29,15 @@ trait ProductmodelproductdescriptioncultureFields {
   def productdescriptionid: IdField[ProductdescriptionId, ProductmodelproductdescriptioncultureRow]
   def cultureid: IdField[CultureId, ProductmodelproductdescriptioncultureRow]
   def modifieddate: Field[TypoLocalDateTime, ProductmodelproductdescriptioncultureRow]
+  def fkProductdescription: ForeignKey[ProductdescriptionFields, ProductdescriptionRow] =
+    ForeignKey[ProductdescriptionFields, ProductdescriptionRow]("production.FK_ProductModelProductDescriptionCulture_ProductDescription_Pro", Nil)
+      .withColumnPair(productdescriptionid, _.productdescriptionid)
+  def fkCulture: ForeignKey[CultureFields, CultureRow] =
+    ForeignKey[CultureFields, CultureRow]("production.FK_ProductModelProductDescriptionCulture_Culture_CultureID", Nil)
+      .withColumnPair(cultureid, _.cultureid)
+  def fkProductmodel: ForeignKey[ProductmodelFields, ProductmodelRow] =
+    ForeignKey[ProductmodelFields, ProductmodelRow]("production.FK_ProductModelProductDescriptionCulture_ProductModel_ProductMo", Nil)
+      .withColumnPair(productmodelid, _.productmodelid)
 }
 
 object ProductmodelproductdescriptioncultureFields {

--- a/typo-tester-anorm/generated-and-checked-in/adventureworks/production/productproductphoto/ProductproductphotoFields.scala
+++ b/typo-tester-anorm/generated-and-checked-in/adventureworks/production/productproductphoto/ProductproductphotoFields.scala
@@ -8,9 +8,14 @@ package production
 package productproductphoto
 
 import adventureworks.customtypes.TypoLocalDateTime
+import adventureworks.production.product.ProductFields
 import adventureworks.production.product.ProductId
+import adventureworks.production.product.ProductRow
+import adventureworks.production.productphoto.ProductphotoFields
 import adventureworks.production.productphoto.ProductphotoId
+import adventureworks.production.productphoto.ProductphotoRow
 import adventureworks.public.Flag
+import typo.dsl.ForeignKey
 import typo.dsl.Path
 import typo.dsl.SqlExpr.Field
 import typo.dsl.SqlExpr.FieldLikeNoHkt
@@ -22,6 +27,12 @@ trait ProductproductphotoFields {
   def productphotoid: IdField[ProductphotoId, ProductproductphotoRow]
   def primary: Field[Flag, ProductproductphotoRow]
   def modifieddate: Field[TypoLocalDateTime, ProductproductphotoRow]
+  def fkProduct: ForeignKey[ProductFields, ProductRow] =
+    ForeignKey[ProductFields, ProductRow]("production.FK_ProductProductPhoto_Product_ProductID", Nil)
+      .withColumnPair(productid, _.productid)
+  def fkProductphoto: ForeignKey[ProductphotoFields, ProductphotoRow] =
+    ForeignKey[ProductphotoFields, ProductphotoRow]("production.FK_ProductProductPhoto_ProductPhoto_ProductPhotoID", Nil)
+      .withColumnPair(productphotoid, _.productphotoid)
 }
 
 object ProductproductphotoFields {

--- a/typo-tester-anorm/generated-and-checked-in/adventureworks/production/productreview/ProductreviewFields.scala
+++ b/typo-tester-anorm/generated-and-checked-in/adventureworks/production/productreview/ProductreviewFields.scala
@@ -8,8 +8,11 @@ package production
 package productreview
 
 import adventureworks.customtypes.TypoLocalDateTime
+import adventureworks.production.product.ProductFields
 import adventureworks.production.product.ProductId
+import adventureworks.production.product.ProductRow
 import adventureworks.public.Name
+import typo.dsl.ForeignKey
 import typo.dsl.Path
 import typo.dsl.SqlExpr.Field
 import typo.dsl.SqlExpr.FieldLikeNoHkt
@@ -26,6 +29,9 @@ trait ProductreviewFields {
   def rating: Field[Int, ProductreviewRow]
   def comments: OptField[/* max 3850 chars */ String, ProductreviewRow]
   def modifieddate: Field[TypoLocalDateTime, ProductreviewRow]
+  def fkProduct: ForeignKey[ProductFields, ProductRow] =
+    ForeignKey[ProductFields, ProductRow]("production.FK_ProductReview_Product_ProductID", Nil)
+      .withColumnPair(productid, _.productid)
 }
 
 object ProductreviewFields {

--- a/typo-tester-anorm/generated-and-checked-in/adventureworks/production/productsubcategory/ProductsubcategoryFields.scala
+++ b/typo-tester-anorm/generated-and-checked-in/adventureworks/production/productsubcategory/ProductsubcategoryFields.scala
@@ -9,8 +9,11 @@ package productsubcategory
 
 import adventureworks.customtypes.TypoLocalDateTime
 import adventureworks.customtypes.TypoUUID
+import adventureworks.production.productcategory.ProductcategoryFields
 import adventureworks.production.productcategory.ProductcategoryId
+import adventureworks.production.productcategory.ProductcategoryRow
 import adventureworks.public.Name
+import typo.dsl.ForeignKey
 import typo.dsl.Path
 import typo.dsl.SqlExpr.Field
 import typo.dsl.SqlExpr.FieldLikeNoHkt
@@ -23,6 +26,9 @@ trait ProductsubcategoryFields {
   def name: Field[Name, ProductsubcategoryRow]
   def rowguid: Field[TypoUUID, ProductsubcategoryRow]
   def modifieddate: Field[TypoLocalDateTime, ProductsubcategoryRow]
+  def fkProductcategory: ForeignKey[ProductcategoryFields, ProductcategoryRow] =
+    ForeignKey[ProductcategoryFields, ProductcategoryRow]("production.FK_ProductSubcategory_ProductCategory_ProductCategoryID", Nil)
+      .withColumnPair(productcategoryid, _.productcategoryid)
 }
 
 object ProductsubcategoryFields {

--- a/typo-tester-anorm/generated-and-checked-in/adventureworks/production/transactionhistory/TransactionhistoryFields.scala
+++ b/typo-tester-anorm/generated-and-checked-in/adventureworks/production/transactionhistory/TransactionhistoryFields.scala
@@ -8,7 +8,10 @@ package production
 package transactionhistory
 
 import adventureworks.customtypes.TypoLocalDateTime
+import adventureworks.production.product.ProductFields
 import adventureworks.production.product.ProductId
+import adventureworks.production.product.ProductRow
+import typo.dsl.ForeignKey
 import typo.dsl.Path
 import typo.dsl.SqlExpr.Field
 import typo.dsl.SqlExpr.FieldLikeNoHkt
@@ -25,6 +28,9 @@ trait TransactionhistoryFields {
   def quantity: Field[Int, TransactionhistoryRow]
   def actualcost: Field[BigDecimal, TransactionhistoryRow]
   def modifieddate: Field[TypoLocalDateTime, TransactionhistoryRow]
+  def fkProduct: ForeignKey[ProductFields, ProductRow] =
+    ForeignKey[ProductFields, ProductRow]("production.FK_TransactionHistory_Product_ProductID", Nil)
+      .withColumnPair(productid, _.productid)
 }
 
 object TransactionhistoryFields {

--- a/typo-tester-anorm/generated-and-checked-in/adventureworks/production/workorder/WorkorderFields.scala
+++ b/typo-tester-anorm/generated-and-checked-in/adventureworks/production/workorder/WorkorderFields.scala
@@ -9,8 +9,13 @@ package workorder
 
 import adventureworks.customtypes.TypoLocalDateTime
 import adventureworks.customtypes.TypoShort
+import adventureworks.production.product.ProductFields
 import adventureworks.production.product.ProductId
+import adventureworks.production.product.ProductRow
+import adventureworks.production.scrapreason.ScrapreasonFields
 import adventureworks.production.scrapreason.ScrapreasonId
+import adventureworks.production.scrapreason.ScrapreasonRow
+import typo.dsl.ForeignKey
 import typo.dsl.Path
 import typo.dsl.SqlExpr.Field
 import typo.dsl.SqlExpr.FieldLikeNoHkt
@@ -28,6 +33,12 @@ trait WorkorderFields {
   def duedate: Field[TypoLocalDateTime, WorkorderRow]
   def scrapreasonid: OptField[ScrapreasonId, WorkorderRow]
   def modifieddate: Field[TypoLocalDateTime, WorkorderRow]
+  def fkProduct: ForeignKey[ProductFields, ProductRow] =
+    ForeignKey[ProductFields, ProductRow]("production.FK_WorkOrder_Product_ProductID", Nil)
+      .withColumnPair(productid, _.productid)
+  def fkScrapreason: ForeignKey[ScrapreasonFields, ScrapreasonRow] =
+    ForeignKey[ScrapreasonFields, ScrapreasonRow]("production.FK_WorkOrder_ScrapReason_ScrapReasonID", Nil)
+      .withColumnPair(scrapreasonid, _.scrapreasonid)
 }
 
 object WorkorderFields {

--- a/typo-tester-anorm/generated-and-checked-in/adventureworks/production/workorderrouting/WorkorderroutingFields.scala
+++ b/typo-tester-anorm/generated-and-checked-in/adventureworks/production/workorderrouting/WorkorderroutingFields.scala
@@ -9,8 +9,13 @@ package workorderrouting
 
 import adventureworks.customtypes.TypoLocalDateTime
 import adventureworks.customtypes.TypoShort
+import adventureworks.production.location.LocationFields
 import adventureworks.production.location.LocationId
+import adventureworks.production.location.LocationRow
+import adventureworks.production.workorder.WorkorderFields
 import adventureworks.production.workorder.WorkorderId
+import adventureworks.production.workorder.WorkorderRow
+import typo.dsl.ForeignKey
 import typo.dsl.Path
 import typo.dsl.SqlExpr.Field
 import typo.dsl.SqlExpr.FieldLikeNoHkt
@@ -31,6 +36,12 @@ trait WorkorderroutingFields {
   def plannedcost: Field[BigDecimal, WorkorderroutingRow]
   def actualcost: OptField[BigDecimal, WorkorderroutingRow]
   def modifieddate: Field[TypoLocalDateTime, WorkorderroutingRow]
+  def fkLocation: ForeignKey[LocationFields, LocationRow] =
+    ForeignKey[LocationFields, LocationRow]("production.FK_WorkOrderRouting_Location_LocationID", Nil)
+      .withColumnPair(locationid, _.locationid)
+  def fkWorkorder: ForeignKey[WorkorderFields, WorkorderRow] =
+    ForeignKey[WorkorderFields, WorkorderRow]("production.FK_WorkOrderRouting_WorkOrder_WorkOrderID", Nil)
+      .withColumnPair(workorderid, _.workorderid)
 }
 
 object WorkorderroutingFields {

--- a/typo-tester-anorm/generated-and-checked-in/adventureworks/public/flaff/FlaffFields.scala
+++ b/typo-tester-anorm/generated-and-checked-in/adventureworks/public/flaff/FlaffFields.scala
@@ -8,6 +8,7 @@ package public
 package flaff
 
 import adventureworks.public.ShortText
+import typo.dsl.ForeignKey
 import typo.dsl.Path
 import typo.dsl.SqlExpr.FieldLikeNoHkt
 import typo.dsl.SqlExpr.IdField
@@ -20,6 +21,12 @@ trait FlaffFields {
   def someNumber: IdField[Int, FlaffRow]
   def specifier: IdField[ShortText, FlaffRow]
   def parentspecifier: OptField[ShortText, FlaffRow]
+  def fkFlaff: ForeignKey[FlaffFields, FlaffRow] =
+    ForeignKey[FlaffFields, FlaffRow]("public.flaff_parent_fk", Nil)
+      .withColumnPair(code, _.code)
+      .withColumnPair(anotherCode, _.anotherCode)
+      .withColumnPair(someNumber, _.someNumber)
+      .withColumnPair(parentspecifier, _.specifier)
 }
 
 object FlaffFields {

--- a/typo-tester-anorm/generated-and-checked-in/adventureworks/purchasing/productvendor/ProductvendorFields.scala
+++ b/typo-tester-anorm/generated-and-checked-in/adventureworks/purchasing/productvendor/ProductvendorFields.scala
@@ -9,8 +9,15 @@ package productvendor
 
 import adventureworks.customtypes.TypoLocalDateTime
 import adventureworks.person.businessentity.BusinessentityId
+import adventureworks.production.product.ProductFields
 import adventureworks.production.product.ProductId
+import adventureworks.production.product.ProductRow
+import adventureworks.production.unitmeasure.UnitmeasureFields
 import adventureworks.production.unitmeasure.UnitmeasureId
+import adventureworks.production.unitmeasure.UnitmeasureRow
+import adventureworks.purchasing.vendor.VendorFields
+import adventureworks.purchasing.vendor.VendorRow
+import typo.dsl.ForeignKey
 import typo.dsl.Path
 import typo.dsl.SqlExpr.Field
 import typo.dsl.SqlExpr.FieldLikeNoHkt
@@ -30,6 +37,15 @@ trait ProductvendorFields {
   def onorderqty: OptField[Int, ProductvendorRow]
   def unitmeasurecode: Field[UnitmeasureId, ProductvendorRow]
   def modifieddate: Field[TypoLocalDateTime, ProductvendorRow]
+  def fkProductionProduct: ForeignKey[ProductFields, ProductRow] =
+    ForeignKey[ProductFields, ProductRow]("purchasing.FK_ProductVendor_Product_ProductID", Nil)
+      .withColumnPair(productid, _.productid)
+  def fkProductionUnitmeasure: ForeignKey[UnitmeasureFields, UnitmeasureRow] =
+    ForeignKey[UnitmeasureFields, UnitmeasureRow]("purchasing.FK_ProductVendor_UnitMeasure_UnitMeasureCode", Nil)
+      .withColumnPair(unitmeasurecode, _.unitmeasurecode)
+  def fkVendor: ForeignKey[VendorFields, VendorRow] =
+    ForeignKey[VendorFields, VendorRow]("purchasing.FK_ProductVendor_Vendor_BusinessEntityID", Nil)
+      .withColumnPair(businessentityid, _.businessentityid)
 }
 
 object ProductvendorFields {

--- a/typo-tester-anorm/generated-and-checked-in/adventureworks/purchasing/purchaseorderdetail/PurchaseorderdetailFields.scala
+++ b/typo-tester-anorm/generated-and-checked-in/adventureworks/purchasing/purchaseorderdetail/PurchaseorderdetailFields.scala
@@ -9,8 +9,13 @@ package purchaseorderdetail
 
 import adventureworks.customtypes.TypoLocalDateTime
 import adventureworks.customtypes.TypoShort
+import adventureworks.production.product.ProductFields
 import adventureworks.production.product.ProductId
+import adventureworks.production.product.ProductRow
+import adventureworks.purchasing.purchaseorderheader.PurchaseorderheaderFields
 import adventureworks.purchasing.purchaseorderheader.PurchaseorderheaderId
+import adventureworks.purchasing.purchaseorderheader.PurchaseorderheaderRow
+import typo.dsl.ForeignKey
 import typo.dsl.Path
 import typo.dsl.SqlExpr.Field
 import typo.dsl.SqlExpr.FieldLikeNoHkt
@@ -27,6 +32,12 @@ trait PurchaseorderdetailFields {
   def receivedqty: Field[BigDecimal, PurchaseorderdetailRow]
   def rejectedqty: Field[BigDecimal, PurchaseorderdetailRow]
   def modifieddate: Field[TypoLocalDateTime, PurchaseorderdetailRow]
+  def fkProductionProduct: ForeignKey[ProductFields, ProductRow] =
+    ForeignKey[ProductFields, ProductRow]("purchasing.FK_PurchaseOrderDetail_Product_ProductID", Nil)
+      .withColumnPair(productid, _.productid)
+  def fkPurchaseorderheader: ForeignKey[PurchaseorderheaderFields, PurchaseorderheaderRow] =
+    ForeignKey[PurchaseorderheaderFields, PurchaseorderheaderRow]("purchasing.FK_PurchaseOrderDetail_PurchaseOrderHeader_PurchaseOrderID", Nil)
+      .withColumnPair(purchaseorderid, _.purchaseorderid)
 }
 
 object PurchaseorderdetailFields {

--- a/typo-tester-anorm/generated-and-checked-in/adventureworks/purchasing/purchaseorderheader/PurchaseorderheaderFields.scala
+++ b/typo-tester-anorm/generated-and-checked-in/adventureworks/purchasing/purchaseorderheader/PurchaseorderheaderFields.scala
@@ -9,8 +9,15 @@ package purchaseorderheader
 
 import adventureworks.customtypes.TypoLocalDateTime
 import adventureworks.customtypes.TypoShort
+import adventureworks.humanresources.employee.EmployeeFields
+import adventureworks.humanresources.employee.EmployeeRow
 import adventureworks.person.businessentity.BusinessentityId
+import adventureworks.purchasing.shipmethod.ShipmethodFields
 import adventureworks.purchasing.shipmethod.ShipmethodId
+import adventureworks.purchasing.shipmethod.ShipmethodRow
+import adventureworks.purchasing.vendor.VendorFields
+import adventureworks.purchasing.vendor.VendorRow
+import typo.dsl.ForeignKey
 import typo.dsl.Path
 import typo.dsl.SqlExpr.Field
 import typo.dsl.SqlExpr.FieldLikeNoHkt
@@ -31,6 +38,15 @@ trait PurchaseorderheaderFields {
   def taxamt: Field[BigDecimal, PurchaseorderheaderRow]
   def freight: Field[BigDecimal, PurchaseorderheaderRow]
   def modifieddate: Field[TypoLocalDateTime, PurchaseorderheaderRow]
+  def fkHumanresourcesEmployee: ForeignKey[EmployeeFields, EmployeeRow] =
+    ForeignKey[EmployeeFields, EmployeeRow]("purchasing.FK_PurchaseOrderHeader_Employee_EmployeeID", Nil)
+      .withColumnPair(employeeid, _.businessentityid)
+  def fkVendor: ForeignKey[VendorFields, VendorRow] =
+    ForeignKey[VendorFields, VendorRow]("purchasing.FK_PurchaseOrderHeader_Vendor_VendorID", Nil)
+      .withColumnPair(vendorid, _.businessentityid)
+  def fkShipmethod: ForeignKey[ShipmethodFields, ShipmethodRow] =
+    ForeignKey[ShipmethodFields, ShipmethodRow]("purchasing.FK_PurchaseOrderHeader_ShipMethod_ShipMethodID", Nil)
+      .withColumnPair(shipmethodid, _.shipmethodid)
 }
 
 object PurchaseorderheaderFields {

--- a/typo-tester-anorm/generated-and-checked-in/adventureworks/purchasing/vendor/VendorFields.scala
+++ b/typo-tester-anorm/generated-and-checked-in/adventureworks/purchasing/vendor/VendorFields.scala
@@ -9,10 +9,13 @@ package vendor
 
 import adventureworks.customtypes.TypoLocalDateTime
 import adventureworks.customtypes.TypoShort
+import adventureworks.person.businessentity.BusinessentityFields
 import adventureworks.person.businessentity.BusinessentityId
+import adventureworks.person.businessentity.BusinessentityRow
 import adventureworks.public.AccountNumber
 import adventureworks.public.Flag
 import adventureworks.public.Name
+import typo.dsl.ForeignKey
 import typo.dsl.Path
 import typo.dsl.SqlExpr.Field
 import typo.dsl.SqlExpr.FieldLikeNoHkt
@@ -29,6 +32,9 @@ trait VendorFields {
   def activeflag: Field[Flag, VendorRow]
   def purchasingwebserviceurl: OptField[/* max 1024 chars */ String, VendorRow]
   def modifieddate: Field[TypoLocalDateTime, VendorRow]
+  def fkPersonBusinessentity: ForeignKey[BusinessentityFields, BusinessentityRow] =
+    ForeignKey[BusinessentityFields, BusinessentityRow]("purchasing.FK_Vendor_BusinessEntity_BusinessEntityID", Nil)
+      .withColumnPair(businessentityid, _.businessentityid)
 }
 
 object VendorFields {

--- a/typo-tester-anorm/generated-and-checked-in/adventureworks/sales/countryregioncurrency/CountryregioncurrencyFields.scala
+++ b/typo-tester-anorm/generated-and-checked-in/adventureworks/sales/countryregioncurrency/CountryregioncurrencyFields.scala
@@ -8,8 +8,13 @@ package sales
 package countryregioncurrency
 
 import adventureworks.customtypes.TypoLocalDateTime
+import adventureworks.person.countryregion.CountryregionFields
 import adventureworks.person.countryregion.CountryregionId
+import adventureworks.person.countryregion.CountryregionRow
+import adventureworks.sales.currency.CurrencyFields
 import adventureworks.sales.currency.CurrencyId
+import adventureworks.sales.currency.CurrencyRow
+import typo.dsl.ForeignKey
 import typo.dsl.Path
 import typo.dsl.SqlExpr.Field
 import typo.dsl.SqlExpr.FieldLikeNoHkt
@@ -20,6 +25,12 @@ trait CountryregioncurrencyFields {
   def countryregioncode: IdField[CountryregionId, CountryregioncurrencyRow]
   def currencycode: IdField[CurrencyId, CountryregioncurrencyRow]
   def modifieddate: Field[TypoLocalDateTime, CountryregioncurrencyRow]
+  def fkPersonCountryregion: ForeignKey[CountryregionFields, CountryregionRow] =
+    ForeignKey[CountryregionFields, CountryregionRow]("sales.FK_CountryRegionCurrency_CountryRegion_CountryRegionCode", Nil)
+      .withColumnPair(countryregioncode, _.countryregioncode)
+  def fkCurrency: ForeignKey[CurrencyFields, CurrencyRow] =
+    ForeignKey[CurrencyFields, CurrencyRow]("sales.FK_CountryRegionCurrency_Currency_CurrencyCode", Nil)
+      .withColumnPair(currencycode, _.currencycode)
 }
 
 object CountryregioncurrencyFields {

--- a/typo-tester-anorm/generated-and-checked-in/adventureworks/sales/currencyrate/CurrencyrateFields.scala
+++ b/typo-tester-anorm/generated-and-checked-in/adventureworks/sales/currencyrate/CurrencyrateFields.scala
@@ -8,7 +8,10 @@ package sales
 package currencyrate
 
 import adventureworks.customtypes.TypoLocalDateTime
+import adventureworks.sales.currency.CurrencyFields
 import adventureworks.sales.currency.CurrencyId
+import adventureworks.sales.currency.CurrencyRow
+import typo.dsl.ForeignKey
 import typo.dsl.Path
 import typo.dsl.SqlExpr.Field
 import typo.dsl.SqlExpr.FieldLikeNoHkt
@@ -23,6 +26,12 @@ trait CurrencyrateFields {
   def averagerate: Field[BigDecimal, CurrencyrateRow]
   def endofdayrate: Field[BigDecimal, CurrencyrateRow]
   def modifieddate: Field[TypoLocalDateTime, CurrencyrateRow]
+  def fkCurrencyFromcurrencycode: ForeignKey[CurrencyFields, CurrencyRow] =
+    ForeignKey[CurrencyFields, CurrencyRow]("sales.FK_CurrencyRate_Currency_FromCurrencyCode", Nil)
+      .withColumnPair(fromcurrencycode, _.currencycode)
+  def fkCurrencyTocurrencycode: ForeignKey[CurrencyFields, CurrencyRow] =
+    ForeignKey[CurrencyFields, CurrencyRow]("sales.FK_CurrencyRate_Currency_ToCurrencyCode", Nil)
+      .withColumnPair(tocurrencycode, _.currencycode)
 }
 
 object CurrencyrateFields {

--- a/typo-tester-anorm/generated-and-checked-in/adventureworks/sales/customer/CustomerFields.scala
+++ b/typo-tester-anorm/generated-and-checked-in/adventureworks/sales/customer/CustomerFields.scala
@@ -10,7 +10,14 @@ package customer
 import adventureworks.customtypes.TypoLocalDateTime
 import adventureworks.customtypes.TypoUUID
 import adventureworks.person.businessentity.BusinessentityId
+import adventureworks.person.person.PersonFields
+import adventureworks.person.person.PersonRow
+import adventureworks.sales.salesterritory.SalesterritoryFields
 import adventureworks.sales.salesterritory.SalesterritoryId
+import adventureworks.sales.salesterritory.SalesterritoryRow
+import adventureworks.sales.store.StoreFields
+import adventureworks.sales.store.StoreRow
+import typo.dsl.ForeignKey
 import typo.dsl.Path
 import typo.dsl.SqlExpr.Field
 import typo.dsl.SqlExpr.FieldLikeNoHkt
@@ -25,6 +32,15 @@ trait CustomerFields {
   def territoryid: OptField[SalesterritoryId, CustomerRow]
   def rowguid: Field[TypoUUID, CustomerRow]
   def modifieddate: Field[TypoLocalDateTime, CustomerRow]
+  def fkPersonPerson: ForeignKey[PersonFields, PersonRow] =
+    ForeignKey[PersonFields, PersonRow]("sales.FK_Customer_Person_PersonID", Nil)
+      .withColumnPair(personid, _.businessentityid)
+  def fkStore: ForeignKey[StoreFields, StoreRow] =
+    ForeignKey[StoreFields, StoreRow]("sales.FK_Customer_Store_StoreID", Nil)
+      .withColumnPair(storeid, _.businessentityid)
+  def fkSalesterritory: ForeignKey[SalesterritoryFields, SalesterritoryRow] =
+    ForeignKey[SalesterritoryFields, SalesterritoryRow]("sales.FK_Customer_SalesTerritory_TerritoryID", Nil)
+      .withColumnPair(territoryid, _.territoryid)
 }
 
 object CustomerFields {

--- a/typo-tester-anorm/generated-and-checked-in/adventureworks/sales/personcreditcard/PersoncreditcardFields.scala
+++ b/typo-tester-anorm/generated-and-checked-in/adventureworks/sales/personcreditcard/PersoncreditcardFields.scala
@@ -9,7 +9,12 @@ package personcreditcard
 
 import adventureworks.customtypes.TypoLocalDateTime
 import adventureworks.person.businessentity.BusinessentityId
+import adventureworks.person.person.PersonFields
+import adventureworks.person.person.PersonRow
+import adventureworks.sales.creditcard.CreditcardFields
+import adventureworks.sales.creditcard.CreditcardRow
 import adventureworks.userdefined.CustomCreditcardId
+import typo.dsl.ForeignKey
 import typo.dsl.Path
 import typo.dsl.SqlExpr.Field
 import typo.dsl.SqlExpr.FieldLikeNoHkt
@@ -20,6 +25,12 @@ trait PersoncreditcardFields {
   def businessentityid: IdField[BusinessentityId, PersoncreditcardRow]
   def creditcardid: IdField[/* user-picked */ CustomCreditcardId, PersoncreditcardRow]
   def modifieddate: Field[TypoLocalDateTime, PersoncreditcardRow]
+  def fkPersonPerson: ForeignKey[PersonFields, PersonRow] =
+    ForeignKey[PersonFields, PersonRow]("sales.FK_PersonCreditCard_Person_BusinessEntityID", Nil)
+      .withColumnPair(businessentityid, _.businessentityid)
+  def fkCreditcard: ForeignKey[CreditcardFields, CreditcardRow] =
+    ForeignKey[CreditcardFields, CreditcardRow]("sales.FK_PersonCreditCard_CreditCard_CreditCardID", Nil)
+      .withColumnPair(creditcardid, _.creditcardid)
 }
 
 object PersoncreditcardFields {

--- a/typo-tester-anorm/generated-and-checked-in/adventureworks/sales/salesorderdetail/SalesorderdetailFields.scala
+++ b/typo-tester-anorm/generated-and-checked-in/adventureworks/sales/salesorderdetail/SalesorderdetailFields.scala
@@ -11,8 +11,13 @@ import adventureworks.customtypes.TypoLocalDateTime
 import adventureworks.customtypes.TypoShort
 import adventureworks.customtypes.TypoUUID
 import adventureworks.production.product.ProductId
+import adventureworks.sales.salesorderheader.SalesorderheaderFields
 import adventureworks.sales.salesorderheader.SalesorderheaderId
+import adventureworks.sales.salesorderheader.SalesorderheaderRow
 import adventureworks.sales.specialoffer.SpecialofferId
+import adventureworks.sales.specialofferproduct.SpecialofferproductFields
+import adventureworks.sales.specialofferproduct.SpecialofferproductRow
+import typo.dsl.ForeignKey
 import typo.dsl.Path
 import typo.dsl.SqlExpr.Field
 import typo.dsl.SqlExpr.FieldLikeNoHkt
@@ -31,6 +36,13 @@ trait SalesorderdetailFields {
   def unitpricediscount: Field[BigDecimal, SalesorderdetailRow]
   def rowguid: Field[TypoUUID, SalesorderdetailRow]
   def modifieddate: Field[TypoLocalDateTime, SalesorderdetailRow]
+  def fkSalesorderheader: ForeignKey[SalesorderheaderFields, SalesorderheaderRow] =
+    ForeignKey[SalesorderheaderFields, SalesorderheaderRow]("sales.FK_SalesOrderDetail_SalesOrderHeader_SalesOrderID", Nil)
+      .withColumnPair(salesorderid, _.salesorderid)
+  def fkSpecialofferproduct: ForeignKey[SpecialofferproductFields, SpecialofferproductRow] =
+    ForeignKey[SpecialofferproductFields, SpecialofferproductRow]("sales.FK_SalesOrderDetail_SpecialOfferProduct_SpecialOfferIDProductID", Nil)
+      .withColumnPair(specialofferid, _.specialofferid)
+      .withColumnPair(productid, _.productid)
 }
 
 object SalesorderdetailFields {

--- a/typo-tester-anorm/generated-and-checked-in/adventureworks/sales/salesorderheader/SalesorderheaderFields.scala
+++ b/typo-tester-anorm/generated-and-checked-in/adventureworks/sales/salesorderheader/SalesorderheaderFields.scala
@@ -10,16 +10,31 @@ package salesorderheader
 import adventureworks.customtypes.TypoLocalDateTime
 import adventureworks.customtypes.TypoShort
 import adventureworks.customtypes.TypoUUID
+import adventureworks.person.address.AddressFields
 import adventureworks.person.address.AddressId
+import adventureworks.person.address.AddressRow
 import adventureworks.person.businessentity.BusinessentityId
 import adventureworks.public.AccountNumber
 import adventureworks.public.Flag
 import adventureworks.public.OrderNumber
+import adventureworks.purchasing.shipmethod.ShipmethodFields
 import adventureworks.purchasing.shipmethod.ShipmethodId
+import adventureworks.purchasing.shipmethod.ShipmethodRow
+import adventureworks.sales.creditcard.CreditcardFields
+import adventureworks.sales.creditcard.CreditcardRow
+import adventureworks.sales.currencyrate.CurrencyrateFields
 import adventureworks.sales.currencyrate.CurrencyrateId
+import adventureworks.sales.currencyrate.CurrencyrateRow
+import adventureworks.sales.customer.CustomerFields
 import adventureworks.sales.customer.CustomerId
+import adventureworks.sales.customer.CustomerRow
+import adventureworks.sales.salesperson.SalespersonFields
+import adventureworks.sales.salesperson.SalespersonRow
+import adventureworks.sales.salesterritory.SalesterritoryFields
 import adventureworks.sales.salesterritory.SalesterritoryId
+import adventureworks.sales.salesterritory.SalesterritoryRow
 import adventureworks.userdefined.CustomCreditcardId
+import typo.dsl.ForeignKey
 import typo.dsl.Path
 import typo.dsl.SqlExpr.Field
 import typo.dsl.SqlExpr.FieldLikeNoHkt
@@ -53,6 +68,30 @@ trait SalesorderheaderFields {
   def comment: OptField[/* max 128 chars */ String, SalesorderheaderRow]
   def rowguid: Field[TypoUUID, SalesorderheaderRow]
   def modifieddate: Field[TypoLocalDateTime, SalesorderheaderRow]
+  def fkPersonAddressBilltoaddressid: ForeignKey[AddressFields, AddressRow] =
+    ForeignKey[AddressFields, AddressRow]("sales.FK_SalesOrderHeader_Address_BillToAddressID", Nil)
+      .withColumnPair(billtoaddressid, _.addressid)
+  def fkPersonAddressShiptoaddressid: ForeignKey[AddressFields, AddressRow] =
+    ForeignKey[AddressFields, AddressRow]("sales.FK_SalesOrderHeader_Address_ShipToAddressID", Nil)
+      .withColumnPair(shiptoaddressid, _.addressid)
+  def fkCreditcard: ForeignKey[CreditcardFields, CreditcardRow] =
+    ForeignKey[CreditcardFields, CreditcardRow]("sales.FK_SalesOrderHeader_CreditCard_CreditCardID", Nil)
+      .withColumnPair(creditcardid, _.creditcardid)
+  def fkCurrencyrate: ForeignKey[CurrencyrateFields, CurrencyrateRow] =
+    ForeignKey[CurrencyrateFields, CurrencyrateRow]("sales.FK_SalesOrderHeader_CurrencyRate_CurrencyRateID", Nil)
+      .withColumnPair(currencyrateid, _.currencyrateid)
+  def fkCustomer: ForeignKey[CustomerFields, CustomerRow] =
+    ForeignKey[CustomerFields, CustomerRow]("sales.FK_SalesOrderHeader_Customer_CustomerID", Nil)
+      .withColumnPair(customerid, _.customerid)
+  def fkSalesperson: ForeignKey[SalespersonFields, SalespersonRow] =
+    ForeignKey[SalespersonFields, SalespersonRow]("sales.FK_SalesOrderHeader_SalesPerson_SalesPersonID", Nil)
+      .withColumnPair(salespersonid, _.businessentityid)
+  def fkPurchasingShipmethod: ForeignKey[ShipmethodFields, ShipmethodRow] =
+    ForeignKey[ShipmethodFields, ShipmethodRow]("sales.FK_SalesOrderHeader_ShipMethod_ShipMethodID", Nil)
+      .withColumnPair(shipmethodid, _.shipmethodid)
+  def fkSalesterritory: ForeignKey[SalesterritoryFields, SalesterritoryRow] =
+    ForeignKey[SalesterritoryFields, SalesterritoryRow]("sales.FK_SalesOrderHeader_SalesTerritory_TerritoryID", Nil)
+      .withColumnPair(territoryid, _.territoryid)
 }
 
 object SalesorderheaderFields {

--- a/typo-tester-anorm/generated-and-checked-in/adventureworks/sales/salesorderheadersalesreason/SalesorderheadersalesreasonFields.scala
+++ b/typo-tester-anorm/generated-and-checked-in/adventureworks/sales/salesorderheadersalesreason/SalesorderheadersalesreasonFields.scala
@@ -8,8 +8,13 @@ package sales
 package salesorderheadersalesreason
 
 import adventureworks.customtypes.TypoLocalDateTime
+import adventureworks.sales.salesorderheader.SalesorderheaderFields
 import adventureworks.sales.salesorderheader.SalesorderheaderId
+import adventureworks.sales.salesorderheader.SalesorderheaderRow
+import adventureworks.sales.salesreason.SalesreasonFields
 import adventureworks.sales.salesreason.SalesreasonId
+import adventureworks.sales.salesreason.SalesreasonRow
+import typo.dsl.ForeignKey
 import typo.dsl.Path
 import typo.dsl.SqlExpr.Field
 import typo.dsl.SqlExpr.FieldLikeNoHkt
@@ -20,6 +25,12 @@ trait SalesorderheadersalesreasonFields {
   def salesorderid: IdField[SalesorderheaderId, SalesorderheadersalesreasonRow]
   def salesreasonid: IdField[SalesreasonId, SalesorderheadersalesreasonRow]
   def modifieddate: Field[TypoLocalDateTime, SalesorderheadersalesreasonRow]
+  def fkSalesreason: ForeignKey[SalesreasonFields, SalesreasonRow] =
+    ForeignKey[SalesreasonFields, SalesreasonRow]("sales.FK_SalesOrderHeaderSalesReason_SalesReason_SalesReasonID", Nil)
+      .withColumnPair(salesreasonid, _.salesreasonid)
+  def fkSalesorderheader: ForeignKey[SalesorderheaderFields, SalesorderheaderRow] =
+    ForeignKey[SalesorderheaderFields, SalesorderheaderRow]("sales.FK_SalesOrderHeaderSalesReason_SalesOrderHeader_SalesOrderID", Nil)
+      .withColumnPair(salesorderid, _.salesorderid)
 }
 
 object SalesorderheadersalesreasonFields {

--- a/typo-tester-anorm/generated-and-checked-in/adventureworks/sales/salesperson/SalespersonFields.scala
+++ b/typo-tester-anorm/generated-and-checked-in/adventureworks/sales/salesperson/SalespersonFields.scala
@@ -9,8 +9,13 @@ package salesperson
 
 import adventureworks.customtypes.TypoLocalDateTime
 import adventureworks.customtypes.TypoUUID
+import adventureworks.humanresources.employee.EmployeeFields
+import adventureworks.humanresources.employee.EmployeeRow
 import adventureworks.person.businessentity.BusinessentityId
+import adventureworks.sales.salesterritory.SalesterritoryFields
 import adventureworks.sales.salesterritory.SalesterritoryId
+import adventureworks.sales.salesterritory.SalesterritoryRow
+import typo.dsl.ForeignKey
 import typo.dsl.Path
 import typo.dsl.SqlExpr.Field
 import typo.dsl.SqlExpr.FieldLikeNoHkt
@@ -28,6 +33,12 @@ trait SalespersonFields {
   def saleslastyear: Field[BigDecimal, SalespersonRow]
   def rowguid: Field[TypoUUID, SalespersonRow]
   def modifieddate: Field[TypoLocalDateTime, SalespersonRow]
+  def fkHumanresourcesEmployee: ForeignKey[EmployeeFields, EmployeeRow] =
+    ForeignKey[EmployeeFields, EmployeeRow]("sales.FK_SalesPerson_Employee_BusinessEntityID", Nil)
+      .withColumnPair(businessentityid, _.businessentityid)
+  def fkSalesterritory: ForeignKey[SalesterritoryFields, SalesterritoryRow] =
+    ForeignKey[SalesterritoryFields, SalesterritoryRow]("sales.FK_SalesPerson_SalesTerritory_TerritoryID", Nil)
+      .withColumnPair(territoryid, _.territoryid)
 }
 
 object SalespersonFields {

--- a/typo-tester-anorm/generated-and-checked-in/adventureworks/sales/salespersonquotahistory/SalespersonquotahistoryFields.scala
+++ b/typo-tester-anorm/generated-and-checked-in/adventureworks/sales/salespersonquotahistory/SalespersonquotahistoryFields.scala
@@ -10,6 +10,9 @@ package salespersonquotahistory
 import adventureworks.customtypes.TypoLocalDateTime
 import adventureworks.customtypes.TypoUUID
 import adventureworks.person.businessentity.BusinessentityId
+import adventureworks.sales.salesperson.SalespersonFields
+import adventureworks.sales.salesperson.SalespersonRow
+import typo.dsl.ForeignKey
 import typo.dsl.Path
 import typo.dsl.SqlExpr.Field
 import typo.dsl.SqlExpr.FieldLikeNoHkt
@@ -22,6 +25,9 @@ trait SalespersonquotahistoryFields {
   def salesquota: Field[BigDecimal, SalespersonquotahistoryRow]
   def rowguid: Field[TypoUUID, SalespersonquotahistoryRow]
   def modifieddate: Field[TypoLocalDateTime, SalespersonquotahistoryRow]
+  def fkSalesperson: ForeignKey[SalespersonFields, SalespersonRow] =
+    ForeignKey[SalespersonFields, SalespersonRow]("sales.FK_SalesPersonQuotaHistory_SalesPerson_BusinessEntityID", Nil)
+      .withColumnPair(businessentityid, _.businessentityid)
 }
 
 object SalespersonquotahistoryFields {

--- a/typo-tester-anorm/generated-and-checked-in/adventureworks/sales/salestaxrate/SalestaxrateFields.scala
+++ b/typo-tester-anorm/generated-and-checked-in/adventureworks/sales/salestaxrate/SalestaxrateFields.scala
@@ -10,8 +10,11 @@ package salestaxrate
 import adventureworks.customtypes.TypoLocalDateTime
 import adventureworks.customtypes.TypoShort
 import adventureworks.customtypes.TypoUUID
+import adventureworks.person.stateprovince.StateprovinceFields
 import adventureworks.person.stateprovince.StateprovinceId
+import adventureworks.person.stateprovince.StateprovinceRow
 import adventureworks.public.Name
+import typo.dsl.ForeignKey
 import typo.dsl.Path
 import typo.dsl.SqlExpr.Field
 import typo.dsl.SqlExpr.FieldLikeNoHkt
@@ -26,6 +29,9 @@ trait SalestaxrateFields {
   def name: Field[Name, SalestaxrateRow]
   def rowguid: Field[TypoUUID, SalestaxrateRow]
   def modifieddate: Field[TypoLocalDateTime, SalestaxrateRow]
+  def fkPersonStateprovince: ForeignKey[StateprovinceFields, StateprovinceRow] =
+    ForeignKey[StateprovinceFields, StateprovinceRow]("sales.FK_SalesTaxRate_StateProvince_StateProvinceID", Nil)
+      .withColumnPair(stateprovinceid, _.stateprovinceid)
 }
 
 object SalestaxrateFields {

--- a/typo-tester-anorm/generated-and-checked-in/adventureworks/sales/salesterritory/SalesterritoryFields.scala
+++ b/typo-tester-anorm/generated-and-checked-in/adventureworks/sales/salesterritory/SalesterritoryFields.scala
@@ -9,8 +9,11 @@ package salesterritory
 
 import adventureworks.customtypes.TypoLocalDateTime
 import adventureworks.customtypes.TypoUUID
+import adventureworks.person.countryregion.CountryregionFields
 import adventureworks.person.countryregion.CountryregionId
+import adventureworks.person.countryregion.CountryregionRow
 import adventureworks.public.Name
+import typo.dsl.ForeignKey
 import typo.dsl.Path
 import typo.dsl.SqlExpr.Field
 import typo.dsl.SqlExpr.FieldLikeNoHkt
@@ -28,6 +31,9 @@ trait SalesterritoryFields {
   def costlastyear: Field[BigDecimal, SalesterritoryRow]
   def rowguid: Field[TypoUUID, SalesterritoryRow]
   def modifieddate: Field[TypoLocalDateTime, SalesterritoryRow]
+  def fkPersonCountryregion: ForeignKey[CountryregionFields, CountryregionRow] =
+    ForeignKey[CountryregionFields, CountryregionRow]("sales.FK_SalesTerritory_CountryRegion_CountryRegionCode", Nil)
+      .withColumnPair(countryregioncode, _.countryregioncode)
 }
 
 object SalesterritoryFields {

--- a/typo-tester-anorm/generated-and-checked-in/adventureworks/sales/salesterritoryhistory/SalesterritoryhistoryFields.scala
+++ b/typo-tester-anorm/generated-and-checked-in/adventureworks/sales/salesterritoryhistory/SalesterritoryhistoryFields.scala
@@ -10,7 +10,12 @@ package salesterritoryhistory
 import adventureworks.customtypes.TypoLocalDateTime
 import adventureworks.customtypes.TypoUUID
 import adventureworks.person.businessentity.BusinessentityId
+import adventureworks.sales.salesperson.SalespersonFields
+import adventureworks.sales.salesperson.SalespersonRow
+import adventureworks.sales.salesterritory.SalesterritoryFields
 import adventureworks.sales.salesterritory.SalesterritoryId
+import adventureworks.sales.salesterritory.SalesterritoryRow
+import typo.dsl.ForeignKey
 import typo.dsl.Path
 import typo.dsl.SqlExpr.Field
 import typo.dsl.SqlExpr.FieldLikeNoHkt
@@ -25,6 +30,12 @@ trait SalesterritoryhistoryFields {
   def enddate: OptField[TypoLocalDateTime, SalesterritoryhistoryRow]
   def rowguid: Field[TypoUUID, SalesterritoryhistoryRow]
   def modifieddate: Field[TypoLocalDateTime, SalesterritoryhistoryRow]
+  def fkSalesperson: ForeignKey[SalespersonFields, SalespersonRow] =
+    ForeignKey[SalespersonFields, SalespersonRow]("sales.FK_SalesTerritoryHistory_SalesPerson_BusinessEntityID", Nil)
+      .withColumnPair(businessentityid, _.businessentityid)
+  def fkSalesterritory: ForeignKey[SalesterritoryFields, SalesterritoryRow] =
+    ForeignKey[SalesterritoryFields, SalesterritoryRow]("sales.FK_SalesTerritoryHistory_SalesTerritory_TerritoryID", Nil)
+      .withColumnPair(territoryid, _.territoryid)
 }
 
 object SalesterritoryhistoryFields {

--- a/typo-tester-anorm/generated-and-checked-in/adventureworks/sales/shoppingcartitem/ShoppingcartitemFields.scala
+++ b/typo-tester-anorm/generated-and-checked-in/adventureworks/sales/shoppingcartitem/ShoppingcartitemFields.scala
@@ -8,7 +8,10 @@ package sales
 package shoppingcartitem
 
 import adventureworks.customtypes.TypoLocalDateTime
+import adventureworks.production.product.ProductFields
 import adventureworks.production.product.ProductId
+import adventureworks.production.product.ProductRow
+import typo.dsl.ForeignKey
 import typo.dsl.Path
 import typo.dsl.SqlExpr.Field
 import typo.dsl.SqlExpr.FieldLikeNoHkt
@@ -22,6 +25,9 @@ trait ShoppingcartitemFields {
   def productid: Field[ProductId, ShoppingcartitemRow]
   def datecreated: Field[TypoLocalDateTime, ShoppingcartitemRow]
   def modifieddate: Field[TypoLocalDateTime, ShoppingcartitemRow]
+  def fkProductionProduct: ForeignKey[ProductFields, ProductRow] =
+    ForeignKey[ProductFields, ProductRow]("sales.FK_ShoppingCartItem_Product_ProductID", Nil)
+      .withColumnPair(productid, _.productid)
 }
 
 object ShoppingcartitemFields {

--- a/typo-tester-anorm/generated-and-checked-in/adventureworks/sales/specialofferproduct/SpecialofferproductFields.scala
+++ b/typo-tester-anorm/generated-and-checked-in/adventureworks/sales/specialofferproduct/SpecialofferproductFields.scala
@@ -9,8 +9,13 @@ package specialofferproduct
 
 import adventureworks.customtypes.TypoLocalDateTime
 import adventureworks.customtypes.TypoUUID
+import adventureworks.production.product.ProductFields
 import adventureworks.production.product.ProductId
+import adventureworks.production.product.ProductRow
+import adventureworks.sales.specialoffer.SpecialofferFields
 import adventureworks.sales.specialoffer.SpecialofferId
+import adventureworks.sales.specialoffer.SpecialofferRow
+import typo.dsl.ForeignKey
 import typo.dsl.Path
 import typo.dsl.SqlExpr.Field
 import typo.dsl.SqlExpr.FieldLikeNoHkt
@@ -22,6 +27,12 @@ trait SpecialofferproductFields {
   def productid: IdField[ProductId, SpecialofferproductRow]
   def rowguid: Field[TypoUUID, SpecialofferproductRow]
   def modifieddate: Field[TypoLocalDateTime, SpecialofferproductRow]
+  def fkProductionProduct: ForeignKey[ProductFields, ProductRow] =
+    ForeignKey[ProductFields, ProductRow]("sales.FK_SpecialOfferProduct_Product_ProductID", Nil)
+      .withColumnPair(productid, _.productid)
+  def fkSpecialoffer: ForeignKey[SpecialofferFields, SpecialofferRow] =
+    ForeignKey[SpecialofferFields, SpecialofferRow]("sales.FK_SpecialOfferProduct_SpecialOffer_SpecialOfferID", Nil)
+      .withColumnPair(specialofferid, _.specialofferid)
 }
 
 object SpecialofferproductFields {

--- a/typo-tester-anorm/generated-and-checked-in/adventureworks/sales/store/StoreFields.scala
+++ b/typo-tester-anorm/generated-and-checked-in/adventureworks/sales/store/StoreFields.scala
@@ -10,8 +10,13 @@ package store
 import adventureworks.customtypes.TypoLocalDateTime
 import adventureworks.customtypes.TypoUUID
 import adventureworks.customtypes.TypoXml
+import adventureworks.person.businessentity.BusinessentityFields
 import adventureworks.person.businessentity.BusinessentityId
+import adventureworks.person.businessentity.BusinessentityRow
 import adventureworks.public.Name
+import adventureworks.sales.salesperson.SalespersonFields
+import adventureworks.sales.salesperson.SalespersonRow
+import typo.dsl.ForeignKey
 import typo.dsl.Path
 import typo.dsl.SqlExpr.Field
 import typo.dsl.SqlExpr.FieldLikeNoHkt
@@ -26,6 +31,12 @@ trait StoreFields {
   def demographics: OptField[TypoXml, StoreRow]
   def rowguid: Field[TypoUUID, StoreRow]
   def modifieddate: Field[TypoLocalDateTime, StoreRow]
+  def fkPersonBusinessentity: ForeignKey[BusinessentityFields, BusinessentityRow] =
+    ForeignKey[BusinessentityFields, BusinessentityRow]("sales.FK_Store_BusinessEntity_BusinessEntityID", Nil)
+      .withColumnPair(businessentityid, _.businessentityid)
+  def fkSalesperson: ForeignKey[SalespersonFields, SalespersonRow] =
+    ForeignKey[SalespersonFields, SalespersonRow]("sales.FK_Store_SalesPerson_SalesPersonID", Nil)
+      .withColumnPair(salespersonid, _.businessentityid)
 }
 
 object StoreFields {

--- a/typo-tester-anorm/src/scala/adventureworks/production/product/ProductTest.scala
+++ b/typo-tester-anorm/src/scala/adventureworks/production/product/ProductTest.scala
@@ -119,6 +119,14 @@ class ProductTest extends AnyFunSuite with TypeCheckedTripleEquals {
       assert(saved3.modifieddate == newModifiedDate): @nowarn
       assert(productRepo.update(saved3.copy(size = None))): @nowarn
 
+      val query0 = productRepo.select
+        .joinFk(_.fkProductmodel)(projectModelRepo.select)
+        .joinFk(_._1.fkProductsubcategory)(productsubcategoryRepo.select)
+        .joinFk(_._2.fkProductcategory)(productcategoryRepo.select)
+      query0.toList.foreach(println)
+      query0.sql.foreach(println)
+      println("foo")
+
       val query =
         productRepo.select
           .where(_.`class` === "H ")

--- a/typo-tester-doobie/generated-and-checked-in/adventureworks/humanresources/employee/EmployeeFields.scala
+++ b/typo-tester-doobie/generated-and-checked-in/adventureworks/humanresources/employee/EmployeeFields.scala
@@ -12,7 +12,10 @@ import adventureworks.customtypes.TypoLocalDateTime
 import adventureworks.customtypes.TypoShort
 import adventureworks.customtypes.TypoUUID
 import adventureworks.person.businessentity.BusinessentityId
+import adventureworks.person.person.PersonFields
+import adventureworks.person.person.PersonRow
 import adventureworks.public.Flag
+import typo.dsl.ForeignKey
 import typo.dsl.Path
 import typo.dsl.SqlExpr.Field
 import typo.dsl.SqlExpr.FieldLikeNoHkt
@@ -36,6 +39,9 @@ trait EmployeeFields {
   def rowguid: Field[TypoUUID, EmployeeRow]
   def modifieddate: Field[TypoLocalDateTime, EmployeeRow]
   def organizationnode: OptField[String, EmployeeRow]
+  def fkPersonPerson: ForeignKey[PersonFields, PersonRow] =
+    ForeignKey[PersonFields, PersonRow]("humanresources.FK_Employee_Person_BusinessEntityID", Nil)
+      .withColumnPair(businessentityid, _.businessentityid)
 }
 
 object EmployeeFields {

--- a/typo-tester-doobie/generated-and-checked-in/adventureworks/humanresources/employeedepartmenthistory/EmployeedepartmenthistoryFields.scala
+++ b/typo-tester-doobie/generated-and-checked-in/adventureworks/humanresources/employeedepartmenthistory/EmployeedepartmenthistoryFields.scala
@@ -9,9 +9,16 @@ package employeedepartmenthistory
 
 import adventureworks.customtypes.TypoLocalDate
 import adventureworks.customtypes.TypoLocalDateTime
+import adventureworks.humanresources.department.DepartmentFields
 import adventureworks.humanresources.department.DepartmentId
+import adventureworks.humanresources.department.DepartmentRow
+import adventureworks.humanresources.employee.EmployeeFields
+import adventureworks.humanresources.employee.EmployeeRow
+import adventureworks.humanresources.shift.ShiftFields
 import adventureworks.humanresources.shift.ShiftId
+import adventureworks.humanresources.shift.ShiftRow
 import adventureworks.person.businessentity.BusinessentityId
+import typo.dsl.ForeignKey
 import typo.dsl.Path
 import typo.dsl.SqlExpr.Field
 import typo.dsl.SqlExpr.FieldLikeNoHkt
@@ -26,6 +33,15 @@ trait EmployeedepartmenthistoryFields {
   def startdate: IdField[TypoLocalDate, EmployeedepartmenthistoryRow]
   def enddate: OptField[TypoLocalDate, EmployeedepartmenthistoryRow]
   def modifieddate: Field[TypoLocalDateTime, EmployeedepartmenthistoryRow]
+  def fkDepartment: ForeignKey[DepartmentFields, DepartmentRow] =
+    ForeignKey[DepartmentFields, DepartmentRow]("humanresources.FK_EmployeeDepartmentHistory_Department_DepartmentID", Nil)
+      .withColumnPair(departmentid, _.departmentid)
+  def fkEmployee: ForeignKey[EmployeeFields, EmployeeRow] =
+    ForeignKey[EmployeeFields, EmployeeRow]("humanresources.FK_EmployeeDepartmentHistory_Employee_BusinessEntityID", Nil)
+      .withColumnPair(businessentityid, _.businessentityid)
+  def fkShift: ForeignKey[ShiftFields, ShiftRow] =
+    ForeignKey[ShiftFields, ShiftRow]("humanresources.FK_EmployeeDepartmentHistory_Shift_ShiftID", Nil)
+      .withColumnPair(shiftid, _.shiftid)
 }
 
 object EmployeedepartmenthistoryFields {

--- a/typo-tester-doobie/generated-and-checked-in/adventureworks/humanresources/employeepayhistory/EmployeepayhistoryFields.scala
+++ b/typo-tester-doobie/generated-and-checked-in/adventureworks/humanresources/employeepayhistory/EmployeepayhistoryFields.scala
@@ -9,7 +9,10 @@ package employeepayhistory
 
 import adventureworks.customtypes.TypoLocalDateTime
 import adventureworks.customtypes.TypoShort
+import adventureworks.humanresources.employee.EmployeeFields
+import adventureworks.humanresources.employee.EmployeeRow
 import adventureworks.person.businessentity.BusinessentityId
+import typo.dsl.ForeignKey
 import typo.dsl.Path
 import typo.dsl.SqlExpr.Field
 import typo.dsl.SqlExpr.FieldLikeNoHkt
@@ -22,6 +25,9 @@ trait EmployeepayhistoryFields {
   def rate: Field[BigDecimal, EmployeepayhistoryRow]
   def payfrequency: Field[TypoShort, EmployeepayhistoryRow]
   def modifieddate: Field[TypoLocalDateTime, EmployeepayhistoryRow]
+  def fkEmployee: ForeignKey[EmployeeFields, EmployeeRow] =
+    ForeignKey[EmployeeFields, EmployeeRow]("humanresources.FK_EmployeePayHistory_Employee_BusinessEntityID", Nil)
+      .withColumnPair(businessentityid, _.businessentityid)
 }
 
 object EmployeepayhistoryFields {

--- a/typo-tester-doobie/generated-and-checked-in/adventureworks/humanresources/jobcandidate/JobcandidateFields.scala
+++ b/typo-tester-doobie/generated-and-checked-in/adventureworks/humanresources/jobcandidate/JobcandidateFields.scala
@@ -9,7 +9,10 @@ package jobcandidate
 
 import adventureworks.customtypes.TypoLocalDateTime
 import adventureworks.customtypes.TypoXml
+import adventureworks.humanresources.employee.EmployeeFields
+import adventureworks.humanresources.employee.EmployeeRow
 import adventureworks.person.businessentity.BusinessentityId
+import typo.dsl.ForeignKey
 import typo.dsl.Path
 import typo.dsl.SqlExpr.Field
 import typo.dsl.SqlExpr.FieldLikeNoHkt
@@ -22,6 +25,9 @@ trait JobcandidateFields {
   def businessentityid: OptField[BusinessentityId, JobcandidateRow]
   def resume: OptField[TypoXml, JobcandidateRow]
   def modifieddate: Field[TypoLocalDateTime, JobcandidateRow]
+  def fkEmployee: ForeignKey[EmployeeFields, EmployeeRow] =
+    ForeignKey[EmployeeFields, EmployeeRow]("humanresources.FK_JobCandidate_Employee_BusinessEntityID", Nil)
+      .withColumnPair(businessentityid, _.businessentityid)
 }
 
 object JobcandidateFields {

--- a/typo-tester-doobie/generated-and-checked-in/adventureworks/person/address/AddressFields.scala
+++ b/typo-tester-doobie/generated-and-checked-in/adventureworks/person/address/AddressFields.scala
@@ -10,7 +10,10 @@ package address
 import adventureworks.customtypes.TypoBytea
 import adventureworks.customtypes.TypoLocalDateTime
 import adventureworks.customtypes.TypoUUID
+import adventureworks.person.stateprovince.StateprovinceFields
 import adventureworks.person.stateprovince.StateprovinceId
+import adventureworks.person.stateprovince.StateprovinceRow
+import typo.dsl.ForeignKey
 import typo.dsl.Path
 import typo.dsl.SqlExpr.Field
 import typo.dsl.SqlExpr.FieldLikeNoHkt
@@ -28,6 +31,9 @@ trait AddressFields {
   def spatiallocation: OptField[TypoBytea, AddressRow]
   def rowguid: Field[TypoUUID, AddressRow]
   def modifieddate: Field[TypoLocalDateTime, AddressRow]
+  def fkStateprovince: ForeignKey[StateprovinceFields, StateprovinceRow] =
+    ForeignKey[StateprovinceFields, StateprovinceRow]("person.FK_Address_StateProvince_StateProvinceID", Nil)
+      .withColumnPair(stateprovinceid, _.stateprovinceid)
 }
 
 object AddressFields {

--- a/typo-tester-doobie/generated-and-checked-in/adventureworks/person/businessentityaddress/BusinessentityaddressFields.scala
+++ b/typo-tester-doobie/generated-and-checked-in/adventureworks/person/businessentityaddress/BusinessentityaddressFields.scala
@@ -9,9 +9,16 @@ package businessentityaddress
 
 import adventureworks.customtypes.TypoLocalDateTime
 import adventureworks.customtypes.TypoUUID
+import adventureworks.person.address.AddressFields
 import adventureworks.person.address.AddressId
+import adventureworks.person.address.AddressRow
+import adventureworks.person.addresstype.AddresstypeFields
 import adventureworks.person.addresstype.AddresstypeId
+import adventureworks.person.addresstype.AddresstypeRow
+import adventureworks.person.businessentity.BusinessentityFields
 import adventureworks.person.businessentity.BusinessentityId
+import adventureworks.person.businessentity.BusinessentityRow
+import typo.dsl.ForeignKey
 import typo.dsl.Path
 import typo.dsl.SqlExpr.Field
 import typo.dsl.SqlExpr.FieldLikeNoHkt
@@ -24,6 +31,15 @@ trait BusinessentityaddressFields {
   def addresstypeid: IdField[AddresstypeId, BusinessentityaddressRow]
   def rowguid: Field[TypoUUID, BusinessentityaddressRow]
   def modifieddate: Field[TypoLocalDateTime, BusinessentityaddressRow]
+  def fkAddress: ForeignKey[AddressFields, AddressRow] =
+    ForeignKey[AddressFields, AddressRow]("person.FK_BusinessEntityAddress_Address_AddressID", Nil)
+      .withColumnPair(addressid, _.addressid)
+  def fkAddresstype: ForeignKey[AddresstypeFields, AddresstypeRow] =
+    ForeignKey[AddresstypeFields, AddresstypeRow]("person.FK_BusinessEntityAddress_AddressType_AddressTypeID", Nil)
+      .withColumnPair(addresstypeid, _.addresstypeid)
+  def fkBusinessentity: ForeignKey[BusinessentityFields, BusinessentityRow] =
+    ForeignKey[BusinessentityFields, BusinessentityRow]("person.FK_BusinessEntityAddress_BusinessEntity_BusinessEntityID", Nil)
+      .withColumnPair(businessentityid, _.businessentityid)
 }
 
 object BusinessentityaddressFields {

--- a/typo-tester-doobie/generated-and-checked-in/adventureworks/person/businessentitycontact/BusinessentitycontactFields.scala
+++ b/typo-tester-doobie/generated-and-checked-in/adventureworks/person/businessentitycontact/BusinessentitycontactFields.scala
@@ -9,8 +9,15 @@ package businessentitycontact
 
 import adventureworks.customtypes.TypoLocalDateTime
 import adventureworks.customtypes.TypoUUID
+import adventureworks.person.businessentity.BusinessentityFields
 import adventureworks.person.businessentity.BusinessentityId
+import adventureworks.person.businessentity.BusinessentityRow
+import adventureworks.person.contacttype.ContacttypeFields
 import adventureworks.person.contacttype.ContacttypeId
+import adventureworks.person.contacttype.ContacttypeRow
+import adventureworks.person.person.PersonFields
+import adventureworks.person.person.PersonRow
+import typo.dsl.ForeignKey
 import typo.dsl.Path
 import typo.dsl.SqlExpr.Field
 import typo.dsl.SqlExpr.FieldLikeNoHkt
@@ -23,6 +30,15 @@ trait BusinessentitycontactFields {
   def contacttypeid: IdField[ContacttypeId, BusinessentitycontactRow]
   def rowguid: Field[TypoUUID, BusinessentitycontactRow]
   def modifieddate: Field[TypoLocalDateTime, BusinessentitycontactRow]
+  def fkPerson: ForeignKey[PersonFields, PersonRow] =
+    ForeignKey[PersonFields, PersonRow]("person.FK_BusinessEntityContact_Person_PersonID", Nil)
+      .withColumnPair(personid, _.businessentityid)
+  def fkContacttype: ForeignKey[ContacttypeFields, ContacttypeRow] =
+    ForeignKey[ContacttypeFields, ContacttypeRow]("person.FK_BusinessEntityContact_ContactType_ContactTypeID", Nil)
+      .withColumnPair(contacttypeid, _.contacttypeid)
+  def fkBusinessentity: ForeignKey[BusinessentityFields, BusinessentityRow] =
+    ForeignKey[BusinessentityFields, BusinessentityRow]("person.FK_BusinessEntityContact_BusinessEntity_BusinessEntityID", Nil)
+      .withColumnPair(businessentityid, _.businessentityid)
 }
 
 object BusinessentitycontactFields {

--- a/typo-tester-doobie/generated-and-checked-in/adventureworks/person/emailaddress/EmailaddressFields.scala
+++ b/typo-tester-doobie/generated-and-checked-in/adventureworks/person/emailaddress/EmailaddressFields.scala
@@ -10,6 +10,9 @@ package emailaddress
 import adventureworks.customtypes.TypoLocalDateTime
 import adventureworks.customtypes.TypoUUID
 import adventureworks.person.businessentity.BusinessentityId
+import adventureworks.person.person.PersonFields
+import adventureworks.person.person.PersonRow
+import typo.dsl.ForeignKey
 import typo.dsl.Path
 import typo.dsl.SqlExpr.Field
 import typo.dsl.SqlExpr.FieldLikeNoHkt
@@ -23,6 +26,9 @@ trait EmailaddressFields {
   def emailaddress: OptField[/* max 50 chars */ String, EmailaddressRow]
   def rowguid: Field[TypoUUID, EmailaddressRow]
   def modifieddate: Field[TypoLocalDateTime, EmailaddressRow]
+  def fkPerson: ForeignKey[PersonFields, PersonRow] =
+    ForeignKey[PersonFields, PersonRow]("person.FK_EmailAddress_Person_BusinessEntityID", Nil)
+      .withColumnPair(businessentityid, _.businessentityid)
 }
 
 object EmailaddressFields {

--- a/typo-tester-doobie/generated-and-checked-in/adventureworks/person/password/PasswordFields.scala
+++ b/typo-tester-doobie/generated-and-checked-in/adventureworks/person/password/PasswordFields.scala
@@ -10,6 +10,9 @@ package password
 import adventureworks.customtypes.TypoLocalDateTime
 import adventureworks.customtypes.TypoUUID
 import adventureworks.person.businessentity.BusinessentityId
+import adventureworks.person.person.PersonFields
+import adventureworks.person.person.PersonRow
+import typo.dsl.ForeignKey
 import typo.dsl.Path
 import typo.dsl.SqlExpr.Field
 import typo.dsl.SqlExpr.FieldLikeNoHkt
@@ -22,6 +25,9 @@ trait PasswordFields {
   def passwordsalt: Field[/* max 10 chars */ String, PasswordRow]
   def rowguid: Field[TypoUUID, PasswordRow]
   def modifieddate: Field[TypoLocalDateTime, PasswordRow]
+  def fkPerson: ForeignKey[PersonFields, PersonRow] =
+    ForeignKey[PersonFields, PersonRow]("person.FK_Password_Person_BusinessEntityID", Nil)
+      .withColumnPair(businessentityid, _.businessentityid)
 }
 
 object PasswordFields {

--- a/typo-tester-doobie/generated-and-checked-in/adventureworks/person/person/PersonFields.scala
+++ b/typo-tester-doobie/generated-and-checked-in/adventureworks/person/person/PersonFields.scala
@@ -10,10 +10,13 @@ package person
 import adventureworks.customtypes.TypoLocalDateTime
 import adventureworks.customtypes.TypoUUID
 import adventureworks.customtypes.TypoXml
+import adventureworks.person.businessentity.BusinessentityFields
 import adventureworks.person.businessentity.BusinessentityId
+import adventureworks.person.businessentity.BusinessentityRow
 import adventureworks.public.Name
 import adventureworks.public.NameStyle
 import adventureworks.userdefined.FirstName
+import typo.dsl.ForeignKey
 import typo.dsl.Path
 import typo.dsl.SqlExpr.Field
 import typo.dsl.SqlExpr.FieldLikeNoHkt
@@ -35,6 +38,9 @@ trait PersonFields {
   def demographics: OptField[TypoXml, PersonRow]
   def rowguid: Field[TypoUUID, PersonRow]
   def modifieddate: Field[TypoLocalDateTime, PersonRow]
+  def fkBusinessentity: ForeignKey[BusinessentityFields, BusinessentityRow] =
+    ForeignKey[BusinessentityFields, BusinessentityRow]("person.FK_Person_BusinessEntity_BusinessEntityID", Nil)
+      .withColumnPair(businessentityid, _.businessentityid)
 }
 
 object PersonFields {

--- a/typo-tester-doobie/generated-and-checked-in/adventureworks/person/personphone/PersonphoneFields.scala
+++ b/typo-tester-doobie/generated-and-checked-in/adventureworks/person/personphone/PersonphoneFields.scala
@@ -9,8 +9,13 @@ package personphone
 
 import adventureworks.customtypes.TypoLocalDateTime
 import adventureworks.person.businessentity.BusinessentityId
+import adventureworks.person.person.PersonFields
+import adventureworks.person.person.PersonRow
+import adventureworks.person.phonenumbertype.PhonenumbertypeFields
 import adventureworks.person.phonenumbertype.PhonenumbertypeId
+import adventureworks.person.phonenumbertype.PhonenumbertypeRow
 import adventureworks.public.Phone
+import typo.dsl.ForeignKey
 import typo.dsl.Path
 import typo.dsl.SqlExpr.Field
 import typo.dsl.SqlExpr.FieldLikeNoHkt
@@ -22,6 +27,12 @@ trait PersonphoneFields {
   def phonenumber: IdField[Phone, PersonphoneRow]
   def phonenumbertypeid: IdField[PhonenumbertypeId, PersonphoneRow]
   def modifieddate: Field[TypoLocalDateTime, PersonphoneRow]
+  def fkPerson: ForeignKey[PersonFields, PersonRow] =
+    ForeignKey[PersonFields, PersonRow]("person.FK_PersonPhone_Person_BusinessEntityID", Nil)
+      .withColumnPair(businessentityid, _.businessentityid)
+  def fkPhonenumbertype: ForeignKey[PhonenumbertypeFields, PhonenumbertypeRow] =
+    ForeignKey[PhonenumbertypeFields, PhonenumbertypeRow]("person.FK_PersonPhone_PhoneNumberType_PhoneNumberTypeID", Nil)
+      .withColumnPair(phonenumbertypeid, _.phonenumbertypeid)
 }
 
 object PersonphoneFields {

--- a/typo-tester-doobie/generated-and-checked-in/adventureworks/person/stateprovince/StateprovinceFields.scala
+++ b/typo-tester-doobie/generated-and-checked-in/adventureworks/person/stateprovince/StateprovinceFields.scala
@@ -9,10 +9,15 @@ package stateprovince
 
 import adventureworks.customtypes.TypoLocalDateTime
 import adventureworks.customtypes.TypoUUID
+import adventureworks.person.countryregion.CountryregionFields
 import adventureworks.person.countryregion.CountryregionId
+import adventureworks.person.countryregion.CountryregionRow
 import adventureworks.public.Flag
 import adventureworks.public.Name
+import adventureworks.sales.salesterritory.SalesterritoryFields
 import adventureworks.sales.salesterritory.SalesterritoryId
+import adventureworks.sales.salesterritory.SalesterritoryRow
+import typo.dsl.ForeignKey
 import typo.dsl.Path
 import typo.dsl.SqlExpr.Field
 import typo.dsl.SqlExpr.FieldLikeNoHkt
@@ -28,6 +33,12 @@ trait StateprovinceFields {
   def territoryid: Field[SalesterritoryId, StateprovinceRow]
   def rowguid: Field[TypoUUID, StateprovinceRow]
   def modifieddate: Field[TypoLocalDateTime, StateprovinceRow]
+  def fkCountryregion: ForeignKey[CountryregionFields, CountryregionRow] =
+    ForeignKey[CountryregionFields, CountryregionRow]("person.FK_StateProvince_CountryRegion_CountryRegionCode", Nil)
+      .withColumnPair(countryregioncode, _.countryregioncode)
+  def fkSalesSalesterritory: ForeignKey[SalesterritoryFields, SalesterritoryRow] =
+    ForeignKey[SalesterritoryFields, SalesterritoryRow]("person.FK_StateProvince_SalesTerritory_TerritoryID", Nil)
+      .withColumnPair(territoryid, _.territoryid)
 }
 
 object StateprovinceFields {

--- a/typo-tester-doobie/generated-and-checked-in/adventureworks/production/billofmaterials/BillofmaterialsFields.scala
+++ b/typo-tester-doobie/generated-and-checked-in/adventureworks/production/billofmaterials/BillofmaterialsFields.scala
@@ -9,8 +9,13 @@ package billofmaterials
 
 import adventureworks.customtypes.TypoLocalDateTime
 import adventureworks.customtypes.TypoShort
+import adventureworks.production.product.ProductFields
 import adventureworks.production.product.ProductId
+import adventureworks.production.product.ProductRow
+import adventureworks.production.unitmeasure.UnitmeasureFields
 import adventureworks.production.unitmeasure.UnitmeasureId
+import adventureworks.production.unitmeasure.UnitmeasureRow
+import typo.dsl.ForeignKey
 import typo.dsl.Path
 import typo.dsl.SqlExpr.Field
 import typo.dsl.SqlExpr.FieldLikeNoHkt
@@ -28,6 +33,15 @@ trait BillofmaterialsFields {
   def bomlevel: Field[TypoShort, BillofmaterialsRow]
   def perassemblyqty: Field[BigDecimal, BillofmaterialsRow]
   def modifieddate: Field[TypoLocalDateTime, BillofmaterialsRow]
+  def fkProductProductassemblyid: ForeignKey[ProductFields, ProductRow] =
+    ForeignKey[ProductFields, ProductRow]("production.FK_BillOfMaterials_Product_ProductAssemblyID", Nil)
+      .withColumnPair(productassemblyid, _.productid)
+  def fkProductComponentid: ForeignKey[ProductFields, ProductRow] =
+    ForeignKey[ProductFields, ProductRow]("production.FK_BillOfMaterials_Product_ComponentID", Nil)
+      .withColumnPair(componentid, _.productid)
+  def fkUnitmeasure: ForeignKey[UnitmeasureFields, UnitmeasureRow] =
+    ForeignKey[UnitmeasureFields, UnitmeasureRow]("production.FK_BillOfMaterials_UnitMeasure_UnitMeasureCode", Nil)
+      .withColumnPair(unitmeasurecode, _.unitmeasurecode)
 }
 
 object BillofmaterialsFields {

--- a/typo-tester-doobie/generated-and-checked-in/adventureworks/production/document/DocumentFields.scala
+++ b/typo-tester-doobie/generated-and-checked-in/adventureworks/production/document/DocumentFields.scala
@@ -11,8 +11,11 @@ import adventureworks.customtypes.TypoBytea
 import adventureworks.customtypes.TypoLocalDateTime
 import adventureworks.customtypes.TypoShort
 import adventureworks.customtypes.TypoUUID
+import adventureworks.humanresources.employee.EmployeeFields
+import adventureworks.humanresources.employee.EmployeeRow
 import adventureworks.person.businessentity.BusinessentityId
 import adventureworks.public.Flag
+import typo.dsl.ForeignKey
 import typo.dsl.Path
 import typo.dsl.SqlExpr.Field
 import typo.dsl.SqlExpr.FieldLikeNoHkt
@@ -34,6 +37,9 @@ trait DocumentFields {
   def rowguid: Field[TypoUUID, DocumentRow]
   def modifieddate: Field[TypoLocalDateTime, DocumentRow]
   def documentnode: IdField[DocumentId, DocumentRow]
+  def fkHumanresourcesEmployee: ForeignKey[EmployeeFields, EmployeeRow] =
+    ForeignKey[EmployeeFields, EmployeeRow]("production.FK_Document_Employee_Owner", Nil)
+      .withColumnPair(owner, _.businessentityid)
 }
 
 object DocumentFields {

--- a/typo-tester-doobie/generated-and-checked-in/adventureworks/production/product/ProductFields.scala
+++ b/typo-tester-doobie/generated-and-checked-in/adventureworks/production/product/ProductFields.scala
@@ -10,11 +10,18 @@ package product
 import adventureworks.customtypes.TypoLocalDateTime
 import adventureworks.customtypes.TypoShort
 import adventureworks.customtypes.TypoUUID
+import adventureworks.production.productmodel.ProductmodelFields
 import adventureworks.production.productmodel.ProductmodelId
+import adventureworks.production.productmodel.ProductmodelRow
+import adventureworks.production.productsubcategory.ProductsubcategoryFields
 import adventureworks.production.productsubcategory.ProductsubcategoryId
+import adventureworks.production.productsubcategory.ProductsubcategoryRow
+import adventureworks.production.unitmeasure.UnitmeasureFields
 import adventureworks.production.unitmeasure.UnitmeasureId
+import adventureworks.production.unitmeasure.UnitmeasureRow
 import adventureworks.public.Flag
 import adventureworks.public.Name
+import typo.dsl.ForeignKey
 import typo.dsl.Path
 import typo.dsl.SqlExpr.Field
 import typo.dsl.SqlExpr.FieldLikeNoHkt
@@ -48,6 +55,18 @@ trait ProductFields {
   def discontinueddate: OptField[TypoLocalDateTime, ProductRow]
   def rowguid: Field[TypoUUID, ProductRow]
   def modifieddate: Field[TypoLocalDateTime, ProductRow]
+  def fkUnitmeasureSizeunitmeasurecode: ForeignKey[UnitmeasureFields, UnitmeasureRow] =
+    ForeignKey[UnitmeasureFields, UnitmeasureRow]("production.FK_Product_UnitMeasure_SizeUnitMeasureCode", Nil)
+      .withColumnPair(sizeunitmeasurecode, _.unitmeasurecode)
+  def fkUnitmeasureWeightunitmeasurecode: ForeignKey[UnitmeasureFields, UnitmeasureRow] =
+    ForeignKey[UnitmeasureFields, UnitmeasureRow]("production.FK_Product_UnitMeasure_WeightUnitMeasureCode", Nil)
+      .withColumnPair(weightunitmeasurecode, _.unitmeasurecode)
+  def fkProductmodel: ForeignKey[ProductmodelFields, ProductmodelRow] =
+    ForeignKey[ProductmodelFields, ProductmodelRow]("production.FK_Product_ProductModel_ProductModelID", Nil)
+      .withColumnPair(productmodelid, _.productmodelid)
+  def fkProductsubcategory: ForeignKey[ProductsubcategoryFields, ProductsubcategoryRow] =
+    ForeignKey[ProductsubcategoryFields, ProductsubcategoryRow]("production.FK_Product_ProductSubcategory_ProductSubcategoryID", Nil)
+      .withColumnPair(productsubcategoryid, _.productsubcategoryid)
 }
 
 object ProductFields {

--- a/typo-tester-doobie/generated-and-checked-in/adventureworks/production/productcosthistory/ProductcosthistoryFields.scala
+++ b/typo-tester-doobie/generated-and-checked-in/adventureworks/production/productcosthistory/ProductcosthistoryFields.scala
@@ -8,7 +8,10 @@ package production
 package productcosthistory
 
 import adventureworks.customtypes.TypoLocalDateTime
+import adventureworks.production.product.ProductFields
 import adventureworks.production.product.ProductId
+import adventureworks.production.product.ProductRow
+import typo.dsl.ForeignKey
 import typo.dsl.Path
 import typo.dsl.SqlExpr.Field
 import typo.dsl.SqlExpr.FieldLikeNoHkt
@@ -22,6 +25,9 @@ trait ProductcosthistoryFields {
   def enddate: OptField[TypoLocalDateTime, ProductcosthistoryRow]
   def standardcost: Field[BigDecimal, ProductcosthistoryRow]
   def modifieddate: Field[TypoLocalDateTime, ProductcosthistoryRow]
+  def fkProduct: ForeignKey[ProductFields, ProductRow] =
+    ForeignKey[ProductFields, ProductRow]("production.FK_ProductCostHistory_Product_ProductID", Nil)
+      .withColumnPair(productid, _.productid)
 }
 
 object ProductcosthistoryFields {

--- a/typo-tester-doobie/generated-and-checked-in/adventureworks/production/productdocument/ProductdocumentFields.scala
+++ b/typo-tester-doobie/generated-and-checked-in/adventureworks/production/productdocument/ProductdocumentFields.scala
@@ -8,8 +8,13 @@ package production
 package productdocument
 
 import adventureworks.customtypes.TypoLocalDateTime
+import adventureworks.production.document.DocumentFields
 import adventureworks.production.document.DocumentId
+import adventureworks.production.document.DocumentRow
+import adventureworks.production.product.ProductFields
 import adventureworks.production.product.ProductId
+import adventureworks.production.product.ProductRow
+import typo.dsl.ForeignKey
 import typo.dsl.Path
 import typo.dsl.SqlExpr.Field
 import typo.dsl.SqlExpr.FieldLikeNoHkt
@@ -20,6 +25,12 @@ trait ProductdocumentFields {
   def productid: IdField[ProductId, ProductdocumentRow]
   def modifieddate: Field[TypoLocalDateTime, ProductdocumentRow]
   def documentnode: IdField[DocumentId, ProductdocumentRow]
+  def fkProduct: ForeignKey[ProductFields, ProductRow] =
+    ForeignKey[ProductFields, ProductRow]("production.FK_ProductDocument_Product_ProductID", Nil)
+      .withColumnPair(productid, _.productid)
+  def fkDocument: ForeignKey[DocumentFields, DocumentRow] =
+    ForeignKey[DocumentFields, DocumentRow]("production.FK_ProductDocument_Document_DocumentNode", Nil)
+      .withColumnPair(documentnode, _.documentnode)
 }
 
 object ProductdocumentFields {

--- a/typo-tester-doobie/generated-and-checked-in/adventureworks/production/productinventory/ProductinventoryFields.scala
+++ b/typo-tester-doobie/generated-and-checked-in/adventureworks/production/productinventory/ProductinventoryFields.scala
@@ -10,8 +10,13 @@ package productinventory
 import adventureworks.customtypes.TypoLocalDateTime
 import adventureworks.customtypes.TypoShort
 import adventureworks.customtypes.TypoUUID
+import adventureworks.production.location.LocationFields
 import adventureworks.production.location.LocationId
+import adventureworks.production.location.LocationRow
+import adventureworks.production.product.ProductFields
 import adventureworks.production.product.ProductId
+import adventureworks.production.product.ProductRow
+import typo.dsl.ForeignKey
 import typo.dsl.Path
 import typo.dsl.SqlExpr.Field
 import typo.dsl.SqlExpr.FieldLikeNoHkt
@@ -26,6 +31,12 @@ trait ProductinventoryFields {
   def quantity: Field[TypoShort, ProductinventoryRow]
   def rowguid: Field[TypoUUID, ProductinventoryRow]
   def modifieddate: Field[TypoLocalDateTime, ProductinventoryRow]
+  def fkLocation: ForeignKey[LocationFields, LocationRow] =
+    ForeignKey[LocationFields, LocationRow]("production.FK_ProductInventory_Location_LocationID", Nil)
+      .withColumnPair(locationid, _.locationid)
+  def fkProduct: ForeignKey[ProductFields, ProductRow] =
+    ForeignKey[ProductFields, ProductRow]("production.FK_ProductInventory_Product_ProductID", Nil)
+      .withColumnPair(productid, _.productid)
 }
 
 object ProductinventoryFields {

--- a/typo-tester-doobie/generated-and-checked-in/adventureworks/production/productlistpricehistory/ProductlistpricehistoryFields.scala
+++ b/typo-tester-doobie/generated-and-checked-in/adventureworks/production/productlistpricehistory/ProductlistpricehistoryFields.scala
@@ -8,7 +8,10 @@ package production
 package productlistpricehistory
 
 import adventureworks.customtypes.TypoLocalDateTime
+import adventureworks.production.product.ProductFields
 import adventureworks.production.product.ProductId
+import adventureworks.production.product.ProductRow
+import typo.dsl.ForeignKey
 import typo.dsl.Path
 import typo.dsl.SqlExpr.Field
 import typo.dsl.SqlExpr.FieldLikeNoHkt
@@ -22,6 +25,9 @@ trait ProductlistpricehistoryFields {
   def enddate: OptField[TypoLocalDateTime, ProductlistpricehistoryRow]
   def listprice: Field[BigDecimal, ProductlistpricehistoryRow]
   def modifieddate: Field[TypoLocalDateTime, ProductlistpricehistoryRow]
+  def fkProduct: ForeignKey[ProductFields, ProductRow] =
+    ForeignKey[ProductFields, ProductRow]("production.FK_ProductListPriceHistory_Product_ProductID", Nil)
+      .withColumnPair(productid, _.productid)
 }
 
 object ProductlistpricehistoryFields {

--- a/typo-tester-doobie/generated-and-checked-in/adventureworks/production/productmodelillustration/ProductmodelillustrationFields.scala
+++ b/typo-tester-doobie/generated-and-checked-in/adventureworks/production/productmodelillustration/ProductmodelillustrationFields.scala
@@ -8,8 +8,13 @@ package production
 package productmodelillustration
 
 import adventureworks.customtypes.TypoLocalDateTime
+import adventureworks.production.illustration.IllustrationFields
 import adventureworks.production.illustration.IllustrationId
+import adventureworks.production.illustration.IllustrationRow
+import adventureworks.production.productmodel.ProductmodelFields
 import adventureworks.production.productmodel.ProductmodelId
+import adventureworks.production.productmodel.ProductmodelRow
+import typo.dsl.ForeignKey
 import typo.dsl.Path
 import typo.dsl.SqlExpr.Field
 import typo.dsl.SqlExpr.FieldLikeNoHkt
@@ -20,6 +25,12 @@ trait ProductmodelillustrationFields {
   def productmodelid: IdField[ProductmodelId, ProductmodelillustrationRow]
   def illustrationid: IdField[IllustrationId, ProductmodelillustrationRow]
   def modifieddate: Field[TypoLocalDateTime, ProductmodelillustrationRow]
+  def fkProductmodel: ForeignKey[ProductmodelFields, ProductmodelRow] =
+    ForeignKey[ProductmodelFields, ProductmodelRow]("production.FK_ProductModelIllustration_ProductModel_ProductModelID", Nil)
+      .withColumnPair(productmodelid, _.productmodelid)
+  def fkIllustration: ForeignKey[IllustrationFields, IllustrationRow] =
+    ForeignKey[IllustrationFields, IllustrationRow]("production.FK_ProductModelIllustration_Illustration_IllustrationID", Nil)
+      .withColumnPair(illustrationid, _.illustrationid)
 }
 
 object ProductmodelillustrationFields {

--- a/typo-tester-doobie/generated-and-checked-in/adventureworks/production/productmodelproductdescriptionculture/ProductmodelproductdescriptioncultureFields.scala
+++ b/typo-tester-doobie/generated-and-checked-in/adventureworks/production/productmodelproductdescriptionculture/ProductmodelproductdescriptioncultureFields.scala
@@ -8,9 +8,16 @@ package production
 package productmodelproductdescriptionculture
 
 import adventureworks.customtypes.TypoLocalDateTime
+import adventureworks.production.culture.CultureFields
 import adventureworks.production.culture.CultureId
+import adventureworks.production.culture.CultureRow
+import adventureworks.production.productdescription.ProductdescriptionFields
 import adventureworks.production.productdescription.ProductdescriptionId
+import adventureworks.production.productdescription.ProductdescriptionRow
+import adventureworks.production.productmodel.ProductmodelFields
 import adventureworks.production.productmodel.ProductmodelId
+import adventureworks.production.productmodel.ProductmodelRow
+import typo.dsl.ForeignKey
 import typo.dsl.Path
 import typo.dsl.SqlExpr.Field
 import typo.dsl.SqlExpr.FieldLikeNoHkt
@@ -22,6 +29,15 @@ trait ProductmodelproductdescriptioncultureFields {
   def productdescriptionid: IdField[ProductdescriptionId, ProductmodelproductdescriptioncultureRow]
   def cultureid: IdField[CultureId, ProductmodelproductdescriptioncultureRow]
   def modifieddate: Field[TypoLocalDateTime, ProductmodelproductdescriptioncultureRow]
+  def fkProductdescription: ForeignKey[ProductdescriptionFields, ProductdescriptionRow] =
+    ForeignKey[ProductdescriptionFields, ProductdescriptionRow]("production.FK_ProductModelProductDescriptionCulture_ProductDescription_Pro", Nil)
+      .withColumnPair(productdescriptionid, _.productdescriptionid)
+  def fkCulture: ForeignKey[CultureFields, CultureRow] =
+    ForeignKey[CultureFields, CultureRow]("production.FK_ProductModelProductDescriptionCulture_Culture_CultureID", Nil)
+      .withColumnPair(cultureid, _.cultureid)
+  def fkProductmodel: ForeignKey[ProductmodelFields, ProductmodelRow] =
+    ForeignKey[ProductmodelFields, ProductmodelRow]("production.FK_ProductModelProductDescriptionCulture_ProductModel_ProductMo", Nil)
+      .withColumnPair(productmodelid, _.productmodelid)
 }
 
 object ProductmodelproductdescriptioncultureFields {

--- a/typo-tester-doobie/generated-and-checked-in/adventureworks/production/productproductphoto/ProductproductphotoFields.scala
+++ b/typo-tester-doobie/generated-and-checked-in/adventureworks/production/productproductphoto/ProductproductphotoFields.scala
@@ -8,9 +8,14 @@ package production
 package productproductphoto
 
 import adventureworks.customtypes.TypoLocalDateTime
+import adventureworks.production.product.ProductFields
 import adventureworks.production.product.ProductId
+import adventureworks.production.product.ProductRow
+import adventureworks.production.productphoto.ProductphotoFields
 import adventureworks.production.productphoto.ProductphotoId
+import adventureworks.production.productphoto.ProductphotoRow
 import adventureworks.public.Flag
+import typo.dsl.ForeignKey
 import typo.dsl.Path
 import typo.dsl.SqlExpr.Field
 import typo.dsl.SqlExpr.FieldLikeNoHkt
@@ -22,6 +27,12 @@ trait ProductproductphotoFields {
   def productphotoid: IdField[ProductphotoId, ProductproductphotoRow]
   def primary: Field[Flag, ProductproductphotoRow]
   def modifieddate: Field[TypoLocalDateTime, ProductproductphotoRow]
+  def fkProduct: ForeignKey[ProductFields, ProductRow] =
+    ForeignKey[ProductFields, ProductRow]("production.FK_ProductProductPhoto_Product_ProductID", Nil)
+      .withColumnPair(productid, _.productid)
+  def fkProductphoto: ForeignKey[ProductphotoFields, ProductphotoRow] =
+    ForeignKey[ProductphotoFields, ProductphotoRow]("production.FK_ProductProductPhoto_ProductPhoto_ProductPhotoID", Nil)
+      .withColumnPair(productphotoid, _.productphotoid)
 }
 
 object ProductproductphotoFields {

--- a/typo-tester-doobie/generated-and-checked-in/adventureworks/production/productreview/ProductreviewFields.scala
+++ b/typo-tester-doobie/generated-and-checked-in/adventureworks/production/productreview/ProductreviewFields.scala
@@ -8,8 +8,11 @@ package production
 package productreview
 
 import adventureworks.customtypes.TypoLocalDateTime
+import adventureworks.production.product.ProductFields
 import adventureworks.production.product.ProductId
+import adventureworks.production.product.ProductRow
 import adventureworks.public.Name
+import typo.dsl.ForeignKey
 import typo.dsl.Path
 import typo.dsl.SqlExpr.Field
 import typo.dsl.SqlExpr.FieldLikeNoHkt
@@ -26,6 +29,9 @@ trait ProductreviewFields {
   def rating: Field[Int, ProductreviewRow]
   def comments: OptField[/* max 3850 chars */ String, ProductreviewRow]
   def modifieddate: Field[TypoLocalDateTime, ProductreviewRow]
+  def fkProduct: ForeignKey[ProductFields, ProductRow] =
+    ForeignKey[ProductFields, ProductRow]("production.FK_ProductReview_Product_ProductID", Nil)
+      .withColumnPair(productid, _.productid)
 }
 
 object ProductreviewFields {

--- a/typo-tester-doobie/generated-and-checked-in/adventureworks/production/productsubcategory/ProductsubcategoryFields.scala
+++ b/typo-tester-doobie/generated-and-checked-in/adventureworks/production/productsubcategory/ProductsubcategoryFields.scala
@@ -9,8 +9,11 @@ package productsubcategory
 
 import adventureworks.customtypes.TypoLocalDateTime
 import adventureworks.customtypes.TypoUUID
+import adventureworks.production.productcategory.ProductcategoryFields
 import adventureworks.production.productcategory.ProductcategoryId
+import adventureworks.production.productcategory.ProductcategoryRow
 import adventureworks.public.Name
+import typo.dsl.ForeignKey
 import typo.dsl.Path
 import typo.dsl.SqlExpr.Field
 import typo.dsl.SqlExpr.FieldLikeNoHkt
@@ -23,6 +26,9 @@ trait ProductsubcategoryFields {
   def name: Field[Name, ProductsubcategoryRow]
   def rowguid: Field[TypoUUID, ProductsubcategoryRow]
   def modifieddate: Field[TypoLocalDateTime, ProductsubcategoryRow]
+  def fkProductcategory: ForeignKey[ProductcategoryFields, ProductcategoryRow] =
+    ForeignKey[ProductcategoryFields, ProductcategoryRow]("production.FK_ProductSubcategory_ProductCategory_ProductCategoryID", Nil)
+      .withColumnPair(productcategoryid, _.productcategoryid)
 }
 
 object ProductsubcategoryFields {

--- a/typo-tester-doobie/generated-and-checked-in/adventureworks/production/transactionhistory/TransactionhistoryFields.scala
+++ b/typo-tester-doobie/generated-and-checked-in/adventureworks/production/transactionhistory/TransactionhistoryFields.scala
@@ -8,7 +8,10 @@ package production
 package transactionhistory
 
 import adventureworks.customtypes.TypoLocalDateTime
+import adventureworks.production.product.ProductFields
 import adventureworks.production.product.ProductId
+import adventureworks.production.product.ProductRow
+import typo.dsl.ForeignKey
 import typo.dsl.Path
 import typo.dsl.SqlExpr.Field
 import typo.dsl.SqlExpr.FieldLikeNoHkt
@@ -25,6 +28,9 @@ trait TransactionhistoryFields {
   def quantity: Field[Int, TransactionhistoryRow]
   def actualcost: Field[BigDecimal, TransactionhistoryRow]
   def modifieddate: Field[TypoLocalDateTime, TransactionhistoryRow]
+  def fkProduct: ForeignKey[ProductFields, ProductRow] =
+    ForeignKey[ProductFields, ProductRow]("production.FK_TransactionHistory_Product_ProductID", Nil)
+      .withColumnPair(productid, _.productid)
 }
 
 object TransactionhistoryFields {

--- a/typo-tester-doobie/generated-and-checked-in/adventureworks/production/workorder/WorkorderFields.scala
+++ b/typo-tester-doobie/generated-and-checked-in/adventureworks/production/workorder/WorkorderFields.scala
@@ -9,8 +9,13 @@ package workorder
 
 import adventureworks.customtypes.TypoLocalDateTime
 import adventureworks.customtypes.TypoShort
+import adventureworks.production.product.ProductFields
 import adventureworks.production.product.ProductId
+import adventureworks.production.product.ProductRow
+import adventureworks.production.scrapreason.ScrapreasonFields
 import adventureworks.production.scrapreason.ScrapreasonId
+import adventureworks.production.scrapreason.ScrapreasonRow
+import typo.dsl.ForeignKey
 import typo.dsl.Path
 import typo.dsl.SqlExpr.Field
 import typo.dsl.SqlExpr.FieldLikeNoHkt
@@ -28,6 +33,12 @@ trait WorkorderFields {
   def duedate: Field[TypoLocalDateTime, WorkorderRow]
   def scrapreasonid: OptField[ScrapreasonId, WorkorderRow]
   def modifieddate: Field[TypoLocalDateTime, WorkorderRow]
+  def fkProduct: ForeignKey[ProductFields, ProductRow] =
+    ForeignKey[ProductFields, ProductRow]("production.FK_WorkOrder_Product_ProductID", Nil)
+      .withColumnPair(productid, _.productid)
+  def fkScrapreason: ForeignKey[ScrapreasonFields, ScrapreasonRow] =
+    ForeignKey[ScrapreasonFields, ScrapreasonRow]("production.FK_WorkOrder_ScrapReason_ScrapReasonID", Nil)
+      .withColumnPair(scrapreasonid, _.scrapreasonid)
 }
 
 object WorkorderFields {

--- a/typo-tester-doobie/generated-and-checked-in/adventureworks/production/workorderrouting/WorkorderroutingFields.scala
+++ b/typo-tester-doobie/generated-and-checked-in/adventureworks/production/workorderrouting/WorkorderroutingFields.scala
@@ -9,8 +9,13 @@ package workorderrouting
 
 import adventureworks.customtypes.TypoLocalDateTime
 import adventureworks.customtypes.TypoShort
+import adventureworks.production.location.LocationFields
 import adventureworks.production.location.LocationId
+import adventureworks.production.location.LocationRow
+import adventureworks.production.workorder.WorkorderFields
 import adventureworks.production.workorder.WorkorderId
+import adventureworks.production.workorder.WorkorderRow
+import typo.dsl.ForeignKey
 import typo.dsl.Path
 import typo.dsl.SqlExpr.Field
 import typo.dsl.SqlExpr.FieldLikeNoHkt
@@ -31,6 +36,12 @@ trait WorkorderroutingFields {
   def plannedcost: Field[BigDecimal, WorkorderroutingRow]
   def actualcost: OptField[BigDecimal, WorkorderroutingRow]
   def modifieddate: Field[TypoLocalDateTime, WorkorderroutingRow]
+  def fkLocation: ForeignKey[LocationFields, LocationRow] =
+    ForeignKey[LocationFields, LocationRow]("production.FK_WorkOrderRouting_Location_LocationID", Nil)
+      .withColumnPair(locationid, _.locationid)
+  def fkWorkorder: ForeignKey[WorkorderFields, WorkorderRow] =
+    ForeignKey[WorkorderFields, WorkorderRow]("production.FK_WorkOrderRouting_WorkOrder_WorkOrderID", Nil)
+      .withColumnPair(workorderid, _.workorderid)
 }
 
 object WorkorderroutingFields {

--- a/typo-tester-doobie/generated-and-checked-in/adventureworks/public/flaff/FlaffFields.scala
+++ b/typo-tester-doobie/generated-and-checked-in/adventureworks/public/flaff/FlaffFields.scala
@@ -8,6 +8,7 @@ package public
 package flaff
 
 import adventureworks.public.ShortText
+import typo.dsl.ForeignKey
 import typo.dsl.Path
 import typo.dsl.SqlExpr.FieldLikeNoHkt
 import typo.dsl.SqlExpr.IdField
@@ -20,6 +21,12 @@ trait FlaffFields {
   def someNumber: IdField[Int, FlaffRow]
   def specifier: IdField[ShortText, FlaffRow]
   def parentspecifier: OptField[ShortText, FlaffRow]
+  def fkFlaff: ForeignKey[FlaffFields, FlaffRow] =
+    ForeignKey[FlaffFields, FlaffRow]("public.flaff_parent_fk", Nil)
+      .withColumnPair(code, _.code)
+      .withColumnPair(anotherCode, _.anotherCode)
+      .withColumnPair(someNumber, _.someNumber)
+      .withColumnPair(parentspecifier, _.specifier)
 }
 
 object FlaffFields {

--- a/typo-tester-doobie/generated-and-checked-in/adventureworks/purchasing/productvendor/ProductvendorFields.scala
+++ b/typo-tester-doobie/generated-and-checked-in/adventureworks/purchasing/productvendor/ProductvendorFields.scala
@@ -9,8 +9,15 @@ package productvendor
 
 import adventureworks.customtypes.TypoLocalDateTime
 import adventureworks.person.businessentity.BusinessentityId
+import adventureworks.production.product.ProductFields
 import adventureworks.production.product.ProductId
+import adventureworks.production.product.ProductRow
+import adventureworks.production.unitmeasure.UnitmeasureFields
 import adventureworks.production.unitmeasure.UnitmeasureId
+import adventureworks.production.unitmeasure.UnitmeasureRow
+import adventureworks.purchasing.vendor.VendorFields
+import adventureworks.purchasing.vendor.VendorRow
+import typo.dsl.ForeignKey
 import typo.dsl.Path
 import typo.dsl.SqlExpr.Field
 import typo.dsl.SqlExpr.FieldLikeNoHkt
@@ -30,6 +37,15 @@ trait ProductvendorFields {
   def onorderqty: OptField[Int, ProductvendorRow]
   def unitmeasurecode: Field[UnitmeasureId, ProductvendorRow]
   def modifieddate: Field[TypoLocalDateTime, ProductvendorRow]
+  def fkProductionProduct: ForeignKey[ProductFields, ProductRow] =
+    ForeignKey[ProductFields, ProductRow]("purchasing.FK_ProductVendor_Product_ProductID", Nil)
+      .withColumnPair(productid, _.productid)
+  def fkProductionUnitmeasure: ForeignKey[UnitmeasureFields, UnitmeasureRow] =
+    ForeignKey[UnitmeasureFields, UnitmeasureRow]("purchasing.FK_ProductVendor_UnitMeasure_UnitMeasureCode", Nil)
+      .withColumnPair(unitmeasurecode, _.unitmeasurecode)
+  def fkVendor: ForeignKey[VendorFields, VendorRow] =
+    ForeignKey[VendorFields, VendorRow]("purchasing.FK_ProductVendor_Vendor_BusinessEntityID", Nil)
+      .withColumnPair(businessentityid, _.businessentityid)
 }
 
 object ProductvendorFields {

--- a/typo-tester-doobie/generated-and-checked-in/adventureworks/purchasing/purchaseorderdetail/PurchaseorderdetailFields.scala
+++ b/typo-tester-doobie/generated-and-checked-in/adventureworks/purchasing/purchaseorderdetail/PurchaseorderdetailFields.scala
@@ -9,8 +9,13 @@ package purchaseorderdetail
 
 import adventureworks.customtypes.TypoLocalDateTime
 import adventureworks.customtypes.TypoShort
+import adventureworks.production.product.ProductFields
 import adventureworks.production.product.ProductId
+import adventureworks.production.product.ProductRow
+import adventureworks.purchasing.purchaseorderheader.PurchaseorderheaderFields
 import adventureworks.purchasing.purchaseorderheader.PurchaseorderheaderId
+import adventureworks.purchasing.purchaseorderheader.PurchaseorderheaderRow
+import typo.dsl.ForeignKey
 import typo.dsl.Path
 import typo.dsl.SqlExpr.Field
 import typo.dsl.SqlExpr.FieldLikeNoHkt
@@ -27,6 +32,12 @@ trait PurchaseorderdetailFields {
   def receivedqty: Field[BigDecimal, PurchaseorderdetailRow]
   def rejectedqty: Field[BigDecimal, PurchaseorderdetailRow]
   def modifieddate: Field[TypoLocalDateTime, PurchaseorderdetailRow]
+  def fkProductionProduct: ForeignKey[ProductFields, ProductRow] =
+    ForeignKey[ProductFields, ProductRow]("purchasing.FK_PurchaseOrderDetail_Product_ProductID", Nil)
+      .withColumnPair(productid, _.productid)
+  def fkPurchaseorderheader: ForeignKey[PurchaseorderheaderFields, PurchaseorderheaderRow] =
+    ForeignKey[PurchaseorderheaderFields, PurchaseorderheaderRow]("purchasing.FK_PurchaseOrderDetail_PurchaseOrderHeader_PurchaseOrderID", Nil)
+      .withColumnPair(purchaseorderid, _.purchaseorderid)
 }
 
 object PurchaseorderdetailFields {

--- a/typo-tester-doobie/generated-and-checked-in/adventureworks/purchasing/purchaseorderheader/PurchaseorderheaderFields.scala
+++ b/typo-tester-doobie/generated-and-checked-in/adventureworks/purchasing/purchaseorderheader/PurchaseorderheaderFields.scala
@@ -9,8 +9,15 @@ package purchaseorderheader
 
 import adventureworks.customtypes.TypoLocalDateTime
 import adventureworks.customtypes.TypoShort
+import adventureworks.humanresources.employee.EmployeeFields
+import adventureworks.humanresources.employee.EmployeeRow
 import adventureworks.person.businessentity.BusinessentityId
+import adventureworks.purchasing.shipmethod.ShipmethodFields
 import adventureworks.purchasing.shipmethod.ShipmethodId
+import adventureworks.purchasing.shipmethod.ShipmethodRow
+import adventureworks.purchasing.vendor.VendorFields
+import adventureworks.purchasing.vendor.VendorRow
+import typo.dsl.ForeignKey
 import typo.dsl.Path
 import typo.dsl.SqlExpr.Field
 import typo.dsl.SqlExpr.FieldLikeNoHkt
@@ -31,6 +38,15 @@ trait PurchaseorderheaderFields {
   def taxamt: Field[BigDecimal, PurchaseorderheaderRow]
   def freight: Field[BigDecimal, PurchaseorderheaderRow]
   def modifieddate: Field[TypoLocalDateTime, PurchaseorderheaderRow]
+  def fkHumanresourcesEmployee: ForeignKey[EmployeeFields, EmployeeRow] =
+    ForeignKey[EmployeeFields, EmployeeRow]("purchasing.FK_PurchaseOrderHeader_Employee_EmployeeID", Nil)
+      .withColumnPair(employeeid, _.businessentityid)
+  def fkVendor: ForeignKey[VendorFields, VendorRow] =
+    ForeignKey[VendorFields, VendorRow]("purchasing.FK_PurchaseOrderHeader_Vendor_VendorID", Nil)
+      .withColumnPair(vendorid, _.businessentityid)
+  def fkShipmethod: ForeignKey[ShipmethodFields, ShipmethodRow] =
+    ForeignKey[ShipmethodFields, ShipmethodRow]("purchasing.FK_PurchaseOrderHeader_ShipMethod_ShipMethodID", Nil)
+      .withColumnPair(shipmethodid, _.shipmethodid)
 }
 
 object PurchaseorderheaderFields {

--- a/typo-tester-doobie/generated-and-checked-in/adventureworks/purchasing/vendor/VendorFields.scala
+++ b/typo-tester-doobie/generated-and-checked-in/adventureworks/purchasing/vendor/VendorFields.scala
@@ -9,10 +9,13 @@ package vendor
 
 import adventureworks.customtypes.TypoLocalDateTime
 import adventureworks.customtypes.TypoShort
+import adventureworks.person.businessentity.BusinessentityFields
 import adventureworks.person.businessentity.BusinessentityId
+import adventureworks.person.businessentity.BusinessentityRow
 import adventureworks.public.AccountNumber
 import adventureworks.public.Flag
 import adventureworks.public.Name
+import typo.dsl.ForeignKey
 import typo.dsl.Path
 import typo.dsl.SqlExpr.Field
 import typo.dsl.SqlExpr.FieldLikeNoHkt
@@ -29,6 +32,9 @@ trait VendorFields {
   def activeflag: Field[Flag, VendorRow]
   def purchasingwebserviceurl: OptField[/* max 1024 chars */ String, VendorRow]
   def modifieddate: Field[TypoLocalDateTime, VendorRow]
+  def fkPersonBusinessentity: ForeignKey[BusinessentityFields, BusinessentityRow] =
+    ForeignKey[BusinessentityFields, BusinessentityRow]("purchasing.FK_Vendor_BusinessEntity_BusinessEntityID", Nil)
+      .withColumnPair(businessentityid, _.businessentityid)
 }
 
 object VendorFields {

--- a/typo-tester-doobie/generated-and-checked-in/adventureworks/sales/countryregioncurrency/CountryregioncurrencyFields.scala
+++ b/typo-tester-doobie/generated-and-checked-in/adventureworks/sales/countryregioncurrency/CountryregioncurrencyFields.scala
@@ -8,8 +8,13 @@ package sales
 package countryregioncurrency
 
 import adventureworks.customtypes.TypoLocalDateTime
+import adventureworks.person.countryregion.CountryregionFields
 import adventureworks.person.countryregion.CountryregionId
+import adventureworks.person.countryregion.CountryregionRow
+import adventureworks.sales.currency.CurrencyFields
 import adventureworks.sales.currency.CurrencyId
+import adventureworks.sales.currency.CurrencyRow
+import typo.dsl.ForeignKey
 import typo.dsl.Path
 import typo.dsl.SqlExpr.Field
 import typo.dsl.SqlExpr.FieldLikeNoHkt
@@ -20,6 +25,12 @@ trait CountryregioncurrencyFields {
   def countryregioncode: IdField[CountryregionId, CountryregioncurrencyRow]
   def currencycode: IdField[CurrencyId, CountryregioncurrencyRow]
   def modifieddate: Field[TypoLocalDateTime, CountryregioncurrencyRow]
+  def fkPersonCountryregion: ForeignKey[CountryregionFields, CountryregionRow] =
+    ForeignKey[CountryregionFields, CountryregionRow]("sales.FK_CountryRegionCurrency_CountryRegion_CountryRegionCode", Nil)
+      .withColumnPair(countryregioncode, _.countryregioncode)
+  def fkCurrency: ForeignKey[CurrencyFields, CurrencyRow] =
+    ForeignKey[CurrencyFields, CurrencyRow]("sales.FK_CountryRegionCurrency_Currency_CurrencyCode", Nil)
+      .withColumnPair(currencycode, _.currencycode)
 }
 
 object CountryregioncurrencyFields {

--- a/typo-tester-doobie/generated-and-checked-in/adventureworks/sales/currencyrate/CurrencyrateFields.scala
+++ b/typo-tester-doobie/generated-and-checked-in/adventureworks/sales/currencyrate/CurrencyrateFields.scala
@@ -8,7 +8,10 @@ package sales
 package currencyrate
 
 import adventureworks.customtypes.TypoLocalDateTime
+import adventureworks.sales.currency.CurrencyFields
 import adventureworks.sales.currency.CurrencyId
+import adventureworks.sales.currency.CurrencyRow
+import typo.dsl.ForeignKey
 import typo.dsl.Path
 import typo.dsl.SqlExpr.Field
 import typo.dsl.SqlExpr.FieldLikeNoHkt
@@ -23,6 +26,12 @@ trait CurrencyrateFields {
   def averagerate: Field[BigDecimal, CurrencyrateRow]
   def endofdayrate: Field[BigDecimal, CurrencyrateRow]
   def modifieddate: Field[TypoLocalDateTime, CurrencyrateRow]
+  def fkCurrencyFromcurrencycode: ForeignKey[CurrencyFields, CurrencyRow] =
+    ForeignKey[CurrencyFields, CurrencyRow]("sales.FK_CurrencyRate_Currency_FromCurrencyCode", Nil)
+      .withColumnPair(fromcurrencycode, _.currencycode)
+  def fkCurrencyTocurrencycode: ForeignKey[CurrencyFields, CurrencyRow] =
+    ForeignKey[CurrencyFields, CurrencyRow]("sales.FK_CurrencyRate_Currency_ToCurrencyCode", Nil)
+      .withColumnPair(tocurrencycode, _.currencycode)
 }
 
 object CurrencyrateFields {

--- a/typo-tester-doobie/generated-and-checked-in/adventureworks/sales/customer/CustomerFields.scala
+++ b/typo-tester-doobie/generated-and-checked-in/adventureworks/sales/customer/CustomerFields.scala
@@ -10,7 +10,14 @@ package customer
 import adventureworks.customtypes.TypoLocalDateTime
 import adventureworks.customtypes.TypoUUID
 import adventureworks.person.businessentity.BusinessentityId
+import adventureworks.person.person.PersonFields
+import adventureworks.person.person.PersonRow
+import adventureworks.sales.salesterritory.SalesterritoryFields
 import adventureworks.sales.salesterritory.SalesterritoryId
+import adventureworks.sales.salesterritory.SalesterritoryRow
+import adventureworks.sales.store.StoreFields
+import adventureworks.sales.store.StoreRow
+import typo.dsl.ForeignKey
 import typo.dsl.Path
 import typo.dsl.SqlExpr.Field
 import typo.dsl.SqlExpr.FieldLikeNoHkt
@@ -25,6 +32,15 @@ trait CustomerFields {
   def territoryid: OptField[SalesterritoryId, CustomerRow]
   def rowguid: Field[TypoUUID, CustomerRow]
   def modifieddate: Field[TypoLocalDateTime, CustomerRow]
+  def fkPersonPerson: ForeignKey[PersonFields, PersonRow] =
+    ForeignKey[PersonFields, PersonRow]("sales.FK_Customer_Person_PersonID", Nil)
+      .withColumnPair(personid, _.businessentityid)
+  def fkStore: ForeignKey[StoreFields, StoreRow] =
+    ForeignKey[StoreFields, StoreRow]("sales.FK_Customer_Store_StoreID", Nil)
+      .withColumnPair(storeid, _.businessentityid)
+  def fkSalesterritory: ForeignKey[SalesterritoryFields, SalesterritoryRow] =
+    ForeignKey[SalesterritoryFields, SalesterritoryRow]("sales.FK_Customer_SalesTerritory_TerritoryID", Nil)
+      .withColumnPair(territoryid, _.territoryid)
 }
 
 object CustomerFields {

--- a/typo-tester-doobie/generated-and-checked-in/adventureworks/sales/personcreditcard/PersoncreditcardFields.scala
+++ b/typo-tester-doobie/generated-and-checked-in/adventureworks/sales/personcreditcard/PersoncreditcardFields.scala
@@ -9,7 +9,12 @@ package personcreditcard
 
 import adventureworks.customtypes.TypoLocalDateTime
 import adventureworks.person.businessentity.BusinessentityId
+import adventureworks.person.person.PersonFields
+import adventureworks.person.person.PersonRow
+import adventureworks.sales.creditcard.CreditcardFields
+import adventureworks.sales.creditcard.CreditcardRow
 import adventureworks.userdefined.CustomCreditcardId
+import typo.dsl.ForeignKey
 import typo.dsl.Path
 import typo.dsl.SqlExpr.Field
 import typo.dsl.SqlExpr.FieldLikeNoHkt
@@ -20,6 +25,12 @@ trait PersoncreditcardFields {
   def businessentityid: IdField[BusinessentityId, PersoncreditcardRow]
   def creditcardid: IdField[/* user-picked */ CustomCreditcardId, PersoncreditcardRow]
   def modifieddate: Field[TypoLocalDateTime, PersoncreditcardRow]
+  def fkPersonPerson: ForeignKey[PersonFields, PersonRow] =
+    ForeignKey[PersonFields, PersonRow]("sales.FK_PersonCreditCard_Person_BusinessEntityID", Nil)
+      .withColumnPair(businessentityid, _.businessentityid)
+  def fkCreditcard: ForeignKey[CreditcardFields, CreditcardRow] =
+    ForeignKey[CreditcardFields, CreditcardRow]("sales.FK_PersonCreditCard_CreditCard_CreditCardID", Nil)
+      .withColumnPair(creditcardid, _.creditcardid)
 }
 
 object PersoncreditcardFields {

--- a/typo-tester-doobie/generated-and-checked-in/adventureworks/sales/salesorderdetail/SalesorderdetailFields.scala
+++ b/typo-tester-doobie/generated-and-checked-in/adventureworks/sales/salesorderdetail/SalesorderdetailFields.scala
@@ -11,8 +11,13 @@ import adventureworks.customtypes.TypoLocalDateTime
 import adventureworks.customtypes.TypoShort
 import adventureworks.customtypes.TypoUUID
 import adventureworks.production.product.ProductId
+import adventureworks.sales.salesorderheader.SalesorderheaderFields
 import adventureworks.sales.salesorderheader.SalesorderheaderId
+import adventureworks.sales.salesorderheader.SalesorderheaderRow
 import adventureworks.sales.specialoffer.SpecialofferId
+import adventureworks.sales.specialofferproduct.SpecialofferproductFields
+import adventureworks.sales.specialofferproduct.SpecialofferproductRow
+import typo.dsl.ForeignKey
 import typo.dsl.Path
 import typo.dsl.SqlExpr.Field
 import typo.dsl.SqlExpr.FieldLikeNoHkt
@@ -31,6 +36,13 @@ trait SalesorderdetailFields {
   def unitpricediscount: Field[BigDecimal, SalesorderdetailRow]
   def rowguid: Field[TypoUUID, SalesorderdetailRow]
   def modifieddate: Field[TypoLocalDateTime, SalesorderdetailRow]
+  def fkSalesorderheader: ForeignKey[SalesorderheaderFields, SalesorderheaderRow] =
+    ForeignKey[SalesorderheaderFields, SalesorderheaderRow]("sales.FK_SalesOrderDetail_SalesOrderHeader_SalesOrderID", Nil)
+      .withColumnPair(salesorderid, _.salesorderid)
+  def fkSpecialofferproduct: ForeignKey[SpecialofferproductFields, SpecialofferproductRow] =
+    ForeignKey[SpecialofferproductFields, SpecialofferproductRow]("sales.FK_SalesOrderDetail_SpecialOfferProduct_SpecialOfferIDProductID", Nil)
+      .withColumnPair(specialofferid, _.specialofferid)
+      .withColumnPair(productid, _.productid)
 }
 
 object SalesorderdetailFields {

--- a/typo-tester-doobie/generated-and-checked-in/adventureworks/sales/salesorderheader/SalesorderheaderFields.scala
+++ b/typo-tester-doobie/generated-and-checked-in/adventureworks/sales/salesorderheader/SalesorderheaderFields.scala
@@ -10,16 +10,31 @@ package salesorderheader
 import adventureworks.customtypes.TypoLocalDateTime
 import adventureworks.customtypes.TypoShort
 import adventureworks.customtypes.TypoUUID
+import adventureworks.person.address.AddressFields
 import adventureworks.person.address.AddressId
+import adventureworks.person.address.AddressRow
 import adventureworks.person.businessentity.BusinessentityId
 import adventureworks.public.AccountNumber
 import adventureworks.public.Flag
 import adventureworks.public.OrderNumber
+import adventureworks.purchasing.shipmethod.ShipmethodFields
 import adventureworks.purchasing.shipmethod.ShipmethodId
+import adventureworks.purchasing.shipmethod.ShipmethodRow
+import adventureworks.sales.creditcard.CreditcardFields
+import adventureworks.sales.creditcard.CreditcardRow
+import adventureworks.sales.currencyrate.CurrencyrateFields
 import adventureworks.sales.currencyrate.CurrencyrateId
+import adventureworks.sales.currencyrate.CurrencyrateRow
+import adventureworks.sales.customer.CustomerFields
 import adventureworks.sales.customer.CustomerId
+import adventureworks.sales.customer.CustomerRow
+import adventureworks.sales.salesperson.SalespersonFields
+import adventureworks.sales.salesperson.SalespersonRow
+import adventureworks.sales.salesterritory.SalesterritoryFields
 import adventureworks.sales.salesterritory.SalesterritoryId
+import adventureworks.sales.salesterritory.SalesterritoryRow
 import adventureworks.userdefined.CustomCreditcardId
+import typo.dsl.ForeignKey
 import typo.dsl.Path
 import typo.dsl.SqlExpr.Field
 import typo.dsl.SqlExpr.FieldLikeNoHkt
@@ -53,6 +68,30 @@ trait SalesorderheaderFields {
   def comment: OptField[/* max 128 chars */ String, SalesorderheaderRow]
   def rowguid: Field[TypoUUID, SalesorderheaderRow]
   def modifieddate: Field[TypoLocalDateTime, SalesorderheaderRow]
+  def fkPersonAddressBilltoaddressid: ForeignKey[AddressFields, AddressRow] =
+    ForeignKey[AddressFields, AddressRow]("sales.FK_SalesOrderHeader_Address_BillToAddressID", Nil)
+      .withColumnPair(billtoaddressid, _.addressid)
+  def fkPersonAddressShiptoaddressid: ForeignKey[AddressFields, AddressRow] =
+    ForeignKey[AddressFields, AddressRow]("sales.FK_SalesOrderHeader_Address_ShipToAddressID", Nil)
+      .withColumnPair(shiptoaddressid, _.addressid)
+  def fkCreditcard: ForeignKey[CreditcardFields, CreditcardRow] =
+    ForeignKey[CreditcardFields, CreditcardRow]("sales.FK_SalesOrderHeader_CreditCard_CreditCardID", Nil)
+      .withColumnPair(creditcardid, _.creditcardid)
+  def fkCurrencyrate: ForeignKey[CurrencyrateFields, CurrencyrateRow] =
+    ForeignKey[CurrencyrateFields, CurrencyrateRow]("sales.FK_SalesOrderHeader_CurrencyRate_CurrencyRateID", Nil)
+      .withColumnPair(currencyrateid, _.currencyrateid)
+  def fkCustomer: ForeignKey[CustomerFields, CustomerRow] =
+    ForeignKey[CustomerFields, CustomerRow]("sales.FK_SalesOrderHeader_Customer_CustomerID", Nil)
+      .withColumnPair(customerid, _.customerid)
+  def fkSalesperson: ForeignKey[SalespersonFields, SalespersonRow] =
+    ForeignKey[SalespersonFields, SalespersonRow]("sales.FK_SalesOrderHeader_SalesPerson_SalesPersonID", Nil)
+      .withColumnPair(salespersonid, _.businessentityid)
+  def fkPurchasingShipmethod: ForeignKey[ShipmethodFields, ShipmethodRow] =
+    ForeignKey[ShipmethodFields, ShipmethodRow]("sales.FK_SalesOrderHeader_ShipMethod_ShipMethodID", Nil)
+      .withColumnPair(shipmethodid, _.shipmethodid)
+  def fkSalesterritory: ForeignKey[SalesterritoryFields, SalesterritoryRow] =
+    ForeignKey[SalesterritoryFields, SalesterritoryRow]("sales.FK_SalesOrderHeader_SalesTerritory_TerritoryID", Nil)
+      .withColumnPair(territoryid, _.territoryid)
 }
 
 object SalesorderheaderFields {

--- a/typo-tester-doobie/generated-and-checked-in/adventureworks/sales/salesorderheadersalesreason/SalesorderheadersalesreasonFields.scala
+++ b/typo-tester-doobie/generated-and-checked-in/adventureworks/sales/salesorderheadersalesreason/SalesorderheadersalesreasonFields.scala
@@ -8,8 +8,13 @@ package sales
 package salesorderheadersalesreason
 
 import adventureworks.customtypes.TypoLocalDateTime
+import adventureworks.sales.salesorderheader.SalesorderheaderFields
 import adventureworks.sales.salesorderheader.SalesorderheaderId
+import adventureworks.sales.salesorderheader.SalesorderheaderRow
+import adventureworks.sales.salesreason.SalesreasonFields
 import adventureworks.sales.salesreason.SalesreasonId
+import adventureworks.sales.salesreason.SalesreasonRow
+import typo.dsl.ForeignKey
 import typo.dsl.Path
 import typo.dsl.SqlExpr.Field
 import typo.dsl.SqlExpr.FieldLikeNoHkt
@@ -20,6 +25,12 @@ trait SalesorderheadersalesreasonFields {
   def salesorderid: IdField[SalesorderheaderId, SalesorderheadersalesreasonRow]
   def salesreasonid: IdField[SalesreasonId, SalesorderheadersalesreasonRow]
   def modifieddate: Field[TypoLocalDateTime, SalesorderheadersalesreasonRow]
+  def fkSalesreason: ForeignKey[SalesreasonFields, SalesreasonRow] =
+    ForeignKey[SalesreasonFields, SalesreasonRow]("sales.FK_SalesOrderHeaderSalesReason_SalesReason_SalesReasonID", Nil)
+      .withColumnPair(salesreasonid, _.salesreasonid)
+  def fkSalesorderheader: ForeignKey[SalesorderheaderFields, SalesorderheaderRow] =
+    ForeignKey[SalesorderheaderFields, SalesorderheaderRow]("sales.FK_SalesOrderHeaderSalesReason_SalesOrderHeader_SalesOrderID", Nil)
+      .withColumnPair(salesorderid, _.salesorderid)
 }
 
 object SalesorderheadersalesreasonFields {

--- a/typo-tester-doobie/generated-and-checked-in/adventureworks/sales/salesperson/SalespersonFields.scala
+++ b/typo-tester-doobie/generated-and-checked-in/adventureworks/sales/salesperson/SalespersonFields.scala
@@ -9,8 +9,13 @@ package salesperson
 
 import adventureworks.customtypes.TypoLocalDateTime
 import adventureworks.customtypes.TypoUUID
+import adventureworks.humanresources.employee.EmployeeFields
+import adventureworks.humanresources.employee.EmployeeRow
 import adventureworks.person.businessentity.BusinessentityId
+import adventureworks.sales.salesterritory.SalesterritoryFields
 import adventureworks.sales.salesterritory.SalesterritoryId
+import adventureworks.sales.salesterritory.SalesterritoryRow
+import typo.dsl.ForeignKey
 import typo.dsl.Path
 import typo.dsl.SqlExpr.Field
 import typo.dsl.SqlExpr.FieldLikeNoHkt
@@ -28,6 +33,12 @@ trait SalespersonFields {
   def saleslastyear: Field[BigDecimal, SalespersonRow]
   def rowguid: Field[TypoUUID, SalespersonRow]
   def modifieddate: Field[TypoLocalDateTime, SalespersonRow]
+  def fkHumanresourcesEmployee: ForeignKey[EmployeeFields, EmployeeRow] =
+    ForeignKey[EmployeeFields, EmployeeRow]("sales.FK_SalesPerson_Employee_BusinessEntityID", Nil)
+      .withColumnPair(businessentityid, _.businessentityid)
+  def fkSalesterritory: ForeignKey[SalesterritoryFields, SalesterritoryRow] =
+    ForeignKey[SalesterritoryFields, SalesterritoryRow]("sales.FK_SalesPerson_SalesTerritory_TerritoryID", Nil)
+      .withColumnPair(territoryid, _.territoryid)
 }
 
 object SalespersonFields {

--- a/typo-tester-doobie/generated-and-checked-in/adventureworks/sales/salespersonquotahistory/SalespersonquotahistoryFields.scala
+++ b/typo-tester-doobie/generated-and-checked-in/adventureworks/sales/salespersonquotahistory/SalespersonquotahistoryFields.scala
@@ -10,6 +10,9 @@ package salespersonquotahistory
 import adventureworks.customtypes.TypoLocalDateTime
 import adventureworks.customtypes.TypoUUID
 import adventureworks.person.businessentity.BusinessentityId
+import adventureworks.sales.salesperson.SalespersonFields
+import adventureworks.sales.salesperson.SalespersonRow
+import typo.dsl.ForeignKey
 import typo.dsl.Path
 import typo.dsl.SqlExpr.Field
 import typo.dsl.SqlExpr.FieldLikeNoHkt
@@ -22,6 +25,9 @@ trait SalespersonquotahistoryFields {
   def salesquota: Field[BigDecimal, SalespersonquotahistoryRow]
   def rowguid: Field[TypoUUID, SalespersonquotahistoryRow]
   def modifieddate: Field[TypoLocalDateTime, SalespersonquotahistoryRow]
+  def fkSalesperson: ForeignKey[SalespersonFields, SalespersonRow] =
+    ForeignKey[SalespersonFields, SalespersonRow]("sales.FK_SalesPersonQuotaHistory_SalesPerson_BusinessEntityID", Nil)
+      .withColumnPair(businessentityid, _.businessentityid)
 }
 
 object SalespersonquotahistoryFields {

--- a/typo-tester-doobie/generated-and-checked-in/adventureworks/sales/salestaxrate/SalestaxrateFields.scala
+++ b/typo-tester-doobie/generated-and-checked-in/adventureworks/sales/salestaxrate/SalestaxrateFields.scala
@@ -10,8 +10,11 @@ package salestaxrate
 import adventureworks.customtypes.TypoLocalDateTime
 import adventureworks.customtypes.TypoShort
 import adventureworks.customtypes.TypoUUID
+import adventureworks.person.stateprovince.StateprovinceFields
 import adventureworks.person.stateprovince.StateprovinceId
+import adventureworks.person.stateprovince.StateprovinceRow
 import adventureworks.public.Name
+import typo.dsl.ForeignKey
 import typo.dsl.Path
 import typo.dsl.SqlExpr.Field
 import typo.dsl.SqlExpr.FieldLikeNoHkt
@@ -26,6 +29,9 @@ trait SalestaxrateFields {
   def name: Field[Name, SalestaxrateRow]
   def rowguid: Field[TypoUUID, SalestaxrateRow]
   def modifieddate: Field[TypoLocalDateTime, SalestaxrateRow]
+  def fkPersonStateprovince: ForeignKey[StateprovinceFields, StateprovinceRow] =
+    ForeignKey[StateprovinceFields, StateprovinceRow]("sales.FK_SalesTaxRate_StateProvince_StateProvinceID", Nil)
+      .withColumnPair(stateprovinceid, _.stateprovinceid)
 }
 
 object SalestaxrateFields {

--- a/typo-tester-doobie/generated-and-checked-in/adventureworks/sales/salesterritory/SalesterritoryFields.scala
+++ b/typo-tester-doobie/generated-and-checked-in/adventureworks/sales/salesterritory/SalesterritoryFields.scala
@@ -9,8 +9,11 @@ package salesterritory
 
 import adventureworks.customtypes.TypoLocalDateTime
 import adventureworks.customtypes.TypoUUID
+import adventureworks.person.countryregion.CountryregionFields
 import adventureworks.person.countryregion.CountryregionId
+import adventureworks.person.countryregion.CountryregionRow
 import adventureworks.public.Name
+import typo.dsl.ForeignKey
 import typo.dsl.Path
 import typo.dsl.SqlExpr.Field
 import typo.dsl.SqlExpr.FieldLikeNoHkt
@@ -28,6 +31,9 @@ trait SalesterritoryFields {
   def costlastyear: Field[BigDecimal, SalesterritoryRow]
   def rowguid: Field[TypoUUID, SalesterritoryRow]
   def modifieddate: Field[TypoLocalDateTime, SalesterritoryRow]
+  def fkPersonCountryregion: ForeignKey[CountryregionFields, CountryregionRow] =
+    ForeignKey[CountryregionFields, CountryregionRow]("sales.FK_SalesTerritory_CountryRegion_CountryRegionCode", Nil)
+      .withColumnPair(countryregioncode, _.countryregioncode)
 }
 
 object SalesterritoryFields {

--- a/typo-tester-doobie/generated-and-checked-in/adventureworks/sales/salesterritoryhistory/SalesterritoryhistoryFields.scala
+++ b/typo-tester-doobie/generated-and-checked-in/adventureworks/sales/salesterritoryhistory/SalesterritoryhistoryFields.scala
@@ -10,7 +10,12 @@ package salesterritoryhistory
 import adventureworks.customtypes.TypoLocalDateTime
 import adventureworks.customtypes.TypoUUID
 import adventureworks.person.businessentity.BusinessentityId
+import adventureworks.sales.salesperson.SalespersonFields
+import adventureworks.sales.salesperson.SalespersonRow
+import adventureworks.sales.salesterritory.SalesterritoryFields
 import adventureworks.sales.salesterritory.SalesterritoryId
+import adventureworks.sales.salesterritory.SalesterritoryRow
+import typo.dsl.ForeignKey
 import typo.dsl.Path
 import typo.dsl.SqlExpr.Field
 import typo.dsl.SqlExpr.FieldLikeNoHkt
@@ -25,6 +30,12 @@ trait SalesterritoryhistoryFields {
   def enddate: OptField[TypoLocalDateTime, SalesterritoryhistoryRow]
   def rowguid: Field[TypoUUID, SalesterritoryhistoryRow]
   def modifieddate: Field[TypoLocalDateTime, SalesterritoryhistoryRow]
+  def fkSalesperson: ForeignKey[SalespersonFields, SalespersonRow] =
+    ForeignKey[SalespersonFields, SalespersonRow]("sales.FK_SalesTerritoryHistory_SalesPerson_BusinessEntityID", Nil)
+      .withColumnPair(businessentityid, _.businessentityid)
+  def fkSalesterritory: ForeignKey[SalesterritoryFields, SalesterritoryRow] =
+    ForeignKey[SalesterritoryFields, SalesterritoryRow]("sales.FK_SalesTerritoryHistory_SalesTerritory_TerritoryID", Nil)
+      .withColumnPair(territoryid, _.territoryid)
 }
 
 object SalesterritoryhistoryFields {

--- a/typo-tester-doobie/generated-and-checked-in/adventureworks/sales/shoppingcartitem/ShoppingcartitemFields.scala
+++ b/typo-tester-doobie/generated-and-checked-in/adventureworks/sales/shoppingcartitem/ShoppingcartitemFields.scala
@@ -8,7 +8,10 @@ package sales
 package shoppingcartitem
 
 import adventureworks.customtypes.TypoLocalDateTime
+import adventureworks.production.product.ProductFields
 import adventureworks.production.product.ProductId
+import adventureworks.production.product.ProductRow
+import typo.dsl.ForeignKey
 import typo.dsl.Path
 import typo.dsl.SqlExpr.Field
 import typo.dsl.SqlExpr.FieldLikeNoHkt
@@ -22,6 +25,9 @@ trait ShoppingcartitemFields {
   def productid: Field[ProductId, ShoppingcartitemRow]
   def datecreated: Field[TypoLocalDateTime, ShoppingcartitemRow]
   def modifieddate: Field[TypoLocalDateTime, ShoppingcartitemRow]
+  def fkProductionProduct: ForeignKey[ProductFields, ProductRow] =
+    ForeignKey[ProductFields, ProductRow]("sales.FK_ShoppingCartItem_Product_ProductID", Nil)
+      .withColumnPair(productid, _.productid)
 }
 
 object ShoppingcartitemFields {

--- a/typo-tester-doobie/generated-and-checked-in/adventureworks/sales/specialofferproduct/SpecialofferproductFields.scala
+++ b/typo-tester-doobie/generated-and-checked-in/adventureworks/sales/specialofferproduct/SpecialofferproductFields.scala
@@ -9,8 +9,13 @@ package specialofferproduct
 
 import adventureworks.customtypes.TypoLocalDateTime
 import adventureworks.customtypes.TypoUUID
+import adventureworks.production.product.ProductFields
 import adventureworks.production.product.ProductId
+import adventureworks.production.product.ProductRow
+import adventureworks.sales.specialoffer.SpecialofferFields
 import adventureworks.sales.specialoffer.SpecialofferId
+import adventureworks.sales.specialoffer.SpecialofferRow
+import typo.dsl.ForeignKey
 import typo.dsl.Path
 import typo.dsl.SqlExpr.Field
 import typo.dsl.SqlExpr.FieldLikeNoHkt
@@ -22,6 +27,12 @@ trait SpecialofferproductFields {
   def productid: IdField[ProductId, SpecialofferproductRow]
   def rowguid: Field[TypoUUID, SpecialofferproductRow]
   def modifieddate: Field[TypoLocalDateTime, SpecialofferproductRow]
+  def fkProductionProduct: ForeignKey[ProductFields, ProductRow] =
+    ForeignKey[ProductFields, ProductRow]("sales.FK_SpecialOfferProduct_Product_ProductID", Nil)
+      .withColumnPair(productid, _.productid)
+  def fkSpecialoffer: ForeignKey[SpecialofferFields, SpecialofferRow] =
+    ForeignKey[SpecialofferFields, SpecialofferRow]("sales.FK_SpecialOfferProduct_SpecialOffer_SpecialOfferID", Nil)
+      .withColumnPair(specialofferid, _.specialofferid)
 }
 
 object SpecialofferproductFields {

--- a/typo-tester-doobie/generated-and-checked-in/adventureworks/sales/store/StoreFields.scala
+++ b/typo-tester-doobie/generated-and-checked-in/adventureworks/sales/store/StoreFields.scala
@@ -10,8 +10,13 @@ package store
 import adventureworks.customtypes.TypoLocalDateTime
 import adventureworks.customtypes.TypoUUID
 import adventureworks.customtypes.TypoXml
+import adventureworks.person.businessentity.BusinessentityFields
 import adventureworks.person.businessentity.BusinessentityId
+import adventureworks.person.businessentity.BusinessentityRow
 import adventureworks.public.Name
+import adventureworks.sales.salesperson.SalespersonFields
+import adventureworks.sales.salesperson.SalespersonRow
+import typo.dsl.ForeignKey
 import typo.dsl.Path
 import typo.dsl.SqlExpr.Field
 import typo.dsl.SqlExpr.FieldLikeNoHkt
@@ -26,6 +31,12 @@ trait StoreFields {
   def demographics: OptField[TypoXml, StoreRow]
   def rowguid: Field[TypoUUID, StoreRow]
   def modifieddate: Field[TypoLocalDateTime, StoreRow]
+  def fkPersonBusinessentity: ForeignKey[BusinessentityFields, BusinessentityRow] =
+    ForeignKey[BusinessentityFields, BusinessentityRow]("sales.FK_Store_BusinessEntity_BusinessEntityID", Nil)
+      .withColumnPair(businessentityid, _.businessentityid)
+  def fkSalesperson: ForeignKey[SalespersonFields, SalespersonRow] =
+    ForeignKey[SalespersonFields, SalespersonRow]("sales.FK_Store_SalesPerson_SalesPersonID", Nil)
+      .withColumnPair(salespersonid, _.businessentityid)
 }
 
 object StoreFields {

--- a/typo-tester-doobie/src/scala/adventureworks/production/product/ProductTest.scala
+++ b/typo-tester-doobie/src/scala/adventureworks/production/product/ProductTest.scala
@@ -90,6 +90,13 @@ class ProductTest extends AnyFunSuite with TypeCheckedTripleEquals {
         }
         _ <- delay(assert(saved3.modifieddate == newModifiedDate))
         _ <- productRepo.update(saved3.copy(size = None)).map(res => assert(res))
+        query0 = productRepo.select
+          .joinFk(_.fkProductmodel)(projectModelRepo.select)
+          .joinFk(_._1.fkProductsubcategory)(productsubcategoryRepo.select)
+          .joinFk(_._2.fkProductcategory)(productcategoryRepo.select)
+        _ <- query0.toList.map(println(_))
+        _ <- delay(query0.sql.foreach(f => println(f)))
+        _ <- delay(println("foo"))
 
         query = productRepo.select
           .where(_.`class` === "H ")

--- a/typo-tester-zio-jdbc/generated-and-checked-in/adventureworks/humanresources/employee/EmployeeFields.scala
+++ b/typo-tester-zio-jdbc/generated-and-checked-in/adventureworks/humanresources/employee/EmployeeFields.scala
@@ -12,7 +12,10 @@ import adventureworks.customtypes.TypoLocalDateTime
 import adventureworks.customtypes.TypoShort
 import adventureworks.customtypes.TypoUUID
 import adventureworks.person.businessentity.BusinessentityId
+import adventureworks.person.person.PersonFields
+import adventureworks.person.person.PersonRow
 import adventureworks.public.Flag
+import typo.dsl.ForeignKey
 import typo.dsl.Path
 import typo.dsl.SqlExpr.Field
 import typo.dsl.SqlExpr.FieldLikeNoHkt
@@ -36,6 +39,9 @@ trait EmployeeFields {
   def rowguid: Field[TypoUUID, EmployeeRow]
   def modifieddate: Field[TypoLocalDateTime, EmployeeRow]
   def organizationnode: OptField[String, EmployeeRow]
+  def fkPersonPerson: ForeignKey[PersonFields, PersonRow] =
+    ForeignKey[PersonFields, PersonRow]("humanresources.FK_Employee_Person_BusinessEntityID", Nil)
+      .withColumnPair(businessentityid, _.businessentityid)
 }
 
 object EmployeeFields {

--- a/typo-tester-zio-jdbc/generated-and-checked-in/adventureworks/humanresources/employeedepartmenthistory/EmployeedepartmenthistoryFields.scala
+++ b/typo-tester-zio-jdbc/generated-and-checked-in/adventureworks/humanresources/employeedepartmenthistory/EmployeedepartmenthistoryFields.scala
@@ -9,9 +9,16 @@ package employeedepartmenthistory
 
 import adventureworks.customtypes.TypoLocalDate
 import adventureworks.customtypes.TypoLocalDateTime
+import adventureworks.humanresources.department.DepartmentFields
 import adventureworks.humanresources.department.DepartmentId
+import adventureworks.humanresources.department.DepartmentRow
+import adventureworks.humanresources.employee.EmployeeFields
+import adventureworks.humanresources.employee.EmployeeRow
+import adventureworks.humanresources.shift.ShiftFields
 import adventureworks.humanresources.shift.ShiftId
+import adventureworks.humanresources.shift.ShiftRow
 import adventureworks.person.businessentity.BusinessentityId
+import typo.dsl.ForeignKey
 import typo.dsl.Path
 import typo.dsl.SqlExpr.Field
 import typo.dsl.SqlExpr.FieldLikeNoHkt
@@ -26,6 +33,15 @@ trait EmployeedepartmenthistoryFields {
   def startdate: IdField[TypoLocalDate, EmployeedepartmenthistoryRow]
   def enddate: OptField[TypoLocalDate, EmployeedepartmenthistoryRow]
   def modifieddate: Field[TypoLocalDateTime, EmployeedepartmenthistoryRow]
+  def fkDepartment: ForeignKey[DepartmentFields, DepartmentRow] =
+    ForeignKey[DepartmentFields, DepartmentRow]("humanresources.FK_EmployeeDepartmentHistory_Department_DepartmentID", Nil)
+      .withColumnPair(departmentid, _.departmentid)
+  def fkEmployee: ForeignKey[EmployeeFields, EmployeeRow] =
+    ForeignKey[EmployeeFields, EmployeeRow]("humanresources.FK_EmployeeDepartmentHistory_Employee_BusinessEntityID", Nil)
+      .withColumnPair(businessentityid, _.businessentityid)
+  def fkShift: ForeignKey[ShiftFields, ShiftRow] =
+    ForeignKey[ShiftFields, ShiftRow]("humanresources.FK_EmployeeDepartmentHistory_Shift_ShiftID", Nil)
+      .withColumnPair(shiftid, _.shiftid)
 }
 
 object EmployeedepartmenthistoryFields {

--- a/typo-tester-zio-jdbc/generated-and-checked-in/adventureworks/humanresources/employeepayhistory/EmployeepayhistoryFields.scala
+++ b/typo-tester-zio-jdbc/generated-and-checked-in/adventureworks/humanresources/employeepayhistory/EmployeepayhistoryFields.scala
@@ -9,7 +9,10 @@ package employeepayhistory
 
 import adventureworks.customtypes.TypoLocalDateTime
 import adventureworks.customtypes.TypoShort
+import adventureworks.humanresources.employee.EmployeeFields
+import adventureworks.humanresources.employee.EmployeeRow
 import adventureworks.person.businessentity.BusinessentityId
+import typo.dsl.ForeignKey
 import typo.dsl.Path
 import typo.dsl.SqlExpr.Field
 import typo.dsl.SqlExpr.FieldLikeNoHkt
@@ -22,6 +25,9 @@ trait EmployeepayhistoryFields {
   def rate: Field[BigDecimal, EmployeepayhistoryRow]
   def payfrequency: Field[TypoShort, EmployeepayhistoryRow]
   def modifieddate: Field[TypoLocalDateTime, EmployeepayhistoryRow]
+  def fkEmployee: ForeignKey[EmployeeFields, EmployeeRow] =
+    ForeignKey[EmployeeFields, EmployeeRow]("humanresources.FK_EmployeePayHistory_Employee_BusinessEntityID", Nil)
+      .withColumnPair(businessentityid, _.businessentityid)
 }
 
 object EmployeepayhistoryFields {

--- a/typo-tester-zio-jdbc/generated-and-checked-in/adventureworks/humanresources/jobcandidate/JobcandidateFields.scala
+++ b/typo-tester-zio-jdbc/generated-and-checked-in/adventureworks/humanresources/jobcandidate/JobcandidateFields.scala
@@ -9,7 +9,10 @@ package jobcandidate
 
 import adventureworks.customtypes.TypoLocalDateTime
 import adventureworks.customtypes.TypoXml
+import adventureworks.humanresources.employee.EmployeeFields
+import adventureworks.humanresources.employee.EmployeeRow
 import adventureworks.person.businessentity.BusinessentityId
+import typo.dsl.ForeignKey
 import typo.dsl.Path
 import typo.dsl.SqlExpr.Field
 import typo.dsl.SqlExpr.FieldLikeNoHkt
@@ -22,6 +25,9 @@ trait JobcandidateFields {
   def businessentityid: OptField[BusinessentityId, JobcandidateRow]
   def resume: OptField[TypoXml, JobcandidateRow]
   def modifieddate: Field[TypoLocalDateTime, JobcandidateRow]
+  def fkEmployee: ForeignKey[EmployeeFields, EmployeeRow] =
+    ForeignKey[EmployeeFields, EmployeeRow]("humanresources.FK_JobCandidate_Employee_BusinessEntityID", Nil)
+      .withColumnPair(businessentityid, _.businessentityid)
 }
 
 object JobcandidateFields {

--- a/typo-tester-zio-jdbc/generated-and-checked-in/adventureworks/person/address/AddressFields.scala
+++ b/typo-tester-zio-jdbc/generated-and-checked-in/adventureworks/person/address/AddressFields.scala
@@ -10,7 +10,10 @@ package address
 import adventureworks.customtypes.TypoBytea
 import adventureworks.customtypes.TypoLocalDateTime
 import adventureworks.customtypes.TypoUUID
+import adventureworks.person.stateprovince.StateprovinceFields
 import adventureworks.person.stateprovince.StateprovinceId
+import adventureworks.person.stateprovince.StateprovinceRow
+import typo.dsl.ForeignKey
 import typo.dsl.Path
 import typo.dsl.SqlExpr.Field
 import typo.dsl.SqlExpr.FieldLikeNoHkt
@@ -28,6 +31,9 @@ trait AddressFields {
   def spatiallocation: OptField[TypoBytea, AddressRow]
   def rowguid: Field[TypoUUID, AddressRow]
   def modifieddate: Field[TypoLocalDateTime, AddressRow]
+  def fkStateprovince: ForeignKey[StateprovinceFields, StateprovinceRow] =
+    ForeignKey[StateprovinceFields, StateprovinceRow]("person.FK_Address_StateProvince_StateProvinceID", Nil)
+      .withColumnPair(stateprovinceid, _.stateprovinceid)
 }
 
 object AddressFields {

--- a/typo-tester-zio-jdbc/generated-and-checked-in/adventureworks/person/businessentityaddress/BusinessentityaddressFields.scala
+++ b/typo-tester-zio-jdbc/generated-and-checked-in/adventureworks/person/businessentityaddress/BusinessentityaddressFields.scala
@@ -9,9 +9,16 @@ package businessentityaddress
 
 import adventureworks.customtypes.TypoLocalDateTime
 import adventureworks.customtypes.TypoUUID
+import adventureworks.person.address.AddressFields
 import adventureworks.person.address.AddressId
+import adventureworks.person.address.AddressRow
+import adventureworks.person.addresstype.AddresstypeFields
 import adventureworks.person.addresstype.AddresstypeId
+import adventureworks.person.addresstype.AddresstypeRow
+import adventureworks.person.businessentity.BusinessentityFields
 import adventureworks.person.businessentity.BusinessentityId
+import adventureworks.person.businessentity.BusinessentityRow
+import typo.dsl.ForeignKey
 import typo.dsl.Path
 import typo.dsl.SqlExpr.Field
 import typo.dsl.SqlExpr.FieldLikeNoHkt
@@ -24,6 +31,15 @@ trait BusinessentityaddressFields {
   def addresstypeid: IdField[AddresstypeId, BusinessentityaddressRow]
   def rowguid: Field[TypoUUID, BusinessentityaddressRow]
   def modifieddate: Field[TypoLocalDateTime, BusinessentityaddressRow]
+  def fkAddress: ForeignKey[AddressFields, AddressRow] =
+    ForeignKey[AddressFields, AddressRow]("person.FK_BusinessEntityAddress_Address_AddressID", Nil)
+      .withColumnPair(addressid, _.addressid)
+  def fkAddresstype: ForeignKey[AddresstypeFields, AddresstypeRow] =
+    ForeignKey[AddresstypeFields, AddresstypeRow]("person.FK_BusinessEntityAddress_AddressType_AddressTypeID", Nil)
+      .withColumnPair(addresstypeid, _.addresstypeid)
+  def fkBusinessentity: ForeignKey[BusinessentityFields, BusinessentityRow] =
+    ForeignKey[BusinessentityFields, BusinessentityRow]("person.FK_BusinessEntityAddress_BusinessEntity_BusinessEntityID", Nil)
+      .withColumnPair(businessentityid, _.businessentityid)
 }
 
 object BusinessentityaddressFields {

--- a/typo-tester-zio-jdbc/generated-and-checked-in/adventureworks/person/businessentitycontact/BusinessentitycontactFields.scala
+++ b/typo-tester-zio-jdbc/generated-and-checked-in/adventureworks/person/businessentitycontact/BusinessentitycontactFields.scala
@@ -9,8 +9,15 @@ package businessentitycontact
 
 import adventureworks.customtypes.TypoLocalDateTime
 import adventureworks.customtypes.TypoUUID
+import adventureworks.person.businessentity.BusinessentityFields
 import adventureworks.person.businessentity.BusinessentityId
+import adventureworks.person.businessentity.BusinessentityRow
+import adventureworks.person.contacttype.ContacttypeFields
 import adventureworks.person.contacttype.ContacttypeId
+import adventureworks.person.contacttype.ContacttypeRow
+import adventureworks.person.person.PersonFields
+import adventureworks.person.person.PersonRow
+import typo.dsl.ForeignKey
 import typo.dsl.Path
 import typo.dsl.SqlExpr.Field
 import typo.dsl.SqlExpr.FieldLikeNoHkt
@@ -23,6 +30,15 @@ trait BusinessentitycontactFields {
   def contacttypeid: IdField[ContacttypeId, BusinessentitycontactRow]
   def rowguid: Field[TypoUUID, BusinessentitycontactRow]
   def modifieddate: Field[TypoLocalDateTime, BusinessentitycontactRow]
+  def fkPerson: ForeignKey[PersonFields, PersonRow] =
+    ForeignKey[PersonFields, PersonRow]("person.FK_BusinessEntityContact_Person_PersonID", Nil)
+      .withColumnPair(personid, _.businessentityid)
+  def fkContacttype: ForeignKey[ContacttypeFields, ContacttypeRow] =
+    ForeignKey[ContacttypeFields, ContacttypeRow]("person.FK_BusinessEntityContact_ContactType_ContactTypeID", Nil)
+      .withColumnPair(contacttypeid, _.contacttypeid)
+  def fkBusinessentity: ForeignKey[BusinessentityFields, BusinessentityRow] =
+    ForeignKey[BusinessentityFields, BusinessentityRow]("person.FK_BusinessEntityContact_BusinessEntity_BusinessEntityID", Nil)
+      .withColumnPair(businessentityid, _.businessentityid)
 }
 
 object BusinessentitycontactFields {

--- a/typo-tester-zio-jdbc/generated-and-checked-in/adventureworks/person/emailaddress/EmailaddressFields.scala
+++ b/typo-tester-zio-jdbc/generated-and-checked-in/adventureworks/person/emailaddress/EmailaddressFields.scala
@@ -10,6 +10,9 @@ package emailaddress
 import adventureworks.customtypes.TypoLocalDateTime
 import adventureworks.customtypes.TypoUUID
 import adventureworks.person.businessentity.BusinessentityId
+import adventureworks.person.person.PersonFields
+import adventureworks.person.person.PersonRow
+import typo.dsl.ForeignKey
 import typo.dsl.Path
 import typo.dsl.SqlExpr.Field
 import typo.dsl.SqlExpr.FieldLikeNoHkt
@@ -23,6 +26,9 @@ trait EmailaddressFields {
   def emailaddress: OptField[/* max 50 chars */ String, EmailaddressRow]
   def rowguid: Field[TypoUUID, EmailaddressRow]
   def modifieddate: Field[TypoLocalDateTime, EmailaddressRow]
+  def fkPerson: ForeignKey[PersonFields, PersonRow] =
+    ForeignKey[PersonFields, PersonRow]("person.FK_EmailAddress_Person_BusinessEntityID", Nil)
+      .withColumnPair(businessentityid, _.businessentityid)
 }
 
 object EmailaddressFields {

--- a/typo-tester-zio-jdbc/generated-and-checked-in/adventureworks/person/password/PasswordFields.scala
+++ b/typo-tester-zio-jdbc/generated-and-checked-in/adventureworks/person/password/PasswordFields.scala
@@ -10,6 +10,9 @@ package password
 import adventureworks.customtypes.TypoLocalDateTime
 import adventureworks.customtypes.TypoUUID
 import adventureworks.person.businessentity.BusinessentityId
+import adventureworks.person.person.PersonFields
+import adventureworks.person.person.PersonRow
+import typo.dsl.ForeignKey
 import typo.dsl.Path
 import typo.dsl.SqlExpr.Field
 import typo.dsl.SqlExpr.FieldLikeNoHkt
@@ -22,6 +25,9 @@ trait PasswordFields {
   def passwordsalt: Field[/* max 10 chars */ String, PasswordRow]
   def rowguid: Field[TypoUUID, PasswordRow]
   def modifieddate: Field[TypoLocalDateTime, PasswordRow]
+  def fkPerson: ForeignKey[PersonFields, PersonRow] =
+    ForeignKey[PersonFields, PersonRow]("person.FK_Password_Person_BusinessEntityID", Nil)
+      .withColumnPair(businessentityid, _.businessentityid)
 }
 
 object PasswordFields {

--- a/typo-tester-zio-jdbc/generated-and-checked-in/adventureworks/person/person/PersonFields.scala
+++ b/typo-tester-zio-jdbc/generated-and-checked-in/adventureworks/person/person/PersonFields.scala
@@ -10,10 +10,13 @@ package person
 import adventureworks.customtypes.TypoLocalDateTime
 import adventureworks.customtypes.TypoUUID
 import adventureworks.customtypes.TypoXml
+import adventureworks.person.businessentity.BusinessentityFields
 import adventureworks.person.businessentity.BusinessentityId
+import adventureworks.person.businessentity.BusinessentityRow
 import adventureworks.public.Name
 import adventureworks.public.NameStyle
 import adventureworks.userdefined.FirstName
+import typo.dsl.ForeignKey
 import typo.dsl.Path
 import typo.dsl.SqlExpr.Field
 import typo.dsl.SqlExpr.FieldLikeNoHkt
@@ -35,6 +38,9 @@ trait PersonFields {
   def demographics: OptField[TypoXml, PersonRow]
   def rowguid: Field[TypoUUID, PersonRow]
   def modifieddate: Field[TypoLocalDateTime, PersonRow]
+  def fkBusinessentity: ForeignKey[BusinessentityFields, BusinessentityRow] =
+    ForeignKey[BusinessentityFields, BusinessentityRow]("person.FK_Person_BusinessEntity_BusinessEntityID", Nil)
+      .withColumnPair(businessentityid, _.businessentityid)
 }
 
 object PersonFields {

--- a/typo-tester-zio-jdbc/generated-and-checked-in/adventureworks/person/personphone/PersonphoneFields.scala
+++ b/typo-tester-zio-jdbc/generated-and-checked-in/adventureworks/person/personphone/PersonphoneFields.scala
@@ -9,8 +9,13 @@ package personphone
 
 import adventureworks.customtypes.TypoLocalDateTime
 import adventureworks.person.businessentity.BusinessentityId
+import adventureworks.person.person.PersonFields
+import adventureworks.person.person.PersonRow
+import adventureworks.person.phonenumbertype.PhonenumbertypeFields
 import adventureworks.person.phonenumbertype.PhonenumbertypeId
+import adventureworks.person.phonenumbertype.PhonenumbertypeRow
 import adventureworks.public.Phone
+import typo.dsl.ForeignKey
 import typo.dsl.Path
 import typo.dsl.SqlExpr.Field
 import typo.dsl.SqlExpr.FieldLikeNoHkt
@@ -22,6 +27,12 @@ trait PersonphoneFields {
   def phonenumber: IdField[Phone, PersonphoneRow]
   def phonenumbertypeid: IdField[PhonenumbertypeId, PersonphoneRow]
   def modifieddate: Field[TypoLocalDateTime, PersonphoneRow]
+  def fkPerson: ForeignKey[PersonFields, PersonRow] =
+    ForeignKey[PersonFields, PersonRow]("person.FK_PersonPhone_Person_BusinessEntityID", Nil)
+      .withColumnPair(businessentityid, _.businessentityid)
+  def fkPhonenumbertype: ForeignKey[PhonenumbertypeFields, PhonenumbertypeRow] =
+    ForeignKey[PhonenumbertypeFields, PhonenumbertypeRow]("person.FK_PersonPhone_PhoneNumberType_PhoneNumberTypeID", Nil)
+      .withColumnPair(phonenumbertypeid, _.phonenumbertypeid)
 }
 
 object PersonphoneFields {

--- a/typo-tester-zio-jdbc/generated-and-checked-in/adventureworks/person/stateprovince/StateprovinceFields.scala
+++ b/typo-tester-zio-jdbc/generated-and-checked-in/adventureworks/person/stateprovince/StateprovinceFields.scala
@@ -9,10 +9,15 @@ package stateprovince
 
 import adventureworks.customtypes.TypoLocalDateTime
 import adventureworks.customtypes.TypoUUID
+import adventureworks.person.countryregion.CountryregionFields
 import adventureworks.person.countryregion.CountryregionId
+import adventureworks.person.countryregion.CountryregionRow
 import adventureworks.public.Flag
 import adventureworks.public.Name
+import adventureworks.sales.salesterritory.SalesterritoryFields
 import adventureworks.sales.salesterritory.SalesterritoryId
+import adventureworks.sales.salesterritory.SalesterritoryRow
+import typo.dsl.ForeignKey
 import typo.dsl.Path
 import typo.dsl.SqlExpr.Field
 import typo.dsl.SqlExpr.FieldLikeNoHkt
@@ -28,6 +33,12 @@ trait StateprovinceFields {
   def territoryid: Field[SalesterritoryId, StateprovinceRow]
   def rowguid: Field[TypoUUID, StateprovinceRow]
   def modifieddate: Field[TypoLocalDateTime, StateprovinceRow]
+  def fkCountryregion: ForeignKey[CountryregionFields, CountryregionRow] =
+    ForeignKey[CountryregionFields, CountryregionRow]("person.FK_StateProvince_CountryRegion_CountryRegionCode", Nil)
+      .withColumnPair(countryregioncode, _.countryregioncode)
+  def fkSalesSalesterritory: ForeignKey[SalesterritoryFields, SalesterritoryRow] =
+    ForeignKey[SalesterritoryFields, SalesterritoryRow]("person.FK_StateProvince_SalesTerritory_TerritoryID", Nil)
+      .withColumnPair(territoryid, _.territoryid)
 }
 
 object StateprovinceFields {

--- a/typo-tester-zio-jdbc/generated-and-checked-in/adventureworks/production/billofmaterials/BillofmaterialsFields.scala
+++ b/typo-tester-zio-jdbc/generated-and-checked-in/adventureworks/production/billofmaterials/BillofmaterialsFields.scala
@@ -9,8 +9,13 @@ package billofmaterials
 
 import adventureworks.customtypes.TypoLocalDateTime
 import adventureworks.customtypes.TypoShort
+import adventureworks.production.product.ProductFields
 import adventureworks.production.product.ProductId
+import adventureworks.production.product.ProductRow
+import adventureworks.production.unitmeasure.UnitmeasureFields
 import adventureworks.production.unitmeasure.UnitmeasureId
+import adventureworks.production.unitmeasure.UnitmeasureRow
+import typo.dsl.ForeignKey
 import typo.dsl.Path
 import typo.dsl.SqlExpr.Field
 import typo.dsl.SqlExpr.FieldLikeNoHkt
@@ -28,6 +33,15 @@ trait BillofmaterialsFields {
   def bomlevel: Field[TypoShort, BillofmaterialsRow]
   def perassemblyqty: Field[BigDecimal, BillofmaterialsRow]
   def modifieddate: Field[TypoLocalDateTime, BillofmaterialsRow]
+  def fkProductProductassemblyid: ForeignKey[ProductFields, ProductRow] =
+    ForeignKey[ProductFields, ProductRow]("production.FK_BillOfMaterials_Product_ProductAssemblyID", Nil)
+      .withColumnPair(productassemblyid, _.productid)
+  def fkProductComponentid: ForeignKey[ProductFields, ProductRow] =
+    ForeignKey[ProductFields, ProductRow]("production.FK_BillOfMaterials_Product_ComponentID", Nil)
+      .withColumnPair(componentid, _.productid)
+  def fkUnitmeasure: ForeignKey[UnitmeasureFields, UnitmeasureRow] =
+    ForeignKey[UnitmeasureFields, UnitmeasureRow]("production.FK_BillOfMaterials_UnitMeasure_UnitMeasureCode", Nil)
+      .withColumnPair(unitmeasurecode, _.unitmeasurecode)
 }
 
 object BillofmaterialsFields {

--- a/typo-tester-zio-jdbc/generated-and-checked-in/adventureworks/production/document/DocumentFields.scala
+++ b/typo-tester-zio-jdbc/generated-and-checked-in/adventureworks/production/document/DocumentFields.scala
@@ -11,8 +11,11 @@ import adventureworks.customtypes.TypoBytea
 import adventureworks.customtypes.TypoLocalDateTime
 import adventureworks.customtypes.TypoShort
 import adventureworks.customtypes.TypoUUID
+import adventureworks.humanresources.employee.EmployeeFields
+import adventureworks.humanresources.employee.EmployeeRow
 import adventureworks.person.businessentity.BusinessentityId
 import adventureworks.public.Flag
+import typo.dsl.ForeignKey
 import typo.dsl.Path
 import typo.dsl.SqlExpr.Field
 import typo.dsl.SqlExpr.FieldLikeNoHkt
@@ -34,6 +37,9 @@ trait DocumentFields {
   def rowguid: Field[TypoUUID, DocumentRow]
   def modifieddate: Field[TypoLocalDateTime, DocumentRow]
   def documentnode: IdField[DocumentId, DocumentRow]
+  def fkHumanresourcesEmployee: ForeignKey[EmployeeFields, EmployeeRow] =
+    ForeignKey[EmployeeFields, EmployeeRow]("production.FK_Document_Employee_Owner", Nil)
+      .withColumnPair(owner, _.businessentityid)
 }
 
 object DocumentFields {

--- a/typo-tester-zio-jdbc/generated-and-checked-in/adventureworks/production/product/ProductFields.scala
+++ b/typo-tester-zio-jdbc/generated-and-checked-in/adventureworks/production/product/ProductFields.scala
@@ -10,11 +10,18 @@ package product
 import adventureworks.customtypes.TypoLocalDateTime
 import adventureworks.customtypes.TypoShort
 import adventureworks.customtypes.TypoUUID
+import adventureworks.production.productmodel.ProductmodelFields
 import adventureworks.production.productmodel.ProductmodelId
+import adventureworks.production.productmodel.ProductmodelRow
+import adventureworks.production.productsubcategory.ProductsubcategoryFields
 import adventureworks.production.productsubcategory.ProductsubcategoryId
+import adventureworks.production.productsubcategory.ProductsubcategoryRow
+import adventureworks.production.unitmeasure.UnitmeasureFields
 import adventureworks.production.unitmeasure.UnitmeasureId
+import adventureworks.production.unitmeasure.UnitmeasureRow
 import adventureworks.public.Flag
 import adventureworks.public.Name
+import typo.dsl.ForeignKey
 import typo.dsl.Path
 import typo.dsl.SqlExpr.Field
 import typo.dsl.SqlExpr.FieldLikeNoHkt
@@ -48,6 +55,18 @@ trait ProductFields {
   def discontinueddate: OptField[TypoLocalDateTime, ProductRow]
   def rowguid: Field[TypoUUID, ProductRow]
   def modifieddate: Field[TypoLocalDateTime, ProductRow]
+  def fkUnitmeasureSizeunitmeasurecode: ForeignKey[UnitmeasureFields, UnitmeasureRow] =
+    ForeignKey[UnitmeasureFields, UnitmeasureRow]("production.FK_Product_UnitMeasure_SizeUnitMeasureCode", Nil)
+      .withColumnPair(sizeunitmeasurecode, _.unitmeasurecode)
+  def fkUnitmeasureWeightunitmeasurecode: ForeignKey[UnitmeasureFields, UnitmeasureRow] =
+    ForeignKey[UnitmeasureFields, UnitmeasureRow]("production.FK_Product_UnitMeasure_WeightUnitMeasureCode", Nil)
+      .withColumnPair(weightunitmeasurecode, _.unitmeasurecode)
+  def fkProductmodel: ForeignKey[ProductmodelFields, ProductmodelRow] =
+    ForeignKey[ProductmodelFields, ProductmodelRow]("production.FK_Product_ProductModel_ProductModelID", Nil)
+      .withColumnPair(productmodelid, _.productmodelid)
+  def fkProductsubcategory: ForeignKey[ProductsubcategoryFields, ProductsubcategoryRow] =
+    ForeignKey[ProductsubcategoryFields, ProductsubcategoryRow]("production.FK_Product_ProductSubcategory_ProductSubcategoryID", Nil)
+      .withColumnPair(productsubcategoryid, _.productsubcategoryid)
 }
 
 object ProductFields {

--- a/typo-tester-zio-jdbc/generated-and-checked-in/adventureworks/production/productcosthistory/ProductcosthistoryFields.scala
+++ b/typo-tester-zio-jdbc/generated-and-checked-in/adventureworks/production/productcosthistory/ProductcosthistoryFields.scala
@@ -8,7 +8,10 @@ package production
 package productcosthistory
 
 import adventureworks.customtypes.TypoLocalDateTime
+import adventureworks.production.product.ProductFields
 import adventureworks.production.product.ProductId
+import adventureworks.production.product.ProductRow
+import typo.dsl.ForeignKey
 import typo.dsl.Path
 import typo.dsl.SqlExpr.Field
 import typo.dsl.SqlExpr.FieldLikeNoHkt
@@ -22,6 +25,9 @@ trait ProductcosthistoryFields {
   def enddate: OptField[TypoLocalDateTime, ProductcosthistoryRow]
   def standardcost: Field[BigDecimal, ProductcosthistoryRow]
   def modifieddate: Field[TypoLocalDateTime, ProductcosthistoryRow]
+  def fkProduct: ForeignKey[ProductFields, ProductRow] =
+    ForeignKey[ProductFields, ProductRow]("production.FK_ProductCostHistory_Product_ProductID", Nil)
+      .withColumnPair(productid, _.productid)
 }
 
 object ProductcosthistoryFields {

--- a/typo-tester-zio-jdbc/generated-and-checked-in/adventureworks/production/productdocument/ProductdocumentFields.scala
+++ b/typo-tester-zio-jdbc/generated-and-checked-in/adventureworks/production/productdocument/ProductdocumentFields.scala
@@ -8,8 +8,13 @@ package production
 package productdocument
 
 import adventureworks.customtypes.TypoLocalDateTime
+import adventureworks.production.document.DocumentFields
 import adventureworks.production.document.DocumentId
+import adventureworks.production.document.DocumentRow
+import adventureworks.production.product.ProductFields
 import adventureworks.production.product.ProductId
+import adventureworks.production.product.ProductRow
+import typo.dsl.ForeignKey
 import typo.dsl.Path
 import typo.dsl.SqlExpr.Field
 import typo.dsl.SqlExpr.FieldLikeNoHkt
@@ -20,6 +25,12 @@ trait ProductdocumentFields {
   def productid: IdField[ProductId, ProductdocumentRow]
   def modifieddate: Field[TypoLocalDateTime, ProductdocumentRow]
   def documentnode: IdField[DocumentId, ProductdocumentRow]
+  def fkProduct: ForeignKey[ProductFields, ProductRow] =
+    ForeignKey[ProductFields, ProductRow]("production.FK_ProductDocument_Product_ProductID", Nil)
+      .withColumnPair(productid, _.productid)
+  def fkDocument: ForeignKey[DocumentFields, DocumentRow] =
+    ForeignKey[DocumentFields, DocumentRow]("production.FK_ProductDocument_Document_DocumentNode", Nil)
+      .withColumnPair(documentnode, _.documentnode)
 }
 
 object ProductdocumentFields {

--- a/typo-tester-zio-jdbc/generated-and-checked-in/adventureworks/production/productinventory/ProductinventoryFields.scala
+++ b/typo-tester-zio-jdbc/generated-and-checked-in/adventureworks/production/productinventory/ProductinventoryFields.scala
@@ -10,8 +10,13 @@ package productinventory
 import adventureworks.customtypes.TypoLocalDateTime
 import adventureworks.customtypes.TypoShort
 import adventureworks.customtypes.TypoUUID
+import adventureworks.production.location.LocationFields
 import adventureworks.production.location.LocationId
+import adventureworks.production.location.LocationRow
+import adventureworks.production.product.ProductFields
 import adventureworks.production.product.ProductId
+import adventureworks.production.product.ProductRow
+import typo.dsl.ForeignKey
 import typo.dsl.Path
 import typo.dsl.SqlExpr.Field
 import typo.dsl.SqlExpr.FieldLikeNoHkt
@@ -26,6 +31,12 @@ trait ProductinventoryFields {
   def quantity: Field[TypoShort, ProductinventoryRow]
   def rowguid: Field[TypoUUID, ProductinventoryRow]
   def modifieddate: Field[TypoLocalDateTime, ProductinventoryRow]
+  def fkLocation: ForeignKey[LocationFields, LocationRow] =
+    ForeignKey[LocationFields, LocationRow]("production.FK_ProductInventory_Location_LocationID", Nil)
+      .withColumnPair(locationid, _.locationid)
+  def fkProduct: ForeignKey[ProductFields, ProductRow] =
+    ForeignKey[ProductFields, ProductRow]("production.FK_ProductInventory_Product_ProductID", Nil)
+      .withColumnPair(productid, _.productid)
 }
 
 object ProductinventoryFields {

--- a/typo-tester-zio-jdbc/generated-and-checked-in/adventureworks/production/productlistpricehistory/ProductlistpricehistoryFields.scala
+++ b/typo-tester-zio-jdbc/generated-and-checked-in/adventureworks/production/productlistpricehistory/ProductlistpricehistoryFields.scala
@@ -8,7 +8,10 @@ package production
 package productlistpricehistory
 
 import adventureworks.customtypes.TypoLocalDateTime
+import adventureworks.production.product.ProductFields
 import adventureworks.production.product.ProductId
+import adventureworks.production.product.ProductRow
+import typo.dsl.ForeignKey
 import typo.dsl.Path
 import typo.dsl.SqlExpr.Field
 import typo.dsl.SqlExpr.FieldLikeNoHkt
@@ -22,6 +25,9 @@ trait ProductlistpricehistoryFields {
   def enddate: OptField[TypoLocalDateTime, ProductlistpricehistoryRow]
   def listprice: Field[BigDecimal, ProductlistpricehistoryRow]
   def modifieddate: Field[TypoLocalDateTime, ProductlistpricehistoryRow]
+  def fkProduct: ForeignKey[ProductFields, ProductRow] =
+    ForeignKey[ProductFields, ProductRow]("production.FK_ProductListPriceHistory_Product_ProductID", Nil)
+      .withColumnPair(productid, _.productid)
 }
 
 object ProductlistpricehistoryFields {

--- a/typo-tester-zio-jdbc/generated-and-checked-in/adventureworks/production/productmodelillustration/ProductmodelillustrationFields.scala
+++ b/typo-tester-zio-jdbc/generated-and-checked-in/adventureworks/production/productmodelillustration/ProductmodelillustrationFields.scala
@@ -8,8 +8,13 @@ package production
 package productmodelillustration
 
 import adventureworks.customtypes.TypoLocalDateTime
+import adventureworks.production.illustration.IllustrationFields
 import adventureworks.production.illustration.IllustrationId
+import adventureworks.production.illustration.IllustrationRow
+import adventureworks.production.productmodel.ProductmodelFields
 import adventureworks.production.productmodel.ProductmodelId
+import adventureworks.production.productmodel.ProductmodelRow
+import typo.dsl.ForeignKey
 import typo.dsl.Path
 import typo.dsl.SqlExpr.Field
 import typo.dsl.SqlExpr.FieldLikeNoHkt
@@ -20,6 +25,12 @@ trait ProductmodelillustrationFields {
   def productmodelid: IdField[ProductmodelId, ProductmodelillustrationRow]
   def illustrationid: IdField[IllustrationId, ProductmodelillustrationRow]
   def modifieddate: Field[TypoLocalDateTime, ProductmodelillustrationRow]
+  def fkProductmodel: ForeignKey[ProductmodelFields, ProductmodelRow] =
+    ForeignKey[ProductmodelFields, ProductmodelRow]("production.FK_ProductModelIllustration_ProductModel_ProductModelID", Nil)
+      .withColumnPair(productmodelid, _.productmodelid)
+  def fkIllustration: ForeignKey[IllustrationFields, IllustrationRow] =
+    ForeignKey[IllustrationFields, IllustrationRow]("production.FK_ProductModelIllustration_Illustration_IllustrationID", Nil)
+      .withColumnPair(illustrationid, _.illustrationid)
 }
 
 object ProductmodelillustrationFields {

--- a/typo-tester-zio-jdbc/generated-and-checked-in/adventureworks/production/productmodelproductdescriptionculture/ProductmodelproductdescriptioncultureFields.scala
+++ b/typo-tester-zio-jdbc/generated-and-checked-in/adventureworks/production/productmodelproductdescriptionculture/ProductmodelproductdescriptioncultureFields.scala
@@ -8,9 +8,16 @@ package production
 package productmodelproductdescriptionculture
 
 import adventureworks.customtypes.TypoLocalDateTime
+import adventureworks.production.culture.CultureFields
 import adventureworks.production.culture.CultureId
+import adventureworks.production.culture.CultureRow
+import adventureworks.production.productdescription.ProductdescriptionFields
 import adventureworks.production.productdescription.ProductdescriptionId
+import adventureworks.production.productdescription.ProductdescriptionRow
+import adventureworks.production.productmodel.ProductmodelFields
 import adventureworks.production.productmodel.ProductmodelId
+import adventureworks.production.productmodel.ProductmodelRow
+import typo.dsl.ForeignKey
 import typo.dsl.Path
 import typo.dsl.SqlExpr.Field
 import typo.dsl.SqlExpr.FieldLikeNoHkt
@@ -22,6 +29,15 @@ trait ProductmodelproductdescriptioncultureFields {
   def productdescriptionid: IdField[ProductdescriptionId, ProductmodelproductdescriptioncultureRow]
   def cultureid: IdField[CultureId, ProductmodelproductdescriptioncultureRow]
   def modifieddate: Field[TypoLocalDateTime, ProductmodelproductdescriptioncultureRow]
+  def fkProductdescription: ForeignKey[ProductdescriptionFields, ProductdescriptionRow] =
+    ForeignKey[ProductdescriptionFields, ProductdescriptionRow]("production.FK_ProductModelProductDescriptionCulture_ProductDescription_Pro", Nil)
+      .withColumnPair(productdescriptionid, _.productdescriptionid)
+  def fkCulture: ForeignKey[CultureFields, CultureRow] =
+    ForeignKey[CultureFields, CultureRow]("production.FK_ProductModelProductDescriptionCulture_Culture_CultureID", Nil)
+      .withColumnPair(cultureid, _.cultureid)
+  def fkProductmodel: ForeignKey[ProductmodelFields, ProductmodelRow] =
+    ForeignKey[ProductmodelFields, ProductmodelRow]("production.FK_ProductModelProductDescriptionCulture_ProductModel_ProductMo", Nil)
+      .withColumnPair(productmodelid, _.productmodelid)
 }
 
 object ProductmodelproductdescriptioncultureFields {

--- a/typo-tester-zio-jdbc/generated-and-checked-in/adventureworks/production/productproductphoto/ProductproductphotoFields.scala
+++ b/typo-tester-zio-jdbc/generated-and-checked-in/adventureworks/production/productproductphoto/ProductproductphotoFields.scala
@@ -8,9 +8,14 @@ package production
 package productproductphoto
 
 import adventureworks.customtypes.TypoLocalDateTime
+import adventureworks.production.product.ProductFields
 import adventureworks.production.product.ProductId
+import adventureworks.production.product.ProductRow
+import adventureworks.production.productphoto.ProductphotoFields
 import adventureworks.production.productphoto.ProductphotoId
+import adventureworks.production.productphoto.ProductphotoRow
 import adventureworks.public.Flag
+import typo.dsl.ForeignKey
 import typo.dsl.Path
 import typo.dsl.SqlExpr.Field
 import typo.dsl.SqlExpr.FieldLikeNoHkt
@@ -22,6 +27,12 @@ trait ProductproductphotoFields {
   def productphotoid: IdField[ProductphotoId, ProductproductphotoRow]
   def primary: Field[Flag, ProductproductphotoRow]
   def modifieddate: Field[TypoLocalDateTime, ProductproductphotoRow]
+  def fkProduct: ForeignKey[ProductFields, ProductRow] =
+    ForeignKey[ProductFields, ProductRow]("production.FK_ProductProductPhoto_Product_ProductID", Nil)
+      .withColumnPair(productid, _.productid)
+  def fkProductphoto: ForeignKey[ProductphotoFields, ProductphotoRow] =
+    ForeignKey[ProductphotoFields, ProductphotoRow]("production.FK_ProductProductPhoto_ProductPhoto_ProductPhotoID", Nil)
+      .withColumnPair(productphotoid, _.productphotoid)
 }
 
 object ProductproductphotoFields {

--- a/typo-tester-zio-jdbc/generated-and-checked-in/adventureworks/production/productreview/ProductreviewFields.scala
+++ b/typo-tester-zio-jdbc/generated-and-checked-in/adventureworks/production/productreview/ProductreviewFields.scala
@@ -8,8 +8,11 @@ package production
 package productreview
 
 import adventureworks.customtypes.TypoLocalDateTime
+import adventureworks.production.product.ProductFields
 import adventureworks.production.product.ProductId
+import adventureworks.production.product.ProductRow
 import adventureworks.public.Name
+import typo.dsl.ForeignKey
 import typo.dsl.Path
 import typo.dsl.SqlExpr.Field
 import typo.dsl.SqlExpr.FieldLikeNoHkt
@@ -26,6 +29,9 @@ trait ProductreviewFields {
   def rating: Field[Int, ProductreviewRow]
   def comments: OptField[/* max 3850 chars */ String, ProductreviewRow]
   def modifieddate: Field[TypoLocalDateTime, ProductreviewRow]
+  def fkProduct: ForeignKey[ProductFields, ProductRow] =
+    ForeignKey[ProductFields, ProductRow]("production.FK_ProductReview_Product_ProductID", Nil)
+      .withColumnPair(productid, _.productid)
 }
 
 object ProductreviewFields {

--- a/typo-tester-zio-jdbc/generated-and-checked-in/adventureworks/production/productsubcategory/ProductsubcategoryFields.scala
+++ b/typo-tester-zio-jdbc/generated-and-checked-in/adventureworks/production/productsubcategory/ProductsubcategoryFields.scala
@@ -9,8 +9,11 @@ package productsubcategory
 
 import adventureworks.customtypes.TypoLocalDateTime
 import adventureworks.customtypes.TypoUUID
+import adventureworks.production.productcategory.ProductcategoryFields
 import adventureworks.production.productcategory.ProductcategoryId
+import adventureworks.production.productcategory.ProductcategoryRow
 import adventureworks.public.Name
+import typo.dsl.ForeignKey
 import typo.dsl.Path
 import typo.dsl.SqlExpr.Field
 import typo.dsl.SqlExpr.FieldLikeNoHkt
@@ -23,6 +26,9 @@ trait ProductsubcategoryFields {
   def name: Field[Name, ProductsubcategoryRow]
   def rowguid: Field[TypoUUID, ProductsubcategoryRow]
   def modifieddate: Field[TypoLocalDateTime, ProductsubcategoryRow]
+  def fkProductcategory: ForeignKey[ProductcategoryFields, ProductcategoryRow] =
+    ForeignKey[ProductcategoryFields, ProductcategoryRow]("production.FK_ProductSubcategory_ProductCategory_ProductCategoryID", Nil)
+      .withColumnPair(productcategoryid, _.productcategoryid)
 }
 
 object ProductsubcategoryFields {

--- a/typo-tester-zio-jdbc/generated-and-checked-in/adventureworks/production/transactionhistory/TransactionhistoryFields.scala
+++ b/typo-tester-zio-jdbc/generated-and-checked-in/adventureworks/production/transactionhistory/TransactionhistoryFields.scala
@@ -8,7 +8,10 @@ package production
 package transactionhistory
 
 import adventureworks.customtypes.TypoLocalDateTime
+import adventureworks.production.product.ProductFields
 import adventureworks.production.product.ProductId
+import adventureworks.production.product.ProductRow
+import typo.dsl.ForeignKey
 import typo.dsl.Path
 import typo.dsl.SqlExpr.Field
 import typo.dsl.SqlExpr.FieldLikeNoHkt
@@ -25,6 +28,9 @@ trait TransactionhistoryFields {
   def quantity: Field[Int, TransactionhistoryRow]
   def actualcost: Field[BigDecimal, TransactionhistoryRow]
   def modifieddate: Field[TypoLocalDateTime, TransactionhistoryRow]
+  def fkProduct: ForeignKey[ProductFields, ProductRow] =
+    ForeignKey[ProductFields, ProductRow]("production.FK_TransactionHistory_Product_ProductID", Nil)
+      .withColumnPair(productid, _.productid)
 }
 
 object TransactionhistoryFields {

--- a/typo-tester-zio-jdbc/generated-and-checked-in/adventureworks/production/workorder/WorkorderFields.scala
+++ b/typo-tester-zio-jdbc/generated-and-checked-in/adventureworks/production/workorder/WorkorderFields.scala
@@ -9,8 +9,13 @@ package workorder
 
 import adventureworks.customtypes.TypoLocalDateTime
 import adventureworks.customtypes.TypoShort
+import adventureworks.production.product.ProductFields
 import adventureworks.production.product.ProductId
+import adventureworks.production.product.ProductRow
+import adventureworks.production.scrapreason.ScrapreasonFields
 import adventureworks.production.scrapreason.ScrapreasonId
+import adventureworks.production.scrapreason.ScrapreasonRow
+import typo.dsl.ForeignKey
 import typo.dsl.Path
 import typo.dsl.SqlExpr.Field
 import typo.dsl.SqlExpr.FieldLikeNoHkt
@@ -28,6 +33,12 @@ trait WorkorderFields {
   def duedate: Field[TypoLocalDateTime, WorkorderRow]
   def scrapreasonid: OptField[ScrapreasonId, WorkorderRow]
   def modifieddate: Field[TypoLocalDateTime, WorkorderRow]
+  def fkProduct: ForeignKey[ProductFields, ProductRow] =
+    ForeignKey[ProductFields, ProductRow]("production.FK_WorkOrder_Product_ProductID", Nil)
+      .withColumnPair(productid, _.productid)
+  def fkScrapreason: ForeignKey[ScrapreasonFields, ScrapreasonRow] =
+    ForeignKey[ScrapreasonFields, ScrapreasonRow]("production.FK_WorkOrder_ScrapReason_ScrapReasonID", Nil)
+      .withColumnPair(scrapreasonid, _.scrapreasonid)
 }
 
 object WorkorderFields {

--- a/typo-tester-zio-jdbc/generated-and-checked-in/adventureworks/production/workorderrouting/WorkorderroutingFields.scala
+++ b/typo-tester-zio-jdbc/generated-and-checked-in/adventureworks/production/workorderrouting/WorkorderroutingFields.scala
@@ -9,8 +9,13 @@ package workorderrouting
 
 import adventureworks.customtypes.TypoLocalDateTime
 import adventureworks.customtypes.TypoShort
+import adventureworks.production.location.LocationFields
 import adventureworks.production.location.LocationId
+import adventureworks.production.location.LocationRow
+import adventureworks.production.workorder.WorkorderFields
 import adventureworks.production.workorder.WorkorderId
+import adventureworks.production.workorder.WorkorderRow
+import typo.dsl.ForeignKey
 import typo.dsl.Path
 import typo.dsl.SqlExpr.Field
 import typo.dsl.SqlExpr.FieldLikeNoHkt
@@ -31,6 +36,12 @@ trait WorkorderroutingFields {
   def plannedcost: Field[BigDecimal, WorkorderroutingRow]
   def actualcost: OptField[BigDecimal, WorkorderroutingRow]
   def modifieddate: Field[TypoLocalDateTime, WorkorderroutingRow]
+  def fkLocation: ForeignKey[LocationFields, LocationRow] =
+    ForeignKey[LocationFields, LocationRow]("production.FK_WorkOrderRouting_Location_LocationID", Nil)
+      .withColumnPair(locationid, _.locationid)
+  def fkWorkorder: ForeignKey[WorkorderFields, WorkorderRow] =
+    ForeignKey[WorkorderFields, WorkorderRow]("production.FK_WorkOrderRouting_WorkOrder_WorkOrderID", Nil)
+      .withColumnPair(workorderid, _.workorderid)
 }
 
 object WorkorderroutingFields {

--- a/typo-tester-zio-jdbc/generated-and-checked-in/adventureworks/public/flaff/FlaffFields.scala
+++ b/typo-tester-zio-jdbc/generated-and-checked-in/adventureworks/public/flaff/FlaffFields.scala
@@ -8,6 +8,7 @@ package public
 package flaff
 
 import adventureworks.public.ShortText
+import typo.dsl.ForeignKey
 import typo.dsl.Path
 import typo.dsl.SqlExpr.FieldLikeNoHkt
 import typo.dsl.SqlExpr.IdField
@@ -20,6 +21,12 @@ trait FlaffFields {
   def someNumber: IdField[Int, FlaffRow]
   def specifier: IdField[ShortText, FlaffRow]
   def parentspecifier: OptField[ShortText, FlaffRow]
+  def fkFlaff: ForeignKey[FlaffFields, FlaffRow] =
+    ForeignKey[FlaffFields, FlaffRow]("public.flaff_parent_fk", Nil)
+      .withColumnPair(code, _.code)
+      .withColumnPair(anotherCode, _.anotherCode)
+      .withColumnPair(someNumber, _.someNumber)
+      .withColumnPair(parentspecifier, _.specifier)
 }
 
 object FlaffFields {

--- a/typo-tester-zio-jdbc/generated-and-checked-in/adventureworks/purchasing/productvendor/ProductvendorFields.scala
+++ b/typo-tester-zio-jdbc/generated-and-checked-in/adventureworks/purchasing/productvendor/ProductvendorFields.scala
@@ -9,8 +9,15 @@ package productvendor
 
 import adventureworks.customtypes.TypoLocalDateTime
 import adventureworks.person.businessentity.BusinessentityId
+import adventureworks.production.product.ProductFields
 import adventureworks.production.product.ProductId
+import adventureworks.production.product.ProductRow
+import adventureworks.production.unitmeasure.UnitmeasureFields
 import adventureworks.production.unitmeasure.UnitmeasureId
+import adventureworks.production.unitmeasure.UnitmeasureRow
+import adventureworks.purchasing.vendor.VendorFields
+import adventureworks.purchasing.vendor.VendorRow
+import typo.dsl.ForeignKey
 import typo.dsl.Path
 import typo.dsl.SqlExpr.Field
 import typo.dsl.SqlExpr.FieldLikeNoHkt
@@ -30,6 +37,15 @@ trait ProductvendorFields {
   def onorderqty: OptField[Int, ProductvendorRow]
   def unitmeasurecode: Field[UnitmeasureId, ProductvendorRow]
   def modifieddate: Field[TypoLocalDateTime, ProductvendorRow]
+  def fkProductionProduct: ForeignKey[ProductFields, ProductRow] =
+    ForeignKey[ProductFields, ProductRow]("purchasing.FK_ProductVendor_Product_ProductID", Nil)
+      .withColumnPair(productid, _.productid)
+  def fkProductionUnitmeasure: ForeignKey[UnitmeasureFields, UnitmeasureRow] =
+    ForeignKey[UnitmeasureFields, UnitmeasureRow]("purchasing.FK_ProductVendor_UnitMeasure_UnitMeasureCode", Nil)
+      .withColumnPair(unitmeasurecode, _.unitmeasurecode)
+  def fkVendor: ForeignKey[VendorFields, VendorRow] =
+    ForeignKey[VendorFields, VendorRow]("purchasing.FK_ProductVendor_Vendor_BusinessEntityID", Nil)
+      .withColumnPair(businessentityid, _.businessentityid)
 }
 
 object ProductvendorFields {

--- a/typo-tester-zio-jdbc/generated-and-checked-in/adventureworks/purchasing/purchaseorderdetail/PurchaseorderdetailFields.scala
+++ b/typo-tester-zio-jdbc/generated-and-checked-in/adventureworks/purchasing/purchaseorderdetail/PurchaseorderdetailFields.scala
@@ -9,8 +9,13 @@ package purchaseorderdetail
 
 import adventureworks.customtypes.TypoLocalDateTime
 import adventureworks.customtypes.TypoShort
+import adventureworks.production.product.ProductFields
 import adventureworks.production.product.ProductId
+import adventureworks.production.product.ProductRow
+import adventureworks.purchasing.purchaseorderheader.PurchaseorderheaderFields
 import adventureworks.purchasing.purchaseorderheader.PurchaseorderheaderId
+import adventureworks.purchasing.purchaseorderheader.PurchaseorderheaderRow
+import typo.dsl.ForeignKey
 import typo.dsl.Path
 import typo.dsl.SqlExpr.Field
 import typo.dsl.SqlExpr.FieldLikeNoHkt
@@ -27,6 +32,12 @@ trait PurchaseorderdetailFields {
   def receivedqty: Field[BigDecimal, PurchaseorderdetailRow]
   def rejectedqty: Field[BigDecimal, PurchaseorderdetailRow]
   def modifieddate: Field[TypoLocalDateTime, PurchaseorderdetailRow]
+  def fkProductionProduct: ForeignKey[ProductFields, ProductRow] =
+    ForeignKey[ProductFields, ProductRow]("purchasing.FK_PurchaseOrderDetail_Product_ProductID", Nil)
+      .withColumnPair(productid, _.productid)
+  def fkPurchaseorderheader: ForeignKey[PurchaseorderheaderFields, PurchaseorderheaderRow] =
+    ForeignKey[PurchaseorderheaderFields, PurchaseorderheaderRow]("purchasing.FK_PurchaseOrderDetail_PurchaseOrderHeader_PurchaseOrderID", Nil)
+      .withColumnPair(purchaseorderid, _.purchaseorderid)
 }
 
 object PurchaseorderdetailFields {

--- a/typo-tester-zio-jdbc/generated-and-checked-in/adventureworks/purchasing/purchaseorderheader/PurchaseorderheaderFields.scala
+++ b/typo-tester-zio-jdbc/generated-and-checked-in/adventureworks/purchasing/purchaseorderheader/PurchaseorderheaderFields.scala
@@ -9,8 +9,15 @@ package purchaseorderheader
 
 import adventureworks.customtypes.TypoLocalDateTime
 import adventureworks.customtypes.TypoShort
+import adventureworks.humanresources.employee.EmployeeFields
+import adventureworks.humanresources.employee.EmployeeRow
 import adventureworks.person.businessentity.BusinessentityId
+import adventureworks.purchasing.shipmethod.ShipmethodFields
 import adventureworks.purchasing.shipmethod.ShipmethodId
+import adventureworks.purchasing.shipmethod.ShipmethodRow
+import adventureworks.purchasing.vendor.VendorFields
+import adventureworks.purchasing.vendor.VendorRow
+import typo.dsl.ForeignKey
 import typo.dsl.Path
 import typo.dsl.SqlExpr.Field
 import typo.dsl.SqlExpr.FieldLikeNoHkt
@@ -31,6 +38,15 @@ trait PurchaseorderheaderFields {
   def taxamt: Field[BigDecimal, PurchaseorderheaderRow]
   def freight: Field[BigDecimal, PurchaseorderheaderRow]
   def modifieddate: Field[TypoLocalDateTime, PurchaseorderheaderRow]
+  def fkHumanresourcesEmployee: ForeignKey[EmployeeFields, EmployeeRow] =
+    ForeignKey[EmployeeFields, EmployeeRow]("purchasing.FK_PurchaseOrderHeader_Employee_EmployeeID", Nil)
+      .withColumnPair(employeeid, _.businessentityid)
+  def fkVendor: ForeignKey[VendorFields, VendorRow] =
+    ForeignKey[VendorFields, VendorRow]("purchasing.FK_PurchaseOrderHeader_Vendor_VendorID", Nil)
+      .withColumnPair(vendorid, _.businessentityid)
+  def fkShipmethod: ForeignKey[ShipmethodFields, ShipmethodRow] =
+    ForeignKey[ShipmethodFields, ShipmethodRow]("purchasing.FK_PurchaseOrderHeader_ShipMethod_ShipMethodID", Nil)
+      .withColumnPair(shipmethodid, _.shipmethodid)
 }
 
 object PurchaseorderheaderFields {

--- a/typo-tester-zio-jdbc/generated-and-checked-in/adventureworks/purchasing/vendor/VendorFields.scala
+++ b/typo-tester-zio-jdbc/generated-and-checked-in/adventureworks/purchasing/vendor/VendorFields.scala
@@ -9,10 +9,13 @@ package vendor
 
 import adventureworks.customtypes.TypoLocalDateTime
 import adventureworks.customtypes.TypoShort
+import adventureworks.person.businessentity.BusinessentityFields
 import adventureworks.person.businessentity.BusinessentityId
+import adventureworks.person.businessentity.BusinessentityRow
 import adventureworks.public.AccountNumber
 import adventureworks.public.Flag
 import adventureworks.public.Name
+import typo.dsl.ForeignKey
 import typo.dsl.Path
 import typo.dsl.SqlExpr.Field
 import typo.dsl.SqlExpr.FieldLikeNoHkt
@@ -29,6 +32,9 @@ trait VendorFields {
   def activeflag: Field[Flag, VendorRow]
   def purchasingwebserviceurl: OptField[/* max 1024 chars */ String, VendorRow]
   def modifieddate: Field[TypoLocalDateTime, VendorRow]
+  def fkPersonBusinessentity: ForeignKey[BusinessentityFields, BusinessentityRow] =
+    ForeignKey[BusinessentityFields, BusinessentityRow]("purchasing.FK_Vendor_BusinessEntity_BusinessEntityID", Nil)
+      .withColumnPair(businessentityid, _.businessentityid)
 }
 
 object VendorFields {

--- a/typo-tester-zio-jdbc/generated-and-checked-in/adventureworks/sales/countryregioncurrency/CountryregioncurrencyFields.scala
+++ b/typo-tester-zio-jdbc/generated-and-checked-in/adventureworks/sales/countryregioncurrency/CountryregioncurrencyFields.scala
@@ -8,8 +8,13 @@ package sales
 package countryregioncurrency
 
 import adventureworks.customtypes.TypoLocalDateTime
+import adventureworks.person.countryregion.CountryregionFields
 import adventureworks.person.countryregion.CountryregionId
+import adventureworks.person.countryregion.CountryregionRow
+import adventureworks.sales.currency.CurrencyFields
 import adventureworks.sales.currency.CurrencyId
+import adventureworks.sales.currency.CurrencyRow
+import typo.dsl.ForeignKey
 import typo.dsl.Path
 import typo.dsl.SqlExpr.Field
 import typo.dsl.SqlExpr.FieldLikeNoHkt
@@ -20,6 +25,12 @@ trait CountryregioncurrencyFields {
   def countryregioncode: IdField[CountryregionId, CountryregioncurrencyRow]
   def currencycode: IdField[CurrencyId, CountryregioncurrencyRow]
   def modifieddate: Field[TypoLocalDateTime, CountryregioncurrencyRow]
+  def fkPersonCountryregion: ForeignKey[CountryregionFields, CountryregionRow] =
+    ForeignKey[CountryregionFields, CountryregionRow]("sales.FK_CountryRegionCurrency_CountryRegion_CountryRegionCode", Nil)
+      .withColumnPair(countryregioncode, _.countryregioncode)
+  def fkCurrency: ForeignKey[CurrencyFields, CurrencyRow] =
+    ForeignKey[CurrencyFields, CurrencyRow]("sales.FK_CountryRegionCurrency_Currency_CurrencyCode", Nil)
+      .withColumnPair(currencycode, _.currencycode)
 }
 
 object CountryregioncurrencyFields {

--- a/typo-tester-zio-jdbc/generated-and-checked-in/adventureworks/sales/currencyrate/CurrencyrateFields.scala
+++ b/typo-tester-zio-jdbc/generated-and-checked-in/adventureworks/sales/currencyrate/CurrencyrateFields.scala
@@ -8,7 +8,10 @@ package sales
 package currencyrate
 
 import adventureworks.customtypes.TypoLocalDateTime
+import adventureworks.sales.currency.CurrencyFields
 import adventureworks.sales.currency.CurrencyId
+import adventureworks.sales.currency.CurrencyRow
+import typo.dsl.ForeignKey
 import typo.dsl.Path
 import typo.dsl.SqlExpr.Field
 import typo.dsl.SqlExpr.FieldLikeNoHkt
@@ -23,6 +26,12 @@ trait CurrencyrateFields {
   def averagerate: Field[BigDecimal, CurrencyrateRow]
   def endofdayrate: Field[BigDecimal, CurrencyrateRow]
   def modifieddate: Field[TypoLocalDateTime, CurrencyrateRow]
+  def fkCurrencyFromcurrencycode: ForeignKey[CurrencyFields, CurrencyRow] =
+    ForeignKey[CurrencyFields, CurrencyRow]("sales.FK_CurrencyRate_Currency_FromCurrencyCode", Nil)
+      .withColumnPair(fromcurrencycode, _.currencycode)
+  def fkCurrencyTocurrencycode: ForeignKey[CurrencyFields, CurrencyRow] =
+    ForeignKey[CurrencyFields, CurrencyRow]("sales.FK_CurrencyRate_Currency_ToCurrencyCode", Nil)
+      .withColumnPair(tocurrencycode, _.currencycode)
 }
 
 object CurrencyrateFields {

--- a/typo-tester-zio-jdbc/generated-and-checked-in/adventureworks/sales/customer/CustomerFields.scala
+++ b/typo-tester-zio-jdbc/generated-and-checked-in/adventureworks/sales/customer/CustomerFields.scala
@@ -10,7 +10,14 @@ package customer
 import adventureworks.customtypes.TypoLocalDateTime
 import adventureworks.customtypes.TypoUUID
 import adventureworks.person.businessentity.BusinessentityId
+import adventureworks.person.person.PersonFields
+import adventureworks.person.person.PersonRow
+import adventureworks.sales.salesterritory.SalesterritoryFields
 import adventureworks.sales.salesterritory.SalesterritoryId
+import adventureworks.sales.salesterritory.SalesterritoryRow
+import adventureworks.sales.store.StoreFields
+import adventureworks.sales.store.StoreRow
+import typo.dsl.ForeignKey
 import typo.dsl.Path
 import typo.dsl.SqlExpr.Field
 import typo.dsl.SqlExpr.FieldLikeNoHkt
@@ -25,6 +32,15 @@ trait CustomerFields {
   def territoryid: OptField[SalesterritoryId, CustomerRow]
   def rowguid: Field[TypoUUID, CustomerRow]
   def modifieddate: Field[TypoLocalDateTime, CustomerRow]
+  def fkPersonPerson: ForeignKey[PersonFields, PersonRow] =
+    ForeignKey[PersonFields, PersonRow]("sales.FK_Customer_Person_PersonID", Nil)
+      .withColumnPair(personid, _.businessentityid)
+  def fkStore: ForeignKey[StoreFields, StoreRow] =
+    ForeignKey[StoreFields, StoreRow]("sales.FK_Customer_Store_StoreID", Nil)
+      .withColumnPair(storeid, _.businessentityid)
+  def fkSalesterritory: ForeignKey[SalesterritoryFields, SalesterritoryRow] =
+    ForeignKey[SalesterritoryFields, SalesterritoryRow]("sales.FK_Customer_SalesTerritory_TerritoryID", Nil)
+      .withColumnPair(territoryid, _.territoryid)
 }
 
 object CustomerFields {

--- a/typo-tester-zio-jdbc/generated-and-checked-in/adventureworks/sales/personcreditcard/PersoncreditcardFields.scala
+++ b/typo-tester-zio-jdbc/generated-and-checked-in/adventureworks/sales/personcreditcard/PersoncreditcardFields.scala
@@ -9,7 +9,12 @@ package personcreditcard
 
 import adventureworks.customtypes.TypoLocalDateTime
 import adventureworks.person.businessentity.BusinessentityId
+import adventureworks.person.person.PersonFields
+import adventureworks.person.person.PersonRow
+import adventureworks.sales.creditcard.CreditcardFields
+import adventureworks.sales.creditcard.CreditcardRow
 import adventureworks.userdefined.CustomCreditcardId
+import typo.dsl.ForeignKey
 import typo.dsl.Path
 import typo.dsl.SqlExpr.Field
 import typo.dsl.SqlExpr.FieldLikeNoHkt
@@ -20,6 +25,12 @@ trait PersoncreditcardFields {
   def businessentityid: IdField[BusinessentityId, PersoncreditcardRow]
   def creditcardid: IdField[/* user-picked */ CustomCreditcardId, PersoncreditcardRow]
   def modifieddate: Field[TypoLocalDateTime, PersoncreditcardRow]
+  def fkPersonPerson: ForeignKey[PersonFields, PersonRow] =
+    ForeignKey[PersonFields, PersonRow]("sales.FK_PersonCreditCard_Person_BusinessEntityID", Nil)
+      .withColumnPair(businessentityid, _.businessentityid)
+  def fkCreditcard: ForeignKey[CreditcardFields, CreditcardRow] =
+    ForeignKey[CreditcardFields, CreditcardRow]("sales.FK_PersonCreditCard_CreditCard_CreditCardID", Nil)
+      .withColumnPair(creditcardid, _.creditcardid)
 }
 
 object PersoncreditcardFields {

--- a/typo-tester-zio-jdbc/generated-and-checked-in/adventureworks/sales/salesorderdetail/SalesorderdetailFields.scala
+++ b/typo-tester-zio-jdbc/generated-and-checked-in/adventureworks/sales/salesorderdetail/SalesorderdetailFields.scala
@@ -11,8 +11,13 @@ import adventureworks.customtypes.TypoLocalDateTime
 import adventureworks.customtypes.TypoShort
 import adventureworks.customtypes.TypoUUID
 import adventureworks.production.product.ProductId
+import adventureworks.sales.salesorderheader.SalesorderheaderFields
 import adventureworks.sales.salesorderheader.SalesorderheaderId
+import adventureworks.sales.salesorderheader.SalesorderheaderRow
 import adventureworks.sales.specialoffer.SpecialofferId
+import adventureworks.sales.specialofferproduct.SpecialofferproductFields
+import adventureworks.sales.specialofferproduct.SpecialofferproductRow
+import typo.dsl.ForeignKey
 import typo.dsl.Path
 import typo.dsl.SqlExpr.Field
 import typo.dsl.SqlExpr.FieldLikeNoHkt
@@ -31,6 +36,13 @@ trait SalesorderdetailFields {
   def unitpricediscount: Field[BigDecimal, SalesorderdetailRow]
   def rowguid: Field[TypoUUID, SalesorderdetailRow]
   def modifieddate: Field[TypoLocalDateTime, SalesorderdetailRow]
+  def fkSalesorderheader: ForeignKey[SalesorderheaderFields, SalesorderheaderRow] =
+    ForeignKey[SalesorderheaderFields, SalesorderheaderRow]("sales.FK_SalesOrderDetail_SalesOrderHeader_SalesOrderID", Nil)
+      .withColumnPair(salesorderid, _.salesorderid)
+  def fkSpecialofferproduct: ForeignKey[SpecialofferproductFields, SpecialofferproductRow] =
+    ForeignKey[SpecialofferproductFields, SpecialofferproductRow]("sales.FK_SalesOrderDetail_SpecialOfferProduct_SpecialOfferIDProductID", Nil)
+      .withColumnPair(specialofferid, _.specialofferid)
+      .withColumnPair(productid, _.productid)
 }
 
 object SalesorderdetailFields {

--- a/typo-tester-zio-jdbc/generated-and-checked-in/adventureworks/sales/salesorderheader/SalesorderheaderFields.scala
+++ b/typo-tester-zio-jdbc/generated-and-checked-in/adventureworks/sales/salesorderheader/SalesorderheaderFields.scala
@@ -10,16 +10,31 @@ package salesorderheader
 import adventureworks.customtypes.TypoLocalDateTime
 import adventureworks.customtypes.TypoShort
 import adventureworks.customtypes.TypoUUID
+import adventureworks.person.address.AddressFields
 import adventureworks.person.address.AddressId
+import adventureworks.person.address.AddressRow
 import adventureworks.person.businessentity.BusinessentityId
 import adventureworks.public.AccountNumber
 import adventureworks.public.Flag
 import adventureworks.public.OrderNumber
+import adventureworks.purchasing.shipmethod.ShipmethodFields
 import adventureworks.purchasing.shipmethod.ShipmethodId
+import adventureworks.purchasing.shipmethod.ShipmethodRow
+import adventureworks.sales.creditcard.CreditcardFields
+import adventureworks.sales.creditcard.CreditcardRow
+import adventureworks.sales.currencyrate.CurrencyrateFields
 import adventureworks.sales.currencyrate.CurrencyrateId
+import adventureworks.sales.currencyrate.CurrencyrateRow
+import adventureworks.sales.customer.CustomerFields
 import adventureworks.sales.customer.CustomerId
+import adventureworks.sales.customer.CustomerRow
+import adventureworks.sales.salesperson.SalespersonFields
+import adventureworks.sales.salesperson.SalespersonRow
+import adventureworks.sales.salesterritory.SalesterritoryFields
 import adventureworks.sales.salesterritory.SalesterritoryId
+import adventureworks.sales.salesterritory.SalesterritoryRow
 import adventureworks.userdefined.CustomCreditcardId
+import typo.dsl.ForeignKey
 import typo.dsl.Path
 import typo.dsl.SqlExpr.Field
 import typo.dsl.SqlExpr.FieldLikeNoHkt
@@ -53,6 +68,30 @@ trait SalesorderheaderFields {
   def comment: OptField[/* max 128 chars */ String, SalesorderheaderRow]
   def rowguid: Field[TypoUUID, SalesorderheaderRow]
   def modifieddate: Field[TypoLocalDateTime, SalesorderheaderRow]
+  def fkPersonAddressBilltoaddressid: ForeignKey[AddressFields, AddressRow] =
+    ForeignKey[AddressFields, AddressRow]("sales.FK_SalesOrderHeader_Address_BillToAddressID", Nil)
+      .withColumnPair(billtoaddressid, _.addressid)
+  def fkPersonAddressShiptoaddressid: ForeignKey[AddressFields, AddressRow] =
+    ForeignKey[AddressFields, AddressRow]("sales.FK_SalesOrderHeader_Address_ShipToAddressID", Nil)
+      .withColumnPair(shiptoaddressid, _.addressid)
+  def fkCreditcard: ForeignKey[CreditcardFields, CreditcardRow] =
+    ForeignKey[CreditcardFields, CreditcardRow]("sales.FK_SalesOrderHeader_CreditCard_CreditCardID", Nil)
+      .withColumnPair(creditcardid, _.creditcardid)
+  def fkCurrencyrate: ForeignKey[CurrencyrateFields, CurrencyrateRow] =
+    ForeignKey[CurrencyrateFields, CurrencyrateRow]("sales.FK_SalesOrderHeader_CurrencyRate_CurrencyRateID", Nil)
+      .withColumnPair(currencyrateid, _.currencyrateid)
+  def fkCustomer: ForeignKey[CustomerFields, CustomerRow] =
+    ForeignKey[CustomerFields, CustomerRow]("sales.FK_SalesOrderHeader_Customer_CustomerID", Nil)
+      .withColumnPair(customerid, _.customerid)
+  def fkSalesperson: ForeignKey[SalespersonFields, SalespersonRow] =
+    ForeignKey[SalespersonFields, SalespersonRow]("sales.FK_SalesOrderHeader_SalesPerson_SalesPersonID", Nil)
+      .withColumnPair(salespersonid, _.businessentityid)
+  def fkPurchasingShipmethod: ForeignKey[ShipmethodFields, ShipmethodRow] =
+    ForeignKey[ShipmethodFields, ShipmethodRow]("sales.FK_SalesOrderHeader_ShipMethod_ShipMethodID", Nil)
+      .withColumnPair(shipmethodid, _.shipmethodid)
+  def fkSalesterritory: ForeignKey[SalesterritoryFields, SalesterritoryRow] =
+    ForeignKey[SalesterritoryFields, SalesterritoryRow]("sales.FK_SalesOrderHeader_SalesTerritory_TerritoryID", Nil)
+      .withColumnPair(territoryid, _.territoryid)
 }
 
 object SalesorderheaderFields {

--- a/typo-tester-zio-jdbc/generated-and-checked-in/adventureworks/sales/salesorderheadersalesreason/SalesorderheadersalesreasonFields.scala
+++ b/typo-tester-zio-jdbc/generated-and-checked-in/adventureworks/sales/salesorderheadersalesreason/SalesorderheadersalesreasonFields.scala
@@ -8,8 +8,13 @@ package sales
 package salesorderheadersalesreason
 
 import adventureworks.customtypes.TypoLocalDateTime
+import adventureworks.sales.salesorderheader.SalesorderheaderFields
 import adventureworks.sales.salesorderheader.SalesorderheaderId
+import adventureworks.sales.salesorderheader.SalesorderheaderRow
+import adventureworks.sales.salesreason.SalesreasonFields
 import adventureworks.sales.salesreason.SalesreasonId
+import adventureworks.sales.salesreason.SalesreasonRow
+import typo.dsl.ForeignKey
 import typo.dsl.Path
 import typo.dsl.SqlExpr.Field
 import typo.dsl.SqlExpr.FieldLikeNoHkt
@@ -20,6 +25,12 @@ trait SalesorderheadersalesreasonFields {
   def salesorderid: IdField[SalesorderheaderId, SalesorderheadersalesreasonRow]
   def salesreasonid: IdField[SalesreasonId, SalesorderheadersalesreasonRow]
   def modifieddate: Field[TypoLocalDateTime, SalesorderheadersalesreasonRow]
+  def fkSalesreason: ForeignKey[SalesreasonFields, SalesreasonRow] =
+    ForeignKey[SalesreasonFields, SalesreasonRow]("sales.FK_SalesOrderHeaderSalesReason_SalesReason_SalesReasonID", Nil)
+      .withColumnPair(salesreasonid, _.salesreasonid)
+  def fkSalesorderheader: ForeignKey[SalesorderheaderFields, SalesorderheaderRow] =
+    ForeignKey[SalesorderheaderFields, SalesorderheaderRow]("sales.FK_SalesOrderHeaderSalesReason_SalesOrderHeader_SalesOrderID", Nil)
+      .withColumnPair(salesorderid, _.salesorderid)
 }
 
 object SalesorderheadersalesreasonFields {

--- a/typo-tester-zio-jdbc/generated-and-checked-in/adventureworks/sales/salesperson/SalespersonFields.scala
+++ b/typo-tester-zio-jdbc/generated-and-checked-in/adventureworks/sales/salesperson/SalespersonFields.scala
@@ -9,8 +9,13 @@ package salesperson
 
 import adventureworks.customtypes.TypoLocalDateTime
 import adventureworks.customtypes.TypoUUID
+import adventureworks.humanresources.employee.EmployeeFields
+import adventureworks.humanresources.employee.EmployeeRow
 import adventureworks.person.businessentity.BusinessentityId
+import adventureworks.sales.salesterritory.SalesterritoryFields
 import adventureworks.sales.salesterritory.SalesterritoryId
+import adventureworks.sales.salesterritory.SalesterritoryRow
+import typo.dsl.ForeignKey
 import typo.dsl.Path
 import typo.dsl.SqlExpr.Field
 import typo.dsl.SqlExpr.FieldLikeNoHkt
@@ -28,6 +33,12 @@ trait SalespersonFields {
   def saleslastyear: Field[BigDecimal, SalespersonRow]
   def rowguid: Field[TypoUUID, SalespersonRow]
   def modifieddate: Field[TypoLocalDateTime, SalespersonRow]
+  def fkHumanresourcesEmployee: ForeignKey[EmployeeFields, EmployeeRow] =
+    ForeignKey[EmployeeFields, EmployeeRow]("sales.FK_SalesPerson_Employee_BusinessEntityID", Nil)
+      .withColumnPair(businessentityid, _.businessentityid)
+  def fkSalesterritory: ForeignKey[SalesterritoryFields, SalesterritoryRow] =
+    ForeignKey[SalesterritoryFields, SalesterritoryRow]("sales.FK_SalesPerson_SalesTerritory_TerritoryID", Nil)
+      .withColumnPair(territoryid, _.territoryid)
 }
 
 object SalespersonFields {

--- a/typo-tester-zio-jdbc/generated-and-checked-in/adventureworks/sales/salespersonquotahistory/SalespersonquotahistoryFields.scala
+++ b/typo-tester-zio-jdbc/generated-and-checked-in/adventureworks/sales/salespersonquotahistory/SalespersonquotahistoryFields.scala
@@ -10,6 +10,9 @@ package salespersonquotahistory
 import adventureworks.customtypes.TypoLocalDateTime
 import adventureworks.customtypes.TypoUUID
 import adventureworks.person.businessentity.BusinessentityId
+import adventureworks.sales.salesperson.SalespersonFields
+import adventureworks.sales.salesperson.SalespersonRow
+import typo.dsl.ForeignKey
 import typo.dsl.Path
 import typo.dsl.SqlExpr.Field
 import typo.dsl.SqlExpr.FieldLikeNoHkt
@@ -22,6 +25,9 @@ trait SalespersonquotahistoryFields {
   def salesquota: Field[BigDecimal, SalespersonquotahistoryRow]
   def rowguid: Field[TypoUUID, SalespersonquotahistoryRow]
   def modifieddate: Field[TypoLocalDateTime, SalespersonquotahistoryRow]
+  def fkSalesperson: ForeignKey[SalespersonFields, SalespersonRow] =
+    ForeignKey[SalespersonFields, SalespersonRow]("sales.FK_SalesPersonQuotaHistory_SalesPerson_BusinessEntityID", Nil)
+      .withColumnPair(businessentityid, _.businessentityid)
 }
 
 object SalespersonquotahistoryFields {

--- a/typo-tester-zio-jdbc/generated-and-checked-in/adventureworks/sales/salestaxrate/SalestaxrateFields.scala
+++ b/typo-tester-zio-jdbc/generated-and-checked-in/adventureworks/sales/salestaxrate/SalestaxrateFields.scala
@@ -10,8 +10,11 @@ package salestaxrate
 import adventureworks.customtypes.TypoLocalDateTime
 import adventureworks.customtypes.TypoShort
 import adventureworks.customtypes.TypoUUID
+import adventureworks.person.stateprovince.StateprovinceFields
 import adventureworks.person.stateprovince.StateprovinceId
+import adventureworks.person.stateprovince.StateprovinceRow
 import adventureworks.public.Name
+import typo.dsl.ForeignKey
 import typo.dsl.Path
 import typo.dsl.SqlExpr.Field
 import typo.dsl.SqlExpr.FieldLikeNoHkt
@@ -26,6 +29,9 @@ trait SalestaxrateFields {
   def name: Field[Name, SalestaxrateRow]
   def rowguid: Field[TypoUUID, SalestaxrateRow]
   def modifieddate: Field[TypoLocalDateTime, SalestaxrateRow]
+  def fkPersonStateprovince: ForeignKey[StateprovinceFields, StateprovinceRow] =
+    ForeignKey[StateprovinceFields, StateprovinceRow]("sales.FK_SalesTaxRate_StateProvince_StateProvinceID", Nil)
+      .withColumnPair(stateprovinceid, _.stateprovinceid)
 }
 
 object SalestaxrateFields {

--- a/typo-tester-zio-jdbc/generated-and-checked-in/adventureworks/sales/salesterritory/SalesterritoryFields.scala
+++ b/typo-tester-zio-jdbc/generated-and-checked-in/adventureworks/sales/salesterritory/SalesterritoryFields.scala
@@ -9,8 +9,11 @@ package salesterritory
 
 import adventureworks.customtypes.TypoLocalDateTime
 import adventureworks.customtypes.TypoUUID
+import adventureworks.person.countryregion.CountryregionFields
 import adventureworks.person.countryregion.CountryregionId
+import adventureworks.person.countryregion.CountryregionRow
 import adventureworks.public.Name
+import typo.dsl.ForeignKey
 import typo.dsl.Path
 import typo.dsl.SqlExpr.Field
 import typo.dsl.SqlExpr.FieldLikeNoHkt
@@ -28,6 +31,9 @@ trait SalesterritoryFields {
   def costlastyear: Field[BigDecimal, SalesterritoryRow]
   def rowguid: Field[TypoUUID, SalesterritoryRow]
   def modifieddate: Field[TypoLocalDateTime, SalesterritoryRow]
+  def fkPersonCountryregion: ForeignKey[CountryregionFields, CountryregionRow] =
+    ForeignKey[CountryregionFields, CountryregionRow]("sales.FK_SalesTerritory_CountryRegion_CountryRegionCode", Nil)
+      .withColumnPair(countryregioncode, _.countryregioncode)
 }
 
 object SalesterritoryFields {

--- a/typo-tester-zio-jdbc/generated-and-checked-in/adventureworks/sales/salesterritoryhistory/SalesterritoryhistoryFields.scala
+++ b/typo-tester-zio-jdbc/generated-and-checked-in/adventureworks/sales/salesterritoryhistory/SalesterritoryhistoryFields.scala
@@ -10,7 +10,12 @@ package salesterritoryhistory
 import adventureworks.customtypes.TypoLocalDateTime
 import adventureworks.customtypes.TypoUUID
 import adventureworks.person.businessentity.BusinessentityId
+import adventureworks.sales.salesperson.SalespersonFields
+import adventureworks.sales.salesperson.SalespersonRow
+import adventureworks.sales.salesterritory.SalesterritoryFields
 import adventureworks.sales.salesterritory.SalesterritoryId
+import adventureworks.sales.salesterritory.SalesterritoryRow
+import typo.dsl.ForeignKey
 import typo.dsl.Path
 import typo.dsl.SqlExpr.Field
 import typo.dsl.SqlExpr.FieldLikeNoHkt
@@ -25,6 +30,12 @@ trait SalesterritoryhistoryFields {
   def enddate: OptField[TypoLocalDateTime, SalesterritoryhistoryRow]
   def rowguid: Field[TypoUUID, SalesterritoryhistoryRow]
   def modifieddate: Field[TypoLocalDateTime, SalesterritoryhistoryRow]
+  def fkSalesperson: ForeignKey[SalespersonFields, SalespersonRow] =
+    ForeignKey[SalespersonFields, SalespersonRow]("sales.FK_SalesTerritoryHistory_SalesPerson_BusinessEntityID", Nil)
+      .withColumnPair(businessentityid, _.businessentityid)
+  def fkSalesterritory: ForeignKey[SalesterritoryFields, SalesterritoryRow] =
+    ForeignKey[SalesterritoryFields, SalesterritoryRow]("sales.FK_SalesTerritoryHistory_SalesTerritory_TerritoryID", Nil)
+      .withColumnPair(territoryid, _.territoryid)
 }
 
 object SalesterritoryhistoryFields {

--- a/typo-tester-zio-jdbc/generated-and-checked-in/adventureworks/sales/shoppingcartitem/ShoppingcartitemFields.scala
+++ b/typo-tester-zio-jdbc/generated-and-checked-in/adventureworks/sales/shoppingcartitem/ShoppingcartitemFields.scala
@@ -8,7 +8,10 @@ package sales
 package shoppingcartitem
 
 import adventureworks.customtypes.TypoLocalDateTime
+import adventureworks.production.product.ProductFields
 import adventureworks.production.product.ProductId
+import adventureworks.production.product.ProductRow
+import typo.dsl.ForeignKey
 import typo.dsl.Path
 import typo.dsl.SqlExpr.Field
 import typo.dsl.SqlExpr.FieldLikeNoHkt
@@ -22,6 +25,9 @@ trait ShoppingcartitemFields {
   def productid: Field[ProductId, ShoppingcartitemRow]
   def datecreated: Field[TypoLocalDateTime, ShoppingcartitemRow]
   def modifieddate: Field[TypoLocalDateTime, ShoppingcartitemRow]
+  def fkProductionProduct: ForeignKey[ProductFields, ProductRow] =
+    ForeignKey[ProductFields, ProductRow]("sales.FK_ShoppingCartItem_Product_ProductID", Nil)
+      .withColumnPair(productid, _.productid)
 }
 
 object ShoppingcartitemFields {

--- a/typo-tester-zio-jdbc/generated-and-checked-in/adventureworks/sales/specialofferproduct/SpecialofferproductFields.scala
+++ b/typo-tester-zio-jdbc/generated-and-checked-in/adventureworks/sales/specialofferproduct/SpecialofferproductFields.scala
@@ -9,8 +9,13 @@ package specialofferproduct
 
 import adventureworks.customtypes.TypoLocalDateTime
 import adventureworks.customtypes.TypoUUID
+import adventureworks.production.product.ProductFields
 import adventureworks.production.product.ProductId
+import adventureworks.production.product.ProductRow
+import adventureworks.sales.specialoffer.SpecialofferFields
 import adventureworks.sales.specialoffer.SpecialofferId
+import adventureworks.sales.specialoffer.SpecialofferRow
+import typo.dsl.ForeignKey
 import typo.dsl.Path
 import typo.dsl.SqlExpr.Field
 import typo.dsl.SqlExpr.FieldLikeNoHkt
@@ -22,6 +27,12 @@ trait SpecialofferproductFields {
   def productid: IdField[ProductId, SpecialofferproductRow]
   def rowguid: Field[TypoUUID, SpecialofferproductRow]
   def modifieddate: Field[TypoLocalDateTime, SpecialofferproductRow]
+  def fkProductionProduct: ForeignKey[ProductFields, ProductRow] =
+    ForeignKey[ProductFields, ProductRow]("sales.FK_SpecialOfferProduct_Product_ProductID", Nil)
+      .withColumnPair(productid, _.productid)
+  def fkSpecialoffer: ForeignKey[SpecialofferFields, SpecialofferRow] =
+    ForeignKey[SpecialofferFields, SpecialofferRow]("sales.FK_SpecialOfferProduct_SpecialOffer_SpecialOfferID", Nil)
+      .withColumnPair(specialofferid, _.specialofferid)
 }
 
 object SpecialofferproductFields {

--- a/typo-tester-zio-jdbc/generated-and-checked-in/adventureworks/sales/store/StoreFields.scala
+++ b/typo-tester-zio-jdbc/generated-and-checked-in/adventureworks/sales/store/StoreFields.scala
@@ -10,8 +10,13 @@ package store
 import adventureworks.customtypes.TypoLocalDateTime
 import adventureworks.customtypes.TypoUUID
 import adventureworks.customtypes.TypoXml
+import adventureworks.person.businessentity.BusinessentityFields
 import adventureworks.person.businessentity.BusinessentityId
+import adventureworks.person.businessentity.BusinessentityRow
 import adventureworks.public.Name
+import adventureworks.sales.salesperson.SalespersonFields
+import adventureworks.sales.salesperson.SalespersonRow
+import typo.dsl.ForeignKey
 import typo.dsl.Path
 import typo.dsl.SqlExpr.Field
 import typo.dsl.SqlExpr.FieldLikeNoHkt
@@ -26,6 +31,12 @@ trait StoreFields {
   def demographics: OptField[TypoXml, StoreRow]
   def rowguid: Field[TypoUUID, StoreRow]
   def modifieddate: Field[TypoLocalDateTime, StoreRow]
+  def fkPersonBusinessentity: ForeignKey[BusinessentityFields, BusinessentityRow] =
+    ForeignKey[BusinessentityFields, BusinessentityRow]("sales.FK_Store_BusinessEntity_BusinessEntityID", Nil)
+      .withColumnPair(businessentityid, _.businessentityid)
+  def fkSalesperson: ForeignKey[SalespersonFields, SalespersonRow] =
+    ForeignKey[SalespersonFields, SalespersonRow]("sales.FK_Store_SalesPerson_SalesPersonID", Nil)
+      .withColumnPair(salespersonid, _.businessentityid)
 }
 
 object StoreFields {

--- a/typo-tester-zio-jdbc/src/scala/adventureworks/production/product/ProductTest.scala
+++ b/typo-tester-zio-jdbc/src/scala/adventureworks/production/product/ProductTest.scala
@@ -90,6 +90,13 @@ class ProductTest extends AnyFunSuite with TypeCheckedTripleEquals {
         }
         _ <- ZIO.succeed(assert(saved3.modifieddate == newModifiedDate))
         _ <- productRepo.update(saved3.copy(size = None)).map(res => assert(res))
+        query0 = productRepo.select
+          .joinFk(_.fkProductmodel)(projectModelRepo.select)
+          .joinFk(_._1.fkProductsubcategory)(productsubcategoryRepo.select)
+          .joinFk(_._2.fkProductcategory)(productcategoryRepo.select)
+        _ <- query0.toChunk.map(println(_))
+        _ <- ZIO.succeed(query0.sql.foreach(f => println(f)))
+        _ <- ZIO.succeed(println("foo"))
         query = productRepo.select
           .where(_.`class` === "H ")
           .where(x => (x.daystomanufacture > 25).or(x.daystomanufacture <= 0))

--- a/typo/src/scala/typo/Naming.scala
+++ b/typo/src/scala/typo/Naming.scala
@@ -59,6 +59,16 @@ class Naming(val pkg: sc.QIdent) {
   def field(name: db.ColName): sc.Ident =
     Naming.camelCaseIdent(name.value.split('_'))
 
+  def fk(baseTable: db.RelationName, fk: db.ForeignKey, includeCols: Boolean): sc.Ident = {
+    val parts = Array[Iterable[String]](
+      List("fk"),
+      fk.otherTable.schema.filterNot(baseTable.schema.contains),
+      List(fk.otherTable.name),
+      if (includeCols) fk.cols.toList.flatMap(_.value.split("_")) else Nil
+    )
+    Naming.camelCaseIdent(parts.flatten)
+  }
+
   // multiple field names together into one name
   def field(colNames: NonEmptyList[db.ColName]): sc.Ident =
     Naming.camelCaseIdent(colNames.map(field).map(_.value).toArray)


### PR DESCRIPTION
these are generated in `Fields` objects so othey are accessible in DSL:

### generated boilerplate:

```scala
  def fkEmployee: ForeignKey[EmployeeFields, EmployeeRow] =
    ForeignKey[EmployeeFields, EmployeeRow]("humanresources.FK_JobCandidate_Employee_BusinessEntityID", Nil)
      .withColumnPair(businessentityid, _.businessentityid)

```

### usage:

```scala
      val query0 = productRepo.select
        .joinFk(_.fkProductmodel)(projectModelRepo.select)
        .joinFk(_._1.fkProductsubcategory)(productsubcategoryRepo.select)
        .joinFk(_._2.fkProductcategory)(productcategoryRepo.select)
      query0.toList.foreach(println)
```
