### PR TITLE
Add `seek`

### DIFF
--- a/typo-dsl-anorm/src/scala/typo/dsl/SelectBuilder.scala
+++ b/typo-dsl-anorm/src/scala/typo/dsl/SelectBuilder.scala
@@ -42,8 +42,18 @@ trait SelectBuilder[Fields[_], Row] {
     *        .orderBy { case ((_, _), productModel) => productModel(_.name).desc.withNullsFirst }
     * }}}
     */
-  final def orderBy(v: Fields[Hidden] => SortOrder[?, Hidden]): SelectBuilder[Fields, Row] =
-    withParams(params.orderBy(v.asInstanceOf[Fields[Row] => SortOrder[?, Row]]))
+  final def orderBy[T, N[_]](v: Fields[Hidden] => SortOrder[T, N, Hidden]): SelectBuilder[Fields, Row] =
+    withParams(params.orderBy(v.asInstanceOf[Fields[Row] => SortOrderNoHkt[?, Row]]))
+
+  final def seek[T, N[_]](v: Fields[Row] => SortOrder[T, N, Row])(value: SqlExpr.Const[T, N, Row]): SelectBuilder[Fields, Row] =
+    withParams(params.seek(SelectParams.Seek[Fields, Row, T, N](v, value)))
+
+  final def maybeSeek[T, N[_]](v: Fields[Row] => SortOrder[T, N, Row])(maybeValue: Option[SqlExpr.Const[T, N, Row]]): SelectBuilder[Fields, Row] =
+    maybeValue match {
+      case Some(value) => seek(v)(value)
+      case None        => orderBy(v.asInstanceOf[Fields[Hidden] => SortOrder[T, N, Hidden]])
+    }
+
   final def offset(v: Int): SelectBuilder[Fields, Row] =
     withParams(params.offset(v))
   final def limit(v: Int): SelectBuilder[Fields, Row] =

--- a/typo-dsl-anorm/src/scala/typo/dsl/SortOrder.scala
+++ b/typo-dsl-anorm/src/scala/typo/dsl/SortOrder.scala
@@ -4,13 +4,24 @@ import typo.dsl.Fragment.FragmentStringInterpolator
 
 import java.util.concurrent.atomic.AtomicInteger
 
-// sort by a field
-case class SortOrder[NT, R](expr: SqlExpr.SqlExprNoHkt[NT, R], ascending: Boolean, nullsFirst: Boolean)(implicit val ordering: Ordering[NT]) {
-  def withNullsFirst: SortOrder[NT, R] = copy(nullsFirst = true)(ordering)
-  def render(counter: AtomicInteger): Fragment =
+sealed trait SortOrderNoHkt[NT, R] {
+  val expr: SqlExpr.SqlExprNoHkt[NT, R]
+  val ascending: Boolean
+  val nullsFirst: Boolean
+
+  def withNullsFirst: SortOrderNoHkt[NT, R]
+
+  final def render(counter: AtomicInteger): Fragment = {
     List[Fragment](
       expr.render(counter),
       if (ascending) frag"ASC" else frag"DESC",
       if (nullsFirst) frag"NULLS FIRST" else Fragment.empty
     ).mkFragment(" ")
+  }
+}
+
+// sort by a field
+final case class SortOrder[T, N[_], R](expr: SqlExpr[T, N, R], ascending: Boolean, nullsFirst: Boolean)(implicit val ordering: Ordering[T], val nullability: Nullability[N])
+    extends SortOrderNoHkt[N[T], R] {
+  def withNullsFirst: SortOrder[T, N, R] = copy(nullsFirst = true)(ordering, nullability)
 }

--- a/typo-dsl-doobie/src/scala/typo/dsl/SelectBuilderMock.scala
+++ b/typo-dsl-doobie/src/scala/typo/dsl/SelectBuilderMock.scala
@@ -2,6 +2,8 @@ package typo.dsl
 
 import doobie.free.connection.ConnectionIO
 import doobie.util.fragment.Fragment
+import typo.dsl.internal.mocks.RowOrdering
+import typo.dsl.internal.seeks
 
 case class SelectBuilderMock[Fields[_], Row](
     structure: Structure[Fields, Row],
@@ -12,7 +14,7 @@ case class SelectBuilderMock[Fields[_], Row](
     copy(params = sqlParams)
 
   override def toList: ConnectionIO[List[Row]] =
-    all.map(all => SelectParams.applyParams(structure.fields, all, params))
+    all.map(all => SelectBuilderMock.applyParams(structure.fields, all, params))
 
   override def joinOn[Fields2[_], N[_]: Nullability, Row2](
       other: SelectBuilder[Fields2, Row2]
@@ -62,4 +64,16 @@ case class SelectBuilderMock[Fields[_], Row](
   }
 
   override def sql: Option[Fragment] = None
+}
+
+object SelectBuilderMock {
+  def applyParams[Fields[_], Row](fields: Fields[Row], rows: List[Row], params: SelectParams[Fields, Row]): List[Row] = {
+    val (filters, orderBys) = seeks.expand(fields, params)
+    implicit val rowOrdering: Ordering[Row] = new RowOrdering(orderBys)
+    rows
+      .filter(row => filters.forall(_.eval(row).getOrElse(false)))
+      .sorted
+      .drop(params.offset.getOrElse(0))
+      .take(params.limit.getOrElse(Int.MaxValue))
+  }
 }

--- a/typo-dsl-doobie/src/scala/typo/dsl/SelectParams.scala
+++ b/typo-dsl-doobie/src/scala/typo/dsl/SelectParams.scala
@@ -4,55 +4,46 @@ import cats.data.NonEmptyList
 import doobie.implicits.toSqlInterpolator
 import doobie.util.fragment.Fragment
 import doobie.util.fragments
+import typo.dsl.internal.seeks
 
 import java.util.concurrent.atomic.AtomicInteger
 
-case class SelectParams[Fields[_], Row](
+final case class SelectParams[Fields[_], Row](
     where: List[Fields[Row] => SqlExpr[Boolean, Option, Row]],
-    orderBy: List[Fields[Row] => SortOrder[?, Row]],
+    orderBy: List[Fields[Row] => SortOrderNoHkt[?, Row]],
+    seeks: List[SelectParams.SeekNoHkt[Fields, Row, ?]],
     offset: Option[Int],
     limit: Option[Int]
 ) {
   def where(v: Fields[Row] => SqlExpr[Boolean, Option, Row]): SelectParams[Fields, Row] = copy(where = where :+ v)
-  def orderBy(v: Fields[Row] => SortOrder[?, Row]): SelectParams[Fields, Row] = copy(orderBy = orderBy :+ v)
+  def orderBy(v: Fields[Row] => SortOrderNoHkt[?, Row]): SelectParams[Fields, Row] = copy(orderBy = orderBy :+ v)
+  def seek(v: SelectParams.SeekNoHkt[Fields, Row, ?]): SelectParams[Fields, Row] = copy(seeks = seeks :+ v)
   def offset(v: Int): SelectParams[Fields, Row] = copy(offset = Some(v))
   def limit(v: Int): SelectParams[Fields, Row] = copy(limit = Some(v))
 }
 
 object SelectParams {
   def empty[Fields[_], Row]: SelectParams[Fields, Row] =
-    SelectParams[Fields, Row](List.empty, List.empty, None, None)
+    SelectParams[Fields, Row](List.empty, List.empty, List.empty, None, None)
+
+  sealed trait SeekNoHkt[Fields[_], Row, NT] {
+    val f: Fields[Row] => SortOrderNoHkt[NT, Row]
+  }
+
+  case class Seek[Fields[_], Row, T, N[_]](
+      f: Fields[Row] => SortOrder[T, N, Row],
+      value: SqlExpr.Const[T, N, Row]
+  ) extends SeekNoHkt[Fields, Row, N[T]]
 
   def render[Row, Fields[_]](fields: Fields[Row], baseSql: Fragment, counter: AtomicInteger, params: SelectParams[Fields, Row]): Fragment = {
+    val (filters, orderBys) = seeks.expand(fields, params)
+
     List[Option[Fragment]](
       Some(baseSql),
-      NonEmptyList.fromFoldable(params.where.map(f => f(fields).render(counter))).map(fragments.whereAnd(_)),
-      NonEmptyList.fromFoldable(params.orderBy.map(f => f(fields).render(counter))).map(fragments.orderBy(_)),
+      NonEmptyList.fromFoldable(filters.map(f => f.render(counter))).map(fragments.whereAnd(_)),
+      NonEmptyList.fromFoldable(orderBys.map(f => f.render(counter))).map(fragments.orderBy(_)),
       params.offset.map(value => fr"offset $value"),
       params.limit.map(value => fr"limit $value")
     ).flatten.reduce(_ ++ _)
-  }
-
-  def applyParams[Fields[_], Row](fields: Fields[Row], rows: List[Row], params: SelectParams[Fields, Row]): List[Row] = {
-    // precompute filters and order bys for this row structure
-    val filters: List[SqlExpr[Boolean, Option, Row]] =
-      params.where.map(f => f(fields))
-    val orderBys: List[SortOrder[?, Row]] =
-      params.orderBy.map(f => f(fields))
-
-    rows
-      .filter(row => filters.forall(_.eval(row).getOrElse(false)))
-      .sorted((row1: Row, row2: Row) =>
-        orderBys.foldLeft(0) {
-          case (acc, so: SortOrder[t, Row]) if acc == 0 =>
-            val t1: t = so.expr.eval(row1)
-            val t2: t = so.expr.eval(row2)
-            val ordering: Ordering[t] = if (so.ascending) so.ordering else so.ordering.reverse
-            ordering.compare(t1, t2)
-          case (acc, _) => acc
-        }
-      )
-      .drop(params.offset.getOrElse(0))
-      .take(params.limit.getOrElse(Int.MaxValue))
   }
 }

--- a/typo-dsl-doobie/src/scala/typo/dsl/SortOrder.scala
+++ b/typo-dsl-doobie/src/scala/typo/dsl/SortOrder.scala
@@ -6,13 +6,23 @@ import doobie.util.fragment.Fragment
 
 import java.util.concurrent.atomic.AtomicInteger
 
-// sort by a field
-case class SortOrder[NT, R](expr: SqlExpr.SqlExprNoHkt[NT, R], ascending: Boolean, nullsFirst: Boolean)(implicit val ordering: Ordering[NT]) {
-  def withNullsFirst: SortOrder[NT, R] = copy(nullsFirst = true)(ordering)
+sealed trait SortOrderNoHkt[NT, R] {
+  val expr: SqlExpr.SqlExprNoHkt[NT, R]
+  val ascending: Boolean
+  val nullsFirst: Boolean
+
+  def withNullsFirst: SortOrderNoHkt[NT, R]
+
   def render(counter: AtomicInteger): Fragment =
     List[Fragment](
       expr.render(counter),
       if (ascending) fr"ASC" else fr"DESC",
       if (nullsFirst) fr"NULLS FIRST" else Fragment.empty
     ).intercalate(fr" ")
+}
+
+// sort by a field
+final case class SortOrder[T, N[_], R](expr: SqlExpr[T, N, R], ascending: Boolean, nullsFirst: Boolean)(implicit val ordering: Ordering[T], val nullability: Nullability[N])
+    extends SortOrderNoHkt[N[T], R] {
+  def withNullsFirst: SortOrder[T, N, R] = copy(nullsFirst = true)(ordering, nullability)
 }

--- a/typo-dsl-doobie/src/scala/typo/dsl/UpdateBuilder.scala
+++ b/typo-dsl-doobie/src/scala/typo/dsl/UpdateBuilder.scala
@@ -6,7 +6,7 @@ import doobie.ConnectionIO
 import doobie.free.connection.delay
 import doobie.implicits.toSqlInterpolator
 import doobie.util.fragment.Fragment
-import doobie.util.{Put, Read, fragments}
+import doobie.util.{Put, Read, Write, fragments}
 
 import java.util.concurrent.atomic.AtomicInteger
 
@@ -20,8 +20,8 @@ trait UpdateBuilder[Fields[_], Row] {
   final def where[N[_]: Nullability](v: Fields[Row] => SqlExpr[Boolean, N, Row]): UpdateBuilder[Fields, Row] =
     withParams(params.where(f => v(f).?.coalesce(false)))
 
-  final def setValue[N[_], T](col: Fields[Row] => SqlExpr.FieldLikeNotId[T, N, Row])(value: N[T])(implicit P: Put[N[T]]): UpdateBuilder[Fields, Row] =
-    withParams(params.set(col, _ => SqlExpr.Const[T, N, Row](value, P)))
+  final def setValue[N[_], T](col: Fields[Row] => SqlExpr.FieldLikeNotId[T, N, Row])(value: N[T])(implicit P: Put[T], W: Write[N[T]]): UpdateBuilder[Fields, Row] =
+    withParams(params.set(col, _ => SqlExpr.Const[T, N, Row](value, P, W)))
 
   final def setComputedValue[T, N[_]](col: Fields[Row] => SqlExpr.FieldLikeNotId[T, N, Row])(value: SqlExpr.FieldLikeNotId[T, N, Row] => SqlExpr[T, N, Row]): UpdateBuilder[Fields, Row] =
     withParams(params.set(col, fields => value(col(fields))))

--- a/typo-dsl-shared/typo/dsl/internal/mocks.scala
+++ b/typo-dsl-shared/typo/dsl/internal/mocks.scala
@@ -1,0 +1,18 @@
+package typo.dsl.internal
+
+import typo.dsl.{SortOrder, SortOrderNoHkt}
+
+object mocks {
+  class RowOrdering[Row](sortOrderings: List[SortOrderNoHkt[?, Row]]) extends Ordering[Row] {
+    override def compare(leftRow: Row, rightRow: Row): Int =
+      sortOrderings.iterator
+        .map { case so: SortOrder[t, n, Row] @unchecked /* for 2.13*/ =>
+          val left = so.expr.eval(leftRow)
+          val right = so.expr.eval(rightRow)
+          val ordering: Ordering[Option[t]] = Ordering.Option(if (so.ascending) so.ordering else so.ordering.reverse)
+          ordering.compare(so.nullability.toOpt(left), so.nullability.toOpt(right))
+        }
+        .find(_ != 0)
+        .getOrElse(0)
+  }
+}

--- a/typo-dsl-shared/typo/dsl/internal/seeks.scala
+++ b/typo-dsl-shared/typo/dsl/internal/seeks.scala
@@ -1,0 +1,60 @@
+package typo.dsl.internal
+
+import typo.dsl.SelectParams.Seek
+import typo.dsl.*
+
+object seeks {
+  def expand[Fields[_], Row](fields: Fields[Row], params: SelectParams[Fields, Row]): (List[SqlExpr[Boolean, Option, Row]], List[SortOrderNoHkt[?, Row]]) =
+    params.seeks match {
+      case Nil => (params.where.map(_.apply(fields)), params.orderBy.map(_.apply(fields)))
+      case nonEmpty =>
+        require(params.orderBy.isEmpty, "Cannot have both seeks and orderBy")
+        val seekOrderBys: List[SortOrderNoHkt[?, Row]] =
+          nonEmpty.map { case seek: Seek[Fields, Row, _, _] @unchecked /* for 2.13*/ => seek.f(fields) }
+
+        val seekWhere: SqlExpr[Boolean, Option, Row] =
+          seekOrderBys.map(_.ascending).distinct match {
+            case List(uniformIsAscending) =>
+              val dbTuple = SqlExpr.RowExpr(seekOrderBys.map(so => so.expr))
+              val valueTuple = SqlExpr.RowExpr(nonEmpty.map { case seek: Seek[Fields, Row, t, n] @unchecked /* for 2.13 */ => seek.value })
+              // this is for mock repositories. it's hard to separate it out from here
+              implicit val ordering: Ordering[List[?]] = (leftRow: List[?], rightRow: List[?]) =>
+                leftRow.iterator
+                  .zip(rightRow.iterator)
+                  .zip(seekOrderBys.iterator)
+                  .map { case ((left, right), so: SortOrder[t, n, Row] @unchecked) /* for 2.13*/ =>
+                    val ordering: Ordering[Option[t]] = Ordering.Option(if (so.ascending) so.ordering else so.ordering.reverse)
+                    ordering.compare(so.nullability.toOpt(left.asInstanceOf[n[t]]), so.nullability.toOpt(right.asInstanceOf[n[t]]))
+                  }
+                  .find(_ != 0)
+                  .getOrElse(0)
+
+              if (uniformIsAscending) dbTuple > valueTuple else dbTuple < valueTuple
+            case _ =>
+              val orConditions: Seq[SqlExpr[Boolean, Option, Row]] =
+                nonEmpty.indices.map { i =>
+                  val equals: List[SqlExpr[Boolean, Option, Row]] =
+                    nonEmpty.take(i).map { case seek: Seek[Fields, Row, t, n] @unchecked /* for 2.13*/ =>
+                      val so: SortOrder[t, n, Row] = seek.f(fields)
+                      implicit val n: Nullability2[n, n, Option] = Nullability2.opt(using so.nullability, so.nullability)
+                      implicit val ordering: Ordering[t] = so.ordering
+                      so.expr === seek.value
+                    }
+
+                  nonEmpty(i) match {
+                    case seek: Seek[Fields, Row, t, n] @unchecked /* for 2.13*/ =>
+                      val so: SortOrder[t, n, Row] = seek.f(fields)
+                      implicit val n: Nullability2[n, n, Option] = Nullability2.opt(using so.nullability, so.nullability)
+                      implicit val ordering: Ordering[t] = so.ordering
+                      val predicate: SqlExpr[Boolean, Option, Row] =
+                        if (so.ascending) so.expr > seek.value else so.expr < seek.value
+                      (equals :+ predicate).reduce(_ and _)
+                  }
+                }
+
+              orConditions.reduce(_ or _)
+          }
+
+        (params.where.map(_.apply(fields)) :+ seekWhere, seekOrderBys)
+    }
+}

--- a/typo-dsl-zio-jdbc/src/scala/typo/dsl/SelectBuilder.scala
+++ b/typo-dsl-zio-jdbc/src/scala/typo/dsl/SelectBuilder.scala
@@ -43,12 +43,21 @@ trait SelectBuilder[Fields[_], Row] {
     *        .orderBy { case ((_, _), productModel) => productModel(_.name).desc.withNullsFirst }
     * }}}
     */
-  final def orderBy(v: Fields[Hidden] => SortOrder[?, Hidden]): SelectBuilder[Fields, Row] =
-    withParams(params.orderBy(v.asInstanceOf[Fields[Row] => SortOrder[?, Row]]))
+  final def orderBy[T, N[_]](v: Fields[Hidden] => SortOrder[T, N, Hidden]): SelectBuilder[Fields, Row] =
+    withParams(params.orderBy(v.asInstanceOf[Fields[Row] => SortOrderNoHkt[?, Row]]))
   final def offset(v: Int): SelectBuilder[Fields, Row] =
     withParams(params.offset(v))
   final def limit(v: Int): SelectBuilder[Fields, Row] =
     withParams(params.limit(v))
+
+  final def seek[T, N[_]](v: Fields[Row] => SortOrder[T, N, Row])(value: SqlExpr.Const[T, N, Row]): SelectBuilder[Fields, Row] =
+    withParams(params.seek(SelectParams.Seek[Fields, Row, T, N](v, value)))
+
+  final def maybeSeek[T, N[_]](v: Fields[Row] => SortOrder[T, N, Row])(maybeValue: Option[SqlExpr.Const[T, N, Row]]): SelectBuilder[Fields, Row] =
+    maybeValue match {
+      case Some(value) => seek(v)(value)
+      case None        => orderBy(v.asInstanceOf[Fields[Hidden] => SortOrder[T, N, Hidden]])
+    }
 
   /** Execute the query and return the results as a list */
   def toChunk: ZIO[ZConnection, Throwable, Chunk[Row]]

--- a/typo-dsl-zio-jdbc/src/scala/typo/dsl/SelectParams.scala
+++ b/typo-dsl-zio-jdbc/src/scala/typo/dsl/SelectParams.scala
@@ -1,56 +1,46 @@
 package typo.dsl
 
+import typo.dsl.internal.seeks
+import zio.NonEmptyChunk
 import zio.jdbc.*
-import zio.{Chunk, NonEmptyChunk}
 
 import java.util.concurrent.atomic.AtomicInteger
 
 final case class SelectParams[Fields[_], Row](
     where: List[Fields[Row] => SqlExpr[Boolean, Option, Row]],
-    orderBy: List[Fields[Row] => SortOrder[?, Row]],
+    orderBy: List[Fields[Row] => SortOrderNoHkt[?, Row]],
+    seeks: List[SelectParams.SeekNoHkt[Fields, Row, ?]],
     offset: Option[Int],
     limit: Option[Int]
 ) {
   def where(v: Fields[Row] => SqlExpr[Boolean, Option, Row]): SelectParams[Fields, Row] = copy(where = where :+ v)
-  def orderBy(v: Fields[Row] => SortOrder[?, Row]): SelectParams[Fields, Row] = copy(orderBy = orderBy :+ v)
+  def orderBy(v: Fields[Row] => SortOrderNoHkt[?, Row]): SelectParams[Fields, Row] = copy(orderBy = orderBy :+ v)
+  def seek(v: SelectParams.SeekNoHkt[Fields, Row, ?]): SelectParams[Fields, Row] = copy(seeks = seeks :+ v)
   def offset(v: Int): SelectParams[Fields, Row] = copy(offset = Some(v))
   def limit(v: Int): SelectParams[Fields, Row] = copy(limit = Some(v))
 }
 
 object SelectParams {
+  sealed trait SeekNoHkt[Fields[_], Row, NT] {
+    val f: Fields[Row] => SortOrderNoHkt[NT, Row]
+  }
+
+  case class Seek[Fields[_], Row, T, N[_]](
+      f: Fields[Row] => SortOrder[T, N, Row],
+      value: SqlExpr.Const[T, N, Row]
+  ) extends SeekNoHkt[Fields, Row, N[T]]
+
   def empty[Fields[_], Row]: SelectParams[Fields, Row] =
-    SelectParams[Fields, Row](List.empty, List.empty, None, None)
+    SelectParams[Fields, Row](List.empty, List.empty, List.empty, None, None)
 
   def render[Row, Fields[_]](fields: Fields[Row], baseSql: SqlFragment, counter: AtomicInteger, params: SelectParams[Fields, Row]): SqlFragment = {
+    val (filters, orderBys) = seeks.expand(fields, params)
     List[Option[SqlFragment]](
       Some(baseSql),
-      NonEmptyChunk.fromIterableOption(params.where.map(f => f(fields).render(counter))).map(fs => fs.mkFragment(" WHERE ", " AND ", "")),
-      NonEmptyChunk.fromIterableOption(params.orderBy.map(f => f(fields).render(counter))).map(fs => fs.mkFragment(" ORDER BY ", ", ", "")),
+      NonEmptyChunk.fromIterableOption(filters.map(f => f.render(counter))).map(fs => fs.mkFragment(" WHERE ", " AND ", "")),
+      NonEmptyChunk.fromIterableOption(orderBys.map(f => f.render(counter))).map(fs => fs.mkFragment(" ORDER BY ", ", ", "")),
       params.offset.map(value => sql" offset $value"),
       params.limit.map(value => sql" limit $value")
     ).flatten.reduce(_ ++ _)
-  }
-
-  def applyParams[Fields[_], Row](fields: Fields[Row], rows: Chunk[Row], params: SelectParams[Fields, Row]): Chunk[Row] = {
-    // precompute filters and order bys for this row structure
-    val filters: List[SqlExpr[Boolean, Option, Row]] =
-      params.where.map(f => f(fields))
-    val orderBys: List[SortOrder[?, Row]] =
-      params.orderBy.map(f => f(fields))
-
-    rows
-      .filter(row => filters.forall(_.eval(row).getOrElse(false)))
-      .sorted((row1: Row, row2: Row) =>
-        orderBys.foldLeft(0) {
-          case (acc, so: SortOrder[t, Row]) if acc == 0 =>
-            val t1: t = so.expr.eval(row1)
-            val t2: t = so.expr.eval(row2)
-            val ordering: Ordering[t] = if (so.ascending) so.ordering else so.ordering.reverse
-            ordering.compare(t1, t2)
-          case (acc, _) => acc
-        }
-      )
-      .drop(params.offset.getOrElse(0))
-      .take(params.limit.getOrElse(Int.MaxValue))
   }
 }

--- a/typo-dsl-zio-jdbc/src/scala/typo/dsl/SortOrder.scala
+++ b/typo-dsl-zio-jdbc/src/scala/typo/dsl/SortOrder.scala
@@ -4,14 +4,24 @@ import zio.Chunk
 import zio.jdbc.*
 import java.util.concurrent.atomic.AtomicInteger
 
-// sort by a field
-final case class SortOrder[NT, R](expr: SqlExpr.SqlExprNoHkt[NT, R], ascending: Boolean, nullsFirst: Boolean)(implicit val ordering: Ordering[NT]) {
-  def withNullsFirst: SortOrder[NT, R] = copy(nullsFirst = true)(ordering)
-  def render(counter: AtomicInteger): SqlFragment = {
+sealed trait SortOrderNoHkt[NT, R] {
+  val expr: SqlExpr.SqlExprNoHkt[NT, R]
+  val ascending: Boolean
+  val nullsFirst: Boolean
+
+  def withNullsFirst: SortOrderNoHkt[NT, R]
+
+  final def render(counter: AtomicInteger): SqlFragment = {
     Chunk(
       expr.render(counter),
       if (ascending) sql"ASC" else sql"DESC",
       if (nullsFirst) sql"NULLS FIRST" else SqlFragment.empty
     ).mkFragment(" ")
   }
+}
+
+// sort by a field
+final case class SortOrder[T, N[_], R](expr: SqlExpr[T, N, R], ascending: Boolean, nullsFirst: Boolean)(implicit val ordering: Ordering[T], val nullability: Nullability[N])
+    extends SortOrderNoHkt[N[T], R] {
+  def withNullsFirst: SortOrder[T, N, R] = copy(nullsFirst = true)(ordering, nullability)
 }

--- a/typo-dsl-zio-jdbc/src/scala/typo/dsl/SqlExpr.scala
+++ b/typo-dsl-zio-jdbc/src/scala/typo/dsl/SqlExpr.scala
@@ -185,7 +185,7 @@ object SqlExpr {
     override def eval(row: R): N[O] =
       N.mapN(left.eval(row), right.eval(row))(op.eval)
     override def render(counter: AtomicInteger): SqlFragment =
-      sql"${left.render(counter)} ${SqlFragment(op.name)} ${right.render(counter)}"
+      sql"(${left.render(counter)} ${SqlFragment(op.name)} ${right.render(counter)})"
   }
 
   final case class Underlying[T, TT, N[_], R](expr: SqlExpr[T, N, R], bijection: Bijection[T, TT], N: Nullability[N]) extends SqlExpr[TT, N, R] {
@@ -233,16 +233,21 @@ object SqlExpr {
   }
 
   // automatically put values in a constant expression
-  implicit def asConstOpt[T, R](t: Option[T])(implicit E: JdbcEncoder[Option[T]], P: ParameterMetaData[T]): SqlExpr[T, Option, R] =
+  implicit def asConstOpt[T, R](t: Option[T])(implicit E: JdbcEncoder[Option[T]], P: ParameterMetaData[T]): SqlExpr.Const[T, Option, R] =
     Const(t, E, P)
 
-  implicit def asConstRequired[T: JdbcEncoder: ParameterMetaData, R](t: T): SqlExpr[T, Required, R] =
+  implicit def asConstRequired[T: JdbcEncoder: ParameterMetaData, R](t: T): SqlExpr.Const[T, Required, R] =
     Const[T, Required, R](t, implicitly, implicitly)
 
   // some syntax to construct field sort order
-  implicit class SqlExprSortSyntax[NT, R](private val expr: SqlExprNoHkt[NT, R]) extends AnyVal {
-    def asc(implicit O: Ordering[NT]): SortOrder[NT, R] = SortOrder(expr, ascending = true, nullsFirst = false)
-    def desc(implicit O: Ordering[NT]): SortOrder[NT, R] = SortOrder(expr, ascending = false, nullsFirst = false)
+  implicit class SqlExprSortSyntax[T, N[_], R](private val expr: SqlExpr[T, N, R]) extends AnyVal {
+    def asc(implicit O: Ordering[T], N: Nullability[N]): SortOrder[T, N, R] = SortOrder(expr, ascending = true, nullsFirst = false)
+    def desc(implicit O: Ordering[T], N: Nullability[N]): SortOrder[T, N, R] = SortOrder(expr, ascending = false, nullsFirst = false)
+  }
+
+  final case class RowExpr[R](exprs: List[SqlExpr.SqlExprNoHkt[?, R]]) extends SqlExpr[List[?], Required, R] {
+    override def eval(row: R): List[?] = exprs.map(_.eval(row))
+    override def render(counter: AtomicInteger): SqlFragment = exprs.map(_.render(counter)).mkFragment(sql"(", sql",", sql")")
   }
 
   implicit class SqlExprArraySyntax[T, N[_], R](private val expr: SqlExpr[Array[T], N, R]) extends AnyVal {

--- a/typo-tester-anorm/src/scala/adventureworks/Reverse.scala
+++ b/typo-tester-anorm/src/scala/adventureworks/Reverse.scala
@@ -1,0 +1,6 @@
+package adventureworks
+
+case class Reverse[T](t: T) extends AnyVal
+object Reverse {
+  implicit def ordering[T: Ordering]: Ordering[Reverse[T]] = Ordering[T].reverse.on(_.t)
+}

--- a/typo-tester-anorm/src/scala/adventureworks/SeekDbTest.scala
+++ b/typo-tester-anorm/src/scala/adventureworks/SeekDbTest.scala
@@ -1,0 +1,94 @@
+package adventureworks
+
+import adventureworks.customtypes.{TypoLocalDateTime, TypoUUID}
+import adventureworks.person.businessentity.*
+import org.scalactic.TypeCheckedTripleEquals
+import org.scalatest.Assertion
+import org.scalatest.funsuite.AnyFunSuite
+
+import java.time.LocalDateTime
+import scala.annotation.nowarn
+
+class SeekDbTest extends AnyFunSuite with TypeCheckedTripleEquals {
+  def testUniformSeek(businessentityRepo: BusinessentityRepo): Assertion = {
+
+    val limit = 3
+    val now = LocalDateTime.of(2021, 1, 1, 0, 0)
+    val rows = List.range(0, limit * 2).map { i =>
+      // ensure some duplicate values
+      val time = TypoLocalDateTime(now.minusDays(i % limit.toLong))
+      BusinessentityRow(BusinessentityId.apply(i), TypoUUID.randomUUID, time)
+    }
+
+    // same as sql below
+    val List(group1, group2) = rows.sortBy(x => (x.modifieddate, x.businessentityid.value)).grouped(limit).toList: @unchecked
+
+    withConnection { implicit c =>
+      // batch insert some rows
+      businessentityRepo.insertStreaming(rows.iterator): Unit
+      val rows1 = businessentityRepo.select
+        .maybeSeek(_.modifieddate.asc)(None)
+        .maybeSeek(_.businessentityid.asc)(None)
+        .maybeSeek(_.rowguid.asc)(None)
+        .limit(limit)
+        .toList
+      assert(rows1 == group1): @nowarn
+      val rows2 = businessentityRepo.select
+        .maybeSeek(_.modifieddate.asc)(Some(rows1.last.modifieddate))
+        .maybeSeek(_.businessentityid.asc)(Some(rows1.last.businessentityid))
+        .maybeSeek(_.rowguid.asc)(Some(rows1.last.rowguid))
+        .limit(limit)
+        .toList
+      assert(rows2 == group2)
+    }
+  }
+
+  test("uniform in-memory") {
+    testUniformSeek(new BusinessentityRepoMock(_.toRow(???, ???, ???)))
+  }
+
+  test("uniform pg") {
+    testUniformSeek(new BusinessentityRepoImpl)
+  }
+
+  def testNonUniformSeek(businessentityRepo: BusinessentityRepo): Assertion = {
+
+    val limit = 3
+    val now = LocalDateTime.of(2021, 1, 1, 0, 0)
+    val rows = List.range(0, limit * 2).map { i =>
+      // ensure some duplicate values
+      val time = TypoLocalDateTime(now.minusDays(i % limit.toLong))
+      BusinessentityRow(BusinessentityId.apply(i), TypoUUID.randomUUID, time)
+    }
+
+    // same as sql below
+    val List(group1, group2) = rows.sortBy(x => (Reverse(x.modifieddate), x.businessentityid.value)).grouped(limit).toList: @unchecked
+
+    withConnection { implicit c =>
+      // batch insert some rows
+      businessentityRepo.insertStreaming(rows.iterator): @nowarn
+      val rows1 = businessentityRepo.select
+        .maybeSeek(_.modifieddate.desc)(None)
+        .maybeSeek(_.businessentityid.asc)(None)
+        .maybeSeek(_.rowguid.asc)(None)
+        .limit(limit)
+        .toList
+      assert(rows1 == group1): @nowarn
+      val rows2 = businessentityRepo.select
+        .maybeSeek(_.modifieddate.desc)(Some(rows1.last.modifieddate))
+        .maybeSeek(_.businessentityid.asc)(Some(rows1.last.businessentityid))
+        .maybeSeek(_.rowguid.asc)(Some(rows1.last.rowguid))
+        .limit(limit)
+        .toList
+      assert(rows2 == group2)
+    }
+  }
+
+  test("non-uniform in-memory") {
+    testNonUniformSeek(new BusinessentityRepoMock(_.toRow(???, ???, ???)))
+  }
+
+  test("non-uniform pg") {
+    testNonUniformSeek(new BusinessentityRepoImpl)
+  }
+}

--- a/typo-tester-anorm/src/scala/adventureworks/production/product/SeekTest.scala
+++ b/typo-tester-anorm/src/scala/adventureworks/production/product/SeekTest.scala
@@ -1,0 +1,48 @@
+package adventureworks.production.product
+
+import adventureworks.public.Name
+import org.scalactic.TypeCheckedTripleEquals
+import org.scalatest.funsuite.AnyFunSuite
+
+class SeekTest extends AnyFunSuite with TypeCheckedTripleEquals {
+  val productRepo = new ProductRepoImpl
+
+  val base =
+    """select "productid", "name", "productnumber", "makeflag", "finishedgoodsflag", "color", "safetystocklevel", "reorderpoint", "standardcost", "listprice", "size", "sizeunitmeasurecode", "weightunitmeasurecode", "weight", "daystomanufacture", "productline", "class", "style", "productsubcategoryid", "productmodelid", "sellstartdate"::text, "sellenddate"::text, "discontinueddate"::text, "rowguid", "modifieddate"::text from production.product"""
+
+  test("uniform ascending") {
+    val query = productRepo.select
+      .seek(_.name.asc)(Name("foo"))
+      .seek(_.weight.asc)(Some(BigDecimal(22.2)))
+      .seek(_.listprice.asc)(BigDecimal(33.3))
+    assertResult(query.sql.get.toString)(
+      s"""Fragment(List(NamedParameter(param1,ParameterValue(Name(foo))), NamedParameter(param2,ParameterValue(Some(22.2))), NamedParameter(param3,ParameterValue(33.3))),select "productid","name","productnumber","makeflag","finishedgoodsflag","color","safetystocklevel","reorderpoint","standardcost","listprice","size","sizeunitmeasurecode","weightunitmeasurecode","weight","daystomanufacture","productline","class","style","productsubcategoryid","productmodelid","sellstartdate"::text,"sellenddate"::text,"discontinueddate"::text,"rowguid","modifieddate"::text from production.product
+         | where ((name,weight,listprice) > ({param1}::VARCHAR,{param2}::DECIMAL,{param3}::DECIMAL)) order by name ASC , weight ASC , listprice ASC${" "}
+         |)""".stripMargin
+    )
+  }
+
+  test("uniform descending") {
+    val query = productRepo.select
+      .seek(_.name.desc)(Name("foo"))
+      .seek(_.weight.desc)(Some(BigDecimal(22.2)))
+      .seek(_.listprice.desc)(BigDecimal(33.3))
+    assertResult(query.sql.get.toString)(
+      s"""Fragment(List(NamedParameter(param1,ParameterValue(Name(foo))), NamedParameter(param2,ParameterValue(Some(22.2))), NamedParameter(param3,ParameterValue(33.3))),select "productid","name","productnumber","makeflag","finishedgoodsflag","color","safetystocklevel","reorderpoint","standardcost","listprice","size","sizeunitmeasurecode","weightunitmeasurecode","weight","daystomanufacture","productline","class","style","productsubcategoryid","productmodelid","sellstartdate"::text,"sellenddate"::text,"discontinueddate"::text,"rowguid","modifieddate"::text from production.product
+         | where ((name,weight,listprice) < ({param1}::VARCHAR,{param2}::DECIMAL,{param3}::DECIMAL)) order by name DESC , weight DESC , listprice DESC${" "}
+         |)""".stripMargin
+    )
+  }
+
+  test("complex") {
+    val query = productRepo.select
+      .seek(_.name.asc)(Name("foo"))
+      .seek(_.weight.desc)(Some(BigDecimal(22.2)))
+      .seek(_.listprice.desc)(BigDecimal(33.3))
+    assertResult(query.sql.get.toString)(
+      s"""Fragment(List(NamedParameter(param1,ParameterValue(Name(foo))), NamedParameter(param2,ParameterValue(Name(foo))), NamedParameter(param3,ParameterValue(Some(22.2))), NamedParameter(param4,ParameterValue(Name(foo))), NamedParameter(param5,ParameterValue(Some(22.2))), NamedParameter(param6,ParameterValue(33.3))),select "productid","name","productnumber","makeflag","finishedgoodsflag","color","safetystocklevel","reorderpoint","standardcost","listprice","size","sizeunitmeasurecode","weightunitmeasurecode","weight","daystomanufacture","productline","class","style","productsubcategoryid","productmodelid","sellstartdate"::text,"sellenddate"::text,"discontinueddate"::text,"rowguid","modifieddate"::text from production.product
+         | where (((name > {param1}::VARCHAR) OR ((name = {param2}::VARCHAR) AND (weight < {param3}::DECIMAL))) OR (((name = {param4}::VARCHAR) AND (weight = {param5}::DECIMAL)) AND (listprice < {param6}::DECIMAL))) order by name ASC , weight DESC , listprice DESC${" "}
+         |)""".stripMargin
+    )
+  }
+}

--- a/typo-tester-doobie/src/scala/adventureworks/Reverse.scala
+++ b/typo-tester-doobie/src/scala/adventureworks/Reverse.scala
@@ -1,0 +1,6 @@
+package adventureworks
+
+case class Reverse[T](t: T) extends AnyVal
+object Reverse {
+  implicit def ordering[T: Ordering]: Ordering[Reverse[T]] = Ordering[T].reverse.on(_.t)
+}

--- a/typo-tester-doobie/src/scala/adventureworks/SeekDbTest.scala
+++ b/typo-tester-doobie/src/scala/adventureworks/SeekDbTest.scala
@@ -1,0 +1,98 @@
+package adventureworks
+
+import adventureworks.customtypes.{TypoLocalDateTime, TypoUUID}
+import adventureworks.person.businessentity.*
+import doobie.free.connection.delay
+import org.scalactic.TypeCheckedTripleEquals
+import org.scalatest.Assertion
+import org.scalatest.funsuite.AnyFunSuite
+
+import java.time.LocalDateTime
+
+class SeekDbTest extends AnyFunSuite with TypeCheckedTripleEquals {
+  def testUniformSeek(businessentityRepo: BusinessentityRepo): Assertion = {
+
+    val limit = 3
+    val now = LocalDateTime.of(2021, 1, 1, 0, 0)
+    val rows = List.range(0, limit * 2).map { i =>
+      // ensure some duplicate values
+      val time = TypoLocalDateTime(now.minusDays(i % limit.toLong))
+      BusinessentityRow(BusinessentityId.apply(i), TypoUUID.randomUUID, time)
+    }
+
+    // same as sql below
+    val List(group1, group2) = rows.sortBy(x => (x.modifieddate, x.businessentityid.value)).grouped(limit).toList: @unchecked
+
+    withConnection(
+      for {
+        // batch insert some rows
+        _ <- businessentityRepo.insertStreaming(fs2.Stream.emits(rows))
+        rows1 <- businessentityRepo.select
+          .maybeSeek(_.modifieddate.asc)(None)
+          .maybeSeek(_.businessentityid.asc)(None)
+          .maybeSeek(_.rowguid.asc)(None)
+          .limit(limit)
+          .toList
+        _ <- delay(assert(rows1 == group1))
+        rows2 <- businessentityRepo.select
+          .maybeSeek(_.modifieddate.asc)(Some(rows1.last.modifieddate))
+          .maybeSeek(_.businessentityid.asc)(Some(rows1.last.businessentityid))
+          .maybeSeek(_.rowguid.asc)(Some(rows1.last.rowguid))
+          .limit(limit)
+          .toList
+        _ <- delay(assert(rows2 == group2))
+      } yield succeed
+    )
+  }
+
+  test("uniform in-memory") {
+    testUniformSeek(new BusinessentityRepoMock(_.toRow(???, ???, ???)))
+  }
+
+  test("uniform pg") {
+    testUniformSeek(new BusinessentityRepoImpl)
+  }
+
+  def testNonUniformSeek(businessentityRepo: BusinessentityRepo): Assertion = {
+
+    val limit = 3
+    val now = LocalDateTime.of(2021, 1, 1, 0, 0)
+    val rows = List.range(0, limit * 2).map { i =>
+      // ensure some duplicate values
+      val time = TypoLocalDateTime(now.minusDays(i % limit.toLong))
+      BusinessentityRow(BusinessentityId.apply(i), TypoUUID.randomUUID, time)
+    }
+
+    // same as sql below
+    val List(group1, group2) = rows.sortBy(x => (Reverse(x.modifieddate), x.businessentityid.value)).grouped(limit).toList: @unchecked
+
+    withConnection(
+      for {
+        // batch insert some rows
+        _ <- businessentityRepo.insertStreaming(fs2.Stream.emits(rows))
+        rows1 <- businessentityRepo.select
+          .maybeSeek(_.modifieddate.desc)(None)
+          .maybeSeek(_.businessentityid.asc)(None)
+          .maybeSeek(_.rowguid.asc)(None)
+          .limit(limit)
+          .toList
+        _ <- delay(assert(rows1 == group1))
+        rows2 <- businessentityRepo.select
+          .maybeSeek(_.modifieddate.desc)(Some(rows1.last.modifieddate))
+          .maybeSeek(_.businessentityid.asc)(Some(rows1.last.businessentityid))
+          .maybeSeek(_.rowguid.asc)(Some(rows1.last.rowguid))
+          .limit(limit)
+          .toList
+        _ <- delay(assert(rows2 == group2))
+      } yield succeed
+    )
+  }
+
+  test("non-uniform in-memory") {
+    testNonUniformSeek(new BusinessentityRepoMock(_.toRow(???, ???, ???)))
+  }
+
+  test("non-uniform pg") {
+    testNonUniformSeek(new BusinessentityRepoImpl)
+  }
+}

--- a/typo-tester-doobie/src/scala/adventureworks/production/product/SeekTest.scala
+++ b/typo-tester-doobie/src/scala/adventureworks/production/product/SeekTest.scala
@@ -1,0 +1,43 @@
+package adventureworks.production.product
+
+import adventureworks.public.Name
+import org.scalactic.TypeCheckedTripleEquals
+import org.scalatest.funsuite.AnyFunSuite
+import typo.dsl.SqlExpr
+
+class SeekTest extends AnyFunSuite with TypeCheckedTripleEquals {
+  val productRepo = new ProductRepoImpl
+
+  val base =
+    """select "productid", "name", "productnumber", "makeflag", "finishedgoodsflag", "color", "safetystocklevel", "reorderpoint", "standardcost", "listprice", "size", "sizeunitmeasurecode", "weightunitmeasurecode", "weight", "daystomanufacture", "productline", "class", "style", "productsubcategoryid", "productmodelid", "sellstartdate"::text, "sellenddate"::text, "discontinueddate"::text, "rowguid", "modifieddate"::text from production.product"""
+
+  test("uniform ascending") {
+    val query = productRepo.select
+      .seek(_.name.asc)(Name("foo"))
+      .seek(_.weight.asc)(SqlExpr.asConstOpt(Some(BigDecimal(22.2))))
+      .seek(_.listprice.asc)(BigDecimal(33.3))
+    assertResult(query.sql.get.toString)(
+      s"""Fragment("select "productid" ,  "name" ,  "productnumber" ,  "makeflag" ,  "finishedgoodsflag" ,  "color" ,  "safetystocklevel" ,  "reorderpoint" ,  "standardcost" ,  "listprice" ,  "size" ,  "sizeunitmeasurecode" ,  "weightunitmeasurecode" ,  "weight" ,  "daystomanufacture" ,  "productline" ,  "class" ,  "style" ,  "productsubcategoryid" ,  "productmodelid" ,  "sellstartdate"::text ,  "sellenddate"::text ,  "discontinueddate"::text ,  "rowguid" ,  "modifieddate"::text  from production.product  WHERE ((name , weight , listprice )  >  (? , ? , ? ) ) ORDER BY name   ASC   , weight   ASC   , listprice   ASC   ")"""
+    )
+  }
+
+  test("uniform descending") {
+    val query = productRepo.select
+      .seek(_.name.desc)(Name("foo"))
+      .seek(_.weight.desc)(Some(BigDecimal(22.2)))
+      .seek(_.listprice.desc)(BigDecimal(33.3))
+    assertResult(query.sql.get.toString)(
+      s"""Fragment("select "productid" ,  "name" ,  "productnumber" ,  "makeflag" ,  "finishedgoodsflag" ,  "color" ,  "safetystocklevel" ,  "reorderpoint" ,  "standardcost" ,  "listprice" ,  "size" ,  "sizeunitmeasurecode" ,  "weightunitmeasurecode" ,  "weight" ,  "daystomanufacture" ,  "productline" ,  "class" ,  "style" ,  "productsubcategoryid" ,  "productmodelid" ,  "sellstartdate"::text ,  "sellenddate"::text ,  "discontinueddate"::text ,  "rowguid" ,  "modifieddate"::text  from production.product  WHERE ((name , weight , listprice )  <  (? , ? , ? ) ) ORDER BY name   DESC   , weight   DESC   , listprice   DESC   ")"""
+    )
+  }
+
+  test("complex") {
+    val query = productRepo.select
+      .seek(_.name.asc)(Name("foo"))
+      .seek(_.weight.desc)(Some(BigDecimal(22.2)))
+      .seek(_.listprice.desc)(BigDecimal(33.3))
+    assertResult(query.sql.get.toString)(
+      s"""Fragment("select "productid" ,  "name" ,  "productnumber" ,  "makeflag" ,  "finishedgoodsflag" ,  "color" ,  "safetystocklevel" ,  "reorderpoint" ,  "standardcost" ,  "listprice" ,  "size" ,  "sizeunitmeasurecode" ,  "weightunitmeasurecode" ,  "weight" ,  "daystomanufacture" ,  "productline" ,  "class" ,  "style" ,  "productsubcategoryid" ,  "productmodelid" ,  "sellstartdate"::text ,  "sellenddate"::text ,  "discontinueddate"::text ,  "rowguid" ,  "modifieddate"::text  from production.product  WHERE (((name  >  ? )  OR  ((name  =  ? )  AND  (weight  <  ? ) ) )  OR  (((name  =  ? )  AND  (weight  =  ? ) )  AND  (listprice  <  ? ) ) ) ORDER BY name   ASC   , weight   DESC   , listprice   DESC   ")"""
+    )
+  }
+}

--- a/typo-tester-zio-jdbc/generated-and-checked-in/adventureworks/Reverse.scala
+++ b/typo-tester-zio-jdbc/generated-and-checked-in/adventureworks/Reverse.scala
@@ -1,0 +1,6 @@
+package adventureworks
+
+case class Reverse[T](t: T) extends AnyVal
+object Reverse {
+  implicit def ordering[T: Ordering]: Ordering[Reverse[T]] = Ordering[T].reverse.on(_.t)
+}

--- a/typo-tester-zio-jdbc/src/scala/adventureworks/SeekDbTest.scala
+++ b/typo-tester-zio-jdbc/src/scala/adventureworks/SeekDbTest.scala
@@ -1,0 +1,100 @@
+package adventureworks
+
+import adventureworks.customtypes.{TypoLocalDateTime, TypoUUID}
+import adventureworks.person.businessentity.*
+import adventureworks.withConnection
+import org.scalactic.TypeCheckedTripleEquals
+import org.scalatest.Assertion
+import org.scalatest.funsuite.AnyFunSuite
+import zio.{Chunk, ZIO}
+import zio.stream.ZStream
+
+import java.time.LocalDateTime
+
+class SeekDbTest extends AnyFunSuite with TypeCheckedTripleEquals {
+  def testUniformSeek(businessentityRepo: BusinessentityRepo): Assertion = {
+
+    val limit = 3
+    val now = LocalDateTime.of(2021, 1, 1, 0, 0)
+    val rows = Chunk.range(0, limit * 2).map { i =>
+      // ensure some duplicate values
+      val time = TypoLocalDateTime(now.minusDays(i % limit.toLong))
+      BusinessentityRow(BusinessentityId.apply(i), TypoUUID.randomUUID, time)
+    }
+
+    // same as sql below
+    val List(group1, group2) = rows.sortBy(x => (x.modifieddate, x.businessentityid.value)).grouped(limit).toList: @unchecked
+
+    withConnection(
+      for {
+        // batch insert some rows
+        _ <- businessentityRepo.insertStreaming(ZStream.fromChunk(rows))
+        rows1 <- businessentityRepo.select
+          .maybeSeek(_.modifieddate.asc)(None)
+          .maybeSeek(_.businessentityid.asc)(None)
+          .maybeSeek(_.rowguid.asc)(None)
+          .limit(limit)
+          .toChunk
+        _ <- ZIO.attempt(assert(rows1 == group1))
+        rows2 <- businessentityRepo.select
+          .maybeSeek(_.modifieddate.asc)(Some(rows1.last.modifieddate))
+          .maybeSeek(_.businessentityid.asc)(Some(rows1.last.businessentityid))
+          .maybeSeek(_.rowguid.asc)(Some(rows1.last.rowguid))
+          .limit(limit)
+          .toChunk
+        _ <- ZIO.attempt(assert(rows2 == group2))
+      } yield succeed
+    )
+  }
+
+  test("uniform in-memory") {
+    testUniformSeek(new BusinessentityRepoMock(_.toRow(???, ???, ???)))
+  }
+
+  test("uniform pg") {
+    testUniformSeek(new BusinessentityRepoImpl)
+  }
+
+  def testNonUniformSeek(businessentityRepo: BusinessentityRepo): Assertion = {
+
+    val limit = 3
+    val now = LocalDateTime.of(2021, 1, 1, 0, 0)
+    val rows = Chunk.range(0, limit * 2).map { i =>
+      // ensure some duplicate values
+      val time = TypoLocalDateTime(now.minusDays(i % limit.toLong))
+      BusinessentityRow(BusinessentityId.apply(i), TypoUUID.randomUUID, time)
+    }
+
+    // same as sql below
+    val List(group1, group2) = rows.sortBy(x => (Reverse(x.modifieddate), x.businessentityid.value)).grouped(limit).toList: @unchecked
+
+    withConnection(
+      for {
+        // batch insert some rows
+        _ <- businessentityRepo.insertStreaming(ZStream.fromChunk(rows))
+        rows1 <- businessentityRepo.select
+          .maybeSeek(_.modifieddate.desc)(None)
+          .maybeSeek(_.businessentityid.asc)(None)
+          .maybeSeek(_.rowguid.asc)(None)
+          .limit(limit)
+          .toChunk
+        _ <- ZIO.attempt(assert(rows1 == group1))
+        rows2 <- businessentityRepo.select
+          .maybeSeek(_.modifieddate.desc)(Some(rows1.last.modifieddate))
+          .maybeSeek(_.businessentityid.asc)(Some(rows1.last.businessentityid))
+          .maybeSeek(_.rowguid.asc)(Some(rows1.last.rowguid))
+          .limit(limit)
+          .toChunk
+        _ <- ZIO.attempt(assert(rows2 == group2))
+      } yield succeed
+    )
+  }
+
+  test("non-uniform in-memory") {
+    testNonUniformSeek(new BusinessentityRepoMock(_.toRow(???, ???, ???)))
+  }
+
+  test("non-uniform pg") {
+    testNonUniformSeek(new BusinessentityRepoImpl)
+  }
+}

--- a/typo-tester-zio-jdbc/src/scala/adventureworks/production/product/SeekTest.scala
+++ b/typo-tester-zio-jdbc/src/scala/adventureworks/production/product/SeekTest.scala
@@ -1,0 +1,42 @@
+package adventureworks.production.product
+
+import adventureworks.public.Name
+import org.scalactic.TypeCheckedTripleEquals
+import org.scalatest.funsuite.AnyFunSuite
+
+class SeekTest extends AnyFunSuite with TypeCheckedTripleEquals {
+  val productRepo = new ProductRepoImpl
+
+  val base =
+    """select "productid", "name", "productnumber", "makeflag", "finishedgoodsflag", "color", "safetystocklevel", "reorderpoint", "standardcost", "listprice", "size", "sizeunitmeasurecode", "weightunitmeasurecode", "weight", "daystomanufacture", "productline", "class", "style", "productsubcategoryid", "productmodelid", "sellstartdate"::text, "sellenddate"::text, "discontinueddate"::text, "rowguid", "modifieddate"::text from production.product"""
+
+  test("uniform ascending") {
+    val query = productRepo.select
+      .seek(_.name.asc)(Name("foo"))
+      .seek(_.weight.asc)(Some(BigDecimal(22.2)))
+      .seek(_.listprice.asc)(BigDecimal(33.3))
+    assertResult(query.sql.get.toString)(
+      s"""Sql($base WHERE ((name,weight,listprice) > (?::VARCHAR,?::DECIMAL,?::DECIMAL)) ORDER BY name ASC , weight ASC , listprice ASC , foo, Some(22.2), 33.3)"""
+    )
+  }
+
+  test("uniform descending") {
+    val query = productRepo.select
+      .seek(_.name.desc)(Name("foo"))
+      .seek(_.weight.desc)(Some(BigDecimal(22.2)))
+      .seek(_.listprice.desc)(BigDecimal(33.3))
+    assertResult(query.sql.get.toString)(
+      s"""Sql($base WHERE ((name,weight,listprice) < (?::VARCHAR,?::DECIMAL,?::DECIMAL)) ORDER BY name DESC , weight DESC , listprice DESC , foo, Some(22.2), 33.3)"""
+    )
+  }
+
+  test("complex") {
+    val query = productRepo.select
+      .seek(_.name.asc)(Name("foo"))
+      .seek(_.weight.desc)(Some(BigDecimal(22.2)))
+      .seek(_.listprice.desc)(BigDecimal(33.3))
+    assertResult(query.sql.get.toString)(
+      s"""Sql($base WHERE (((name > ?::VARCHAR) OR ((name = ?::VARCHAR) AND (weight < ?::DECIMAL))) OR (((name = ?::VARCHAR) AND (weight = ?::DECIMAL)) AND (listprice < ?::DECIMAL))) ORDER BY name ASC , weight DESC , listprice DESC , foo, foo, Some(22.2), foo, Some(22.2), 33.3)"""
+    )
+  }
+}


### PR DESCRIPTION
## `seek`

Is a way to do pagination with good properties, see [this introduction for jooq](https://www.jooq.org/doc/latest/manual/sql-building/sql-statements/select-statement/seek-clause/).

It needed some interesting sql generation, these tests should show how it works:
```scala
  val base =
    """select "productid", "name", "productnumber", "makeflag", "finishedgoodsflag", "color", "safetystocklevel", "reorderpoint", "standardcost", "listprice", "size", "sizeunitmeasurecode", "weightunitmeasurecode", "weight", "daystomanufacture", "productline", "class", "style", "productsubcategoryid", "productmodelid", "sellstartdate"::text, "sellenddate"::text, "discontinueddate"::text, "rowguid", "modifieddate"::text from production.product"""

  test("uniform ascending") {
    val query = productRepo.select
      .seek(_.name.asc)(Name("foo"))
      .seek(_.weight.asc)(Some(BigDecimal(22.2)))
      .seek(_.listprice.asc)(BigDecimal(33.3))
    assertResult(query.sql.get.toString)(
      s"""Sql($base WHERE ((name,weight,listprice) > (?::VARCHAR,?::DECIMAL,?::DECIMAL)) ORDER BY name ASC , weight ASC , listprice ASC , foo, Some(22.2), 33.3)"""
    )
  }

  test("uniform descending") {
    val query = productRepo.select
      .seek(_.name.desc)(Name("foo"))
      .seek(_.weight.desc)(Some(BigDecimal(22.2)))
      .seek(_.listprice.desc)(BigDecimal(33.3))
    assertResult(query.sql.get.toString)(
      s"""Sql($base WHERE ((name,weight,listprice) < (?::VARCHAR,?::DECIMAL,?::DECIMAL)) ORDER BY name DESC , weight DESC , listprice DESC , foo, Some(22.2), 33.3)"""
    )
  }

  test("complex") {
    val query = productRepo.select
      .seek(_.name.asc)(Name("foo"))
      .seek(_.weight.desc)(Some(BigDecimal(22.2)))
      .seek(_.listprice.desc)(BigDecimal(33.3))
    assertResult(query.sql.get.toString)(
      s"""Sql($base WHERE (((name > ?::VARCHAR) OR ((name = ?::VARCHAR) AND (weight < ?::DECIMAL))) OR (((name = ?::VARCHAR) AND (weight = ?::DECIMAL)) AND (listprice < ?::DECIMAL))) ORDER BY name ASC , weight DESC , listprice DESC , foo, foo, Some(22.2), foo, Some(22.2), 33.3)"""
    )
  }
```
