### PR TITLE
Simplified DSL

### DIFF
--- a/.bleep/generated-sources/typo-tester-anorm@jvm213/scripts.GenHardcodedFiles/testdb/hardcoded/compositepk/person/PersonRepoMock.scala
+++ b/.bleep/generated-sources/typo-tester-anorm@jvm213/scripts.GenHardcodedFiles/testdb/hardcoded/compositepk/person/PersonRepoMock.scala
@@ -23,7 +23,7 @@ import typo.dsl.UpdateParams
 class PersonRepoMock(toRow: Function1[PersonRowUnsaved, PersonRow],
                      map: scala.collection.mutable.Map[PersonId, PersonRow] = scala.collection.mutable.Map.empty) extends PersonRepo {
   override def delete: DeleteBuilder[PersonFields, PersonRow] = {
-    DeleteBuilderMock(DeleteParams.empty, PersonFields.structure.fields, map)
+    DeleteBuilderMock(DeleteParams.empty, PersonFields.structure, map)
   }
   override def deleteById(compositeId: PersonId)(implicit c: Connection): Boolean = {
     map.remove(compositeId).isDefined
@@ -70,7 +70,7 @@ class PersonRepoMock(toRow: Function1[PersonRowUnsaved, PersonRow],
     map.get(compositeId)
   }
   override def update: UpdateBuilder[PersonFields, PersonRow] = {
-    UpdateBuilderMock(UpdateParams.empty, PersonFields.structure.fields, map)
+    UpdateBuilderMock(UpdateParams.empty, PersonFields.structure, map)
   }
   override def update(row: PersonRow)(implicit c: Connection): Boolean = {
     map.get(row.compositeId) match {

--- a/.bleep/generated-sources/typo-tester-anorm@jvm213/scripts.GenHardcodedFiles/testdb/hardcoded/myschema/football_club/FootballClubRepoMock.scala
+++ b/.bleep/generated-sources/typo-tester-anorm@jvm213/scripts.GenHardcodedFiles/testdb/hardcoded/myschema/football_club/FootballClubRepoMock.scala
@@ -22,7 +22,7 @@ import typo.dsl.UpdateParams
 
 class FootballClubRepoMock(map: scala.collection.mutable.Map[FootballClubId, FootballClubRow] = scala.collection.mutable.Map.empty) extends FootballClubRepo {
   override def delete: DeleteBuilder[FootballClubFields, FootballClubRow] = {
-    DeleteBuilderMock(DeleteParams.empty, FootballClubFields.structure.fields, map)
+    DeleteBuilderMock(DeleteParams.empty, FootballClubFields.structure, map)
   }
   override def deleteById(id: FootballClubId)(implicit c: Connection): Boolean = {
     map.remove(id).isDefined
@@ -67,7 +67,7 @@ class FootballClubRepoMock(map: scala.collection.mutable.Map[FootballClubId, Foo
     ids.view.flatMap(id => byId.get(id).map(x => (id, x))).toMap
   }
   override def update: UpdateBuilder[FootballClubFields, FootballClubRow] = {
-    UpdateBuilderMock(UpdateParams.empty, FootballClubFields.structure.fields, map)
+    UpdateBuilderMock(UpdateParams.empty, FootballClubFields.structure, map)
   }
   override def update(row: FootballClubRow)(implicit c: Connection): Boolean = {
     map.get(row.id) match {

--- a/.bleep/generated-sources/typo-tester-anorm@jvm213/scripts.GenHardcodedFiles/testdb/hardcoded/myschema/marital_status/MaritalStatusFields.scala
+++ b/.bleep/generated-sources/typo-tester-anorm@jvm213/scripts.GenHardcodedFiles/testdb/hardcoded/myschema/marital_status/MaritalStatusFields.scala
@@ -8,30 +8,31 @@ package hardcoded
 package myschema
 package marital_status
 
+import typo.dsl.Path
 import typo.dsl.SqlExpr.FieldLikeNoHkt
 import typo.dsl.SqlExpr.IdField
 import typo.dsl.Structure.Relation
 
-trait MaritalStatusFields[Row] {
-  val id: IdField[MaritalStatusId, Row]
+trait MaritalStatusFields {
+  def id: IdField[MaritalStatusId, MaritalStatusRow]
 }
 
 object MaritalStatusFields {
-  val structure: Relation[MaritalStatusFields, MaritalStatusRow, MaritalStatusRow] = 
-    new Impl(None, identity, (_, x) => x)
+  lazy val structure: Relation[MaritalStatusFields, MaritalStatusRow] =
+    new Impl(Nil)
     
-  private final class Impl[Row](val prefix: Option[String], val extract: Row => MaritalStatusRow, val merge: (Row, MaritalStatusRow) => Row)
-    extends Relation[MaritalStatusFields, MaritalStatusRow, Row] { 
+  private final class Impl(val _path: List[Path])
+    extends Relation[MaritalStatusFields, MaritalStatusRow] {
   
-    override val fields: MaritalStatusFields[Row] = new MaritalStatusFields[Row] {
-      override val id = new IdField[MaritalStatusId, Row](prefix, "id", None, Some("int8"))(x => extract(x).id, (row, value) => merge(row, extract(row).copy(id = value)))
+    override lazy val fields: MaritalStatusFields = new MaritalStatusFields {
+      override def id = IdField[MaritalStatusId, MaritalStatusRow](_path, "id", None, Some("int8"), x => x.id, (row, value) => row.copy(id = value))
     }
   
-    override val columns: List[FieldLikeNoHkt[?, Row]] =
-      List[FieldLikeNoHkt[?, Row]](fields.id)
+    override lazy val columns: List[FieldLikeNoHkt[?, MaritalStatusRow]] =
+      List[FieldLikeNoHkt[?, MaritalStatusRow]](fields.id)
   
-    override def copy[NewRow](prefix: Option[String], extract: NewRow => MaritalStatusRow, merge: (NewRow, MaritalStatusRow) => NewRow): Impl[NewRow] =
-      new Impl(prefix, extract, merge)
+    override def copy(path: List[Path]): Impl =
+      new Impl(path)
   }
   
 }

--- a/.bleep/generated-sources/typo-tester-anorm@jvm213/scripts.GenHardcodedFiles/testdb/hardcoded/myschema/marital_status/MaritalStatusRepoMock.scala
+++ b/.bleep/generated-sources/typo-tester-anorm@jvm213/scripts.GenHardcodedFiles/testdb/hardcoded/myschema/marital_status/MaritalStatusRepoMock.scala
@@ -22,7 +22,7 @@ import typo.dsl.UpdateParams
 
 class MaritalStatusRepoMock(map: scala.collection.mutable.Map[MaritalStatusId, MaritalStatusRow] = scala.collection.mutable.Map.empty) extends MaritalStatusRepo {
   override def delete: DeleteBuilder[MaritalStatusFields, MaritalStatusRow] = {
-    DeleteBuilderMock(DeleteParams.empty, MaritalStatusFields.structure.fields, map)
+    DeleteBuilderMock(DeleteParams.empty, MaritalStatusFields.structure, map)
   }
   override def deleteById(id: MaritalStatusId)(implicit c: Connection): Boolean = {
     map.remove(id).isDefined
@@ -66,7 +66,7 @@ class MaritalStatusRepoMock(map: scala.collection.mutable.Map[MaritalStatusId, M
     ids.view.flatMap(id => byId.get(id).map(x => (id, x))).toMap
   }
   override def update: UpdateBuilder[MaritalStatusFields, MaritalStatusRow] = {
-    UpdateBuilderMock(UpdateParams.empty, MaritalStatusFields.structure.fields, map)
+    UpdateBuilderMock(UpdateParams.empty, MaritalStatusFields.structure, map)
   }
   override def upsert(unsaved: MaritalStatusRow)(implicit c: Connection): MaritalStatusRow = {
     map.put(unsaved.id, unsaved): @nowarn

--- a/.bleep/generated-sources/typo-tester-anorm@jvm213/scripts.GenHardcodedFiles/testdb/hardcoded/myschema/person/PersonFields.scala
+++ b/.bleep/generated-sources/typo-tester-anorm@jvm213/scripts.GenHardcodedFiles/testdb/hardcoded/myschema/person/PersonFields.scala
@@ -12,54 +12,55 @@ import testdb.hardcoded.myschema.Number
 import testdb.hardcoded.myschema.Sector
 import testdb.hardcoded.myschema.football_club.FootballClubId
 import testdb.hardcoded.myschema.marital_status.MaritalStatusId
+import typo.dsl.Path
 import typo.dsl.SqlExpr.Field
 import typo.dsl.SqlExpr.FieldLikeNoHkt
 import typo.dsl.SqlExpr.IdField
 import typo.dsl.SqlExpr.OptField
 import typo.dsl.Structure.Relation
 
-trait PersonFields[Row] {
-  val id: IdField[PersonId, Row]
-  val favouriteFootballClubId: Field[FootballClubId, Row]
-  val name: Field[/* max 100 chars */ String, Row]
-  val nickName: OptField[/* max 30 chars */ String, Row]
-  val blogUrl: OptField[/* max 100 chars */ String, Row]
-  val email: Field[/* max 254 chars */ String, Row]
-  val phone: Field[/* max 8 chars */ String, Row]
-  val likesPizza: Field[Boolean, Row]
-  val maritalStatusId: Field[MaritalStatusId, Row]
-  val workEmail: OptField[/* max 254 chars */ String, Row]
-  val sector: Field[Sector, Row]
-  val favoriteNumber: Field[Number, Row]
+trait PersonFields {
+  def id: IdField[PersonId, PersonRow]
+  def favouriteFootballClubId: Field[FootballClubId, PersonRow]
+  def name: Field[/* max 100 chars */ String, PersonRow]
+  def nickName: OptField[/* max 30 chars */ String, PersonRow]
+  def blogUrl: OptField[/* max 100 chars */ String, PersonRow]
+  def email: Field[/* max 254 chars */ String, PersonRow]
+  def phone: Field[/* max 8 chars */ String, PersonRow]
+  def likesPizza: Field[Boolean, PersonRow]
+  def maritalStatusId: Field[MaritalStatusId, PersonRow]
+  def workEmail: OptField[/* max 254 chars */ String, PersonRow]
+  def sector: Field[Sector, PersonRow]
+  def favoriteNumber: Field[Number, PersonRow]
 }
 
 object PersonFields {
-  val structure: Relation[PersonFields, PersonRow, PersonRow] = 
-    new Impl(None, identity, (_, x) => x)
+  lazy val structure: Relation[PersonFields, PersonRow] =
+    new Impl(Nil)
     
-  private final class Impl[Row](val prefix: Option[String], val extract: Row => PersonRow, val merge: (Row, PersonRow) => Row)
-    extends Relation[PersonFields, PersonRow, Row] { 
+  private final class Impl(val _path: List[Path])
+    extends Relation[PersonFields, PersonRow] {
   
-    override val fields: PersonFields[Row] = new PersonFields[Row] {
-      override val id = new IdField[PersonId, Row](prefix, "id", None, Some("int8"))(x => extract(x).id, (row, value) => merge(row, extract(row).copy(id = value)))
-      override val favouriteFootballClubId = new Field[FootballClubId, Row](prefix, "favourite_football_club_id", None, None)(x => extract(x).favouriteFootballClubId, (row, value) => merge(row, extract(row).copy(favouriteFootballClubId = value)))
-      override val name = new Field[/* max 100 chars */ String, Row](prefix, "name", None, None)(x => extract(x).name, (row, value) => merge(row, extract(row).copy(name = value)))
-      override val nickName = new OptField[/* max 30 chars */ String, Row](prefix, "nick_name", None, None)(x => extract(x).nickName, (row, value) => merge(row, extract(row).copy(nickName = value)))
-      override val blogUrl = new OptField[/* max 100 chars */ String, Row](prefix, "blog_url", None, None)(x => extract(x).blogUrl, (row, value) => merge(row, extract(row).copy(blogUrl = value)))
-      override val email = new Field[/* max 254 chars */ String, Row](prefix, "email", None, None)(x => extract(x).email, (row, value) => merge(row, extract(row).copy(email = value)))
-      override val phone = new Field[/* max 8 chars */ String, Row](prefix, "phone", None, None)(x => extract(x).phone, (row, value) => merge(row, extract(row).copy(phone = value)))
-      override val likesPizza = new Field[Boolean, Row](prefix, "likes_pizza", None, None)(x => extract(x).likesPizza, (row, value) => merge(row, extract(row).copy(likesPizza = value)))
-      override val maritalStatusId = new Field[MaritalStatusId, Row](prefix, "marital_status_id", None, None)(x => extract(x).maritalStatusId, (row, value) => merge(row, extract(row).copy(maritalStatusId = value)))
-      override val workEmail = new OptField[/* max 254 chars */ String, Row](prefix, "work_email", None, None)(x => extract(x).workEmail, (row, value) => merge(row, extract(row).copy(workEmail = value)))
-      override val sector = new Field[Sector, Row](prefix, "sector", None, Some("myschema.sector"))(x => extract(x).sector, (row, value) => merge(row, extract(row).copy(sector = value)))
-      override val favoriteNumber = new Field[Number, Row](prefix, "favorite_number", None, Some("myschema.number"))(x => extract(x).favoriteNumber, (row, value) => merge(row, extract(row).copy(favoriteNumber = value)))
+    override lazy val fields: PersonFields = new PersonFields {
+      override def id = IdField[PersonId, PersonRow](_path, "id", None, Some("int8"), x => x.id, (row, value) => row.copy(id = value))
+      override def favouriteFootballClubId = Field[FootballClubId, PersonRow](_path, "favourite_football_club_id", None, None, x => x.favouriteFootballClubId, (row, value) => row.copy(favouriteFootballClubId = value))
+      override def name = Field[/* max 100 chars */ String, PersonRow](_path, "name", None, None, x => x.name, (row, value) => row.copy(name = value))
+      override def nickName = OptField[/* max 30 chars */ String, PersonRow](_path, "nick_name", None, None, x => x.nickName, (row, value) => row.copy(nickName = value))
+      override def blogUrl = OptField[/* max 100 chars */ String, PersonRow](_path, "blog_url", None, None, x => x.blogUrl, (row, value) => row.copy(blogUrl = value))
+      override def email = Field[/* max 254 chars */ String, PersonRow](_path, "email", None, None, x => x.email, (row, value) => row.copy(email = value))
+      override def phone = Field[/* max 8 chars */ String, PersonRow](_path, "phone", None, None, x => x.phone, (row, value) => row.copy(phone = value))
+      override def likesPizza = Field[Boolean, PersonRow](_path, "likes_pizza", None, None, x => x.likesPizza, (row, value) => row.copy(likesPizza = value))
+      override def maritalStatusId = Field[MaritalStatusId, PersonRow](_path, "marital_status_id", None, None, x => x.maritalStatusId, (row, value) => row.copy(maritalStatusId = value))
+      override def workEmail = OptField[/* max 254 chars */ String, PersonRow](_path, "work_email", None, None, x => x.workEmail, (row, value) => row.copy(workEmail = value))
+      override def sector = Field[Sector, PersonRow](_path, "sector", None, Some("myschema.sector"), x => x.sector, (row, value) => row.copy(sector = value))
+      override def favoriteNumber = Field[Number, PersonRow](_path, "favorite_number", None, Some("myschema.number"), x => x.favoriteNumber, (row, value) => row.copy(favoriteNumber = value))
     }
   
-    override val columns: List[FieldLikeNoHkt[?, Row]] =
-      List[FieldLikeNoHkt[?, Row]](fields.id, fields.favouriteFootballClubId, fields.name, fields.nickName, fields.blogUrl, fields.email, fields.phone, fields.likesPizza, fields.maritalStatusId, fields.workEmail, fields.sector, fields.favoriteNumber)
+    override lazy val columns: List[FieldLikeNoHkt[?, PersonRow]] =
+      List[FieldLikeNoHkt[?, PersonRow]](fields.id, fields.favouriteFootballClubId, fields.name, fields.nickName, fields.blogUrl, fields.email, fields.phone, fields.likesPizza, fields.maritalStatusId, fields.workEmail, fields.sector, fields.favoriteNumber)
   
-    override def copy[NewRow](prefix: Option[String], extract: NewRow => PersonRow, merge: (NewRow, PersonRow) => NewRow): Impl[NewRow] =
-      new Impl(prefix, extract, merge)
+    override def copy(path: List[Path]): Impl =
+      new Impl(path)
   }
   
 }

--- a/.bleep/generated-sources/typo-tester-anorm@jvm213/scripts.GenHardcodedFiles/testdb/hardcoded/myschema/person/PersonRepoMock.scala
+++ b/.bleep/generated-sources/typo-tester-anorm@jvm213/scripts.GenHardcodedFiles/testdb/hardcoded/myschema/person/PersonRepoMock.scala
@@ -23,7 +23,7 @@ import typo.dsl.UpdateParams
 class PersonRepoMock(toRow: Function1[PersonRowUnsaved, PersonRow],
                      map: scala.collection.mutable.Map[PersonId, PersonRow] = scala.collection.mutable.Map.empty) extends PersonRepo {
   override def delete: DeleteBuilder[PersonFields, PersonRow] = {
-    DeleteBuilderMock(DeleteParams.empty, PersonFields.structure.fields, map)
+    DeleteBuilderMock(DeleteParams.empty, PersonFields.structure, map)
   }
   override def deleteById(id: PersonId)(implicit c: Connection): Boolean = {
     map.remove(id).isDefined
@@ -89,7 +89,7 @@ class PersonRepoMock(toRow: Function1[PersonRowUnsaved, PersonRow],
     ids.view.flatMap(id => byId.get(id).map(x => (id, x))).toMap
   }
   override def update: UpdateBuilder[PersonFields, PersonRow] = {
-    UpdateBuilderMock(UpdateParams.empty, PersonFields.structure.fields, map)
+    UpdateBuilderMock(UpdateParams.empty, PersonFields.structure, map)
   }
   override def update(row: PersonRow)(implicit c: Connection): Boolean = {
     map.get(row.id) match {

--- a/.bleep/generated-sources/typo-tester-anorm@jvm3/scripts.GenHardcodedFiles/testdb/hardcoded/compositepk/person/PersonRepoMock.scala
+++ b/.bleep/generated-sources/typo-tester-anorm@jvm3/scripts.GenHardcodedFiles/testdb/hardcoded/compositepk/person/PersonRepoMock.scala
@@ -23,7 +23,7 @@ import typo.dsl.UpdateParams
 class PersonRepoMock(toRow: Function1[PersonRowUnsaved, PersonRow],
                      map: scala.collection.mutable.Map[PersonId, PersonRow] = scala.collection.mutable.Map.empty) extends PersonRepo {
   override def delete: DeleteBuilder[PersonFields, PersonRow] = {
-    DeleteBuilderMock(DeleteParams.empty, PersonFields.structure.fields, map)
+    DeleteBuilderMock(DeleteParams.empty, PersonFields.structure, map)
   }
   override def deleteById(compositeId: PersonId)(implicit c: Connection): Boolean = {
     map.remove(compositeId).isDefined
@@ -70,7 +70,7 @@ class PersonRepoMock(toRow: Function1[PersonRowUnsaved, PersonRow],
     map.get(compositeId)
   }
   override def update: UpdateBuilder[PersonFields, PersonRow] = {
-    UpdateBuilderMock(UpdateParams.empty, PersonFields.structure.fields, map)
+    UpdateBuilderMock(UpdateParams.empty, PersonFields.structure, map)
   }
   override def update(row: PersonRow)(implicit c: Connection): Boolean = {
     map.get(row.compositeId) match {

--- a/.bleep/generated-sources/typo-tester-anorm@jvm3/scripts.GenHardcodedFiles/testdb/hardcoded/myschema/football_club/FootballClubRepoMock.scala
+++ b/.bleep/generated-sources/typo-tester-anorm@jvm3/scripts.GenHardcodedFiles/testdb/hardcoded/myschema/football_club/FootballClubRepoMock.scala
@@ -22,7 +22,7 @@ import typo.dsl.UpdateParams
 
 class FootballClubRepoMock(map: scala.collection.mutable.Map[FootballClubId, FootballClubRow] = scala.collection.mutable.Map.empty) extends FootballClubRepo {
   override def delete: DeleteBuilder[FootballClubFields, FootballClubRow] = {
-    DeleteBuilderMock(DeleteParams.empty, FootballClubFields.structure.fields, map)
+    DeleteBuilderMock(DeleteParams.empty, FootballClubFields.structure, map)
   }
   override def deleteById(id: FootballClubId)(implicit c: Connection): Boolean = {
     map.remove(id).isDefined
@@ -67,7 +67,7 @@ class FootballClubRepoMock(map: scala.collection.mutable.Map[FootballClubId, Foo
     ids.view.flatMap(id => byId.get(id).map(x => (id, x))).toMap
   }
   override def update: UpdateBuilder[FootballClubFields, FootballClubRow] = {
-    UpdateBuilderMock(UpdateParams.empty, FootballClubFields.structure.fields, map)
+    UpdateBuilderMock(UpdateParams.empty, FootballClubFields.structure, map)
   }
   override def update(row: FootballClubRow)(implicit c: Connection): Boolean = {
     map.get(row.id) match {

--- a/.bleep/generated-sources/typo-tester-anorm@jvm3/scripts.GenHardcodedFiles/testdb/hardcoded/myschema/marital_status/MaritalStatusFields.scala
+++ b/.bleep/generated-sources/typo-tester-anorm@jvm3/scripts.GenHardcodedFiles/testdb/hardcoded/myschema/marital_status/MaritalStatusFields.scala
@@ -8,30 +8,31 @@ package hardcoded
 package myschema
 package marital_status
 
+import typo.dsl.Path
 import typo.dsl.SqlExpr.FieldLikeNoHkt
 import typo.dsl.SqlExpr.IdField
 import typo.dsl.Structure.Relation
 
-trait MaritalStatusFields[Row] {
-  val id: IdField[MaritalStatusId, Row]
+trait MaritalStatusFields {
+  def id: IdField[MaritalStatusId, MaritalStatusRow]
 }
 
 object MaritalStatusFields {
-  val structure: Relation[MaritalStatusFields, MaritalStatusRow, MaritalStatusRow] = 
-    new Impl(None, identity, (_, x) => x)
+  lazy val structure: Relation[MaritalStatusFields, MaritalStatusRow] =
+    new Impl(Nil)
     
-  private final class Impl[Row](val prefix: Option[String], val extract: Row => MaritalStatusRow, val merge: (Row, MaritalStatusRow) => Row)
-    extends Relation[MaritalStatusFields, MaritalStatusRow, Row] { 
+  private final class Impl(val _path: List[Path])
+    extends Relation[MaritalStatusFields, MaritalStatusRow] {
   
-    override val fields: MaritalStatusFields[Row] = new MaritalStatusFields[Row] {
-      override val id = new IdField[MaritalStatusId, Row](prefix, "id", None, Some("int8"))(x => extract(x).id, (row, value) => merge(row, extract(row).copy(id = value)))
+    override lazy val fields: MaritalStatusFields = new MaritalStatusFields {
+      override def id = IdField[MaritalStatusId, MaritalStatusRow](_path, "id", None, Some("int8"), x => x.id, (row, value) => row.copy(id = value))
     }
   
-    override val columns: List[FieldLikeNoHkt[?, Row]] =
-      List[FieldLikeNoHkt[?, Row]](fields.id)
+    override lazy val columns: List[FieldLikeNoHkt[?, MaritalStatusRow]] =
+      List[FieldLikeNoHkt[?, MaritalStatusRow]](fields.id)
   
-    override def copy[NewRow](prefix: Option[String], extract: NewRow => MaritalStatusRow, merge: (NewRow, MaritalStatusRow) => NewRow): Impl[NewRow] =
-      new Impl(prefix, extract, merge)
+    override def copy(path: List[Path]): Impl =
+      new Impl(path)
   }
   
 }

--- a/.bleep/generated-sources/typo-tester-anorm@jvm3/scripts.GenHardcodedFiles/testdb/hardcoded/myschema/marital_status/MaritalStatusRepoMock.scala
+++ b/.bleep/generated-sources/typo-tester-anorm@jvm3/scripts.GenHardcodedFiles/testdb/hardcoded/myschema/marital_status/MaritalStatusRepoMock.scala
@@ -22,7 +22,7 @@ import typo.dsl.UpdateParams
 
 class MaritalStatusRepoMock(map: scala.collection.mutable.Map[MaritalStatusId, MaritalStatusRow] = scala.collection.mutable.Map.empty) extends MaritalStatusRepo {
   override def delete: DeleteBuilder[MaritalStatusFields, MaritalStatusRow] = {
-    DeleteBuilderMock(DeleteParams.empty, MaritalStatusFields.structure.fields, map)
+    DeleteBuilderMock(DeleteParams.empty, MaritalStatusFields.structure, map)
   }
   override def deleteById(id: MaritalStatusId)(implicit c: Connection): Boolean = {
     map.remove(id).isDefined
@@ -66,7 +66,7 @@ class MaritalStatusRepoMock(map: scala.collection.mutable.Map[MaritalStatusId, M
     ids.view.flatMap(id => byId.get(id).map(x => (id, x))).toMap
   }
   override def update: UpdateBuilder[MaritalStatusFields, MaritalStatusRow] = {
-    UpdateBuilderMock(UpdateParams.empty, MaritalStatusFields.structure.fields, map)
+    UpdateBuilderMock(UpdateParams.empty, MaritalStatusFields.structure, map)
   }
   override def upsert(unsaved: MaritalStatusRow)(implicit c: Connection): MaritalStatusRow = {
     map.put(unsaved.id, unsaved): @nowarn

--- a/.bleep/generated-sources/typo-tester-anorm@jvm3/scripts.GenHardcodedFiles/testdb/hardcoded/myschema/person/PersonFields.scala
+++ b/.bleep/generated-sources/typo-tester-anorm@jvm3/scripts.GenHardcodedFiles/testdb/hardcoded/myschema/person/PersonFields.scala
@@ -12,54 +12,55 @@ import testdb.hardcoded.myschema.Number
 import testdb.hardcoded.myschema.Sector
 import testdb.hardcoded.myschema.football_club.FootballClubId
 import testdb.hardcoded.myschema.marital_status.MaritalStatusId
+import typo.dsl.Path
 import typo.dsl.SqlExpr.Field
 import typo.dsl.SqlExpr.FieldLikeNoHkt
 import typo.dsl.SqlExpr.IdField
 import typo.dsl.SqlExpr.OptField
 import typo.dsl.Structure.Relation
 
-trait PersonFields[Row] {
-  val id: IdField[PersonId, Row]
-  val favouriteFootballClubId: Field[FootballClubId, Row]
-  val name: Field[/* max 100 chars */ String, Row]
-  val nickName: OptField[/* max 30 chars */ String, Row]
-  val blogUrl: OptField[/* max 100 chars */ String, Row]
-  val email: Field[/* max 254 chars */ String, Row]
-  val phone: Field[/* max 8 chars */ String, Row]
-  val likesPizza: Field[Boolean, Row]
-  val maritalStatusId: Field[MaritalStatusId, Row]
-  val workEmail: OptField[/* max 254 chars */ String, Row]
-  val sector: Field[Sector, Row]
-  val favoriteNumber: Field[Number, Row]
+trait PersonFields {
+  def id: IdField[PersonId, PersonRow]
+  def favouriteFootballClubId: Field[FootballClubId, PersonRow]
+  def name: Field[/* max 100 chars */ String, PersonRow]
+  def nickName: OptField[/* max 30 chars */ String, PersonRow]
+  def blogUrl: OptField[/* max 100 chars */ String, PersonRow]
+  def email: Field[/* max 254 chars */ String, PersonRow]
+  def phone: Field[/* max 8 chars */ String, PersonRow]
+  def likesPizza: Field[Boolean, PersonRow]
+  def maritalStatusId: Field[MaritalStatusId, PersonRow]
+  def workEmail: OptField[/* max 254 chars */ String, PersonRow]
+  def sector: Field[Sector, PersonRow]
+  def favoriteNumber: Field[Number, PersonRow]
 }
 
 object PersonFields {
-  val structure: Relation[PersonFields, PersonRow, PersonRow] = 
-    new Impl(None, identity, (_, x) => x)
+  lazy val structure: Relation[PersonFields, PersonRow] =
+    new Impl(Nil)
     
-  private final class Impl[Row](val prefix: Option[String], val extract: Row => PersonRow, val merge: (Row, PersonRow) => Row)
-    extends Relation[PersonFields, PersonRow, Row] { 
+  private final class Impl(val _path: List[Path])
+    extends Relation[PersonFields, PersonRow] {
   
-    override val fields: PersonFields[Row] = new PersonFields[Row] {
-      override val id = new IdField[PersonId, Row](prefix, "id", None, Some("int8"))(x => extract(x).id, (row, value) => merge(row, extract(row).copy(id = value)))
-      override val favouriteFootballClubId = new Field[FootballClubId, Row](prefix, "favourite_football_club_id", None, None)(x => extract(x).favouriteFootballClubId, (row, value) => merge(row, extract(row).copy(favouriteFootballClubId = value)))
-      override val name = new Field[/* max 100 chars */ String, Row](prefix, "name", None, None)(x => extract(x).name, (row, value) => merge(row, extract(row).copy(name = value)))
-      override val nickName = new OptField[/* max 30 chars */ String, Row](prefix, "nick_name", None, None)(x => extract(x).nickName, (row, value) => merge(row, extract(row).copy(nickName = value)))
-      override val blogUrl = new OptField[/* max 100 chars */ String, Row](prefix, "blog_url", None, None)(x => extract(x).blogUrl, (row, value) => merge(row, extract(row).copy(blogUrl = value)))
-      override val email = new Field[/* max 254 chars */ String, Row](prefix, "email", None, None)(x => extract(x).email, (row, value) => merge(row, extract(row).copy(email = value)))
-      override val phone = new Field[/* max 8 chars */ String, Row](prefix, "phone", None, None)(x => extract(x).phone, (row, value) => merge(row, extract(row).copy(phone = value)))
-      override val likesPizza = new Field[Boolean, Row](prefix, "likes_pizza", None, None)(x => extract(x).likesPizza, (row, value) => merge(row, extract(row).copy(likesPizza = value)))
-      override val maritalStatusId = new Field[MaritalStatusId, Row](prefix, "marital_status_id", None, None)(x => extract(x).maritalStatusId, (row, value) => merge(row, extract(row).copy(maritalStatusId = value)))
-      override val workEmail = new OptField[/* max 254 chars */ String, Row](prefix, "work_email", None, None)(x => extract(x).workEmail, (row, value) => merge(row, extract(row).copy(workEmail = value)))
-      override val sector = new Field[Sector, Row](prefix, "sector", None, Some("myschema.sector"))(x => extract(x).sector, (row, value) => merge(row, extract(row).copy(sector = value)))
-      override val favoriteNumber = new Field[Number, Row](prefix, "favorite_number", None, Some("myschema.number"))(x => extract(x).favoriteNumber, (row, value) => merge(row, extract(row).copy(favoriteNumber = value)))
+    override lazy val fields: PersonFields = new PersonFields {
+      override def id = IdField[PersonId, PersonRow](_path, "id", None, Some("int8"), x => x.id, (row, value) => row.copy(id = value))
+      override def favouriteFootballClubId = Field[FootballClubId, PersonRow](_path, "favourite_football_club_id", None, None, x => x.favouriteFootballClubId, (row, value) => row.copy(favouriteFootballClubId = value))
+      override def name = Field[/* max 100 chars */ String, PersonRow](_path, "name", None, None, x => x.name, (row, value) => row.copy(name = value))
+      override def nickName = OptField[/* max 30 chars */ String, PersonRow](_path, "nick_name", None, None, x => x.nickName, (row, value) => row.copy(nickName = value))
+      override def blogUrl = OptField[/* max 100 chars */ String, PersonRow](_path, "blog_url", None, None, x => x.blogUrl, (row, value) => row.copy(blogUrl = value))
+      override def email = Field[/* max 254 chars */ String, PersonRow](_path, "email", None, None, x => x.email, (row, value) => row.copy(email = value))
+      override def phone = Field[/* max 8 chars */ String, PersonRow](_path, "phone", None, None, x => x.phone, (row, value) => row.copy(phone = value))
+      override def likesPizza = Field[Boolean, PersonRow](_path, "likes_pizza", None, None, x => x.likesPizza, (row, value) => row.copy(likesPizza = value))
+      override def maritalStatusId = Field[MaritalStatusId, PersonRow](_path, "marital_status_id", None, None, x => x.maritalStatusId, (row, value) => row.copy(maritalStatusId = value))
+      override def workEmail = OptField[/* max 254 chars */ String, PersonRow](_path, "work_email", None, None, x => x.workEmail, (row, value) => row.copy(workEmail = value))
+      override def sector = Field[Sector, PersonRow](_path, "sector", None, Some("myschema.sector"), x => x.sector, (row, value) => row.copy(sector = value))
+      override def favoriteNumber = Field[Number, PersonRow](_path, "favorite_number", None, Some("myschema.number"), x => x.favoriteNumber, (row, value) => row.copy(favoriteNumber = value))
     }
   
-    override val columns: List[FieldLikeNoHkt[?, Row]] =
-      List[FieldLikeNoHkt[?, Row]](fields.id, fields.favouriteFootballClubId, fields.name, fields.nickName, fields.blogUrl, fields.email, fields.phone, fields.likesPizza, fields.maritalStatusId, fields.workEmail, fields.sector, fields.favoriteNumber)
+    override lazy val columns: List[FieldLikeNoHkt[?, PersonRow]] =
+      List[FieldLikeNoHkt[?, PersonRow]](fields.id, fields.favouriteFootballClubId, fields.name, fields.nickName, fields.blogUrl, fields.email, fields.phone, fields.likesPizza, fields.maritalStatusId, fields.workEmail, fields.sector, fields.favoriteNumber)
   
-    override def copy[NewRow](prefix: Option[String], extract: NewRow => PersonRow, merge: (NewRow, PersonRow) => NewRow): Impl[NewRow] =
-      new Impl(prefix, extract, merge)
+    override def copy(path: List[Path]): Impl =
+      new Impl(path)
   }
   
 }

--- a/.bleep/generated-sources/typo-tester-anorm@jvm3/scripts.GenHardcodedFiles/testdb/hardcoded/myschema/person/PersonRepoMock.scala
+++ b/.bleep/generated-sources/typo-tester-anorm@jvm3/scripts.GenHardcodedFiles/testdb/hardcoded/myschema/person/PersonRepoMock.scala
@@ -23,7 +23,7 @@ import typo.dsl.UpdateParams
 class PersonRepoMock(toRow: Function1[PersonRowUnsaved, PersonRow],
                      map: scala.collection.mutable.Map[PersonId, PersonRow] = scala.collection.mutable.Map.empty) extends PersonRepo {
   override def delete: DeleteBuilder[PersonFields, PersonRow] = {
-    DeleteBuilderMock(DeleteParams.empty, PersonFields.structure.fields, map)
+    DeleteBuilderMock(DeleteParams.empty, PersonFields.structure, map)
   }
   override def deleteById(id: PersonId)(implicit c: Connection): Boolean = {
     map.remove(id).isDefined
@@ -89,7 +89,7 @@ class PersonRepoMock(toRow: Function1[PersonRowUnsaved, PersonRow],
     ids.view.flatMap(id => byId.get(id).map(x => (id, x))).toMap
   }
   override def update: UpdateBuilder[PersonFields, PersonRow] = {
-    UpdateBuilderMock(UpdateParams.empty, PersonFields.structure.fields, map)
+    UpdateBuilderMock(UpdateParams.empty, PersonFields.structure, map)
   }
   override def update(row: PersonRow)(implicit c: Connection): Boolean = {
     map.get(row.id) match {

--- a/.bleep/generated-sources/typo-tester-doobie@jvm213/scripts.GenHardcodedFiles/testdb/hardcoded/compositepk/person/PersonRepoMock.scala
+++ b/.bleep/generated-sources/typo-tester-doobie@jvm213/scripts.GenHardcodedFiles/testdb/hardcoded/compositepk/person/PersonRepoMock.scala
@@ -25,7 +25,7 @@ import typo.dsl.UpdateParams
 class PersonRepoMock(toRow: Function1[PersonRowUnsaved, PersonRow],
                      map: scala.collection.mutable.Map[PersonId, PersonRow] = scala.collection.mutable.Map.empty) extends PersonRepo {
   override def delete: DeleteBuilder[PersonFields, PersonRow] = {
-    DeleteBuilderMock(DeleteParams.empty, PersonFields.structure.fields, map)
+    DeleteBuilderMock(DeleteParams.empty, PersonFields.structure, map)
   }
   override def deleteById(compositeId: PersonId): ConnectionIO[Boolean] = {
     delay(map.remove(compositeId).isDefined)
@@ -84,7 +84,7 @@ class PersonRepoMock(toRow: Function1[PersonRowUnsaved, PersonRow],
     delay(map.get(compositeId))
   }
   override def update: UpdateBuilder[PersonFields, PersonRow] = {
-    UpdateBuilderMock(UpdateParams.empty, PersonFields.structure.fields, map)
+    UpdateBuilderMock(UpdateParams.empty, PersonFields.structure, map)
   }
   override def update(row: PersonRow): ConnectionIO[Boolean] = {
     delay {

--- a/.bleep/generated-sources/typo-tester-doobie@jvm213/scripts.GenHardcodedFiles/testdb/hardcoded/myschema/football_club/FootballClubRepoMock.scala
+++ b/.bleep/generated-sources/typo-tester-doobie@jvm213/scripts.GenHardcodedFiles/testdb/hardcoded/myschema/football_club/FootballClubRepoMock.scala
@@ -24,7 +24,7 @@ import typo.dsl.UpdateParams
 
 class FootballClubRepoMock(map: scala.collection.mutable.Map[FootballClubId, FootballClubRow] = scala.collection.mutable.Map.empty) extends FootballClubRepo {
   override def delete: DeleteBuilder[FootballClubFields, FootballClubRow] = {
-    DeleteBuilderMock(DeleteParams.empty, FootballClubFields.structure.fields, map)
+    DeleteBuilderMock(DeleteParams.empty, FootballClubFields.structure, map)
   }
   override def deleteById(id: FootballClubId): ConnectionIO[Boolean] = {
     delay(map.remove(id).isDefined)
@@ -79,7 +79,7 @@ class FootballClubRepoMock(map: scala.collection.mutable.Map[FootballClubId, Foo
     }
   }
   override def update: UpdateBuilder[FootballClubFields, FootballClubRow] = {
-    UpdateBuilderMock(UpdateParams.empty, FootballClubFields.structure.fields, map)
+    UpdateBuilderMock(UpdateParams.empty, FootballClubFields.structure, map)
   }
   override def update(row: FootballClubRow): ConnectionIO[Boolean] = {
     delay {

--- a/.bleep/generated-sources/typo-tester-doobie@jvm213/scripts.GenHardcodedFiles/testdb/hardcoded/myschema/marital_status/MaritalStatusFields.scala
+++ b/.bleep/generated-sources/typo-tester-doobie@jvm213/scripts.GenHardcodedFiles/testdb/hardcoded/myschema/marital_status/MaritalStatusFields.scala
@@ -8,30 +8,31 @@ package hardcoded
 package myschema
 package marital_status
 
+import typo.dsl.Path
 import typo.dsl.SqlExpr.FieldLikeNoHkt
 import typo.dsl.SqlExpr.IdField
 import typo.dsl.Structure.Relation
 
-trait MaritalStatusFields[Row] {
-  val id: IdField[MaritalStatusId, Row]
+trait MaritalStatusFields {
+  def id: IdField[MaritalStatusId, MaritalStatusRow]
 }
 
 object MaritalStatusFields {
-  val structure: Relation[MaritalStatusFields, MaritalStatusRow, MaritalStatusRow] = 
-    new Impl(None, identity, (_, x) => x)
+  lazy val structure: Relation[MaritalStatusFields, MaritalStatusRow] =
+    new Impl(Nil)
     
-  private final class Impl[Row](val prefix: Option[String], val extract: Row => MaritalStatusRow, val merge: (Row, MaritalStatusRow) => Row)
-    extends Relation[MaritalStatusFields, MaritalStatusRow, Row] { 
+  private final class Impl(val _path: List[Path])
+    extends Relation[MaritalStatusFields, MaritalStatusRow] {
   
-    override val fields: MaritalStatusFields[Row] = new MaritalStatusFields[Row] {
-      override val id = new IdField[MaritalStatusId, Row](prefix, "id", None, Some("int8"))(x => extract(x).id, (row, value) => merge(row, extract(row).copy(id = value)))
+    override lazy val fields: MaritalStatusFields = new MaritalStatusFields {
+      override def id = IdField[MaritalStatusId, MaritalStatusRow](_path, "id", None, Some("int8"), x => x.id, (row, value) => row.copy(id = value))
     }
   
-    override val columns: List[FieldLikeNoHkt[?, Row]] =
-      List[FieldLikeNoHkt[?, Row]](fields.id)
+    override lazy val columns: List[FieldLikeNoHkt[?, MaritalStatusRow]] =
+      List[FieldLikeNoHkt[?, MaritalStatusRow]](fields.id)
   
-    override def copy[NewRow](prefix: Option[String], extract: NewRow => MaritalStatusRow, merge: (NewRow, MaritalStatusRow) => NewRow): Impl[NewRow] =
-      new Impl(prefix, extract, merge)
+    override def copy(path: List[Path]): Impl =
+      new Impl(path)
   }
   
 }

--- a/.bleep/generated-sources/typo-tester-doobie@jvm213/scripts.GenHardcodedFiles/testdb/hardcoded/myschema/marital_status/MaritalStatusRepoMock.scala
+++ b/.bleep/generated-sources/typo-tester-doobie@jvm213/scripts.GenHardcodedFiles/testdb/hardcoded/myschema/marital_status/MaritalStatusRepoMock.scala
@@ -24,7 +24,7 @@ import typo.dsl.UpdateParams
 
 class MaritalStatusRepoMock(map: scala.collection.mutable.Map[MaritalStatusId, MaritalStatusRow] = scala.collection.mutable.Map.empty) extends MaritalStatusRepo {
   override def delete: DeleteBuilder[MaritalStatusFields, MaritalStatusRow] = {
-    DeleteBuilderMock(DeleteParams.empty, MaritalStatusFields.structure.fields, map)
+    DeleteBuilderMock(DeleteParams.empty, MaritalStatusFields.structure, map)
   }
   override def deleteById(id: MaritalStatusId): ConnectionIO[Boolean] = {
     delay(map.remove(id).isDefined)
@@ -78,7 +78,7 @@ class MaritalStatusRepoMock(map: scala.collection.mutable.Map[MaritalStatusId, M
     }
   }
   override def update: UpdateBuilder[MaritalStatusFields, MaritalStatusRow] = {
-    UpdateBuilderMock(UpdateParams.empty, MaritalStatusFields.structure.fields, map)
+    UpdateBuilderMock(UpdateParams.empty, MaritalStatusFields.structure, map)
   }
   override def upsert(unsaved: MaritalStatusRow): ConnectionIO[MaritalStatusRow] = {
     delay {

--- a/.bleep/generated-sources/typo-tester-doobie@jvm213/scripts.GenHardcodedFiles/testdb/hardcoded/myschema/person/PersonFields.scala
+++ b/.bleep/generated-sources/typo-tester-doobie@jvm213/scripts.GenHardcodedFiles/testdb/hardcoded/myschema/person/PersonFields.scala
@@ -12,54 +12,55 @@ import testdb.hardcoded.myschema.Number
 import testdb.hardcoded.myschema.Sector
 import testdb.hardcoded.myschema.football_club.FootballClubId
 import testdb.hardcoded.myschema.marital_status.MaritalStatusId
+import typo.dsl.Path
 import typo.dsl.SqlExpr.Field
 import typo.dsl.SqlExpr.FieldLikeNoHkt
 import typo.dsl.SqlExpr.IdField
 import typo.dsl.SqlExpr.OptField
 import typo.dsl.Structure.Relation
 
-trait PersonFields[Row] {
-  val id: IdField[PersonId, Row]
-  val favouriteFootballClubId: Field[FootballClubId, Row]
-  val name: Field[/* max 100 chars */ String, Row]
-  val nickName: OptField[/* max 30 chars */ String, Row]
-  val blogUrl: OptField[/* max 100 chars */ String, Row]
-  val email: Field[/* max 254 chars */ String, Row]
-  val phone: Field[/* max 8 chars */ String, Row]
-  val likesPizza: Field[Boolean, Row]
-  val maritalStatusId: Field[MaritalStatusId, Row]
-  val workEmail: OptField[/* max 254 chars */ String, Row]
-  val sector: Field[Sector, Row]
-  val favoriteNumber: Field[Number, Row]
+trait PersonFields {
+  def id: IdField[PersonId, PersonRow]
+  def favouriteFootballClubId: Field[FootballClubId, PersonRow]
+  def name: Field[/* max 100 chars */ String, PersonRow]
+  def nickName: OptField[/* max 30 chars */ String, PersonRow]
+  def blogUrl: OptField[/* max 100 chars */ String, PersonRow]
+  def email: Field[/* max 254 chars */ String, PersonRow]
+  def phone: Field[/* max 8 chars */ String, PersonRow]
+  def likesPizza: Field[Boolean, PersonRow]
+  def maritalStatusId: Field[MaritalStatusId, PersonRow]
+  def workEmail: OptField[/* max 254 chars */ String, PersonRow]
+  def sector: Field[Sector, PersonRow]
+  def favoriteNumber: Field[Number, PersonRow]
 }
 
 object PersonFields {
-  val structure: Relation[PersonFields, PersonRow, PersonRow] = 
-    new Impl(None, identity, (_, x) => x)
+  lazy val structure: Relation[PersonFields, PersonRow] =
+    new Impl(Nil)
     
-  private final class Impl[Row](val prefix: Option[String], val extract: Row => PersonRow, val merge: (Row, PersonRow) => Row)
-    extends Relation[PersonFields, PersonRow, Row] { 
+  private final class Impl(val _path: List[Path])
+    extends Relation[PersonFields, PersonRow] {
   
-    override val fields: PersonFields[Row] = new PersonFields[Row] {
-      override val id = new IdField[PersonId, Row](prefix, "id", None, Some("int8"))(x => extract(x).id, (row, value) => merge(row, extract(row).copy(id = value)))
-      override val favouriteFootballClubId = new Field[FootballClubId, Row](prefix, "favourite_football_club_id", None, None)(x => extract(x).favouriteFootballClubId, (row, value) => merge(row, extract(row).copy(favouriteFootballClubId = value)))
-      override val name = new Field[/* max 100 chars */ String, Row](prefix, "name", None, None)(x => extract(x).name, (row, value) => merge(row, extract(row).copy(name = value)))
-      override val nickName = new OptField[/* max 30 chars */ String, Row](prefix, "nick_name", None, None)(x => extract(x).nickName, (row, value) => merge(row, extract(row).copy(nickName = value)))
-      override val blogUrl = new OptField[/* max 100 chars */ String, Row](prefix, "blog_url", None, None)(x => extract(x).blogUrl, (row, value) => merge(row, extract(row).copy(blogUrl = value)))
-      override val email = new Field[/* max 254 chars */ String, Row](prefix, "email", None, None)(x => extract(x).email, (row, value) => merge(row, extract(row).copy(email = value)))
-      override val phone = new Field[/* max 8 chars */ String, Row](prefix, "phone", None, None)(x => extract(x).phone, (row, value) => merge(row, extract(row).copy(phone = value)))
-      override val likesPizza = new Field[Boolean, Row](prefix, "likes_pizza", None, None)(x => extract(x).likesPizza, (row, value) => merge(row, extract(row).copy(likesPizza = value)))
-      override val maritalStatusId = new Field[MaritalStatusId, Row](prefix, "marital_status_id", None, None)(x => extract(x).maritalStatusId, (row, value) => merge(row, extract(row).copy(maritalStatusId = value)))
-      override val workEmail = new OptField[/* max 254 chars */ String, Row](prefix, "work_email", None, None)(x => extract(x).workEmail, (row, value) => merge(row, extract(row).copy(workEmail = value)))
-      override val sector = new Field[Sector, Row](prefix, "sector", None, Some("myschema.sector"))(x => extract(x).sector, (row, value) => merge(row, extract(row).copy(sector = value)))
-      override val favoriteNumber = new Field[Number, Row](prefix, "favorite_number", None, Some("myschema.number"))(x => extract(x).favoriteNumber, (row, value) => merge(row, extract(row).copy(favoriteNumber = value)))
+    override lazy val fields: PersonFields = new PersonFields {
+      override def id = IdField[PersonId, PersonRow](_path, "id", None, Some("int8"), x => x.id, (row, value) => row.copy(id = value))
+      override def favouriteFootballClubId = Field[FootballClubId, PersonRow](_path, "favourite_football_club_id", None, None, x => x.favouriteFootballClubId, (row, value) => row.copy(favouriteFootballClubId = value))
+      override def name = Field[/* max 100 chars */ String, PersonRow](_path, "name", None, None, x => x.name, (row, value) => row.copy(name = value))
+      override def nickName = OptField[/* max 30 chars */ String, PersonRow](_path, "nick_name", None, None, x => x.nickName, (row, value) => row.copy(nickName = value))
+      override def blogUrl = OptField[/* max 100 chars */ String, PersonRow](_path, "blog_url", None, None, x => x.blogUrl, (row, value) => row.copy(blogUrl = value))
+      override def email = Field[/* max 254 chars */ String, PersonRow](_path, "email", None, None, x => x.email, (row, value) => row.copy(email = value))
+      override def phone = Field[/* max 8 chars */ String, PersonRow](_path, "phone", None, None, x => x.phone, (row, value) => row.copy(phone = value))
+      override def likesPizza = Field[Boolean, PersonRow](_path, "likes_pizza", None, None, x => x.likesPizza, (row, value) => row.copy(likesPizza = value))
+      override def maritalStatusId = Field[MaritalStatusId, PersonRow](_path, "marital_status_id", None, None, x => x.maritalStatusId, (row, value) => row.copy(maritalStatusId = value))
+      override def workEmail = OptField[/* max 254 chars */ String, PersonRow](_path, "work_email", None, None, x => x.workEmail, (row, value) => row.copy(workEmail = value))
+      override def sector = Field[Sector, PersonRow](_path, "sector", None, Some("myschema.sector"), x => x.sector, (row, value) => row.copy(sector = value))
+      override def favoriteNumber = Field[Number, PersonRow](_path, "favorite_number", None, Some("myschema.number"), x => x.favoriteNumber, (row, value) => row.copy(favoriteNumber = value))
     }
   
-    override val columns: List[FieldLikeNoHkt[?, Row]] =
-      List[FieldLikeNoHkt[?, Row]](fields.id, fields.favouriteFootballClubId, fields.name, fields.nickName, fields.blogUrl, fields.email, fields.phone, fields.likesPizza, fields.maritalStatusId, fields.workEmail, fields.sector, fields.favoriteNumber)
+    override lazy val columns: List[FieldLikeNoHkt[?, PersonRow]] =
+      List[FieldLikeNoHkt[?, PersonRow]](fields.id, fields.favouriteFootballClubId, fields.name, fields.nickName, fields.blogUrl, fields.email, fields.phone, fields.likesPizza, fields.maritalStatusId, fields.workEmail, fields.sector, fields.favoriteNumber)
   
-    override def copy[NewRow](prefix: Option[String], extract: NewRow => PersonRow, merge: (NewRow, PersonRow) => NewRow): Impl[NewRow] =
-      new Impl(prefix, extract, merge)
+    override def copy(path: List[Path]): Impl =
+      new Impl(path)
   }
   
 }

--- a/.bleep/generated-sources/typo-tester-doobie@jvm213/scripts.GenHardcodedFiles/testdb/hardcoded/myschema/person/PersonRepoMock.scala
+++ b/.bleep/generated-sources/typo-tester-doobie@jvm213/scripts.GenHardcodedFiles/testdb/hardcoded/myschema/person/PersonRepoMock.scala
@@ -25,7 +25,7 @@ import typo.dsl.UpdateParams
 class PersonRepoMock(toRow: Function1[PersonRowUnsaved, PersonRow],
                      map: scala.collection.mutable.Map[PersonId, PersonRow] = scala.collection.mutable.Map.empty) extends PersonRepo {
   override def delete: DeleteBuilder[PersonFields, PersonRow] = {
-    DeleteBuilderMock(DeleteParams.empty, PersonFields.structure.fields, map)
+    DeleteBuilderMock(DeleteParams.empty, PersonFields.structure, map)
   }
   override def deleteById(id: PersonId): ConnectionIO[Boolean] = {
     delay(map.remove(id).isDefined)
@@ -105,7 +105,7 @@ class PersonRepoMock(toRow: Function1[PersonRowUnsaved, PersonRow],
     }
   }
   override def update: UpdateBuilder[PersonFields, PersonRow] = {
-    UpdateBuilderMock(UpdateParams.empty, PersonFields.structure.fields, map)
+    UpdateBuilderMock(UpdateParams.empty, PersonFields.structure, map)
   }
   override def update(row: PersonRow): ConnectionIO[Boolean] = {
     delay {

--- a/.bleep/generated-sources/typo-tester-doobie@jvm3/scripts.GenHardcodedFiles/testdb/hardcoded/compositepk/person/PersonRepoMock.scala
+++ b/.bleep/generated-sources/typo-tester-doobie@jvm3/scripts.GenHardcodedFiles/testdb/hardcoded/compositepk/person/PersonRepoMock.scala
@@ -25,7 +25,7 @@ import typo.dsl.UpdateParams
 class PersonRepoMock(toRow: Function1[PersonRowUnsaved, PersonRow],
                      map: scala.collection.mutable.Map[PersonId, PersonRow] = scala.collection.mutable.Map.empty) extends PersonRepo {
   override def delete: DeleteBuilder[PersonFields, PersonRow] = {
-    DeleteBuilderMock(DeleteParams.empty, PersonFields.structure.fields, map)
+    DeleteBuilderMock(DeleteParams.empty, PersonFields.structure, map)
   }
   override def deleteById(compositeId: PersonId): ConnectionIO[Boolean] = {
     delay(map.remove(compositeId).isDefined)
@@ -84,7 +84,7 @@ class PersonRepoMock(toRow: Function1[PersonRowUnsaved, PersonRow],
     delay(map.get(compositeId))
   }
   override def update: UpdateBuilder[PersonFields, PersonRow] = {
-    UpdateBuilderMock(UpdateParams.empty, PersonFields.structure.fields, map)
+    UpdateBuilderMock(UpdateParams.empty, PersonFields.structure, map)
   }
   override def update(row: PersonRow): ConnectionIO[Boolean] = {
     delay {

--- a/.bleep/generated-sources/typo-tester-doobie@jvm3/scripts.GenHardcodedFiles/testdb/hardcoded/myschema/football_club/FootballClubRepoMock.scala
+++ b/.bleep/generated-sources/typo-tester-doobie@jvm3/scripts.GenHardcodedFiles/testdb/hardcoded/myschema/football_club/FootballClubRepoMock.scala
@@ -24,7 +24,7 @@ import typo.dsl.UpdateParams
 
 class FootballClubRepoMock(map: scala.collection.mutable.Map[FootballClubId, FootballClubRow] = scala.collection.mutable.Map.empty) extends FootballClubRepo {
   override def delete: DeleteBuilder[FootballClubFields, FootballClubRow] = {
-    DeleteBuilderMock(DeleteParams.empty, FootballClubFields.structure.fields, map)
+    DeleteBuilderMock(DeleteParams.empty, FootballClubFields.structure, map)
   }
   override def deleteById(id: FootballClubId): ConnectionIO[Boolean] = {
     delay(map.remove(id).isDefined)
@@ -79,7 +79,7 @@ class FootballClubRepoMock(map: scala.collection.mutable.Map[FootballClubId, Foo
     }
   }
   override def update: UpdateBuilder[FootballClubFields, FootballClubRow] = {
-    UpdateBuilderMock(UpdateParams.empty, FootballClubFields.structure.fields, map)
+    UpdateBuilderMock(UpdateParams.empty, FootballClubFields.structure, map)
   }
   override def update(row: FootballClubRow): ConnectionIO[Boolean] = {
     delay {

--- a/.bleep/generated-sources/typo-tester-doobie@jvm3/scripts.GenHardcodedFiles/testdb/hardcoded/myschema/marital_status/MaritalStatusFields.scala
+++ b/.bleep/generated-sources/typo-tester-doobie@jvm3/scripts.GenHardcodedFiles/testdb/hardcoded/myschema/marital_status/MaritalStatusFields.scala
@@ -8,30 +8,31 @@ package hardcoded
 package myschema
 package marital_status
 
+import typo.dsl.Path
 import typo.dsl.SqlExpr.FieldLikeNoHkt
 import typo.dsl.SqlExpr.IdField
 import typo.dsl.Structure.Relation
 
-trait MaritalStatusFields[Row] {
-  val id: IdField[MaritalStatusId, Row]
+trait MaritalStatusFields {
+  def id: IdField[MaritalStatusId, MaritalStatusRow]
 }
 
 object MaritalStatusFields {
-  val structure: Relation[MaritalStatusFields, MaritalStatusRow, MaritalStatusRow] = 
-    new Impl(None, identity, (_, x) => x)
+  lazy val structure: Relation[MaritalStatusFields, MaritalStatusRow] =
+    new Impl(Nil)
     
-  private final class Impl[Row](val prefix: Option[String], val extract: Row => MaritalStatusRow, val merge: (Row, MaritalStatusRow) => Row)
-    extends Relation[MaritalStatusFields, MaritalStatusRow, Row] { 
+  private final class Impl(val _path: List[Path])
+    extends Relation[MaritalStatusFields, MaritalStatusRow] {
   
-    override val fields: MaritalStatusFields[Row] = new MaritalStatusFields[Row] {
-      override val id = new IdField[MaritalStatusId, Row](prefix, "id", None, Some("int8"))(x => extract(x).id, (row, value) => merge(row, extract(row).copy(id = value)))
+    override lazy val fields: MaritalStatusFields = new MaritalStatusFields {
+      override def id = IdField[MaritalStatusId, MaritalStatusRow](_path, "id", None, Some("int8"), x => x.id, (row, value) => row.copy(id = value))
     }
   
-    override val columns: List[FieldLikeNoHkt[?, Row]] =
-      List[FieldLikeNoHkt[?, Row]](fields.id)
+    override lazy val columns: List[FieldLikeNoHkt[?, MaritalStatusRow]] =
+      List[FieldLikeNoHkt[?, MaritalStatusRow]](fields.id)
   
-    override def copy[NewRow](prefix: Option[String], extract: NewRow => MaritalStatusRow, merge: (NewRow, MaritalStatusRow) => NewRow): Impl[NewRow] =
-      new Impl(prefix, extract, merge)
+    override def copy(path: List[Path]): Impl =
+      new Impl(path)
   }
   
 }

--- a/.bleep/generated-sources/typo-tester-doobie@jvm3/scripts.GenHardcodedFiles/testdb/hardcoded/myschema/marital_status/MaritalStatusRepoMock.scala
+++ b/.bleep/generated-sources/typo-tester-doobie@jvm3/scripts.GenHardcodedFiles/testdb/hardcoded/myschema/marital_status/MaritalStatusRepoMock.scala
@@ -24,7 +24,7 @@ import typo.dsl.UpdateParams
 
 class MaritalStatusRepoMock(map: scala.collection.mutable.Map[MaritalStatusId, MaritalStatusRow] = scala.collection.mutable.Map.empty) extends MaritalStatusRepo {
   override def delete: DeleteBuilder[MaritalStatusFields, MaritalStatusRow] = {
-    DeleteBuilderMock(DeleteParams.empty, MaritalStatusFields.structure.fields, map)
+    DeleteBuilderMock(DeleteParams.empty, MaritalStatusFields.structure, map)
   }
   override def deleteById(id: MaritalStatusId): ConnectionIO[Boolean] = {
     delay(map.remove(id).isDefined)
@@ -78,7 +78,7 @@ class MaritalStatusRepoMock(map: scala.collection.mutable.Map[MaritalStatusId, M
     }
   }
   override def update: UpdateBuilder[MaritalStatusFields, MaritalStatusRow] = {
-    UpdateBuilderMock(UpdateParams.empty, MaritalStatusFields.structure.fields, map)
+    UpdateBuilderMock(UpdateParams.empty, MaritalStatusFields.structure, map)
   }
   override def upsert(unsaved: MaritalStatusRow): ConnectionIO[MaritalStatusRow] = {
     delay {

--- a/.bleep/generated-sources/typo-tester-doobie@jvm3/scripts.GenHardcodedFiles/testdb/hardcoded/myschema/person/PersonFields.scala
+++ b/.bleep/generated-sources/typo-tester-doobie@jvm3/scripts.GenHardcodedFiles/testdb/hardcoded/myschema/person/PersonFields.scala
@@ -12,54 +12,55 @@ import testdb.hardcoded.myschema.Number
 import testdb.hardcoded.myschema.Sector
 import testdb.hardcoded.myschema.football_club.FootballClubId
 import testdb.hardcoded.myschema.marital_status.MaritalStatusId
+import typo.dsl.Path
 import typo.dsl.SqlExpr.Field
 import typo.dsl.SqlExpr.FieldLikeNoHkt
 import typo.dsl.SqlExpr.IdField
 import typo.dsl.SqlExpr.OptField
 import typo.dsl.Structure.Relation
 
-trait PersonFields[Row] {
-  val id: IdField[PersonId, Row]
-  val favouriteFootballClubId: Field[FootballClubId, Row]
-  val name: Field[/* max 100 chars */ String, Row]
-  val nickName: OptField[/* max 30 chars */ String, Row]
-  val blogUrl: OptField[/* max 100 chars */ String, Row]
-  val email: Field[/* max 254 chars */ String, Row]
-  val phone: Field[/* max 8 chars */ String, Row]
-  val likesPizza: Field[Boolean, Row]
-  val maritalStatusId: Field[MaritalStatusId, Row]
-  val workEmail: OptField[/* max 254 chars */ String, Row]
-  val sector: Field[Sector, Row]
-  val favoriteNumber: Field[Number, Row]
+trait PersonFields {
+  def id: IdField[PersonId, PersonRow]
+  def favouriteFootballClubId: Field[FootballClubId, PersonRow]
+  def name: Field[/* max 100 chars */ String, PersonRow]
+  def nickName: OptField[/* max 30 chars */ String, PersonRow]
+  def blogUrl: OptField[/* max 100 chars */ String, PersonRow]
+  def email: Field[/* max 254 chars */ String, PersonRow]
+  def phone: Field[/* max 8 chars */ String, PersonRow]
+  def likesPizza: Field[Boolean, PersonRow]
+  def maritalStatusId: Field[MaritalStatusId, PersonRow]
+  def workEmail: OptField[/* max 254 chars */ String, PersonRow]
+  def sector: Field[Sector, PersonRow]
+  def favoriteNumber: Field[Number, PersonRow]
 }
 
 object PersonFields {
-  val structure: Relation[PersonFields, PersonRow, PersonRow] = 
-    new Impl(None, identity, (_, x) => x)
+  lazy val structure: Relation[PersonFields, PersonRow] =
+    new Impl(Nil)
     
-  private final class Impl[Row](val prefix: Option[String], val extract: Row => PersonRow, val merge: (Row, PersonRow) => Row)
-    extends Relation[PersonFields, PersonRow, Row] { 
+  private final class Impl(val _path: List[Path])
+    extends Relation[PersonFields, PersonRow] {
   
-    override val fields: PersonFields[Row] = new PersonFields[Row] {
-      override val id = new IdField[PersonId, Row](prefix, "id", None, Some("int8"))(x => extract(x).id, (row, value) => merge(row, extract(row).copy(id = value)))
-      override val favouriteFootballClubId = new Field[FootballClubId, Row](prefix, "favourite_football_club_id", None, None)(x => extract(x).favouriteFootballClubId, (row, value) => merge(row, extract(row).copy(favouriteFootballClubId = value)))
-      override val name = new Field[/* max 100 chars */ String, Row](prefix, "name", None, None)(x => extract(x).name, (row, value) => merge(row, extract(row).copy(name = value)))
-      override val nickName = new OptField[/* max 30 chars */ String, Row](prefix, "nick_name", None, None)(x => extract(x).nickName, (row, value) => merge(row, extract(row).copy(nickName = value)))
-      override val blogUrl = new OptField[/* max 100 chars */ String, Row](prefix, "blog_url", None, None)(x => extract(x).blogUrl, (row, value) => merge(row, extract(row).copy(blogUrl = value)))
-      override val email = new Field[/* max 254 chars */ String, Row](prefix, "email", None, None)(x => extract(x).email, (row, value) => merge(row, extract(row).copy(email = value)))
-      override val phone = new Field[/* max 8 chars */ String, Row](prefix, "phone", None, None)(x => extract(x).phone, (row, value) => merge(row, extract(row).copy(phone = value)))
-      override val likesPizza = new Field[Boolean, Row](prefix, "likes_pizza", None, None)(x => extract(x).likesPizza, (row, value) => merge(row, extract(row).copy(likesPizza = value)))
-      override val maritalStatusId = new Field[MaritalStatusId, Row](prefix, "marital_status_id", None, None)(x => extract(x).maritalStatusId, (row, value) => merge(row, extract(row).copy(maritalStatusId = value)))
-      override val workEmail = new OptField[/* max 254 chars */ String, Row](prefix, "work_email", None, None)(x => extract(x).workEmail, (row, value) => merge(row, extract(row).copy(workEmail = value)))
-      override val sector = new Field[Sector, Row](prefix, "sector", None, Some("myschema.sector"))(x => extract(x).sector, (row, value) => merge(row, extract(row).copy(sector = value)))
-      override val favoriteNumber = new Field[Number, Row](prefix, "favorite_number", None, Some("myschema.number"))(x => extract(x).favoriteNumber, (row, value) => merge(row, extract(row).copy(favoriteNumber = value)))
+    override lazy val fields: PersonFields = new PersonFields {
+      override def id = IdField[PersonId, PersonRow](_path, "id", None, Some("int8"), x => x.id, (row, value) => row.copy(id = value))
+      override def favouriteFootballClubId = Field[FootballClubId, PersonRow](_path, "favourite_football_club_id", None, None, x => x.favouriteFootballClubId, (row, value) => row.copy(favouriteFootballClubId = value))
+      override def name = Field[/* max 100 chars */ String, PersonRow](_path, "name", None, None, x => x.name, (row, value) => row.copy(name = value))
+      override def nickName = OptField[/* max 30 chars */ String, PersonRow](_path, "nick_name", None, None, x => x.nickName, (row, value) => row.copy(nickName = value))
+      override def blogUrl = OptField[/* max 100 chars */ String, PersonRow](_path, "blog_url", None, None, x => x.blogUrl, (row, value) => row.copy(blogUrl = value))
+      override def email = Field[/* max 254 chars */ String, PersonRow](_path, "email", None, None, x => x.email, (row, value) => row.copy(email = value))
+      override def phone = Field[/* max 8 chars */ String, PersonRow](_path, "phone", None, None, x => x.phone, (row, value) => row.copy(phone = value))
+      override def likesPizza = Field[Boolean, PersonRow](_path, "likes_pizza", None, None, x => x.likesPizza, (row, value) => row.copy(likesPizza = value))
+      override def maritalStatusId = Field[MaritalStatusId, PersonRow](_path, "marital_status_id", None, None, x => x.maritalStatusId, (row, value) => row.copy(maritalStatusId = value))
+      override def workEmail = OptField[/* max 254 chars */ String, PersonRow](_path, "work_email", None, None, x => x.workEmail, (row, value) => row.copy(workEmail = value))
+      override def sector = Field[Sector, PersonRow](_path, "sector", None, Some("myschema.sector"), x => x.sector, (row, value) => row.copy(sector = value))
+      override def favoriteNumber = Field[Number, PersonRow](_path, "favorite_number", None, Some("myschema.number"), x => x.favoriteNumber, (row, value) => row.copy(favoriteNumber = value))
     }
   
-    override val columns: List[FieldLikeNoHkt[?, Row]] =
-      List[FieldLikeNoHkt[?, Row]](fields.id, fields.favouriteFootballClubId, fields.name, fields.nickName, fields.blogUrl, fields.email, fields.phone, fields.likesPizza, fields.maritalStatusId, fields.workEmail, fields.sector, fields.favoriteNumber)
+    override lazy val columns: List[FieldLikeNoHkt[?, PersonRow]] =
+      List[FieldLikeNoHkt[?, PersonRow]](fields.id, fields.favouriteFootballClubId, fields.name, fields.nickName, fields.blogUrl, fields.email, fields.phone, fields.likesPizza, fields.maritalStatusId, fields.workEmail, fields.sector, fields.favoriteNumber)
   
-    override def copy[NewRow](prefix: Option[String], extract: NewRow => PersonRow, merge: (NewRow, PersonRow) => NewRow): Impl[NewRow] =
-      new Impl(prefix, extract, merge)
+    override def copy(path: List[Path]): Impl =
+      new Impl(path)
   }
   
 }

--- a/.bleep/generated-sources/typo-tester-doobie@jvm3/scripts.GenHardcodedFiles/testdb/hardcoded/myschema/person/PersonRepoMock.scala
+++ b/.bleep/generated-sources/typo-tester-doobie@jvm3/scripts.GenHardcodedFiles/testdb/hardcoded/myschema/person/PersonRepoMock.scala
@@ -25,7 +25,7 @@ import typo.dsl.UpdateParams
 class PersonRepoMock(toRow: Function1[PersonRowUnsaved, PersonRow],
                      map: scala.collection.mutable.Map[PersonId, PersonRow] = scala.collection.mutable.Map.empty) extends PersonRepo {
   override def delete: DeleteBuilder[PersonFields, PersonRow] = {
-    DeleteBuilderMock(DeleteParams.empty, PersonFields.structure.fields, map)
+    DeleteBuilderMock(DeleteParams.empty, PersonFields.structure, map)
   }
   override def deleteById(id: PersonId): ConnectionIO[Boolean] = {
     delay(map.remove(id).isDefined)
@@ -105,7 +105,7 @@ class PersonRepoMock(toRow: Function1[PersonRowUnsaved, PersonRow],
     }
   }
   override def update: UpdateBuilder[PersonFields, PersonRow] = {
-    UpdateBuilderMock(UpdateParams.empty, PersonFields.structure.fields, map)
+    UpdateBuilderMock(UpdateParams.empty, PersonFields.structure, map)
   }
   override def update(row: PersonRow): ConnectionIO[Boolean] = {
     delay {

--- a/.bleep/generated-sources/typo-tester-zio-jdbc@jvm213/scripts.GenHardcodedFiles/testdb/hardcoded/compositepk/person/PersonRepoMock.scala
+++ b/.bleep/generated-sources/typo-tester-zio-jdbc@jvm213/scripts.GenHardcodedFiles/testdb/hardcoded/compositepk/person/PersonRepoMock.scala
@@ -27,7 +27,7 @@ import zio.stream.ZStream
 class PersonRepoMock(toRow: Function1[PersonRowUnsaved, PersonRow],
                      map: scala.collection.mutable.Map[PersonId, PersonRow] = scala.collection.mutable.Map.empty) extends PersonRepo {
   override def delete: DeleteBuilder[PersonFields, PersonRow] = {
-    DeleteBuilderMock(DeleteParams.empty, PersonFields.structure.fields, map)
+    DeleteBuilderMock(DeleteParams.empty, PersonFields.structure, map)
   }
   override def deleteById(compositeId: PersonId): ZIO[ZConnection, Throwable, Boolean] = {
     ZIO.succeed(map.remove(compositeId).isDefined)
@@ -83,7 +83,7 @@ class PersonRepoMock(toRow: Function1[PersonRowUnsaved, PersonRow],
     ZIO.succeed(map.get(compositeId))
   }
   override def update: UpdateBuilder[PersonFields, PersonRow] = {
-    UpdateBuilderMock(UpdateParams.empty, PersonFields.structure.fields, map)
+    UpdateBuilderMock(UpdateParams.empty, PersonFields.structure, map)
   }
   override def update(row: PersonRow): ZIO[ZConnection, Throwable, Boolean] = {
     ZIO.succeed {

--- a/.bleep/generated-sources/typo-tester-zio-jdbc@jvm213/scripts.GenHardcodedFiles/testdb/hardcoded/myschema/football_club/FootballClubRepoMock.scala
+++ b/.bleep/generated-sources/typo-tester-zio-jdbc@jvm213/scripts.GenHardcodedFiles/testdb/hardcoded/myschema/football_club/FootballClubRepoMock.scala
@@ -26,7 +26,7 @@ import zio.stream.ZStream
 
 class FootballClubRepoMock(map: scala.collection.mutable.Map[FootballClubId, FootballClubRow] = scala.collection.mutable.Map.empty) extends FootballClubRepo {
   override def delete: DeleteBuilder[FootballClubFields, FootballClubRow] = {
-    DeleteBuilderMock(DeleteParams.empty, FootballClubFields.structure.fields, map)
+    DeleteBuilderMock(DeleteParams.empty, FootballClubFields.structure, map)
   }
   override def deleteById(id: FootballClubId): ZIO[ZConnection, Throwable, Boolean] = {
     ZIO.succeed(map.remove(id).isDefined)
@@ -80,7 +80,7 @@ class FootballClubRepoMock(map: scala.collection.mutable.Map[FootballClubId, Foo
     }
   }
   override def update: UpdateBuilder[FootballClubFields, FootballClubRow] = {
-    UpdateBuilderMock(UpdateParams.empty, FootballClubFields.structure.fields, map)
+    UpdateBuilderMock(UpdateParams.empty, FootballClubFields.structure, map)
   }
   override def update(row: FootballClubRow): ZIO[ZConnection, Throwable, Boolean] = {
     ZIO.succeed {

--- a/.bleep/generated-sources/typo-tester-zio-jdbc@jvm213/scripts.GenHardcodedFiles/testdb/hardcoded/myschema/marital_status/MaritalStatusFields.scala
+++ b/.bleep/generated-sources/typo-tester-zio-jdbc@jvm213/scripts.GenHardcodedFiles/testdb/hardcoded/myschema/marital_status/MaritalStatusFields.scala
@@ -8,30 +8,31 @@ package hardcoded
 package myschema
 package marital_status
 
+import typo.dsl.Path
 import typo.dsl.SqlExpr.FieldLikeNoHkt
 import typo.dsl.SqlExpr.IdField
 import typo.dsl.Structure.Relation
 
-trait MaritalStatusFields[Row] {
-  val id: IdField[MaritalStatusId, Row]
+trait MaritalStatusFields {
+  def id: IdField[MaritalStatusId, MaritalStatusRow]
 }
 
 object MaritalStatusFields {
-  val structure: Relation[MaritalStatusFields, MaritalStatusRow, MaritalStatusRow] = 
-    new Impl(None, identity, (_, x) => x)
+  lazy val structure: Relation[MaritalStatusFields, MaritalStatusRow] =
+    new Impl(Nil)
     
-  private final class Impl[Row](val prefix: Option[String], val extract: Row => MaritalStatusRow, val merge: (Row, MaritalStatusRow) => Row)
-    extends Relation[MaritalStatusFields, MaritalStatusRow, Row] { 
+  private final class Impl(val _path: List[Path])
+    extends Relation[MaritalStatusFields, MaritalStatusRow] {
   
-    override val fields: MaritalStatusFields[Row] = new MaritalStatusFields[Row] {
-      override val id = new IdField[MaritalStatusId, Row](prefix, "id", None, Some("int8"))(x => extract(x).id, (row, value) => merge(row, extract(row).copy(id = value)))
+    override lazy val fields: MaritalStatusFields = new MaritalStatusFields {
+      override def id = IdField[MaritalStatusId, MaritalStatusRow](_path, "id", None, Some("int8"), x => x.id, (row, value) => row.copy(id = value))
     }
   
-    override val columns: List[FieldLikeNoHkt[?, Row]] =
-      List[FieldLikeNoHkt[?, Row]](fields.id)
+    override lazy val columns: List[FieldLikeNoHkt[?, MaritalStatusRow]] =
+      List[FieldLikeNoHkt[?, MaritalStatusRow]](fields.id)
   
-    override def copy[NewRow](prefix: Option[String], extract: NewRow => MaritalStatusRow, merge: (NewRow, MaritalStatusRow) => NewRow): Impl[NewRow] =
-      new Impl(prefix, extract, merge)
+    override def copy(path: List[Path]): Impl =
+      new Impl(path)
   }
   
 }

--- a/.bleep/generated-sources/typo-tester-zio-jdbc@jvm213/scripts.GenHardcodedFiles/testdb/hardcoded/myschema/marital_status/MaritalStatusRepoMock.scala
+++ b/.bleep/generated-sources/typo-tester-zio-jdbc@jvm213/scripts.GenHardcodedFiles/testdb/hardcoded/myschema/marital_status/MaritalStatusRepoMock.scala
@@ -26,7 +26,7 @@ import zio.stream.ZStream
 
 class MaritalStatusRepoMock(map: scala.collection.mutable.Map[MaritalStatusId, MaritalStatusRow] = scala.collection.mutable.Map.empty) extends MaritalStatusRepo {
   override def delete: DeleteBuilder[MaritalStatusFields, MaritalStatusRow] = {
-    DeleteBuilderMock(DeleteParams.empty, MaritalStatusFields.structure.fields, map)
+    DeleteBuilderMock(DeleteParams.empty, MaritalStatusFields.structure, map)
   }
   override def deleteById(id: MaritalStatusId): ZIO[ZConnection, Throwable, Boolean] = {
     ZIO.succeed(map.remove(id).isDefined)
@@ -79,7 +79,7 @@ class MaritalStatusRepoMock(map: scala.collection.mutable.Map[MaritalStatusId, M
     }
   }
   override def update: UpdateBuilder[MaritalStatusFields, MaritalStatusRow] = {
-    UpdateBuilderMock(UpdateParams.empty, MaritalStatusFields.structure.fields, map)
+    UpdateBuilderMock(UpdateParams.empty, MaritalStatusFields.structure, map)
   }
   override def upsert(unsaved: MaritalStatusRow): ZIO[ZConnection, Throwable, UpdateResult[MaritalStatusRow]] = {
     ZIO.succeed {

--- a/.bleep/generated-sources/typo-tester-zio-jdbc@jvm213/scripts.GenHardcodedFiles/testdb/hardcoded/myschema/person/PersonFields.scala
+++ b/.bleep/generated-sources/typo-tester-zio-jdbc@jvm213/scripts.GenHardcodedFiles/testdb/hardcoded/myschema/person/PersonFields.scala
@@ -12,54 +12,55 @@ import testdb.hardcoded.myschema.Number
 import testdb.hardcoded.myschema.Sector
 import testdb.hardcoded.myschema.football_club.FootballClubId
 import testdb.hardcoded.myschema.marital_status.MaritalStatusId
+import typo.dsl.Path
 import typo.dsl.SqlExpr.Field
 import typo.dsl.SqlExpr.FieldLikeNoHkt
 import typo.dsl.SqlExpr.IdField
 import typo.dsl.SqlExpr.OptField
 import typo.dsl.Structure.Relation
 
-trait PersonFields[Row] {
-  val id: IdField[PersonId, Row]
-  val favouriteFootballClubId: Field[FootballClubId, Row]
-  val name: Field[/* max 100 chars */ String, Row]
-  val nickName: OptField[/* max 30 chars */ String, Row]
-  val blogUrl: OptField[/* max 100 chars */ String, Row]
-  val email: Field[/* max 254 chars */ String, Row]
-  val phone: Field[/* max 8 chars */ String, Row]
-  val likesPizza: Field[Boolean, Row]
-  val maritalStatusId: Field[MaritalStatusId, Row]
-  val workEmail: OptField[/* max 254 chars */ String, Row]
-  val sector: Field[Sector, Row]
-  val favoriteNumber: Field[Number, Row]
+trait PersonFields {
+  def id: IdField[PersonId, PersonRow]
+  def favouriteFootballClubId: Field[FootballClubId, PersonRow]
+  def name: Field[/* max 100 chars */ String, PersonRow]
+  def nickName: OptField[/* max 30 chars */ String, PersonRow]
+  def blogUrl: OptField[/* max 100 chars */ String, PersonRow]
+  def email: Field[/* max 254 chars */ String, PersonRow]
+  def phone: Field[/* max 8 chars */ String, PersonRow]
+  def likesPizza: Field[Boolean, PersonRow]
+  def maritalStatusId: Field[MaritalStatusId, PersonRow]
+  def workEmail: OptField[/* max 254 chars */ String, PersonRow]
+  def sector: Field[Sector, PersonRow]
+  def favoriteNumber: Field[Number, PersonRow]
 }
 
 object PersonFields {
-  val structure: Relation[PersonFields, PersonRow, PersonRow] = 
-    new Impl(None, identity, (_, x) => x)
+  lazy val structure: Relation[PersonFields, PersonRow] =
+    new Impl(Nil)
     
-  private final class Impl[Row](val prefix: Option[String], val extract: Row => PersonRow, val merge: (Row, PersonRow) => Row)
-    extends Relation[PersonFields, PersonRow, Row] { 
+  private final class Impl(val _path: List[Path])
+    extends Relation[PersonFields, PersonRow] {
   
-    override val fields: PersonFields[Row] = new PersonFields[Row] {
-      override val id = new IdField[PersonId, Row](prefix, "id", None, Some("int8"))(x => extract(x).id, (row, value) => merge(row, extract(row).copy(id = value)))
-      override val favouriteFootballClubId = new Field[FootballClubId, Row](prefix, "favourite_football_club_id", None, None)(x => extract(x).favouriteFootballClubId, (row, value) => merge(row, extract(row).copy(favouriteFootballClubId = value)))
-      override val name = new Field[/* max 100 chars */ String, Row](prefix, "name", None, None)(x => extract(x).name, (row, value) => merge(row, extract(row).copy(name = value)))
-      override val nickName = new OptField[/* max 30 chars */ String, Row](prefix, "nick_name", None, None)(x => extract(x).nickName, (row, value) => merge(row, extract(row).copy(nickName = value)))
-      override val blogUrl = new OptField[/* max 100 chars */ String, Row](prefix, "blog_url", None, None)(x => extract(x).blogUrl, (row, value) => merge(row, extract(row).copy(blogUrl = value)))
-      override val email = new Field[/* max 254 chars */ String, Row](prefix, "email", None, None)(x => extract(x).email, (row, value) => merge(row, extract(row).copy(email = value)))
-      override val phone = new Field[/* max 8 chars */ String, Row](prefix, "phone", None, None)(x => extract(x).phone, (row, value) => merge(row, extract(row).copy(phone = value)))
-      override val likesPizza = new Field[Boolean, Row](prefix, "likes_pizza", None, None)(x => extract(x).likesPizza, (row, value) => merge(row, extract(row).copy(likesPizza = value)))
-      override val maritalStatusId = new Field[MaritalStatusId, Row](prefix, "marital_status_id", None, None)(x => extract(x).maritalStatusId, (row, value) => merge(row, extract(row).copy(maritalStatusId = value)))
-      override val workEmail = new OptField[/* max 254 chars */ String, Row](prefix, "work_email", None, None)(x => extract(x).workEmail, (row, value) => merge(row, extract(row).copy(workEmail = value)))
-      override val sector = new Field[Sector, Row](prefix, "sector", None, Some("myschema.sector"))(x => extract(x).sector, (row, value) => merge(row, extract(row).copy(sector = value)))
-      override val favoriteNumber = new Field[Number, Row](prefix, "favorite_number", None, Some("myschema.number"))(x => extract(x).favoriteNumber, (row, value) => merge(row, extract(row).copy(favoriteNumber = value)))
+    override lazy val fields: PersonFields = new PersonFields {
+      override def id = IdField[PersonId, PersonRow](_path, "id", None, Some("int8"), x => x.id, (row, value) => row.copy(id = value))
+      override def favouriteFootballClubId = Field[FootballClubId, PersonRow](_path, "favourite_football_club_id", None, None, x => x.favouriteFootballClubId, (row, value) => row.copy(favouriteFootballClubId = value))
+      override def name = Field[/* max 100 chars */ String, PersonRow](_path, "name", None, None, x => x.name, (row, value) => row.copy(name = value))
+      override def nickName = OptField[/* max 30 chars */ String, PersonRow](_path, "nick_name", None, None, x => x.nickName, (row, value) => row.copy(nickName = value))
+      override def blogUrl = OptField[/* max 100 chars */ String, PersonRow](_path, "blog_url", None, None, x => x.blogUrl, (row, value) => row.copy(blogUrl = value))
+      override def email = Field[/* max 254 chars */ String, PersonRow](_path, "email", None, None, x => x.email, (row, value) => row.copy(email = value))
+      override def phone = Field[/* max 8 chars */ String, PersonRow](_path, "phone", None, None, x => x.phone, (row, value) => row.copy(phone = value))
+      override def likesPizza = Field[Boolean, PersonRow](_path, "likes_pizza", None, None, x => x.likesPizza, (row, value) => row.copy(likesPizza = value))
+      override def maritalStatusId = Field[MaritalStatusId, PersonRow](_path, "marital_status_id", None, None, x => x.maritalStatusId, (row, value) => row.copy(maritalStatusId = value))
+      override def workEmail = OptField[/* max 254 chars */ String, PersonRow](_path, "work_email", None, None, x => x.workEmail, (row, value) => row.copy(workEmail = value))
+      override def sector = Field[Sector, PersonRow](_path, "sector", None, Some("myschema.sector"), x => x.sector, (row, value) => row.copy(sector = value))
+      override def favoriteNumber = Field[Number, PersonRow](_path, "favorite_number", None, Some("myschema.number"), x => x.favoriteNumber, (row, value) => row.copy(favoriteNumber = value))
     }
   
-    override val columns: List[FieldLikeNoHkt[?, Row]] =
-      List[FieldLikeNoHkt[?, Row]](fields.id, fields.favouriteFootballClubId, fields.name, fields.nickName, fields.blogUrl, fields.email, fields.phone, fields.likesPizza, fields.maritalStatusId, fields.workEmail, fields.sector, fields.favoriteNumber)
+    override lazy val columns: List[FieldLikeNoHkt[?, PersonRow]] =
+      List[FieldLikeNoHkt[?, PersonRow]](fields.id, fields.favouriteFootballClubId, fields.name, fields.nickName, fields.blogUrl, fields.email, fields.phone, fields.likesPizza, fields.maritalStatusId, fields.workEmail, fields.sector, fields.favoriteNumber)
   
-    override def copy[NewRow](prefix: Option[String], extract: NewRow => PersonRow, merge: (NewRow, PersonRow) => NewRow): Impl[NewRow] =
-      new Impl(prefix, extract, merge)
+    override def copy(path: List[Path]): Impl =
+      new Impl(path)
   }
   
 }

--- a/.bleep/generated-sources/typo-tester-zio-jdbc@jvm213/scripts.GenHardcodedFiles/testdb/hardcoded/myschema/person/PersonRepoMock.scala
+++ b/.bleep/generated-sources/typo-tester-zio-jdbc@jvm213/scripts.GenHardcodedFiles/testdb/hardcoded/myschema/person/PersonRepoMock.scala
@@ -27,7 +27,7 @@ import zio.stream.ZStream
 class PersonRepoMock(toRow: Function1[PersonRowUnsaved, PersonRow],
                      map: scala.collection.mutable.Map[PersonId, PersonRow] = scala.collection.mutable.Map.empty) extends PersonRepo {
   override def delete: DeleteBuilder[PersonFields, PersonRow] = {
-    DeleteBuilderMock(DeleteParams.empty, PersonFields.structure.fields, map)
+    DeleteBuilderMock(DeleteParams.empty, PersonFields.structure, map)
   }
   override def deleteById(id: PersonId): ZIO[ZConnection, Throwable, Boolean] = {
     ZIO.succeed(map.remove(id).isDefined)
@@ -104,7 +104,7 @@ class PersonRepoMock(toRow: Function1[PersonRowUnsaved, PersonRow],
     }
   }
   override def update: UpdateBuilder[PersonFields, PersonRow] = {
-    UpdateBuilderMock(UpdateParams.empty, PersonFields.structure.fields, map)
+    UpdateBuilderMock(UpdateParams.empty, PersonFields.structure, map)
   }
   override def update(row: PersonRow): ZIO[ZConnection, Throwable, Boolean] = {
     ZIO.succeed {

--- a/.bleep/generated-sources/typo-tester-zio-jdbc@jvm3/scripts.GenHardcodedFiles/testdb/hardcoded/compositepk/person/PersonRepoMock.scala
+++ b/.bleep/generated-sources/typo-tester-zio-jdbc@jvm3/scripts.GenHardcodedFiles/testdb/hardcoded/compositepk/person/PersonRepoMock.scala
@@ -27,7 +27,7 @@ import zio.stream.ZStream
 class PersonRepoMock(toRow: Function1[PersonRowUnsaved, PersonRow],
                      map: scala.collection.mutable.Map[PersonId, PersonRow] = scala.collection.mutable.Map.empty) extends PersonRepo {
   override def delete: DeleteBuilder[PersonFields, PersonRow] = {
-    DeleteBuilderMock(DeleteParams.empty, PersonFields.structure.fields, map)
+    DeleteBuilderMock(DeleteParams.empty, PersonFields.structure, map)
   }
   override def deleteById(compositeId: PersonId): ZIO[ZConnection, Throwable, Boolean] = {
     ZIO.succeed(map.remove(compositeId).isDefined)
@@ -83,7 +83,7 @@ class PersonRepoMock(toRow: Function1[PersonRowUnsaved, PersonRow],
     ZIO.succeed(map.get(compositeId))
   }
   override def update: UpdateBuilder[PersonFields, PersonRow] = {
-    UpdateBuilderMock(UpdateParams.empty, PersonFields.structure.fields, map)
+    UpdateBuilderMock(UpdateParams.empty, PersonFields.structure, map)
   }
   override def update(row: PersonRow): ZIO[ZConnection, Throwable, Boolean] = {
     ZIO.succeed {

--- a/.bleep/generated-sources/typo-tester-zio-jdbc@jvm3/scripts.GenHardcodedFiles/testdb/hardcoded/myschema/football_club/FootballClubRepoMock.scala
+++ b/.bleep/generated-sources/typo-tester-zio-jdbc@jvm3/scripts.GenHardcodedFiles/testdb/hardcoded/myschema/football_club/FootballClubRepoMock.scala
@@ -26,7 +26,7 @@ import zio.stream.ZStream
 
 class FootballClubRepoMock(map: scala.collection.mutable.Map[FootballClubId, FootballClubRow] = scala.collection.mutable.Map.empty) extends FootballClubRepo {
   override def delete: DeleteBuilder[FootballClubFields, FootballClubRow] = {
-    DeleteBuilderMock(DeleteParams.empty, FootballClubFields.structure.fields, map)
+    DeleteBuilderMock(DeleteParams.empty, FootballClubFields.structure, map)
   }
   override def deleteById(id: FootballClubId): ZIO[ZConnection, Throwable, Boolean] = {
     ZIO.succeed(map.remove(id).isDefined)
@@ -80,7 +80,7 @@ class FootballClubRepoMock(map: scala.collection.mutable.Map[FootballClubId, Foo
     }
   }
   override def update: UpdateBuilder[FootballClubFields, FootballClubRow] = {
-    UpdateBuilderMock(UpdateParams.empty, FootballClubFields.structure.fields, map)
+    UpdateBuilderMock(UpdateParams.empty, FootballClubFields.structure, map)
   }
   override def update(row: FootballClubRow): ZIO[ZConnection, Throwable, Boolean] = {
     ZIO.succeed {

--- a/.bleep/generated-sources/typo-tester-zio-jdbc@jvm3/scripts.GenHardcodedFiles/testdb/hardcoded/myschema/marital_status/MaritalStatusFields.scala
+++ b/.bleep/generated-sources/typo-tester-zio-jdbc@jvm3/scripts.GenHardcodedFiles/testdb/hardcoded/myschema/marital_status/MaritalStatusFields.scala
@@ -8,30 +8,31 @@ package hardcoded
 package myschema
 package marital_status
 
+import typo.dsl.Path
 import typo.dsl.SqlExpr.FieldLikeNoHkt
 import typo.dsl.SqlExpr.IdField
 import typo.dsl.Structure.Relation
 
-trait MaritalStatusFields[Row] {
-  val id: IdField[MaritalStatusId, Row]
+trait MaritalStatusFields {
+  def id: IdField[MaritalStatusId, MaritalStatusRow]
 }
 
 object MaritalStatusFields {
-  val structure: Relation[MaritalStatusFields, MaritalStatusRow, MaritalStatusRow] = 
-    new Impl(None, identity, (_, x) => x)
+  lazy val structure: Relation[MaritalStatusFields, MaritalStatusRow] =
+    new Impl(Nil)
     
-  private final class Impl[Row](val prefix: Option[String], val extract: Row => MaritalStatusRow, val merge: (Row, MaritalStatusRow) => Row)
-    extends Relation[MaritalStatusFields, MaritalStatusRow, Row] { 
+  private final class Impl(val _path: List[Path])
+    extends Relation[MaritalStatusFields, MaritalStatusRow] {
   
-    override val fields: MaritalStatusFields[Row] = new MaritalStatusFields[Row] {
-      override val id = new IdField[MaritalStatusId, Row](prefix, "id", None, Some("int8"))(x => extract(x).id, (row, value) => merge(row, extract(row).copy(id = value)))
+    override lazy val fields: MaritalStatusFields = new MaritalStatusFields {
+      override def id = IdField[MaritalStatusId, MaritalStatusRow](_path, "id", None, Some("int8"), x => x.id, (row, value) => row.copy(id = value))
     }
   
-    override val columns: List[FieldLikeNoHkt[?, Row]] =
-      List[FieldLikeNoHkt[?, Row]](fields.id)
+    override lazy val columns: List[FieldLikeNoHkt[?, MaritalStatusRow]] =
+      List[FieldLikeNoHkt[?, MaritalStatusRow]](fields.id)
   
-    override def copy[NewRow](prefix: Option[String], extract: NewRow => MaritalStatusRow, merge: (NewRow, MaritalStatusRow) => NewRow): Impl[NewRow] =
-      new Impl(prefix, extract, merge)
+    override def copy(path: List[Path]): Impl =
+      new Impl(path)
   }
   
 }

--- a/.bleep/generated-sources/typo-tester-zio-jdbc@jvm3/scripts.GenHardcodedFiles/testdb/hardcoded/myschema/marital_status/MaritalStatusRepoMock.scala
+++ b/.bleep/generated-sources/typo-tester-zio-jdbc@jvm3/scripts.GenHardcodedFiles/testdb/hardcoded/myschema/marital_status/MaritalStatusRepoMock.scala
@@ -26,7 +26,7 @@ import zio.stream.ZStream
 
 class MaritalStatusRepoMock(map: scala.collection.mutable.Map[MaritalStatusId, MaritalStatusRow] = scala.collection.mutable.Map.empty) extends MaritalStatusRepo {
   override def delete: DeleteBuilder[MaritalStatusFields, MaritalStatusRow] = {
-    DeleteBuilderMock(DeleteParams.empty, MaritalStatusFields.structure.fields, map)
+    DeleteBuilderMock(DeleteParams.empty, MaritalStatusFields.structure, map)
   }
   override def deleteById(id: MaritalStatusId): ZIO[ZConnection, Throwable, Boolean] = {
     ZIO.succeed(map.remove(id).isDefined)
@@ -79,7 +79,7 @@ class MaritalStatusRepoMock(map: scala.collection.mutable.Map[MaritalStatusId, M
     }
   }
   override def update: UpdateBuilder[MaritalStatusFields, MaritalStatusRow] = {
-    UpdateBuilderMock(UpdateParams.empty, MaritalStatusFields.structure.fields, map)
+    UpdateBuilderMock(UpdateParams.empty, MaritalStatusFields.structure, map)
   }
   override def upsert(unsaved: MaritalStatusRow): ZIO[ZConnection, Throwable, UpdateResult[MaritalStatusRow]] = {
     ZIO.succeed {

--- a/.bleep/generated-sources/typo-tester-zio-jdbc@jvm3/scripts.GenHardcodedFiles/testdb/hardcoded/myschema/person/PersonFields.scala
+++ b/.bleep/generated-sources/typo-tester-zio-jdbc@jvm3/scripts.GenHardcodedFiles/testdb/hardcoded/myschema/person/PersonFields.scala
@@ -12,54 +12,55 @@ import testdb.hardcoded.myschema.Number
 import testdb.hardcoded.myschema.Sector
 import testdb.hardcoded.myschema.football_club.FootballClubId
 import testdb.hardcoded.myschema.marital_status.MaritalStatusId
+import typo.dsl.Path
 import typo.dsl.SqlExpr.Field
 import typo.dsl.SqlExpr.FieldLikeNoHkt
 import typo.dsl.SqlExpr.IdField
 import typo.dsl.SqlExpr.OptField
 import typo.dsl.Structure.Relation
 
-trait PersonFields[Row] {
-  val id: IdField[PersonId, Row]
-  val favouriteFootballClubId: Field[FootballClubId, Row]
-  val name: Field[/* max 100 chars */ String, Row]
-  val nickName: OptField[/* max 30 chars */ String, Row]
-  val blogUrl: OptField[/* max 100 chars */ String, Row]
-  val email: Field[/* max 254 chars */ String, Row]
-  val phone: Field[/* max 8 chars */ String, Row]
-  val likesPizza: Field[Boolean, Row]
-  val maritalStatusId: Field[MaritalStatusId, Row]
-  val workEmail: OptField[/* max 254 chars */ String, Row]
-  val sector: Field[Sector, Row]
-  val favoriteNumber: Field[Number, Row]
+trait PersonFields {
+  def id: IdField[PersonId, PersonRow]
+  def favouriteFootballClubId: Field[FootballClubId, PersonRow]
+  def name: Field[/* max 100 chars */ String, PersonRow]
+  def nickName: OptField[/* max 30 chars */ String, PersonRow]
+  def blogUrl: OptField[/* max 100 chars */ String, PersonRow]
+  def email: Field[/* max 254 chars */ String, PersonRow]
+  def phone: Field[/* max 8 chars */ String, PersonRow]
+  def likesPizza: Field[Boolean, PersonRow]
+  def maritalStatusId: Field[MaritalStatusId, PersonRow]
+  def workEmail: OptField[/* max 254 chars */ String, PersonRow]
+  def sector: Field[Sector, PersonRow]
+  def favoriteNumber: Field[Number, PersonRow]
 }
 
 object PersonFields {
-  val structure: Relation[PersonFields, PersonRow, PersonRow] = 
-    new Impl(None, identity, (_, x) => x)
+  lazy val structure: Relation[PersonFields, PersonRow] =
+    new Impl(Nil)
     
-  private final class Impl[Row](val prefix: Option[String], val extract: Row => PersonRow, val merge: (Row, PersonRow) => Row)
-    extends Relation[PersonFields, PersonRow, Row] { 
+  private final class Impl(val _path: List[Path])
+    extends Relation[PersonFields, PersonRow] {
   
-    override val fields: PersonFields[Row] = new PersonFields[Row] {
-      override val id = new IdField[PersonId, Row](prefix, "id", None, Some("int8"))(x => extract(x).id, (row, value) => merge(row, extract(row).copy(id = value)))
-      override val favouriteFootballClubId = new Field[FootballClubId, Row](prefix, "favourite_football_club_id", None, None)(x => extract(x).favouriteFootballClubId, (row, value) => merge(row, extract(row).copy(favouriteFootballClubId = value)))
-      override val name = new Field[/* max 100 chars */ String, Row](prefix, "name", None, None)(x => extract(x).name, (row, value) => merge(row, extract(row).copy(name = value)))
-      override val nickName = new OptField[/* max 30 chars */ String, Row](prefix, "nick_name", None, None)(x => extract(x).nickName, (row, value) => merge(row, extract(row).copy(nickName = value)))
-      override val blogUrl = new OptField[/* max 100 chars */ String, Row](prefix, "blog_url", None, None)(x => extract(x).blogUrl, (row, value) => merge(row, extract(row).copy(blogUrl = value)))
-      override val email = new Field[/* max 254 chars */ String, Row](prefix, "email", None, None)(x => extract(x).email, (row, value) => merge(row, extract(row).copy(email = value)))
-      override val phone = new Field[/* max 8 chars */ String, Row](prefix, "phone", None, None)(x => extract(x).phone, (row, value) => merge(row, extract(row).copy(phone = value)))
-      override val likesPizza = new Field[Boolean, Row](prefix, "likes_pizza", None, None)(x => extract(x).likesPizza, (row, value) => merge(row, extract(row).copy(likesPizza = value)))
-      override val maritalStatusId = new Field[MaritalStatusId, Row](prefix, "marital_status_id", None, None)(x => extract(x).maritalStatusId, (row, value) => merge(row, extract(row).copy(maritalStatusId = value)))
-      override val workEmail = new OptField[/* max 254 chars */ String, Row](prefix, "work_email", None, None)(x => extract(x).workEmail, (row, value) => merge(row, extract(row).copy(workEmail = value)))
-      override val sector = new Field[Sector, Row](prefix, "sector", None, Some("myschema.sector"))(x => extract(x).sector, (row, value) => merge(row, extract(row).copy(sector = value)))
-      override val favoriteNumber = new Field[Number, Row](prefix, "favorite_number", None, Some("myschema.number"))(x => extract(x).favoriteNumber, (row, value) => merge(row, extract(row).copy(favoriteNumber = value)))
+    override lazy val fields: PersonFields = new PersonFields {
+      override def id = IdField[PersonId, PersonRow](_path, "id", None, Some("int8"), x => x.id, (row, value) => row.copy(id = value))
+      override def favouriteFootballClubId = Field[FootballClubId, PersonRow](_path, "favourite_football_club_id", None, None, x => x.favouriteFootballClubId, (row, value) => row.copy(favouriteFootballClubId = value))
+      override def name = Field[/* max 100 chars */ String, PersonRow](_path, "name", None, None, x => x.name, (row, value) => row.copy(name = value))
+      override def nickName = OptField[/* max 30 chars */ String, PersonRow](_path, "nick_name", None, None, x => x.nickName, (row, value) => row.copy(nickName = value))
+      override def blogUrl = OptField[/* max 100 chars */ String, PersonRow](_path, "blog_url", None, None, x => x.blogUrl, (row, value) => row.copy(blogUrl = value))
+      override def email = Field[/* max 254 chars */ String, PersonRow](_path, "email", None, None, x => x.email, (row, value) => row.copy(email = value))
+      override def phone = Field[/* max 8 chars */ String, PersonRow](_path, "phone", None, None, x => x.phone, (row, value) => row.copy(phone = value))
+      override def likesPizza = Field[Boolean, PersonRow](_path, "likes_pizza", None, None, x => x.likesPizza, (row, value) => row.copy(likesPizza = value))
+      override def maritalStatusId = Field[MaritalStatusId, PersonRow](_path, "marital_status_id", None, None, x => x.maritalStatusId, (row, value) => row.copy(maritalStatusId = value))
+      override def workEmail = OptField[/* max 254 chars */ String, PersonRow](_path, "work_email", None, None, x => x.workEmail, (row, value) => row.copy(workEmail = value))
+      override def sector = Field[Sector, PersonRow](_path, "sector", None, Some("myschema.sector"), x => x.sector, (row, value) => row.copy(sector = value))
+      override def favoriteNumber = Field[Number, PersonRow](_path, "favorite_number", None, Some("myschema.number"), x => x.favoriteNumber, (row, value) => row.copy(favoriteNumber = value))
     }
   
-    override val columns: List[FieldLikeNoHkt[?, Row]] =
-      List[FieldLikeNoHkt[?, Row]](fields.id, fields.favouriteFootballClubId, fields.name, fields.nickName, fields.blogUrl, fields.email, fields.phone, fields.likesPizza, fields.maritalStatusId, fields.workEmail, fields.sector, fields.favoriteNumber)
+    override lazy val columns: List[FieldLikeNoHkt[?, PersonRow]] =
+      List[FieldLikeNoHkt[?, PersonRow]](fields.id, fields.favouriteFootballClubId, fields.name, fields.nickName, fields.blogUrl, fields.email, fields.phone, fields.likesPizza, fields.maritalStatusId, fields.workEmail, fields.sector, fields.favoriteNumber)
   
-    override def copy[NewRow](prefix: Option[String], extract: NewRow => PersonRow, merge: (NewRow, PersonRow) => NewRow): Impl[NewRow] =
-      new Impl(prefix, extract, merge)
+    override def copy(path: List[Path]): Impl =
+      new Impl(path)
   }
   
 }

--- a/.bleep/generated-sources/typo-tester-zio-jdbc@jvm3/scripts.GenHardcodedFiles/testdb/hardcoded/myschema/person/PersonRepoMock.scala
+++ b/.bleep/generated-sources/typo-tester-zio-jdbc@jvm3/scripts.GenHardcodedFiles/testdb/hardcoded/myschema/person/PersonRepoMock.scala
@@ -27,7 +27,7 @@ import zio.stream.ZStream
 class PersonRepoMock(toRow: Function1[PersonRowUnsaved, PersonRow],
                      map: scala.collection.mutable.Map[PersonId, PersonRow] = scala.collection.mutable.Map.empty) extends PersonRepo {
   override def delete: DeleteBuilder[PersonFields, PersonRow] = {
-    DeleteBuilderMock(DeleteParams.empty, PersonFields.structure.fields, map)
+    DeleteBuilderMock(DeleteParams.empty, PersonFields.structure, map)
   }
   override def deleteById(id: PersonId): ZIO[ZConnection, Throwable, Boolean] = {
     ZIO.succeed(map.remove(id).isDefined)
@@ -104,7 +104,7 @@ class PersonRepoMock(toRow: Function1[PersonRowUnsaved, PersonRow],
     }
   }
   override def update: UpdateBuilder[PersonFields, PersonRow] = {
-    UpdateBuilderMock(UpdateParams.empty, PersonFields.structure.fields, map)
+    UpdateBuilderMock(UpdateParams.empty, PersonFields.structure, map)
   }
   override def update(row: PersonRow): ZIO[ZConnection, Throwable, Boolean] = {
     ZIO.succeed {

--- a/bleep.yaml
+++ b/bleep.yaml
@@ -20,23 +20,14 @@ projects:
       mainClass: com.foo.App
     sources: ./generated-and-checked-in
   typo-dsl-anorm:
-    cross:
-      jvm213:
-        extends: template-kind-projector
     dependencies: org.playframework.anorm::anorm:2.7.0
     extends: template-cross
     sources: ../typo-dsl-shared
   typo-dsl-doobie:
-    cross:
-      jvm213:
-        extends: template-kind-projector
     dependencies: org.tpolecat::doobie-postgres:1.0.0-RC5
     extends: template-cross
     sources: ../typo-dsl-shared
   typo-dsl-zio-jdbc:
-    cross:
-      jvm213:
-        extends: template-kind-projector
     dependencies: dev.zio::zio-jdbc:0.1.2
     extends: template-cross
     sources: ../typo-dsl-shared
@@ -130,11 +121,8 @@ templates:
       jvm3:
         extends: template-nocross
     extends: template-common
-  template-kind-projector:
-    scala:
-      compilerPlugins: org.typelevel:::kind-projector:0.13.2
   template-nocross:
     extends: template-common
     scala:
-      version: 3.4.0
+      version: 3.4.1
       options: -source 3.4

--- a/site-in/other-features/testing-with-stubs.md
+++ b/site-in/other-features/testing-with-stubs.md
@@ -42,7 +42,7 @@ import scala.annotation.nowarn
 class AddressRepoMock(toRow: Function1[AddressRowUnsaved, AddressRow],
                       map: scala.collection.mutable.Map[AddressId, AddressRow] = scala.collection.mutable.Map.empty) extends AddressRepo {
   override def delete: DeleteBuilder[AddressFields, AddressRow] = {
-    DeleteBuilderMock(DeleteParams.empty, AddressFields.structure.fields, map)
+    DeleteBuilderMock(DeleteParams.empty, AddressFields.structure, map)
   }
   override def deleteById(addressid: AddressId)(implicit c: Connection): Boolean = {
     map.remove(addressid).isDefined
@@ -61,14 +61,14 @@ class AddressRepoMock(toRow: Function1[AddressRowUnsaved, AddressRow],
   override def insert(unsaved: AddressRowUnsaved)(implicit c: Connection): AddressRow = {
     insert(toRow(unsaved))
   }
-  override def insertStreaming(unsaved: Iterator[AddressRow], batchSize: Int)(implicit c: Connection): Long = {
+  override def insertStreaming(unsaved: Iterator[AddressRow], batchSize: Int = 10000)(implicit c: Connection): Long = {
     unsaved.foreach { row =>
       map += (row.addressid -> row)
     }
     unsaved.size.toLong
   }
   /* NOTE: this functionality requires PostgreSQL 16 or later! */
-  override def insertUnsavedStreaming(unsaved: Iterator[AddressRowUnsaved], batchSize: Int)(implicit c: Connection): Long = {
+  override def insertUnsavedStreaming(unsaved: Iterator[AddressRowUnsaved], batchSize: Int = 10000)(implicit c: Connection): Long = {
     unsaved.foreach { unsavedRow =>
       val row = toRow(unsavedRow)
       map += (row.addressid -> row)
@@ -92,7 +92,7 @@ class AddressRepoMock(toRow: Function1[AddressRowUnsaved, AddressRow],
     addressids.view.flatMap(id => byId.get(id).map(x => (id, x))).toMap
   }
   override def update: UpdateBuilder[AddressFields, AddressRow] = {
-    UpdateBuilderMock(UpdateParams.empty, AddressFields.structure.fields, map)
+    UpdateBuilderMock(UpdateParams.empty, AddressFields.structure, map)
   }
   override def update(row: AddressRow)(implicit c: Connection): Boolean = {
     map.get(row.addressid) match {
@@ -108,6 +108,5 @@ class AddressRepoMock(toRow: Function1[AddressRowUnsaved, AddressRow],
     unsaved
   }
 }
-
 ```
 

--- a/site/blog/emailaddress/EmailaddressFields.scala
+++ b/site/blog/emailaddress/EmailaddressFields.scala
@@ -14,7 +14,7 @@ import typo.dsl.SqlExpr.Field
 import typo.dsl.SqlExpr.IdField
 import typo.dsl.SqlExpr.OptField
 
-trait EmailaddressFields[Row] {
+trait EmailaddressFields {
   val businessentityid: IdField[BusinessentityId, Row]
   val emailaddressid: IdField[Int, Row]
   val emailaddress: OptField[/* max 50 chars */ String, Row]

--- a/site/blog/emailaddress/EmailaddressStructure.scala
+++ b/site/blog/emailaddress/EmailaddressStructure.scala
@@ -18,7 +18,7 @@ import typo.dsl.Structure.Relation
 
 class EmailaddressStructure[Row](val prefix: Option[String], val extract: Row => EmailaddressRow, val merge: (Row, EmailaddressRow) => Row)
   extends Relation[EmailaddressFields, EmailaddressRow, Row]
-    with EmailaddressFields[Row] { outer =>
+    with EmailaddressFields { outer =>
 
   override val businessentityid = new IdField[BusinessentityId, Row](prefix, "businessentityid", None, Some("int4"))(x => extract(x).businessentityid, (row, value) => merge(row, extract(row).copy(businessentityid = value)))
   override val emailaddressid = new IdField[Int, Row](prefix, "emailaddressid", None, Some("int4"))(x => extract(x).emailaddressid, (row, value) => merge(row, extract(row).copy(emailaddressid = value)))

--- a/typo-dsl-anorm/src/scala/typo/dsl/DeleteBuilder.scala
+++ b/typo-dsl-anorm/src/scala/typo/dsl/DeleteBuilder.scala
@@ -7,14 +7,14 @@ import java.sql.Connection
 import java.util.concurrent.atomic.AtomicInteger
 import scala.annotation.nowarn
 
-trait DeleteBuilder[Fields[_], Row] {
-  protected def params: DeleteParams[Fields, Row]
-  protected def withParams(sqlParams: DeleteParams[Fields, Row]): DeleteBuilder[Fields, Row]
+trait DeleteBuilder[Fields, Row] {
+  protected def params: DeleteParams[Fields]
+  protected def withParams(sqlParams: DeleteParams[Fields]): DeleteBuilder[Fields, Row]
 
-  final def where[N[_]: Nullability](v: Fields[Row] => SqlExpr[Boolean, N, Row]): DeleteBuilder[Fields, Row] =
+  final def where[N[_]: Nullability](v: Fields => SqlExpr[Boolean, N]): DeleteBuilder[Fields, Row] =
     whereStrict(f => v(f).?.coalesce(false))
 
-  final def whereStrict(v: Fields[Row] => SqlExpr[Boolean, Required, Row]): DeleteBuilder[Fields, Row] =
+  final def whereStrict(v: Fields => SqlExpr[Boolean, Required]): DeleteBuilder[Fields, Row] =
     withParams(params.where(v))
 
   def sql: Option[Fragment]
@@ -22,52 +22,51 @@ trait DeleteBuilder[Fields[_], Row] {
 }
 
 object DeleteBuilder {
-  def apply[Fields[_], Row](name: String, structure: Structure.Relation[Fields, ?, Row]): DeleteBuilderSql[Fields, Row] =
+  def apply[Fields, Row](name: String, structure: Structure.Relation[Fields, Row]): DeleteBuilderSql[Fields, Row] =
     DeleteBuilderSql(name, structure, DeleteParams.empty)
 
-  case class DeleteBuilderSql[Fields[_], Row](
+  final case class DeleteBuilderSql[Fields, Row](
       name: String,
-      structure: Structure.Relation[Fields, ?, Row],
-      params: DeleteParams[Fields, Row]
+      structure: Structure.Relation[Fields, Row],
+      params: DeleteParams[Fields]
   ) extends DeleteBuilder[Fields, Row] {
-    override def withParams(sqlParams: DeleteParams[Fields, Row]): DeleteBuilder[Fields, Row] =
+    override def withParams(sqlParams: DeleteParams[Fields]): DeleteBuilder[Fields, Row] =
       copy(params = sqlParams)
 
-    def mkSql(counter: AtomicInteger): Fragment = {
+    def mkSql(ctx: RenderCtx): Fragment = {
       List[Iterable[Fragment]](
         Some(frag"delete from ${Fragment(name)}"),
         params.where
           .map(w => w(structure.fields))
           .reduceLeftOption(_.and(_))
-          .map { where => Fragment(" where ") ++ where.render(counter) }
+          .map { where => Fragment(" where ") ++ where.render(ctx, new AtomicInteger(0)) }
       ).flatten.reduce(_ ++ _)
     }
 
-    override def sql: Option[Fragment] = {
-      Some(mkSql(new AtomicInteger(1)))
-    }
+    override def sql: Option[Fragment] =
+      Some(mkSql(RenderCtx.Empty))
 
     override def execute()(implicit c: Connection): Int = {
-      val frag = mkSql(new AtomicInteger(0))
+      val frag = mkSql(RenderCtx.Empty)
       SimpleSql(SQL(frag.sql), frag.params.map(_.tupled).toMap, RowParser.successful).executeUpdate()
     }
   }
 
-  case class DeleteBuilderMock[Id, Fields[_], Row](
-      params: DeleteParams[Fields, Row],
-      fields: Fields[Row],
+  final case class DeleteBuilderMock[Id, Fields, Row](
+      params: DeleteParams[Fields],
+      structure: Structure[Fields, Row],
       map: scala.collection.mutable.Map[Id, Row]
   ) extends DeleteBuilder[Fields, Row] {
-    override def withParams(sqlParams: DeleteParams[Fields, Row]): DeleteBuilder[Fields, Row] =
+    override def withParams(sqlParams: DeleteParams[Fields]): DeleteBuilder[Fields, Row] =
       copy(params = sqlParams)
 
     override def sql: Option[Fragment] =
       None
 
     override def execute()(implicit @nowarn c: Connection): Int = {
-      var changed = 0
+      var changed: Int = 0
       map.foreach { case (id, row) =>
-        if (params.where.forall(w => w(fields).eval(row))) {
+        if (params.where.forall(w => structure.untypedEval(w(structure.fields), row))) {
           map.remove(id): @nowarn
           changed += 1
         }

--- a/typo-dsl-anorm/src/scala/typo/dsl/SelectBuilderMock.scala
+++ b/typo-dsl-anorm/src/scala/typo/dsl/SelectBuilderMock.scala
@@ -4,66 +4,74 @@ import java.sql.Connection
 import typo.dsl.internal.seeks
 import typo.dsl.internal.mocks.RowOrdering
 
-case class SelectBuilderMock[Fields[_], Row](
+final case class SelectBuilderMock[Fields, Row](
     structure: Structure[Fields, Row],
     all: () => List[Row],
     params: SelectParams[Fields, Row]
 ) extends SelectBuilder[Fields, Row] {
+  def withPath(path: Path): SelectBuilderMock[Fields, Row] =
+    copy(structure = structure.withPath(path))
+
+  override val renderCtx: RenderCtx = RenderCtx.Empty
+
   override def withParams(sqlParams: SelectParams[Fields, Row]): SelectBuilder[Fields, Row] =
     copy(params = sqlParams)
 
   override def toList(implicit c: Connection): List[Row] =
-    SelectBuilderMock.applyParams(structure.fields, all(), params)
+    SelectBuilderMock.applyParams(structure, all(), params)
 
-  override def joinOn[Fields2[_], N[_]: Nullability, Row2](
+  override def joinOn[Fields2, N[_]: Nullability, Row2](
       other: SelectBuilder[Fields2, Row2]
-  )(pred: Joined[Fields, Fields2, (Row, Row2)] => SqlExpr[Boolean, N, (Row, Row2)]): SelectBuilder[Joined[Fields, Fields2, *], (Row, Row2)] = {
-    def otherMock: SelectBuilderMock[Fields2, Row2] = other match {
-      case x: SelectBuilderMock[Fields2, Row2] => x
+  )(pred: Joined[Fields, Fields2] => SqlExpr[Boolean, N]): SelectBuilderMock[Joined[Fields, Fields2], (Row, Row2)] = {
+    val otherMock: SelectBuilderMock[Fields2, Row2] = other match {
+      case x: SelectBuilderMock[Fields2, Row2] => x.withPath(Path.RightInJoin)
       case _                                   => sys.error("you cannot mix mock and sql repos")
     }
 
-    val newStructure = structure.join(otherMock.structure)
+    val self = this.withPath(Path.LeftInJoin)
+    val newStructure = self.structure.join(otherMock.structure)
 
     val newRows: () => List[(Row, Row2)] = () =>
       for {
-        left <- this.toList(null)
+        left <- self.toList(null)
         right <- otherMock.toList(null)
         newRow = (left, right)
-        if Nullability[N].toOpt(pred(newStructure.fields).eval(newRow)).getOrElse(false)
+        if Nullability[N].toOpt(newStructure.untypedEval(pred(newStructure.fields), newRow)).getOrElse(false)
       } yield newRow
 
-    SelectBuilderMock[Joined[Fields, Fields2, *], (Row, Row2)](newStructure, newRows, SelectParams.empty)
+    SelectBuilderMock[Joined[Fields, Fields2], (Row, Row2)](newStructure, newRows, SelectParams.empty)
   }
-  override def leftJoinOn[Fields2[_], N[_]: Nullability, Row2](other: SelectBuilder[Fields2, Row2])(
-      pred: Joined[Fields, Fields2, (Row, Row2)] => SqlExpr[Boolean, N, (Row, Row2)]
-  ): SelectBuilder[LeftJoined[Fields, Fields2, *], (Row, Option[Row2])] = {
-    def otherMock: SelectBuilderMock[Fields2, Row2] = other match {
-      case x: SelectBuilderMock[Fields2, Row2] => x
+  override def leftJoinOn[Fields2, N[_]: Nullability, Row2](
+      other: SelectBuilder[Fields2, Row2]
+  )(pred: Joined[Fields, Fields2] => SqlExpr[Boolean, N]): SelectBuilder[LeftJoined[Fields, Fields2], (Row, Option[Row2])] = {
+    val otherMock: SelectBuilderMock[Fields2, Row2] = other match {
+      case x: SelectBuilderMock[Fields2, Row2] => x.withPath(Path.RightInJoin)
       case _                                   => sys.error("you cannot mix mock and sql repos")
     }
+    val self = this.withPath(Path.LeftInJoin)
 
     val newRows: () => List[(Row, Option[Row2])] = () => {
       val rights = otherMock.toList(null)
-      this.toList(null).map { left =>
+      self.toList(null).map { left =>
         val maybeRight = rights.find { right =>
-          Nullability[N].toOpt(pred(structure.join(otherMock.structure).fields).eval((left, right))).getOrElse(false)
+          val newStructure = self.structure.join(otherMock.structure)
+          Nullability[N].toOpt(newStructure.untypedEval(pred(newStructure.fields), (left, right))).getOrElse(false)
         }
         (left, maybeRight)
       }
     }
-    SelectBuilderMock[LeftJoined[Fields, Fields2, *], (Row, Option[Row2])](structure.leftJoin(otherMock.structure), newRows, SelectParams.empty)
+    SelectBuilderMock[LeftJoined[Fields, Fields2], (Row, Option[Row2])](self.structure.leftJoin(otherMock.structure), newRows, SelectParams.empty)
   }
 
   override def sql: Option[Fragment] = None
 }
 
 object SelectBuilderMock {
-  def applyParams[Fields[_], Row](fields: Fields[Row], rows: List[Row], params: SelectParams[Fields, Row]): List[Row] = {
-    val (filters, orderBys) = seeks.expand(fields, params)
-    implicit val rowOrdering: Ordering[Row] = new RowOrdering(orderBys)
+  def applyParams[Fields, R](structure: Structure[Fields, R], rows: List[R], params: SelectParams[Fields, R]): List[R] = {
+    val (filters, orderBys) = seeks.expand(structure.fields, params)
+    implicit val rowOrdering: Ordering[R] = new RowOrdering(structure, orderBys)
     rows
-      .filter(row => filters.forall(_.eval(row).getOrElse(false)))
+      .filter(row => filters.forall(expr => structure.untypedEval(expr, row).getOrElse(false)))
       .sorted
       .drop(params.offset.getOrElse(0))
       .take(params.limit.getOrElse(Int.MaxValue))

--- a/typo-dsl-anorm/src/scala/typo/dsl/SelectBuilderSql.scala
+++ b/typo-dsl-anorm/src/scala/typo/dsl/SelectBuilderSql.scala
@@ -6,96 +6,108 @@ import typo.dsl.Fragment.FragmentStringInterpolator
 import java.sql.Connection
 import java.util.concurrent.atomic.AtomicInteger
 
-sealed trait SelectBuilderSql[Fields[_], Row] extends SelectBuilder[Fields, Row] {
-  def instantiate(counter: AtomicInteger): SelectBuilderSql.Instantiated[Fields, Row]
-  def sqlFor(counter: AtomicInteger): (Fragment, RowParser[Row])
+sealed trait SelectBuilderSql[Fields, Row] extends SelectBuilder[Fields, Row] {
+  def withPath(path: Path): SelectBuilderSql[Fields, Row]
+  def instantiate(ctx: RenderCtx, counter: AtomicInteger): SelectBuilderSql.Instantiated[Fields, Row]
+  def sqlFor(ctx: RenderCtx, counter: AtomicInteger): (Fragment, RowParser[Row])
 
-  override def sql: Option[Fragment] = Some(sqlFor(new AtomicInteger(0))._1)
+  override lazy val renderCtx: RenderCtx = RenderCtx.from(this)
+  override lazy val sql: Option[Fragment] = Some(sqlFor(renderCtx, new AtomicInteger(0))._1)
 
-  final override def joinOn[Fields2[_], N[_]: Nullability, Row2](other: SelectBuilder[Fields2, Row2])(
-      pred: Joined[Fields, Fields2, (Row, Row2)] => SqlExpr[Boolean, N, (Row, Row2)]
-  ): SelectBuilder[Joined[Fields, Fields2, *], (Row, Row2)] =
+  final override def joinOn[Fields2, N[_]: Nullability, Row2](
+      other: SelectBuilder[Fields2, Row2]
+  )(pred: Joined[Fields, Fields2] => SqlExpr[Boolean, N]): SelectBuilder[Joined[Fields, Fields2], (Row, Row2)] =
     other match {
       case otherSql: SelectBuilderSql[Fields2, Row2] =>
-        new SelectBuilderSql.TableJoin[Fields, Fields2, N, Row, Row2](this, otherSql, pred, SelectParams.empty)
-      case _ =>
-        sys.error("you cannot mix mock and sql repos")
+        new SelectBuilderSql.TableJoin[Fields, Fields2, N, Row, Row2](this.withPath(Path.LeftInJoin), otherSql.withPath(Path.RightInJoin), pred, SelectParams.empty)
+      case _ => sys.error("you cannot mix mock and sql repos")
     }
 
-  final override def leftJoinOn[Fields2[_], N[_]: Nullability, Row2](other: SelectBuilder[Fields2, Row2])(
-      pred: Joined[Fields, Fields2, (Row, Row2)] => SqlExpr[Boolean, N, (Row, Row2)]
-  ): SelectBuilder[LeftJoined[Fields, Fields2, *], (Row, Option[Row2])] =
+  final override def leftJoinOn[Fields2, N[_]: Nullability, Row2](other: SelectBuilder[Fields2, Row2])(
+      pred: Joined[Fields, Fields2] => SqlExpr[Boolean, N]
+  ): SelectBuilder[LeftJoined[Fields, Fields2], (Row, Option[Row2])] =
     other match {
       case otherSql: SelectBuilderSql[Fields2, Row2] =>
-        SelectBuilderSql.TableLeftJoin(this, otherSql, pred, SelectParams.empty)
-      case _ =>
-        sys.error("you cannot mix mock and sql repos")
+        SelectBuilderSql.TableLeftJoin(this.withPath(Path.LeftInJoin), otherSql.withPath(Path.RightInJoin), pred, SelectParams.empty)
+      case _ => sys.error("you cannot mix mock and sql repos")
     }
 
   final override def toList(implicit c: Connection): List[Row] = {
-    val (frag, rowParser) = sqlFor(new AtomicInteger(0))
+    val (frag, rowParser) = sqlFor(renderCtx, new AtomicInteger(0))
     SimpleSql(SQL(frag.sql), frag.params.map(_.tupled).toMap, RowParser.successful).as(rowParser.*)(c)
   }
 }
 
 object SelectBuilderSql {
-  def apply[Fields[_], OriginalRow, Row](
+  def apply[Fields, Row](
       name: String,
-      structure: Structure.Relation[Fields, OriginalRow, Row],
+      structure: Structure.Relation[Fields, Row],
       rowParser: Int => RowParser[Row]
   ): SelectBuilderSql[Fields, Row] =
     Relation(name, structure, rowParser, SelectParams.empty)
 
-  private case class Relation[Fields[_], OriginalRow, Row](
+  final case class Relation[Fields, Row](
       name: String,
-      structure: Structure.Relation[Fields, OriginalRow, Row],
+      structure: Structure.Relation[Fields, Row],
       rowParser: Int => RowParser[Row],
       params: SelectParams[Fields, Row]
   ) extends SelectBuilderSql[Fields, Row] {
+    override def withPath(path: Path): SelectBuilderSql[Fields, Row] =
+      copy(structure = structure.withPath(path))
+
     override def withParams(sqlParams: SelectParams[Fields, Row]): SelectBuilder[Fields, Row] =
       copy(params = sqlParams)
 
-    private def sql(counter: AtomicInteger): Fragment = {
+    private def sql(ctx: RenderCtx, counter: AtomicInteger): Fragment = {
       val cols = structure.columns
-        .map(x => x.sqlReadCast.foldLeft("\"" + x.value + "\"") { case (acc, cast) => s"$acc::$cast" })
+        .map(x => x.sqlReadCast.foldLeft(s"\"${x.name}\"") { case (acc, cast) => s"$acc::$cast" })
         .mkString(",")
-
-      val baseSql = frag"select ${Fragment(cols)} from ${Fragment(name)}"
-      SelectParams.render(structure.fields, baseSql, counter, params)
+      val alias = ctx.alias(structure._path)
+      val baseSql = frag"select ${Fragment(cols)} from ${Fragment(name)} ${Fragment(alias)}"
+      SelectParams.render(structure.fields, baseSql, ctx, counter, params)
     }
 
-    override def sqlFor(counter: AtomicInteger): (Fragment, RowParser[Row]) =
-      (sql(counter), rowParser(1))
+    override def sqlFor(ctx: RenderCtx, counter: AtomicInteger): (Fragment, RowParser[Row]) =
+      (sql(ctx, counter), rowParser(1))
 
-    override def instantiate(counter: AtomicInteger): SelectBuilderSql.Instantiated[Fields, Row] = {
-      val completeSql = sql(counter)
-      val alias = s"${name.split("\\.").last}${counter.incrementAndGet()}"
-      val prefixed = structure.withPrefix(alias)
-      val subquery = SelectBuilderSql.InstantiatedPart(alias, prefixed.columns, completeSql, joinFrag = Fragment.empty)
-      SelectBuilderSql.Instantiated(prefixed, List(subquery), rowParser = rowParser)
+    override def instantiate(ctx: RenderCtx, counter: AtomicInteger): SelectBuilderSql.Instantiated[Fields, Row] = {
+      val part = SelectBuilderSql.InstantiatedPart(
+        alias = ctx.alias(structure._path),
+        columns = structure.columns,
+        sqlFrag = sql(ctx, counter),
+        joinFrag = Fragment.empty
+      )
+      SelectBuilderSql.Instantiated(structure, List(part), rowParser = rowParser)
     }
   }
 
-  private case class TableJoin[Fields1[_], Fields2[_], N[_]: Nullability, Row1, Row2](
+  final case class TableJoin[Fields1, Fields2, N[_]: Nullability, Row1, Row2](
       left: SelectBuilderSql[Fields1, Row1],
       right: SelectBuilderSql[Fields2, Row2],
-      pred: Joined[Fields1, Fields2, (Row1, Row2)] => SqlExpr[Boolean, N, (Row1, Row2)],
-      params: SelectParams[Joined[Fields1, Fields2, *], (Row1, Row2)]
-  ) extends SelectBuilderSql[Joined[Fields1, Fields2, *], (Row1, Row2)] {
+      pred: Joined[Fields1, Fields2] => SqlExpr[Boolean, N],
+      params: SelectParams[Joined[Fields1, Fields2], (Row1, Row2)]
+  ) extends SelectBuilderSql[Joined[Fields1, Fields2], (Row1, Row2)] {
+    override lazy val structure: Structure[(Fields1, Fields2), (Row1, Row2)] =
+      left.structure.join(right.structure)
 
-    override def withParams(sqlParams: SelectParams[Joined[Fields1, Fields2, *], (Row1, Row2)]): SelectBuilder[Joined[Fields1, Fields2, *], (Row1, Row2)] =
+    override def withPath(path: Path): SelectBuilderSql[Joined[Fields1, Fields2], (Row1, Row2)] =
+      copy(left = left.withPath(path), right = right.withPath(path))
+
+    override def withParams(sqlParams: SelectParams[Joined[Fields1, Fields2], (Row1, Row2)]): SelectBuilder[Joined[Fields1, Fields2], (Row1, Row2)] =
       copy(params = sqlParams)
 
-    override def instantiate(counter: AtomicInteger): Instantiated[Joined[Fields1, Fields2, *], (Row1, Row2)] = {
-      val leftInstantiated = left.instantiate(counter)
-      val rightInstantiated = right.instantiate(counter)
+    override def instantiate(ctx: RenderCtx, counter: AtomicInteger): Instantiated[Joined[Fields1, Fields2], (Row1, Row2)] = {
+
+      val leftInstantiated: Instantiated[Fields1, Row1] = left.instantiate(ctx, counter)
+      val rightInstantiated: Instantiated[Fields2, Row2] = right.instantiate(ctx, counter)
+
       val newStructure = leftInstantiated.structure.join(rightInstantiated.structure)
       val newRightInstantiatedParts = rightInstantiated.parts
-        .mapLast(_.copy(joinFrag = pred(newStructure.fields).render(counter)))
+        .mapLast(_.copy(joinFrag = pred(newStructure.fields).render(ctx, counter)))
 
       SelectBuilderSql.Instantiated(
-        newStructure,
-        leftInstantiated.parts ++ newRightInstantiatedParts,
+        structure = newStructure,
+        parts = leftInstantiated.parts ++ newRightInstantiatedParts,
         rowParser = (i: Int) =>
           for {
             r1 <- leftInstantiated.rowParser(i)
@@ -104,14 +116,14 @@ object SelectBuilderSql {
       )
     }
 
-    override def sqlFor(paramCounter: AtomicInteger): (Fragment, RowParser[(Row1, Row2)]) = {
-      val instance = instantiate(paramCounter)
+    override def sqlFor(ctx: RenderCtx, counter: AtomicInteger): (Fragment, RowParser[(Row1, Row2)]) = {
+      val instance = instantiate(ctx, counter)
       val combinedFrag = instance.parts match {
         case Nil       => sys.error("unreachable (tm)")
         case List(one) => one.sqlFrag
         case first :: rest =>
           val prelude =
-            frag"""|select ${instance.columns.map(c => Fragment(c.value)).mkFragment(", ")}
+            frag"""|select ${instance.columns.map(c => c.render(ctx, counter)).mkFragment(", ")}
                    |from (
                    |${first.sqlFrag.indent(2)}
                    |) ${Fragment(first.alias)}
@@ -123,32 +135,39 @@ object SelectBuilderSql {
                    |) ${Fragment(alias)} on $joinFrag
                    |""".stripMargin
           }
+
           prelude ++ joins.mkFragment("")
       }
-      val newCombinedFrag = SelectParams.render[(Row1, Row2), Joined[Fields1, Fields2, *]](instance.structure.fields, combinedFrag, paramCounter, params)
+      val newCombinedFrag = SelectParams.render[Joined[Fields1, Fields2], (Row1, Row2)](instance.structure.fields, combinedFrag, ctx, counter, params)
 
       (newCombinedFrag, instance.rowParser(1))
     }
   }
 
-  private case class TableLeftJoin[Fields1[_], Fields2[_], N[_]: Nullability, Row1, Row2](
+  final case class TableLeftJoin[Fields1, Fields2, N[_]: Nullability, Row1, Row2](
       left: SelectBuilderSql[Fields1, Row1],
       right: SelectBuilderSql[Fields2, Row2],
-      pred: Joined[Fields1, Fields2, (Row1, Row2)] => SqlExpr[Boolean, N, (Row1, Row2)],
-      params: SelectParams[LeftJoined[Fields1, Fields2, *], (Row1, Option[Row2])]
-  ) extends SelectBuilderSql[LeftJoined[Fields1, Fields2, *], (Row1, Option[Row2])] {
+      pred: Joined[Fields1, Fields2] => SqlExpr[Boolean, N],
+      params: SelectParams[LeftJoined[Fields1, Fields2], (Row1, Option[Row2])]
+  ) extends SelectBuilderSql[LeftJoined[Fields1, Fields2], (Row1, Option[Row2])] {
+    override lazy val structure: Structure[LeftJoined[Fields1, Fields2], (Row1, Option[Row2])] =
+      left.structure.leftJoin(right.structure)
+
+    override def withPath(path: Path): SelectBuilderSql[LeftJoined[Fields1, Fields2], (Row1, Option[Row2])] =
+      copy(left = left.withPath(path), right = right.withPath(path))
 
     override def withParams(
-        sqlParams: SelectParams[LeftJoined[Fields1, Fields2, *], (Row1, Option[Row2])]
-    ): SelectBuilder[LeftJoined[Fields1, Fields2, *], (Row1, Option[Row2])] =
+        sqlParams: SelectParams[LeftJoined[Fields1, Fields2], (Row1, Option[Row2])]
+    ): SelectBuilder[LeftJoined[Fields1, Fields2], (Row1, Option[Row2])] =
       copy(params = sqlParams)
 
-    override def instantiate(counter: AtomicInteger): Instantiated[LeftJoined[Fields1, Fields2, *], (Row1, Option[Row2])] = {
-      val leftInstantiated = left.instantiate(counter)
-      val rightInstantiated = right.instantiate(counter)
+    override def instantiate(ctx: RenderCtx, counter: AtomicInteger): Instantiated[LeftJoined[Fields1, Fields2], (Row1, Option[Row2])] = {
+      val leftInstantiated = left.instantiate(ctx, counter)
+      val rightInstantiated = right.instantiate(ctx, counter)
+
       val newStructure = leftInstantiated.structure.leftJoin(rightInstantiated.structure)
       val newRightInstantiatedParts = rightInstantiated.parts
-        .mapLast(_.copy(joinFrag = pred(leftInstantiated.structure.join(rightInstantiated.structure).fields).render(counter)))
+        .mapLast(_.copy(joinFrag = pred(leftInstantiated.structure.join(rightInstantiated.structure).fields).render(ctx, counter)))
 
       SelectBuilderSql.Instantiated(
         newStructure,
@@ -167,14 +186,14 @@ object SelectBuilderSql {
       )
     }
 
-    override def sqlFor(paramCounter: AtomicInteger): (Fragment, RowParser[(Row1, Option[Row2])]) = {
-      val instance = instantiate(paramCounter)
+    override def sqlFor(ctx: RenderCtx, counter: AtomicInteger): (Fragment, RowParser[(Row1, Option[Row2])]) = {
+      val instance = instantiate(ctx, counter)
       val combinedFrag = instance.parts match {
         case Nil       => sys.error("unreachable (tm)")
         case List(one) => one.sqlFrag
         case first :: rest =>
           val prelude =
-            frag"""|select ${instance.columns.map(c => Fragment(c.value)).mkFragment(", ")}
+            frag"""|select ${instance.columns.map(c => c.render(ctx, counter)).mkFragment(", ")}
                    |from (
                    |${first.sqlFrag.indent(2)}
                    |) ${Fragment(first.alias)}
@@ -189,7 +208,7 @@ object SelectBuilderSql {
           prelude ++ joins.mkFragment("")
       }
       val newCombinedFrag =
-        SelectParams.render[(Row1, Option[Row2]), LeftJoined[Fields1, Fields2, *]](instance.structure.fields, combinedFrag, paramCounter, params)
+        SelectParams.render[LeftJoined[Fields1, Fields2], (Row1, Option[Row2])](instance.structure.fields, combinedFrag, ctx, counter, params)
 
       (newCombinedFrag, instance.rowParser(1))
     }
@@ -202,7 +221,7 @@ object SelectBuilderSql {
   /** Need this intermediate data structure to generate aliases for tables (and prefixes for column selections) when we have a tree of joined tables. Need to start from the root after the user has
     * constructed the tree
     */
-  case class Instantiated[Fields[_], Row](
+  final case class Instantiated[Fields, Row](
       structure: Structure[Fields, Row],
       parts: List[SelectBuilderSql.InstantiatedPart],
       rowParser: Int => RowParser[Row]
@@ -211,7 +230,7 @@ object SelectBuilderSql {
   }
 
   /** This is needlessly awkward because the we start with a tree, but we need to make it linear to render it */
-  case class InstantiatedPart(
+  final case class InstantiatedPart(
       alias: String,
       columns: List[SqlExpr.FieldLikeNoHkt[?, ?]],
       sqlFrag: Fragment,

--- a/typo-dsl-anorm/src/scala/typo/dsl/SortOrder.scala
+++ b/typo-dsl-anorm/src/scala/typo/dsl/SortOrder.scala
@@ -4,16 +4,16 @@ import typo.dsl.Fragment.FragmentStringInterpolator
 
 import java.util.concurrent.atomic.AtomicInteger
 
-sealed trait SortOrderNoHkt[NT, R] {
-  val expr: SqlExpr.SqlExprNoHkt[NT, R]
+sealed trait SortOrderNoHkt[NT] {
+  val expr: SqlExpr.SqlExprNoHkt[NT]
   val ascending: Boolean
   val nullsFirst: Boolean
 
-  def withNullsFirst: SortOrderNoHkt[NT, R]
+  def withNullsFirst: SortOrderNoHkt[NT]
 
-  final def render(counter: AtomicInteger): Fragment = {
+  final def render(ctx: RenderCtx, counter: AtomicInteger): Fragment = {
     List[Fragment](
-      expr.render(counter),
+      expr.render(ctx, counter: AtomicInteger),
       if (ascending) frag"ASC" else frag"DESC",
       if (nullsFirst) frag"NULLS FIRST" else Fragment.empty
     ).mkFragment(" ")
@@ -21,7 +21,6 @@ sealed trait SortOrderNoHkt[NT, R] {
 }
 
 // sort by a field
-final case class SortOrder[T, N[_], R](expr: SqlExpr[T, N, R], ascending: Boolean, nullsFirst: Boolean)(implicit val ordering: Ordering[T], val nullability: Nullability[N])
-    extends SortOrderNoHkt[N[T], R] {
-  def withNullsFirst: SortOrder[T, N, R] = copy(nullsFirst = true)(ordering, nullability)
+final case class SortOrder[T, N[_]](expr: SqlExpr[T, N], ascending: Boolean, nullsFirst: Boolean)(implicit val ordering: Ordering[T], val nullability: Nullability[N]) extends SortOrderNoHkt[N[T]] {
+  def withNullsFirst: SortOrder[T, N] = copy(nullsFirst = true)(ordering, nullability)
 }

--- a/typo-dsl-anorm/src/scala/typo/dsl/SqlExpr.scala
+++ b/typo-dsl-anorm/src/scala/typo/dsl/SqlExpr.scala
@@ -6,285 +6,251 @@ import typo.dsl.Fragment.FragmentStringInterpolator
 import java.util.concurrent.atomic.AtomicInteger
 import scala.reflect.ClassTag
 
-trait SqlExpr[T, N[_], R] extends SqlExpr.SqlExprNoHkt[N[T], R] {
-  final def isEqual[N2[_], NC[_]](t: SqlExpr[T, N2, R])(implicit O: Ordering[T], N: Nullability2[N, N2, NC]): SqlExpr[Boolean, NC, R] =
+sealed trait SqlExpr[T, N[_]] extends SqlExpr.SqlExprNoHkt[N[T]] {
+  final def isEqual[N2[_], NC[_]](t: SqlExpr[T, N2])(implicit O: Ordering[T], N: Nullability2[N, N2, NC]): SqlExpr[Boolean, NC] =
     this === t
 
-  final def isNotEqual[N2[_], NC[_]](t: SqlExpr[T, N2, R])(implicit O: Ordering[T], N: Nullability2[N, N2, NC]): SqlExpr[Boolean, NC, R] =
+  final def isNotEqual[N2[_], NC[_]](t: SqlExpr[T, N2])(implicit O: Ordering[T], N: Nullability2[N, N2, NC]): SqlExpr[Boolean, NC] =
     this !== t
 
-  final def ===[N2[_], NC[_]](t: SqlExpr[T, N2, R])(implicit O: Ordering[T], N: Nullability2[N, N2, NC]): SqlExpr[Boolean, NC, R] =
+  final def ===[N2[_], NC[_]](t: SqlExpr[T, N2])(implicit O: Ordering[T], N: Nullability2[N, N2, NC]): SqlExpr[Boolean, NC] =
     SqlExpr.Binary(this, SqlOperator.eq, t, N)
 
-  final def !==[N2[_], NC[_]](t: SqlExpr[T, N2, R])(implicit O: Ordering[T], N: Nullability2[N, N2, NC]): SqlExpr[Boolean, NC, R] =
+  final def !==[N2[_], NC[_]](t: SqlExpr[T, N2])(implicit O: Ordering[T], N: Nullability2[N, N2, NC]): SqlExpr[Boolean, NC] =
     SqlExpr.Binary(this, SqlOperator.neq, t, N)
 
-  final def >[N2[_], NC[_]](t: SqlExpr[T, N2, R])(implicit O: Ordering[T], N: Nullability2[N, N2, NC]): SqlExpr[Boolean, NC, R] =
+  final def >[N2[_], NC[_]](t: SqlExpr[T, N2])(implicit O: Ordering[T], N: Nullability2[N, N2, NC]): SqlExpr[Boolean, NC] =
     SqlExpr.Binary(this, SqlOperator.gt, t, N)
 
-  final def >=[N2[_], NC[_]](t: SqlExpr[T, N2, R])(implicit O: Ordering[T], N: Nullability2[N, N2, NC]): SqlExpr[Boolean, NC, R] =
+  final def >=[N2[_], NC[_]](t: SqlExpr[T, N2])(implicit O: Ordering[T], N: Nullability2[N, N2, NC]): SqlExpr[Boolean, NC] =
     SqlExpr.Binary(this, SqlOperator.gte, t, N)
 
-  final def <[N2[_], NC[_]](t: SqlExpr[T, N2, R])(implicit O: Ordering[T], N: Nullability2[N, N2, NC]): SqlExpr[Boolean, NC, R] =
+  final def <[N2[_], NC[_]](t: SqlExpr[T, N2])(implicit O: Ordering[T], N: Nullability2[N, N2, NC]): SqlExpr[Boolean, NC] =
     SqlExpr.Binary(this, SqlOperator.lt, t, N)
 
-  final def <=[N2[_], NC[_]](t: SqlExpr[T, N2, R])(implicit O: Ordering[T], N: Nullability2[N, N2, NC]): SqlExpr[Boolean, NC, R] =
+  final def <=[N2[_], NC[_]](t: SqlExpr[T, N2])(implicit O: Ordering[T], N: Nullability2[N, N2, NC]): SqlExpr[Boolean, NC] =
     SqlExpr.Binary(this, SqlOperator.lte, t, N)
 
-  final infix def or[N2[_], NC[_]](other: SqlExpr[T, N2, R])(implicit B: Bijection[T, Boolean], N: Nullability2[N, N2, NC]): SqlExpr[T, NC, R] =
+  final infix def or[N2[_], NC[_]](other: SqlExpr[T, N2])(implicit B: Bijection[T, Boolean], N: Nullability2[N, N2, NC]): SqlExpr[T, NC] =
     SqlExpr.Binary(this, SqlOperator.or[T], other, N)
 
-  final infix def and[N2[_], NC[_]](other: SqlExpr[T, N2, R])(implicit B: Bijection[T, Boolean], N: Nullability2[N, N2, NC]): SqlExpr[T, NC, R] =
+  final infix def and[N2[_], NC[_]](other: SqlExpr[T, N2])(implicit B: Bijection[T, Boolean], N: Nullability2[N, N2, NC]): SqlExpr[T, NC] =
     SqlExpr.Binary(this, SqlOperator.and[T], other, N)
 
-  def unary_!(implicit B: Bijection[T, Boolean], N: Nullability[N]): SqlExpr[T, N, R] =
+  def unary_!(implicit B: Bijection[T, Boolean], N: Nullability[N]): SqlExpr[T, N] =
     SqlExpr.Not(this, B, N)
 
-  final def +[N2[_], NC[_]](t: SqlExpr[T, N2, R])(implicit Num: Numeric[T], N: Nullability2[N, N2, NC]): SqlExpr[T, NC, R] =
+  final def +[N2[_], NC[_]](t: SqlExpr[T, N2])(implicit Num: Numeric[T], N: Nullability2[N, N2, NC]): SqlExpr[T, NC] =
     plus(t)
-  final def plus[N2[_], NC[_]](t: SqlExpr[T, N2, R])(implicit Num: Numeric[T], N: Nullability2[N, N2, NC]): SqlExpr[T, NC, R] =
+  final def plus[N2[_], NC[_]](t: SqlExpr[T, N2])(implicit Num: Numeric[T], N: Nullability2[N, N2, NC]): SqlExpr[T, NC] =
     SqlExpr.Binary(this, SqlOperator.plus, t, N)
 
-  final def -[N2[_], NC[_]](t: SqlExpr[T, N2, R])(implicit Num: Numeric[T], N: Nullability2[N, N2, NC]): SqlExpr[T, NC, R] =
+  final def -[N2[_], NC[_]](t: SqlExpr[T, N2])(implicit Num: Numeric[T], N: Nullability2[N, N2, NC]): SqlExpr[T, NC] =
     sub(t)
-  final def sub[N2[_], NC[_]](t: SqlExpr[T, N2, R])(implicit Num: Numeric[T], N: Nullability2[N, N2, NC]): SqlExpr[T, NC, R] =
+  final def sub[N2[_], NC[_]](t: SqlExpr[T, N2])(implicit Num: Numeric[T], N: Nullability2[N, N2, NC]): SqlExpr[T, NC] =
     SqlExpr.Binary(this, SqlOperator.minus, t, N)
 
-  final def *[N2[_], NC[_]](t: SqlExpr[T, N2, R])(implicit Num: Numeric[T], N: Nullability2[N, N2, NC]): SqlExpr[T, NC, R] =
+  final def *[N2[_], NC[_]](t: SqlExpr[T, N2])(implicit Num: Numeric[T], N: Nullability2[N, N2, NC]): SqlExpr[T, NC] =
     mul(t)
-  final def mul[N2[_], NC[_]](t: SqlExpr[T, N2, R])(implicit Num: Numeric[T], N: Nullability2[N, N2, NC]): SqlExpr[T, NC, R] =
+  final def mul[N2[_], NC[_]](t: SqlExpr[T, N2])(implicit Num: Numeric[T], N: Nullability2[N, N2, NC]): SqlExpr[T, NC] =
     SqlExpr.Binary(this, SqlOperator.mul, t, N)
 
-  final def underlying[TT](implicit B: Bijection[T, TT], N: Nullability[N]): SqlExpr[TT, N, R] =
+  final def underlying[TT](implicit B: Bijection[T, TT], N: Nullability[N]): SqlExpr[TT, N] =
     SqlExpr.Underlying(this, B, N)
 
-  final def like(str: String)(implicit B: Bijection[T, String], N: Nullability[N]): SqlExpr[Boolean, N, R] =
+  final def like(str: String)(implicit B: Bijection[T, String], N: Nullability[N]): SqlExpr[Boolean, N] =
     SqlExpr.Binary(this, SqlOperator.like, SqlExpr.asConstRequired(str), N.withRequired)
 
-  final def ||[N2[_], NC[_]](other: SqlExpr[T, N2, R])(implicit B: Bijection[T, String], N: Nullability2[N, N2, NC]): SqlExpr[T, NC, R] =
+  final def ||[N2[_], NC[_]](other: SqlExpr[T, N2])(implicit B: Bijection[T, String], N: Nullability2[N, N2, NC]): SqlExpr[T, NC] =
     stringAppend(other)
-  final def stringAppend[N2[_], NC[_]](other: SqlExpr[T, N2, R])(implicit B: Bijection[T, String], N: Nullability2[N, N2, NC]): SqlExpr[T, NC, R] =
+  final def stringAppend[N2[_], NC[_]](other: SqlExpr[T, N2])(implicit B: Bijection[T, String], N: Nullability2[N, N2, NC]): SqlExpr[T, NC] =
     SqlExpr.Binary(this, SqlOperator.strAdd, other, N)
 
-  final def lower(implicit B: Bijection[T, String], N: Nullability[N]): SqlExpr[T, N, R] =
+  final def lower(implicit B: Bijection[T, String], N: Nullability[N]): SqlExpr[T, N] =
     SqlExpr.Apply1(SqlFunction1.lower, this, N)
 
-  final def reverse(implicit B: Bijection[T, String], N: Nullability[N]): SqlExpr[T, N, R] =
+  final def reverse(implicit B: Bijection[T, String], N: Nullability[N]): SqlExpr[T, N] =
     SqlExpr.Apply1(SqlFunction1.reverse, this, N)
 
-  final def upper(implicit B: Bijection[T, String], N: Nullability[N]): SqlExpr[T, N, R] =
+  final def upper(implicit B: Bijection[T, String], N: Nullability[N]): SqlExpr[T, N] =
     SqlExpr.Apply1(SqlFunction1.upper, this, N)
 
-  final def strpos[N2[_], NC[_]](substring: SqlExpr[String, N2, R])(implicit B: Bijection[T, String], N: Nullability2[N, N2, NC]): SqlExpr[Int, NC, R] =
+  final def strpos[N2[_], NC[_]](substring: SqlExpr[String, N2])(implicit B: Bijection[T, String], N: Nullability2[N, N2, NC]): SqlExpr[Int, NC] =
     SqlExpr.Apply2(SqlFunction2.strpos, this, substring, N)
 
-  final def strLength(implicit B: Bijection[T, String], N: Nullability[N]): SqlExpr[Int, N, R] =
+  final def strLength(implicit B: Bijection[T, String], N: Nullability[N]): SqlExpr[Int, N] =
     SqlExpr.Apply1(SqlFunction1.length, this, N)
 
-  final def substring[N2[_], N3[_], NC[_]](from: SqlExpr[Int, N2, R], count: SqlExpr[Int, N3, R])(implicit
+  final def substring[N2[_], N3[_], NC[_]](from: SqlExpr[Int, N2], count: SqlExpr[Int, N3])(implicit
       B: Bijection[T, String],
       N: Nullability3[N, N2, N3, NC]
-  ): SqlExpr[T, NC, R] =
+  ): SqlExpr[T, NC] =
     SqlExpr.Apply3(SqlFunction3.substring[T](), this, from, count, N)
 
-  final infix def in(ts: Array[T])(implicit ev: ToParameterValue[Array[T]], N: Nullability[N]): SqlExpr[Boolean, N, R] =
+  final infix def in(ts: Array[T])(implicit ev: ToParameterValue[Array[T]], N: Nullability[N]): SqlExpr[Boolean, N] =
     SqlExpr.In(this, ts, ev, N)
 
-  final def ?(implicit N: Nullability[N]): SqlExpr[T, Option, R] = opt
-  final def opt(implicit N: Nullability[N]): SqlExpr[T, Option, R] = SqlExpr.ToNullable(this, N)
+  final def ?(implicit N: Nullability[N]): SqlExpr[T, Option] = opt
+  final def opt(implicit N: Nullability[N]): SqlExpr[T, Option] = SqlExpr.ToNullable(this, N)
 }
 
 object SqlExpr {
-  trait SqlExprNoHkt[NT, R] {
-    def eval(row: R): NT
-
-    def render(counter: AtomicInteger): Fragment
+  sealed trait SqlExprNoHkt[NT] {
+    def render(ctx: RenderCtx, counter: AtomicInteger): Fragment
   }
 
-  sealed trait FieldLikeNoHkt[NT, Row] extends SqlExprNoHkt[NT, Row] {
-    val prefix: Option[String]
+  sealed trait FieldLikeNoHkt[NT, Row] extends SqlExprNoHkt[NT] with Product {
+    val path: List[Path]
     val name: String
     val get: Row => NT
     val set: (Row, NT) => Row
     val sqlReadCast: Option[String]
     val sqlWriteCast: Option[String]
-    final def value: String = prefix.fold("")(_ + ".") + name
+
+    final def value(ctx: RenderCtx): String = ctx.alias.get(path).fold("")(_ + ".") + name
+    final def render(ctx: RenderCtx, counter: AtomicInteger): Fragment = Fragment(value(ctx))
   }
 
   sealed trait FieldLikeNotIdNoHkt[NT, R] extends FieldLikeNoHkt[NT, R]
 
-  sealed abstract class FieldLike[T, N[_], R](val prefix: Option[String], val name: String, val sqlReadCast: Option[String], val sqlWriteCast: Option[String])(
-      val get: R => N[T],
-      val set: (R, N[T]) => R
-  ) extends SqlExpr[T, N, R]
-      with FieldLikeNoHkt[N[T], R] {
-    override def eval(row: R): N[T] = get(row)
-    override def render(counter: AtomicInteger): Fragment = Fragment(value)
+  sealed trait FieldLike[T, N[_], R] extends SqlExpr[T, N] with FieldLikeNoHkt[N[T], R] with Product {
+    val path: List[Path]
+    val name: String
+    val sqlReadCast: Option[String]
+    val sqlWriteCast: Option[String]
+    val get: R => N[T]
+    val set: (R, N[T]) => R
   }
 
   sealed trait FieldLikeNotId[T, N[_], R] extends FieldLike[T, N, R] with FieldLikeNotIdNoHkt[N[T], R]
 
   // connect a field `name` to a type `T` for a relation `R`
-  class Field[T, R](prefix: Option[String], name: String, sqlReadCast: Option[String] = None, sqlWriteCast: Option[String] = None)(get: R => T, set: (R, T) => R)
-      extends FieldLike[T, Required, R](prefix, name, sqlReadCast, sqlWriteCast)(get, set)
-      with FieldLikeNotId[T, Required, R]
+  case class Field[T, R](path: List[Path], name: String, sqlReadCast: Option[String], sqlWriteCast: Option[String], get: R => T, set: (R, T) => R) extends FieldLikeNotId[T, Required, R]
 
-  class IdField[T, R](prefix: Option[String], name: String, sqlReadCast: Option[String] = None, sqlWriteCast: Option[String] = None)(get: R => T, set: (R, T) => R)
-      extends FieldLike[T, Required, R](prefix, name, sqlReadCast, sqlWriteCast)(get, set)
+  case class IdField[T, R](path: List[Path], name: String, sqlReadCast: Option[String], sqlWriteCast: Option[String], get: R => T, set: (R, T) => R) extends FieldLike[T, Required, R]
 
-  class OptField[T, R](prefix: Option[String], name: String, sqlReadCast: Option[String] = None, sqlWriteCast: Option[String] = None)(get: R => Option[T], set: (R, Option[T]) => R)
-      extends FieldLike[T, Option, R](prefix, name, sqlReadCast, sqlWriteCast)(get, set)
-      with FieldLikeNotId[T, Option, R]
+  case class OptField[T, R](path: List[Path], name: String, sqlReadCast: Option[String], sqlWriteCast: Option[String], get: R => Option[T], set: (R, Option[T]) => R)
+      extends FieldLikeNotId[T, Option, R]
 
-  case class Const[T, N[_], R](value: N[T], T: ToParameterValue[N[T]], P: ParameterMetaData[T]) extends SqlExpr[T, N, R] {
-    override def eval(row: R): N[T] =
-      value
-    override def render(counter: AtomicInteger): Fragment = {
+  case class Const[T, N[_]](value: N[T], T: ToParameterValue[N[T]], P: ParameterMetaData[T]) extends SqlExpr[T, N] {
+    override def render(ctx: RenderCtx, counter: AtomicInteger): Fragment = {
       val paramName = s"param${counter.incrementAndGet()}"
       Fragment(List(NamedParameter(paramName, T(value))), s"{$paramName}::${P.sqlType}")
     }
   }
 
   object Const {
-    trait As[T, N[_], R] {
-      def apply(value: N[T]): SqlExpr.Const[T, N, R]
+    trait As[T, N[_]] {
+      def apply(value: N[T]): SqlExpr.Const[T, N]
     }
 
     object As {
-      implicit def as[T, N[_], R](implicit T: ToParameterValue[N[T]], P: ParameterMetaData[T]): As[T, N, R] =
+      implicit def as[T, N[_]](implicit T: ToParameterValue[N[T]], P: ParameterMetaData[T]): As[T, N] =
         (value: N[T]) => SqlExpr.Const(value, T, P)
     }
   }
 
-  case class ArrayIndex[T, N1[_], N2[_], R](arr: SqlExpr[Array[T], N1, R], idx: SqlExpr[Int, N2, R], N: Nullability2[N1, N2, Option]) extends SqlExpr[T, Option, R] {
-    override def eval(row: R): Option[T] = {
-      N.mapN(arr.eval(row), idx.eval(row)) { (arr, idx) =>
-        if (idx < 0 || idx >= arr.length) None
-        else Some(arr(idx))
-      }.flatten
-    }
-
-    override def render(counter: AtomicInteger): Fragment =
-      frag"${arr.render(counter)}[${idx.render(counter)}]"
+  case class ArrayIndex[T, N1[_], N2[_]](arr: SqlExpr[Array[T], N1], idx: SqlExpr[Int, N2], N: Nullability2[N1, N2, Option]) extends SqlExpr[T, Option] {
+    override def render(ctx: RenderCtx, counter: AtomicInteger): Fragment =
+      frag"${arr.render(ctx, counter)}[${idx.render(ctx, counter)}]"
   }
 
-  case class Apply1[T1, O, N[_], R](f: SqlFunction1[T1, O], arg1: SqlExpr[T1, N, R], N: Nullability[N]) extends SqlExpr[O, N, R] {
-    override def eval(row: R): N[O] =
-      N.mapN(arg1.eval(row))(f.eval)
-    override def render(counter: AtomicInteger): Fragment =
-      frag"${Fragment(f.name)}(${arg1.render(counter)})"
+  case class Apply1[T1, O, N[_]](f: SqlFunction1[T1, O], arg1: SqlExpr[T1, N], N: Nullability[N]) extends SqlExpr[O, N] {
+    override def render(ctx: RenderCtx, counter: AtomicInteger): Fragment =
+      frag"${Fragment(f.name)}(${arg1.render(ctx, counter)})"
   }
 
-  case class Apply2[T1, T2, O, N1[_], N2[_], N[_], R](f: SqlFunction2[T1, T2, O], arg1: SqlExpr[T1, N1, R], arg2: SqlExpr[T2, N2, R], N: Nullability2[N1, N2, N]) extends SqlExpr[O, N, R] {
-    override def eval(row: R): N[O] =
-      N.mapN(arg1.eval(row), arg2.eval(row))(f.eval)
-    override def render(counter: AtomicInteger): Fragment =
-      frag"${Fragment(f.name)}(${arg1.render(counter)}, ${arg2.render(counter)})"
+  case class Apply2[T1, T2, O, N1[_], N2[_], N[_]](f: SqlFunction2[T1, T2, O], arg1: SqlExpr[T1, N1], arg2: SqlExpr[T2, N2], N: Nullability2[N1, N2, N]) extends SqlExpr[O, N] {
+    override def render(ctx: RenderCtx, counter: AtomicInteger): Fragment =
+      frag"${Fragment(f.name)}(${arg1.render(ctx, counter)}, ${arg2.render(ctx, counter)})"
   }
 
-  case class Apply3[T1, T2, T3, N1[_], N2[_], N3[_], N[_], O, R](
+  case class Apply3[T1, T2, T3, N1[_], N2[_], N3[_], N[_], O](
       f: SqlFunction3[T1, T2, T3, O],
-      arg1: SqlExpr[T1, N1, R],
-      arg2: SqlExpr[T2, N2, R],
-      arg3: SqlExpr[T3, N3, R],
+      arg1: SqlExpr[T1, N1],
+      arg2: SqlExpr[T2, N2],
+      arg3: SqlExpr[T3, N3],
       N: Nullability3[N1, N2, N3, N]
-  ) extends SqlExpr[O, N, R] {
-    override def eval(row: R): N[O] =
-      N.mapN(arg1.eval(row), arg2.eval(row), arg3.eval(row))(f.eval)
-    override def render(counter: AtomicInteger): Fragment =
-      frag"${Fragment(f.name)}(${arg1.render(counter)}, ${arg2.render(counter)}, ${arg3.render(counter)})"
+  ) extends SqlExpr[O, N] {
+    override def render(ctx: RenderCtx, counter: AtomicInteger): Fragment =
+      frag"${Fragment(f.name)}(${arg1.render(ctx, counter)}, ${arg2.render(ctx, counter)}, ${arg3.render(ctx, counter)})"
   }
 
-  case class Binary[T1, T2, O, N1[_], N2[_], N[_], R](left: SqlExpr[T1, N1, R], op: SqlOperator[T1, T2, O], right: SqlExpr[T2, N2, R], N: Nullability2[N1, N2, N]) extends SqlExpr[O, N, R] {
-    override def eval(row: R): N[O] =
-      N.mapN(left.eval(row), right.eval(row))(op.eval)
-    override def render(counter: AtomicInteger): Fragment =
-      frag"(${left.render(counter)} ${Fragment(op.name)} ${right.render(counter)})"
+  case class Binary[T1, T2, O, N1[_], N2[_], N[_]](left: SqlExpr[T1, N1], op: SqlOperator[T1, T2, O], right: SqlExpr[T2, N2], N: Nullability2[N1, N2, N]) extends SqlExpr[O, N] {
+    override def render(ctx: RenderCtx, counter: AtomicInteger): Fragment =
+      frag"(${left.render(ctx, counter)} ${Fragment(op.name)} ${right.render(ctx, counter)})"
   }
 
-  case class Underlying[T, TT, N[_], R](expr: SqlExpr[T, N, R], bijection: Bijection[T, TT], N: Nullability[N]) extends SqlExpr[TT, N, R] {
-    override def eval(row: R): N[TT] =
-      N.mapN(expr.eval(row))(bijection.underlying)
-    override def render(counter: AtomicInteger): Fragment =
-      expr.render(counter)
+  case class Underlying[T, TT, N[_]](expr: SqlExpr[T, N], bijection: Bijection[T, TT], N: Nullability[N]) extends SqlExpr[TT, N] {
+    override def render(ctx: RenderCtx, counter: AtomicInteger): Fragment =
+      expr.render(ctx, counter)
   }
 
-  case class Coalesce[T, R](expr: SqlExpr[T, Option, R], getOrElse: SqlExpr[T, Required, R]) extends SqlExpr[T, Required, R] {
-    override def eval(row: R): T =
-      expr.eval(row).getOrElse(getOrElse.eval(row))
-    override def render(counter: AtomicInteger): Fragment =
-      frag"coalesce(${expr.render(counter)}, ${getOrElse.render(counter)})"
+  case class Coalesce[T](expr: SqlExpr[T, Option], getOrElse: SqlExpr[T, Required]) extends SqlExpr[T, Required] {
+    override def render(ctx: RenderCtx, counter: AtomicInteger): Fragment =
+      frag"coalesce(${expr.render(ctx, counter)}, ${getOrElse.render(ctx, counter)})"
   }
 
-  case class In[T, N[_], R](expr: SqlExpr[T, N, R], values: Array[T], ev: ToParameterValue[Array[T]], N: Nullability[N]) extends SqlExpr[Boolean, N, R] {
-    override def eval(row: R): N[Boolean] =
-      N.mapN(expr.eval(row))(values.contains)
-
-    override def render(counter: AtomicInteger): Fragment = {
+  case class In[T, N[_]](expr: SqlExpr[T, N], values: Array[T], ev: ToParameterValue[Array[T]], N: Nullability[N]) extends SqlExpr[Boolean, N] {
+    override def render(ctx: RenderCtx, counter: AtomicInteger): Fragment = {
       val paramName = s"param${counter.incrementAndGet()}"
       val np = NamedParameter(paramName, ParameterValue.from(values)(ev))
-      frag"${expr.render(counter)} = ANY({${Fragment(List(np), paramName)}})"
+      frag"${expr.render(ctx, counter)} = ANY({${Fragment(List(np), paramName)}})"
     }
   }
 
-  case class IsNull[T, R](expr: SqlExpr[T, Option, R]) extends SqlExpr[Boolean, Required, R] {
-    override def eval(row: R): Boolean =
-      expr.eval(row).isEmpty
-    override def render(counter: AtomicInteger): Fragment =
-      frag"${expr.render(counter)} IS NULL"
+  final case class IsNull[T](expr: SqlExpr[T, Option]) extends SqlExpr[Boolean, Required] {
+    override def render(ctx: RenderCtx, counter: AtomicInteger): Fragment =
+      frag"${expr.render(ctx, counter)} IS NULL"
   }
 
-  case class Not[T, N[_], R](expr: SqlExpr[T, N, R], B: Bijection[T, Boolean], N: Nullability[N]) extends SqlExpr[T, N, R] {
-    override def eval(row: R): N[T] =
-      N.mapN(expr.eval(row))(t => B.map(t)(b => !b))
-    override def render(counter: AtomicInteger): Fragment =
-      frag"NOT ${expr.render(counter)}"
+  case class Not[T, N[_]](expr: SqlExpr[T, N], B: Bijection[T, Boolean], N: Nullability[N]) extends SqlExpr[T, N] {
+    override def render(ctx: RenderCtx, counter: AtomicInteger): Fragment =
+      frag"NOT ${expr.render(ctx, counter)}"
   }
 
-  case class ToNullable[T, R, N1[_]](expr: SqlExpr[T, N1, R], N: Nullability[N1]) extends SqlExpr[T, Option, R] {
-    override def eval(row: R): Option[T] =
-      N.toOpt(expr.eval(row))
-    override def render(counter: AtomicInteger): Fragment =
-      expr.render(counter)
+  case class ToNullable[T, N[_]](expr: SqlExpr[T, N], N: Nullability[N]) extends SqlExpr[T, Option] {
+    override def render(ctx: RenderCtx, counter: AtomicInteger): Fragment =
+      expr.render(ctx, counter)
   }
 
   // automatically put values in a constant expression
-  implicit def asConstOpt[T, R](t: Option[T])(implicit T: ToParameterValue[Option[T]], P: ParameterMetaData[T]): SqlExpr.Const[T, Option, R] =
+  implicit def asConstOpt[T, R](t: Option[T])(implicit T: ToParameterValue[Option[T]], P: ParameterMetaData[T]): SqlExpr.Const[T, Option] =
     Const(t, T, P)
 
-  implicit def asConstRequired[T, R](t: T)(implicit T: ToParameterValue[T], P: ParameterMetaData[T]): SqlExpr.Const[T, Required, R] =
-    Const[T, Required, R](t, T, P)
+  implicit def asConstRequired[T, R](t: T)(implicit T: ToParameterValue[T], P: ParameterMetaData[T]): SqlExpr.Const[T, Required] =
+    Const[T, Required](t, T, P)
 
   // some syntax to construct field sort order
-  implicit class SqlExprSortSyntax[T, N[_], R](private val expr: SqlExpr[T, N, R]) extends AnyVal {
-    def asc(implicit O: Ordering[T], N: Nullability[N]): SortOrder[T, N, R] = SortOrder(expr, ascending = true, nullsFirst = false)
-    def desc(implicit O: Ordering[T], N: Nullability[N]): SortOrder[T, N, R] = SortOrder(expr, ascending = false, nullsFirst = false)
+  implicit class SqlExprSortSyntax[T, N[_]](private val expr: SqlExpr[T, N]) extends AnyVal {
+    def asc(implicit O: Ordering[T], N: Nullability[N]): SortOrder[T, N] = SortOrder(expr, ascending = true, nullsFirst = false)
+    def desc(implicit O: Ordering[T], N: Nullability[N]): SortOrder[T, N] = SortOrder(expr, ascending = false, nullsFirst = false)
   }
 
-  final case class RowExpr[R](exprs: List[SqlExpr.SqlExprNoHkt[?, R]]) extends SqlExpr[List[?], Required, R] {
-    override def eval(row: R): List[?] = exprs.map(_.eval(row))
-    override def render(counter: AtomicInteger): Fragment = frag"(" ++ exprs.map(_.render(counter)).mkFragment(",") ++ frag")"
+  final case class RowExpr(exprs: List[SqlExpr.SqlExprNoHkt[?]]) extends SqlExpr[List[?], Required] {
+    override def render(ctx: RenderCtx, counter: AtomicInteger): Fragment =
+      frag"(" ++ exprs.map(_.render(ctx, counter)).mkFragment(",") ++ frag")"
   }
 
-  implicit class SqlExprArraySyntax[T, N[_], R](private val expr: SqlExpr[Array[T], N, R]) extends AnyVal {
+  implicit class SqlExprArraySyntax[T, N[_]](private val expr: SqlExpr[Array[T], N]) extends AnyVal {
 
     /** look up an element in an array at index `idx` */
-    def arrayIndex[N2[_]](idx: SqlExpr[Int, N2, R])(implicit N: Nullability2[N, N2, Option]): SqlExpr[T, Option, R] =
-      SqlExpr.ArrayIndex[T, N, N2, R](expr, idx, N)
+    def arrayIndex[N2[_]](idx: SqlExpr[Int, N2])(implicit N: Nullability2[N, N2, Option]): SqlExpr[T, Option] =
+      SqlExpr.ArrayIndex[T, N, N2](expr, idx, N)
 
     /** concatenate two arrays */
-    def arrayConcat[N2[_], NC[_]](other: SqlExpr[Array[T], N2, R])(implicit C: ClassTag[T], N: Nullability2[N, N2, NC]): SqlExpr[Array[T], NC, R] =
+    def arrayConcat[N2[_], NC[_]](other: SqlExpr[Array[T], N2])(implicit C: ClassTag[T], N: Nullability2[N, N2, NC]): SqlExpr[Array[T], NC] =
       SqlExpr.Binary(expr, SqlOperator.arrayConcat, other, N)
 
     /** does arrays have elements in common */
-    def arrayOverlaps[N2[_], NC[_]](other: SqlExpr[Array[T], N2, R])(implicit N: Nullability2[N, N2, NC]): SqlExpr[Boolean, NC, R] =
+    def arrayOverlaps[N2[_], NC[_]](other: SqlExpr[Array[T], N2])(implicit N: Nullability2[N, N2, NC]): SqlExpr[Boolean, NC] =
       SqlExpr.Binary(expr, SqlOperator.arrayOverlaps[Array[T], T], other, N)
   }
 
-  implicit class SqlExprOptionalSyntax[T, R](private val expr: SqlExpr[T, Option, R]) extends AnyVal {
-    def isNull: SqlExpr[Boolean, Required, R] =
+  implicit class SqlExprOptionalSyntax[T](private val expr: SqlExpr[T, Option]) extends AnyVal {
+    def isNull: SqlExpr[Boolean, Required] =
       SqlExpr.IsNull(expr)
-    def coalesce(orElse: SqlExpr[T, Required, R]): SqlExpr[T, Required, R] =
+    def coalesce(orElse: SqlExpr[T, Required]): SqlExpr[T, Required] =
       SqlExpr.Coalesce(expr, orElse)
   }
 }

--- a/typo-dsl-anorm/src/scala/typo/dsl/UpdateBuilder.scala
+++ b/typo-dsl-anorm/src/scala/typo/dsl/UpdateBuilder.scala
@@ -7,22 +7,23 @@ import java.sql.Connection
 import java.util.concurrent.atomic.AtomicInteger
 import scala.annotation.nowarn
 
-trait UpdateBuilder[Fields[_], Row] {
+trait UpdateBuilder[Fields, Row] {
   protected def params: UpdateParams[Fields, Row]
   protected def withParams(sqlParams: UpdateParams[Fields, Row]): UpdateBuilder[Fields, Row]
 
-  final def whereStrict(v: Fields[Row] => SqlExpr[Boolean, Required, Row]): UpdateBuilder[Fields, Row] =
+  final def whereStrict(v: Fields => SqlExpr[Boolean, Required]): UpdateBuilder[Fields, Row] =
     withParams(params.where(v))
-  final def where[N[_]: Nullability](v: Fields[Row] => SqlExpr[Boolean, N, Row]): UpdateBuilder[Fields, Row] =
+
+  final def where[N[_]: Nullability](v: Fields => SqlExpr[Boolean, N]): UpdateBuilder[Fields, Row] =
     withParams(params.where(f => v(f).?.coalesce(false)))
 
-  final def setValue[N[_], T](col: Fields[Row] => SqlExpr.FieldLikeNotId[T, N, Row])(value: N[T])(implicit T: ToParameterValue[N[T]], P: ParameterMetaData[T]): UpdateBuilder[Fields, Row] =
-    withParams(params.set(col, _ => SqlExpr.Const[T, N, Row](value, T, P)))
+  final def setValue[N[_], T](col: Fields => SqlExpr.FieldLikeNotId[T, N, Row])(value: N[T])(implicit T: ToParameterValue[N[T]], P: ParameterMetaData[T]): UpdateBuilder[Fields, Row] =
+    withParams(params.set(col, _ => SqlExpr.Const[T, N](value, T, P)))
 
-  final def setComputedValue[T, N[_]](col: Fields[Row] => SqlExpr.FieldLikeNotId[T, N, Row])(value: SqlExpr.FieldLikeNotId[T, N, Row] => SqlExpr[T, N, Row]): UpdateBuilder[Fields, Row] =
+  final def setComputedValue[T, N[_]](col: Fields => SqlExpr.FieldLikeNotId[T, N, Row])(value: SqlExpr.FieldLikeNotId[T, N, Row] => SqlExpr[T, N]): UpdateBuilder[Fields, Row] =
     withParams(params.set(col, fields => value(col(fields))))
 
-  final def setComputedValueFromRow[T, N[_]](col: Fields[Row] => SqlExpr.FieldLikeNotId[T, N, Row])(value: Fields[Row] => SqlExpr[T, N, Row]): UpdateBuilder[Fields, Row] =
+  final def setComputedValueFromRow[T, N[_]](col: Fields => SqlExpr.FieldLikeNotId[T, N, Row])(value: Fields => SqlExpr[T, N]): UpdateBuilder[Fields, Row] =
     withParams(params.set(col, value))
 
   def sql(returning: Boolean): Option[Fragment]
@@ -31,19 +32,22 @@ trait UpdateBuilder[Fields[_], Row] {
 }
 
 object UpdateBuilder {
-  def apply[Fields[_], Row](name: String, structure: Structure.Relation[Fields, ?, Row], rowParser: Int => RowParser[Row]): UpdateBuilderSql[Fields, Row] =
+  def apply[Fields, Row](name: String, structure: Structure.Relation[Fields, Row], rowParser: Int => RowParser[Row]): UpdateBuilderSql[Fields, Row] =
     UpdateBuilderSql(name, structure, rowParser, UpdateParams.empty)
 
-  case class UpdateBuilderSql[Fields[_], Row](
+  final case class UpdateBuilderSql[Fields, Row](
       name: String,
-      structure: Structure.Relation[Fields, ?, Row],
+      structure: Structure.Relation[Fields, Row],
       rowParser: Int => RowParser[Row],
       params: UpdateParams[Fields, Row]
   ) extends UpdateBuilder[Fields, Row] {
     override def withParams(sqlParams: UpdateParams[Fields, Row]): UpdateBuilder[Fields, Row] =
       copy(params = sqlParams)
 
-    def mkSql(counter: AtomicInteger, returning: Boolean): Fragment = {
+    def mkSql(returning: Boolean): Fragment =
+      mkSql(RenderCtx.Empty, new AtomicInteger(0), returning)
+
+    def mkSql(ctx: RenderCtx, counter: AtomicInteger, returning: Boolean): Fragment = {
       params.setters match {
         case Nil => sys.error("you must specify a columns to set. use `set` method")
         case _   => ()
@@ -54,15 +58,15 @@ object UpdateBuilder {
           val fieldExpr = setter.col(structure.fields)
           val valueExpr = setter.value(structure.fields)
           val cast = fieldExpr.sqlWriteCast.fold(Fragment.empty)(cast => Fragment(s"::$cast"))
-          Fragment(if (idx == 0) " set " else ", ") ++ fieldExpr.render(counter) ++ frag" = " ++ valueExpr.render(counter) ++ cast
+          Fragment(if (idx == 0) " set " else ", ") ++ fieldExpr.render(ctx, counter) ++ frag" = " ++ valueExpr.render(ctx, counter) ++ cast
         },
         params.where
           .map(w => w(structure.fields))
           .reduceLeftOption(_.and(_))
-          .map { where => Fragment(" where ") ++ where.render(counter) },
+          .map { where => Fragment(" where ") ++ where.render(ctx, counter) },
         if (returning) {
           val cols = structure.columns
-            .map(x => x.sqlReadCast.foldLeft("\"" + x.value + "\"") { case (acc, cast) => s"$acc::$cast" })
+            .map(x => x.sqlReadCast.foldLeft("\"" + x.value(ctx) + "\"") { case (acc, cast) => s"$acc::$cast" })
             .mkString(",")
 
           Some(frag" returning ${Fragment(cols)}")
@@ -70,24 +74,23 @@ object UpdateBuilder {
       ).flatten.reduce(_ ++ _)
     }
 
-    override def sql(returning: Boolean): Option[Fragment] = {
-      Some(mkSql(new AtomicInteger(1), returning))
-    }
+    override def sql(returning: Boolean): Option[Fragment] =
+      Some(mkSql(returning))
 
     override def execute()(implicit c: Connection): Int = {
-      val frag = mkSql(new AtomicInteger(0), returning = false)
+      val frag = mkSql(returning = false)
       SimpleSql(SQL(frag.sql), frag.params.map(_.tupled).toMap, RowParser.successful).executeUpdate()
     }
 
     override def executeReturnChanged()(implicit c: Connection): List[Row] = {
-      val frag = mkSql(new AtomicInteger(0), returning = true)
+      val frag = mkSql(returning = true)
       SimpleSql(SQL(frag.sql), frag.params.map(_.tupled).toMap, RowParser.successful).as(rowParser(1).*)
     }
   }
 
-  case class UpdateBuilderMock[Id, Fields[_], Row](
+  final case class UpdateBuilderMock[Id, Fields, Row](
       params: UpdateParams[Fields, Row],
-      fields: Fields[Row],
+      structure: Structure[Fields, Row],
       map: scala.collection.mutable.Map[Id, Row]
   ) extends UpdateBuilder[Fields, Row] {
     override def withParams(sqlParams: UpdateParams[Fields, Row]): UpdateBuilder[Fields, Row] =
@@ -102,8 +105,12 @@ object UpdateBuilder {
     override def executeReturnChanged()(implicit @nowarn c: Connection): List[Row] = {
       val changed = List.newBuilder[Row]
       map.foreach { case (id, row) =>
-        if (params.where.forall(w => w(fields).eval(row))) {
-          val newRow = params.setters.foldLeft(row) { case (row, set) => set.transform(fields, row) }
+        if (params.where.forall(w => structure.untypedEval(w(structure.fields), row))) {
+          val newRow = params.setters.foldLeft(row) { case (row, set: UpdateParams.Setter[Fields, nt, Row]) =>
+            val field: SqlExpr.FieldLikeNotIdNoHkt[nt, Row] = set.col(structure.fields)
+            val newValue: nt = structure.untypedEval(set.value(structure.fields), row)
+            field.set(row, newValue)
+          }
           map.update(id, newRow)
           changed += newRow
         }

--- a/typo-dsl-anorm/src/scala/typo/dsl/pagination/SortOrderRepr.scala
+++ b/typo-dsl-anorm/src/scala/typo/dsl/pagination/SortOrderRepr.scala
@@ -1,6 +1,6 @@
 package typo.dsl.pagination
 
-import typo.dsl.SortOrderNoHkt
+import typo.dsl.{RenderCtx, SortOrderNoHkt}
 
 import java.util.concurrent.atomic.AtomicInteger
 
@@ -11,9 +11,9 @@ import java.util.concurrent.atomic.AtomicInteger
 case class SortOrderRepr(expr: String) extends AnyVal
 
 object SortOrderRepr {
-  def from[NT, R](x: SortOrderNoHkt[NT, R]): SortOrderRepr = {
+  def from[NT](x: SortOrderNoHkt[NT], ctx: RenderCtx): SortOrderRepr = {
     // note `x.expr`! the value is independent of ascending/descending and nulls first/last
-    val fragment = x.expr.render(new AtomicInteger(0))
+    val fragment = x.expr.render(ctx, new AtomicInteger(0))
     // todo: deconstructing the sql string and replacing `?` with the value would yield a more readable result
     val sql = fragment.params match {
       case Nil      => fragment.sql

--- a/typo-dsl-doobie/src/scala/typo/dsl/DeleteBuilder.scala
+++ b/typo-dsl-doobie/src/scala/typo/dsl/DeleteBuilder.scala
@@ -5,17 +5,16 @@ import doobie.free.connection.delay
 import doobie.implicits.toSqlInterpolator
 import doobie.util.fragment.Fragment
 
-import java.util.concurrent.atomic.AtomicInteger
 import scala.annotation.nowarn
 
-trait DeleteBuilder[Fields[_], Row] {
-  protected def params: DeleteParams[Fields, Row]
-  protected def withParams(sqlParams: DeleteParams[Fields, Row]): DeleteBuilder[Fields, Row]
+trait DeleteBuilder[Fields, Row] {
+  protected def params: DeleteParams[Fields]
+  protected def withParams(sqlParams: DeleteParams[Fields]): DeleteBuilder[Fields, Row]
 
-  final def where[N[_]: Nullability](v: Fields[Row] => SqlExpr[Boolean, N, Row]): DeleteBuilder[Fields, Row] =
+  final def where[N[_]: Nullability](v: Fields => SqlExpr[Boolean, N]): DeleteBuilder[Fields, Row] =
     whereStrict(f => v(f).?.coalesce(false))
 
-  final def whereStrict(v: Fields[Row] => SqlExpr[Boolean, Required, Row]): DeleteBuilder[Fields, Row] =
+  final def whereStrict(v: Fields => SqlExpr[Boolean, Required]): DeleteBuilder[Fields, Row] =
     withParams(params.where(v))
 
   def sql: Option[Fragment]
@@ -23,42 +22,40 @@ trait DeleteBuilder[Fields[_], Row] {
 }
 
 object DeleteBuilder {
-  def apply[Fields[_], Row](name: String, structure: Structure.Relation[Fields, ?, Row]): DeleteBuilderSql[Fields, Row] =
+  def apply[Fields, Row](name: String, structure: Structure.Relation[Fields, Row]): DeleteBuilderSql[Fields, Row] =
     DeleteBuilderSql(name, structure, DeleteParams.empty)
 
-  case class DeleteBuilderSql[Fields[_], Row](
+  final case class DeleteBuilderSql[Fields, Row](
       name: String,
-      structure: Structure.Relation[Fields, ?, Row],
-      params: DeleteParams[Fields, Row]
+      structure: Structure.Relation[Fields, Row],
+      params: DeleteParams[Fields]
   ) extends DeleteBuilder[Fields, Row] {
-    override def withParams(sqlParams: DeleteParams[Fields, Row]): DeleteBuilder[Fields, Row] =
+    override def withParams(sqlParams: DeleteParams[Fields]): DeleteBuilder[Fields, Row] =
       copy(params = sqlParams)
 
-    def mkSql(counter: AtomicInteger): Fragment = {
+    def mkSql(ctx: RenderCtx): Fragment = {
       List[Iterable[Fragment]](
         Some(fr"delete from ${Fragment.const0(name)}"),
         params.where
           .map(w => w(structure.fields))
           .reduceLeftOption(_.and(_))
-          .map { where => fr" where " ++ where.render(counter) }
+          .map { where => fr" where " ++ where.render(ctx: RenderCtx) }
       ).flatten.reduce(_ ++ _)
     }
 
-    override def sql: Option[Fragment] = {
-      Some(mkSql(new AtomicInteger(1)))
-    }
+    override def sql: Option[Fragment] =
+      Some(mkSql(RenderCtx.Empty))
 
-    override def execute: ConnectionIO[Int] = {
-      mkSql(new AtomicInteger(0)).update.run
-    }
+    override def execute: ConnectionIO[Int] =
+      mkSql(RenderCtx.Empty).update.run
   }
 
-  case class DeleteBuilderMock[Id, Fields[_], Row](
-      params: DeleteParams[Fields, Row],
-      fields: Fields[Row],
+  final case class DeleteBuilderMock[Id, Fields, Row](
+      params: DeleteParams[Fields],
+      structure: Structure[Fields, Row],
       map: scala.collection.mutable.Map[Id, Row]
   ) extends DeleteBuilder[Fields, Row] {
-    override def withParams(sqlParams: DeleteParams[Fields, Row]): DeleteBuilder[Fields, Row] =
+    override def withParams(sqlParams: DeleteParams[Fields]): DeleteBuilder[Fields, Row] =
       copy(params = sqlParams)
 
     override def sql: Option[Fragment] =
@@ -67,7 +64,7 @@ object DeleteBuilder {
     override def execute: ConnectionIO[Int] = delay {
       var changed = 0
       map.foreach { case (id, row) =>
-        if (params.where.forall(w => w(fields).eval(row))) {
+        if (params.where.forall(w => structure.untypedEval(w(structure.fields), row))) {
           map.remove(id): @nowarn
           changed += 1
         }

--- a/typo-dsl-doobie/src/scala/typo/dsl/SelectBuilder.scala
+++ b/typo-dsl-doobie/src/scala/typo/dsl/SelectBuilder.scala
@@ -3,7 +3,9 @@ package typo.dsl
 import doobie.free.connection.ConnectionIO
 import doobie.util.fragment.Fragment
 
-trait SelectBuilder[Fields[_], Row] {
+trait SelectBuilder[Fields, Row] {
+  def renderCtx: RenderCtx
+  def structure: Structure[Fields, Row]
 
   /** Add a where clause to the query.
     *
@@ -16,18 +18,18 @@ trait SelectBuilder[Fields[_], Row] {
     *    .where(x => x.productline === "foo")
     * }}}
     */
-  final def where[N[_]: Nullability](v: Fields[Hidden] => SqlExpr[Boolean, N, Hidden]): SelectBuilder[Fields, Row] =
-    withParams(params.where(fields => v(fields.asInstanceOf[Fields[Hidden]]).asInstanceOf[SqlExpr[Boolean, N, Row]].?))
+  final def where[N[_]: Nullability](v: Fields => SqlExpr[Boolean, N]): SelectBuilder[Fields, Row] =
+    withParams(params.where(fields => v(fields).?))
 
-  final def maybeWhere[N[_]: Nullability, T](ot: Option[T])(v: (Fields[Hidden], T) => SqlExpr[Boolean, N, Hidden]): SelectBuilder[Fields, Row] =
+  final def maybeWhere[N[_]: Nullability, T](ot: Option[T])(v: (Fields, T) => SqlExpr[Boolean, N]): SelectBuilder[Fields, Row] =
     ot match {
       case Some(t) => where(fields => v(fields, t))
       case None    => this
     }
 
   /** Same as [[where]], but requires the expression to not be nullable */
-  final def whereStrict(v: Fields[Hidden] => SqlExpr[Boolean, Required, Hidden]): SelectBuilder[Fields, Row] =
-    withParams(params.where(fields => v(fields.asInstanceOf[Fields[Hidden]]).asInstanceOf[SqlExpr[Boolean, Required, Row]].?))
+  final def whereStrict(v: Fields => SqlExpr[Boolean, Required]): SelectBuilder[Fields, Row] =
+    withParams(params.where(fields => v(fields).?))
 
   /** Add an order by clause to the query.
     *
@@ -43,17 +45,18 @@ trait SelectBuilder[Fields[_], Row] {
     *        .orderBy { case ((_, _), productModel) => productModel(_.name).desc.withNullsFirst }
     * }}}
     */
-  final def orderBy[T, N[_]](v: Fields[Hidden] => SortOrder[T, N, Hidden]): SelectBuilder[Fields, Row] =
-    withParams(params.orderBy(v.asInstanceOf[Fields[Row] => SortOrderNoHkt[?, Row]]))
+  final def orderBy[T, N[_]](v: Fields => SortOrder[T, N]): SelectBuilder[Fields, Row] =
+    withParams(params.orderBy(v))
 
-  final def seek[T, N[_]](v: Fields[Row] => SortOrder[T, N, Row])(value: SqlExpr.Const[T, N, Row]): SelectBuilder[Fields, Row] =
-    withParams(params.seek(SelectParams.Seek[Fields, Row, T, N](v, value)))
+  final def seek[T, N[_]](v: Fields => SortOrder[T, N])(value: SqlExpr.Const[T, N]): SelectBuilder[Fields, Row] =
+    withParams(params.seek(SelectParams.Seek[Fields, T, N](v, value)))
 
-  final def maybeSeek[T, N[_]](v: Fields[Row] => SortOrder[T, N, Row])(maybeValue: Option[SqlExpr.Const[T, N, Row]]): SelectBuilder[Fields, Row] =
+  final def maybeSeek[T, N[_]](v: Fields => SortOrder[T, N])(maybeValue: Option[SqlExpr.Const[T, N]]): SelectBuilder[Fields, Row] =
     maybeValue match {
       case Some(value) => seek(v)(value)
-      case None        => orderBy(v.asInstanceOf[Fields[Hidden] => SortOrder[T, N, Hidden]])
+      case None        => orderBy(v)
     }
+
   final def offset(v: Int): SelectBuilder[Fields, Row] =
     withParams(params.offset(v))
   final def limit(v: Int): SelectBuilder[Fields, Row] =
@@ -66,10 +69,10 @@ trait SelectBuilder[Fields[_], Row] {
   def sql: Option[Fragment]
 
   /** start constructing a join */
-  final def join[F2[_], Row2](other: SelectBuilder[F2, Row2]): PartialJoin[F2, Row2] =
+  final def join[F2, Row2](other: SelectBuilder[F2, Row2]): PartialJoin[F2, Row2] =
     new PartialJoin[F2, Row2](other)
 
-  final class PartialJoin[Fields2[_], Row2](other: SelectBuilder[Fields2, Row2]) {
+  final class PartialJoin[Fields2, Row2](other: SelectBuilder[Fields2, Row2]) {
 
     /** inner join with the given predicate
       * {{{
@@ -78,12 +81,12 @@ trait SelectBuilder[Fields[_], Row] {
       *   .on { case (p, um) => p.sizeunitmeasurecode === um.unitmeasurecode }
       * }}}
       */
-    def on[N[_]: Nullability](pred: Joined[Fields, Fields2, Hidden] => SqlExpr[Boolean, N, Hidden]): SelectBuilder[Joined[Fields, Fields2, *], (Row, Row2)] =
-      joinOn(other)(pred.asInstanceOf[Joined[Fields, Fields2, (Row, Row2)] => SqlExpr[Boolean, N, (Row, Row2)]])
+    def on[N[_]: Nullability](pred: Joined[Fields, Fields2] => SqlExpr[Boolean, N]): SelectBuilder[Joined[Fields, Fields2], (Row, Row2)] =
+      joinOn(other)(pred)
 
     /** Variant of `on` that requires the join predicate to not be nullable */
-    def onStrict(pred: Joined[Fields, Fields2, Hidden] => SqlExpr[Boolean, Required, Hidden]): SelectBuilder[Joined[Fields, Fields2, *], (Row, Row2)] =
-      joinOn(other)(pred.asInstanceOf[Joined[Fields, Fields2, (Row, Row2)] => SqlExpr[Boolean, Required, (Row, Row2)]])
+    def onStrict(pred: Joined[Fields, Fields2] => SqlExpr[Boolean, Required]): SelectBuilder[Joined[Fields, Fields2], (Row, Row2)] =
+      joinOn(other)(pred)
 
     /** left join with the given predicate
       * {{{
@@ -92,23 +95,23 @@ trait SelectBuilder[Fields[_], Row] {
       * .leftOn { case (p, pm) => p.productmodelid === pm.productmodelid }
       * }}}
       */
-    def leftOn[N[_]: Nullability](pred: Joined[Fields, Fields2, Hidden] => SqlExpr[Boolean, N, Hidden]): SelectBuilder[LeftJoined[Fields, Fields2, *], (Row, Option[Row2])] =
-      leftJoinOn(other)(pred.asInstanceOf[Joined[Fields, Fields2, (Row, Row2)] => SqlExpr[Boolean, N, (Row, Row2)]])
+    def leftOn[N[_]: Nullability](pred: Joined[Fields, Fields2] => SqlExpr[Boolean, N]): SelectBuilder[LeftJoined[Fields, Fields2], (Row, Option[Row2])] =
+      leftJoinOn(other)(pred)
 
     /** Variant of `leftOn` that requires the join predicate to not be nullable */
-    def leftOnStrict(pred: Joined[Fields, Fields2, Hidden] => SqlExpr[Boolean, Required, Hidden]): SelectBuilder[LeftJoined[Fields, Fields2, *], (Row, Option[Row2])] =
-      leftJoinOn(other)(pred.asInstanceOf[Joined[Fields, Fields2, (Row, Row2)] => SqlExpr[Boolean, Required, (Row, Row2)]])
+    def leftOnStrict(pred: Joined[Fields, Fields2] => SqlExpr[Boolean, Required]): SelectBuilder[LeftJoined[Fields, Fields2], (Row, Option[Row2])] =
+      leftJoinOn(other)(pred)
   }
 
   protected def params: SelectParams[Fields, Row]
 
   protected def withParams(sqlParams: SelectParams[Fields, Row]): SelectBuilder[Fields, Row]
 
-  protected def joinOn[Fields2[_], N[_]: Nullability, Row2](other: SelectBuilder[Fields2, Row2])(
-      pred: Joined[Fields, Fields2, (Row, Row2)] => SqlExpr[Boolean, N, (Row, Row2)]
-  ): SelectBuilder[Joined[Fields, Fields2, *], (Row, Row2)]
+  protected def joinOn[Fields2, N[_]: Nullability, Row2](other: SelectBuilder[Fields2, Row2])(
+      pred: Joined[Fields, Fields2] => SqlExpr[Boolean, N]
+  ): SelectBuilder[Joined[Fields, Fields2], (Row, Row2)]
 
-  protected def leftJoinOn[Fields2[_], N[_]: Nullability, Row2](other: SelectBuilder[Fields2, Row2])(
-      pred: Joined[Fields, Fields2, (Row, Row2)] => SqlExpr[Boolean, N, (Row, Row2)]
-  ): SelectBuilder[LeftJoined[Fields, Fields2, *], (Row, Option[Row2])]
+  protected def leftJoinOn[Fields2, N[_]: Nullability, Row2](other: SelectBuilder[Fields2, Row2])(
+      pred: Joined[Fields, Fields2] => SqlExpr[Boolean, N]
+  ): SelectBuilder[LeftJoined[Fields, Fields2], (Row, Option[Row2])]
 }

--- a/typo-dsl-doobie/src/scala/typo/dsl/SelectBuilderMock.scala
+++ b/typo-dsl-doobie/src/scala/typo/dsl/SelectBuilderMock.scala
@@ -5,26 +5,32 @@ import doobie.util.fragment.Fragment
 import typo.dsl.internal.mocks.RowOrdering
 import typo.dsl.internal.seeks
 
-case class SelectBuilderMock[Fields[_], Row](
+final case class SelectBuilderMock[Fields, Row](
     structure: Structure[Fields, Row],
     all: ConnectionIO[List[Row]],
     params: SelectParams[Fields, Row]
 ) extends SelectBuilder[Fields, Row] {
+  def withPath(path: Path): SelectBuilderMock[Fields, Row] =
+    copy(structure = structure.withPath(path))
+
+  override val renderCtx: RenderCtx = RenderCtx.Empty
+
   override def withParams(sqlParams: SelectParams[Fields, Row]): SelectBuilder[Fields, Row] =
     copy(params = sqlParams)
 
   override def toList: ConnectionIO[List[Row]] =
-    all.map(all => SelectBuilderMock.applyParams(structure.fields, all, params))
+    all.map(all => SelectBuilderMock.applyParams(structure, all, params))
 
-  override def joinOn[Fields2[_], N[_]: Nullability, Row2](
+  override def joinOn[Fields2, N[_]: Nullability, Row2](
       other: SelectBuilder[Fields2, Row2]
-  )(pred: Joined[Fields, Fields2, (Row, Row2)] => SqlExpr[Boolean, N, (Row, Row2)]): SelectBuilder[Joined[Fields, Fields2, *], (Row, Row2)] = {
-    def otherMock: SelectBuilderMock[Fields2, Row2] = other match {
-      case x: SelectBuilderMock[Fields2, Row2] => x
+  )(pred: Joined[Fields, Fields2] => SqlExpr[Boolean, N]): SelectBuilderMock[Joined[Fields, Fields2], (Row, Row2)] = {
+    val otherMock: SelectBuilderMock[Fields2, Row2] = other match {
+      case x: SelectBuilderMock[Fields2, Row2] => x.withPath(Path.RightInJoin)
       case _                                   => sys.error("you cannot mix mock and sql repos")
     }
 
-    val newStructure = structure.join(otherMock.structure)
+    val self = this.withPath(Path.LeftInJoin)
+    val newStructure = self.structure.join(otherMock.structure)
 
     val newRows: ConnectionIO[List[(Row, Row2)]] =
       for {
@@ -34,44 +40,46 @@ case class SelectBuilderMock[Fields[_], Row](
         left <- lefts
         right <- rights
         newRow = (left, right)
-        if Nullability[N].toOpt(pred(newStructure.fields).eval(newRow)).getOrElse(false)
+        if Nullability[N].toOpt(newStructure.untypedEval(pred(newStructure.fields), newRow)).getOrElse(false)
       } yield newRow
 
-    SelectBuilderMock[Joined[Fields, Fields2, *], (Row, Row2)](newStructure, newRows, SelectParams.empty)
+    SelectBuilderMock[Joined[Fields, Fields2], (Row, Row2)](newStructure, newRows, SelectParams.empty)
   }
-  override def leftJoinOn[Fields2[_], N[_]: Nullability, Row2](other: SelectBuilder[Fields2, Row2])(
-      pred: Joined[Fields, Fields2, (Row, Row2)] => SqlExpr[Boolean, N, (Row, Row2)]
-  ): SelectBuilder[LeftJoined[Fields, Fields2, *], (Row, Option[Row2])] = {
-    def otherMock: SelectBuilderMock[Fields2, Row2] = other match {
-      case x: SelectBuilderMock[Fields2, Row2] => x
+  override def leftJoinOn[Fields2, N[_]: Nullability, Row2](
+      other: SelectBuilder[Fields2, Row2]
+  )(pred: Joined[Fields, Fields2] => SqlExpr[Boolean, N]): SelectBuilder[LeftJoined[Fields, Fields2], (Row, Option[Row2])] = {
+    val otherMock: SelectBuilderMock[Fields2, Row2] = other match {
+      case x: SelectBuilderMock[Fields2, Row2] => x.withPath(Path.RightInJoin)
       case _                                   => sys.error("you cannot mix mock and sql repos")
     }
+    val self = this.withPath(Path.LeftInJoin)
 
     val newRows: ConnectionIO[List[(Row, Option[Row2])]] = {
       for {
-        lefts <- this.toList
+        lefts <- self.toList
         rights <- otherMock.toList
       } yield {
         lefts.map { left =>
           val maybeRight = rights.find { right =>
-            Nullability[N].toOpt(pred(structure.join(otherMock.structure).fields).eval((left, right))).getOrElse(false)
+            val newStructure = structure.join(otherMock.structure)
+            Nullability[N].toOpt(newStructure.untypedEval(pred(newStructure.fields), (left, right))).getOrElse(false)
           }
           (left, maybeRight)
         }
       }
     }
-    SelectBuilderMock[LeftJoined[Fields, Fields2, *], (Row, Option[Row2])](structure.leftJoin(otherMock.structure), newRows, SelectParams.empty)
+    SelectBuilderMock[LeftJoined[Fields, Fields2], (Row, Option[Row2])](self.structure.leftJoin(otherMock.structure), newRows, SelectParams.empty)
   }
 
   override def sql: Option[Fragment] = None
 }
 
 object SelectBuilderMock {
-  def applyParams[Fields[_], Row](fields: Fields[Row], rows: List[Row], params: SelectParams[Fields, Row]): List[Row] = {
-    val (filters, orderBys) = seeks.expand(fields, params)
-    implicit val rowOrdering: Ordering[Row] = new RowOrdering(orderBys)
+  def applyParams[Fields, R](structure: Structure[Fields, R], rows: List[R], params: SelectParams[Fields, R]): List[R] = {
+    val (filters, orderBys) = seeks.expand(structure.fields, params)
+    implicit val rowOrdering: Ordering[R] = new RowOrdering(structure, orderBys)
     rows
-      .filter(row => filters.forall(_.eval(row).getOrElse(false)))
+      .filter(row => filters.forall(expr => structure.untypedEval(expr, row).getOrElse(false)))
       .sorted
       .drop(params.offset.getOrElse(0))
       .take(params.limit.getOrElse(Int.MaxValue))

--- a/typo-dsl-doobie/src/scala/typo/dsl/SortOrder.scala
+++ b/typo-dsl-doobie/src/scala/typo/dsl/SortOrder.scala
@@ -4,25 +4,22 @@ import cats.syntax.foldable.*
 import doobie.implicits.toSqlInterpolator
 import doobie.util.fragment.Fragment
 
-import java.util.concurrent.atomic.AtomicInteger
-
-sealed trait SortOrderNoHkt[NT, R] {
-  val expr: SqlExpr.SqlExprNoHkt[NT, R]
+sealed trait SortOrderNoHkt[NT] {
+  val expr: SqlExpr.SqlExprNoHkt[NT]
   val ascending: Boolean
   val nullsFirst: Boolean
 
-  def withNullsFirst: SortOrderNoHkt[NT, R]
+  def withNullsFirst: SortOrderNoHkt[NT]
 
-  def render(counter: AtomicInteger): Fragment =
-    List[Fragment](
-      expr.render(counter),
+  def render(ctx: RenderCtx): Fragment =
+    List(
+      expr.render(ctx),
       if (ascending) fr"ASC" else fr"DESC",
       if (nullsFirst) fr"NULLS FIRST" else Fragment.empty
     ).intercalate(fr" ")
 }
 
 // sort by a field
-final case class SortOrder[T, N[_], R](expr: SqlExpr[T, N, R], ascending: Boolean, nullsFirst: Boolean)(implicit val ordering: Ordering[T], val nullability: Nullability[N])
-    extends SortOrderNoHkt[N[T], R] {
-  def withNullsFirst: SortOrder[T, N, R] = copy(nullsFirst = true)(ordering, nullability)
+final case class SortOrder[T, N[_]](expr: SqlExpr[T, N], ascending: Boolean, nullsFirst: Boolean)(implicit val ordering: Ordering[T], val nullability: Nullability[N]) extends SortOrderNoHkt[N[T]] {
+  def withNullsFirst: SortOrder[T, N] = copy(nullsFirst = true)(ordering, nullability)
 }

--- a/typo-dsl-doobie/src/scala/typo/dsl/SqlExpr.scala
+++ b/typo-dsl-doobie/src/scala/typo/dsl/SqlExpr.scala
@@ -5,145 +5,135 @@ import doobie.Fragment
 import doobie.implicits.toSqlInterpolator
 import doobie.util.{Put, Write}
 
-import java.util.concurrent.atomic.AtomicInteger
 import scala.reflect.ClassTag
 
-trait SqlExpr[T, N[_], R] extends SqlExpr.SqlExprNoHkt[N[T], R] {
-  final def isEqual[N2[_], NC[_]](t: SqlExpr[T, N2, R])(implicit O: Ordering[T], N: Nullability2[N, N2, NC]): SqlExpr[Boolean, NC, R] =
+sealed trait SqlExpr[T, N[_]] extends SqlExpr.SqlExprNoHkt[N[T]] {
+  final def isEqual[N2[_], NC[_]](t: SqlExpr[T, N2])(implicit O: Ordering[T], N: Nullability2[N, N2, NC]): SqlExpr[Boolean, NC] =
     this === t
 
-  final def isNotEqual[N2[_], NC[_]](t: SqlExpr[T, N2, R])(implicit O: Ordering[T], N: Nullability2[N, N2, NC]): SqlExpr[Boolean, NC, R] =
+  final def isNotEqual[N2[_], NC[_]](t: SqlExpr[T, N2])(implicit O: Ordering[T], N: Nullability2[N, N2, NC]): SqlExpr[Boolean, NC] =
     this !== t
 
-  final def ===[N2[_], NC[_]](t: SqlExpr[T, N2, R])(implicit O: Ordering[T], N: Nullability2[N, N2, NC]): SqlExpr[Boolean, NC, R] =
+  final def ===[N2[_], NC[_]](t: SqlExpr[T, N2])(implicit O: Ordering[T], N: Nullability2[N, N2, NC]): SqlExpr[Boolean, NC] =
     SqlExpr.Binary(this, SqlOperator.eq, t, N)
 
-  final def !==[N2[_], NC[_]](t: SqlExpr[T, N2, R])(implicit O: Ordering[T], N: Nullability2[N, N2, NC]): SqlExpr[Boolean, NC, R] =
+  final def !==[N2[_], NC[_]](t: SqlExpr[T, N2])(implicit O: Ordering[T], N: Nullability2[N, N2, NC]): SqlExpr[Boolean, NC] =
     SqlExpr.Binary(this, SqlOperator.neq, t, N)
 
-  final def >[N2[_], NC[_]](t: SqlExpr[T, N2, R])(implicit O: Ordering[T], N: Nullability2[N, N2, NC]): SqlExpr[Boolean, NC, R] =
+  final def >[N2[_], NC[_]](t: SqlExpr[T, N2])(implicit O: Ordering[T], N: Nullability2[N, N2, NC]): SqlExpr[Boolean, NC] =
     SqlExpr.Binary(this, SqlOperator.gt, t, N)
 
-  final def >=[N2[_], NC[_]](t: SqlExpr[T, N2, R])(implicit O: Ordering[T], N: Nullability2[N, N2, NC]): SqlExpr[Boolean, NC, R] =
+  final def >=[N2[_], NC[_]](t: SqlExpr[T, N2])(implicit O: Ordering[T], N: Nullability2[N, N2, NC]): SqlExpr[Boolean, NC] =
     SqlExpr.Binary(this, SqlOperator.gte, t, N)
 
-  final def <[N2[_], NC[_]](t: SqlExpr[T, N2, R])(implicit O: Ordering[T], N: Nullability2[N, N2, NC]): SqlExpr[Boolean, NC, R] =
+  final def <[N2[_], NC[_]](t: SqlExpr[T, N2])(implicit O: Ordering[T], N: Nullability2[N, N2, NC]): SqlExpr[Boolean, NC] =
     SqlExpr.Binary(this, SqlOperator.lt, t, N)
 
-  final def <=[N2[_], NC[_]](t: SqlExpr[T, N2, R])(implicit O: Ordering[T], N: Nullability2[N, N2, NC]): SqlExpr[Boolean, NC, R] =
+  final def <=[N2[_], NC[_]](t: SqlExpr[T, N2])(implicit O: Ordering[T], N: Nullability2[N, N2, NC]): SqlExpr[Boolean, NC] =
     SqlExpr.Binary(this, SqlOperator.lte, t, N)
 
-  final infix def or[N2[_], NC[_]](other: SqlExpr[T, N2, R])(implicit B: Bijection[T, Boolean], N: Nullability2[N, N2, NC]): SqlExpr[T, NC, R] =
+  final infix def or[N2[_], NC[_]](other: SqlExpr[T, N2])(implicit B: Bijection[T, Boolean], N: Nullability2[N, N2, NC]): SqlExpr[T, NC] =
     SqlExpr.Binary(this, SqlOperator.or[T], other, N)
 
-  final infix def and[N2[_], NC[_]](other: SqlExpr[T, N2, R])(implicit B: Bijection[T, Boolean], N: Nullability2[N, N2, NC]): SqlExpr[T, NC, R] =
+  final infix def and[N2[_], NC[_]](other: SqlExpr[T, N2])(implicit B: Bijection[T, Boolean], N: Nullability2[N, N2, NC]): SqlExpr[T, NC] =
     SqlExpr.Binary(this, SqlOperator.and[T], other, N)
 
-  def unary_!(implicit B: Bijection[T, Boolean], N: Nullability[N]): SqlExpr[T, N, R] =
+  def unary_!(implicit B: Bijection[T, Boolean], N: Nullability[N]): SqlExpr[T, N] =
     SqlExpr.Not(this, B, N)
 
-  final def +[N2[_], NC[_]](t: SqlExpr[T, N2, R])(implicit Num: Numeric[T], N: Nullability2[N, N2, NC]): SqlExpr[T, NC, R] =
+  final def +[N2[_], NC[_]](t: SqlExpr[T, N2])(implicit Num: Numeric[T], N: Nullability2[N, N2, NC]): SqlExpr[T, NC] =
     plus(t)
-  final def plus[N2[_], NC[_]](t: SqlExpr[T, N2, R])(implicit Num: Numeric[T], N: Nullability2[N, N2, NC]): SqlExpr[T, NC, R] =
+  final def plus[N2[_], NC[_]](t: SqlExpr[T, N2])(implicit Num: Numeric[T], N: Nullability2[N, N2, NC]): SqlExpr[T, NC] =
     SqlExpr.Binary(this, SqlOperator.plus, t, N)
 
-  final def -[N2[_], NC[_]](t: SqlExpr[T, N2, R])(implicit Num: Numeric[T], N: Nullability2[N, N2, NC]): SqlExpr[T, NC, R] =
+  final def -[N2[_], NC[_]](t: SqlExpr[T, N2])(implicit Num: Numeric[T], N: Nullability2[N, N2, NC]): SqlExpr[T, NC] =
     sub(t)
-  final def sub[N2[_], NC[_]](t: SqlExpr[T, N2, R])(implicit Num: Numeric[T], N: Nullability2[N, N2, NC]): SqlExpr[T, NC, R] =
+  final def sub[N2[_], NC[_]](t: SqlExpr[T, N2])(implicit Num: Numeric[T], N: Nullability2[N, N2, NC]): SqlExpr[T, NC] =
     SqlExpr.Binary(this, SqlOperator.minus, t, N)
 
-  final def *[N2[_], NC[_]](t: SqlExpr[T, N2, R])(implicit Num: Numeric[T], N: Nullability2[N, N2, NC]): SqlExpr[T, NC, R] =
+  final def *[N2[_], NC[_]](t: SqlExpr[T, N2])(implicit Num: Numeric[T], N: Nullability2[N, N2, NC]): SqlExpr[T, NC] =
     mul(t)
-  final def mul[N2[_], NC[_]](t: SqlExpr[T, N2, R])(implicit Num: Numeric[T], N: Nullability2[N, N2, NC]): SqlExpr[T, NC, R] =
+  final def mul[N2[_], NC[_]](t: SqlExpr[T, N2])(implicit Num: Numeric[T], N: Nullability2[N, N2, NC]): SqlExpr[T, NC] =
     SqlExpr.Binary(this, SqlOperator.mul, t, N)
 
-  final def underlying[TT](implicit B: Bijection[T, TT], N: Nullability[N]): SqlExpr[TT, N, R] =
+  final def underlying[TT](implicit B: Bijection[T, TT], N: Nullability[N]): SqlExpr[TT, N] =
     SqlExpr.Underlying(this, B, N)
 
-  final def like(str: String)(implicit B: Bijection[T, String], N: Nullability[N]): SqlExpr[Boolean, N, R] =
+  final def like(str: String)(implicit B: Bijection[T, String], N: Nullability[N]): SqlExpr[Boolean, N] =
     SqlExpr.Binary(this, SqlOperator.like, SqlExpr.asConstRequired(str), N.withRequired)
 
-  final def ||[N2[_], NC[_]](other: SqlExpr[T, N2, R])(implicit B: Bijection[T, String], N: Nullability2[N, N2, NC]): SqlExpr[T, NC, R] =
+  final def ||[N2[_], NC[_]](other: SqlExpr[T, N2])(implicit B: Bijection[T, String], N: Nullability2[N, N2, NC]): SqlExpr[T, NC] =
     stringAppend(other)
-  final def stringAppend[N2[_], NC[_]](other: SqlExpr[T, N2, R])(implicit B: Bijection[T, String], N: Nullability2[N, N2, NC]): SqlExpr[T, NC, R] =
+  final def stringAppend[N2[_], NC[_]](other: SqlExpr[T, N2])(implicit B: Bijection[T, String], N: Nullability2[N, N2, NC]): SqlExpr[T, NC] =
     SqlExpr.Binary(this, SqlOperator.strAdd, other, N)
 
-  final def lower(implicit B: Bijection[T, String], N: Nullability[N]): SqlExpr[T, N, R] =
+  final def lower(implicit B: Bijection[T, String], N: Nullability[N]): SqlExpr[T, N] =
     SqlExpr.Apply1(SqlFunction1.lower, this, N)
 
-  final def reverse(implicit B: Bijection[T, String], N: Nullability[N]): SqlExpr[T, N, R] =
+  final def reverse(implicit B: Bijection[T, String], N: Nullability[N]): SqlExpr[T, N] =
     SqlExpr.Apply1(SqlFunction1.reverse, this, N)
 
-  final def upper(implicit B: Bijection[T, String], N: Nullability[N]): SqlExpr[T, N, R] =
+  final def upper(implicit B: Bijection[T, String], N: Nullability[N]): SqlExpr[T, N] =
     SqlExpr.Apply1(SqlFunction1.upper, this, N)
 
-  final def strpos[N2[_], NC[_]](substring: SqlExpr[String, N2, R])(implicit B: Bijection[T, String], N: Nullability2[N, N2, NC]): SqlExpr[Int, NC, R] =
+  final def strpos[N2[_], NC[_]](substring: SqlExpr[String, N2])(implicit B: Bijection[T, String], N: Nullability2[N, N2, NC]): SqlExpr[Int, NC] =
     SqlExpr.Apply2(SqlFunction2.strpos, this, substring, N)
 
-  final def strLength(implicit B: Bijection[T, String], N: Nullability[N]): SqlExpr[Int, N, R] =
+  final def strLength(implicit B: Bijection[T, String], N: Nullability[N]): SqlExpr[Int, N] =
     SqlExpr.Apply1(SqlFunction1.length, this, N)
 
-  final def substring[N2[_], N3[_], NC[_]](from: SqlExpr[Int, N2, R], count: SqlExpr[Int, N3, R])(implicit
+  final def substring[N2[_], N3[_], NC[_]](from: SqlExpr[Int, N2], count: SqlExpr[Int, N3])(implicit
       B: Bijection[T, String],
       N: Nullability3[N, N2, N3, NC]
-  ): SqlExpr[T, NC, R] =
+  ): SqlExpr[T, NC] =
     SqlExpr.Apply3(SqlFunction3.substring[T](), this, from, count, N)
 
-  final infix def in(ts: Array[T])(implicit ev: Put[Array[T]], N: Nullability[N]): SqlExpr[Boolean, N, R] =
+  final infix def in(ts: Array[T])(implicit ev: Put[Array[T]], N: Nullability[N]): SqlExpr[Boolean, N] =
     SqlExpr.In(this, ts, ev, N)
 
-  final def ?(implicit N: Nullability[N]): SqlExpr[T, Option, R] = opt
-  final def opt(implicit N: Nullability[N]): SqlExpr[T, Option, R] = SqlExpr.ToNullable(this, N)
+  final def ?(implicit N: Nullability[N]): SqlExpr[T, Option] = opt
+  final def opt(implicit N: Nullability[N]): SqlExpr[T, Option] = SqlExpr.ToNullable(this, N)
 }
 
 object SqlExpr {
-  trait SqlExprNoHkt[NT, R] {
-    def eval(row: R): NT
-
-    def render(counter: AtomicInteger): Fragment
+  sealed trait SqlExprNoHkt[NT] {
+    def render(ctx: RenderCtx): Fragment
   }
 
-  sealed trait FieldLikeNoHkt[NT, Row] extends SqlExprNoHkt[NT, Row] {
-    private[typo] val prefix: Option[String]
-    private[typo] val name: String
-    private[typo] val get: Row => NT
-    private[typo] val set: (Row, NT) => Row
-    private[typo] val sqlReadCast: Option[String]
-    private[typo] val sqlWriteCast: Option[String]
-
-    final def value: String = prefix.fold("")(_ + ".") + name
+  sealed trait FieldLikeNoHkt[NT, R] extends SqlExprNoHkt[NT] with Product {
+    val path: List[Path]
+    val name: String
+    val get: R => NT
+    val set: (R, NT) => R
+    val sqlReadCast: Option[String]
+    val sqlWriteCast: Option[String]
+    final def value(ctx: RenderCtx): String = ctx.alias.get(path).fold("")(_ + ".") + name
+    final def render(ctx: RenderCtx): Fragment = Fragment.const0(value(ctx))
   }
 
   sealed trait FieldLikeNotIdNoHkt[NT, R] extends FieldLikeNoHkt[NT, R]
 
-  sealed abstract class FieldLike[T, N[_], R](val prefix: Option[String], val name: String, val sqlReadCast: Option[String], val sqlWriteCast: Option[String])(
-      val get: R => N[T],
-      val set: (R, N[T]) => R
-  ) extends SqlExpr[T, N, R]
-      with FieldLikeNoHkt[N[T], R] {
-    override def eval(row: R): N[T] = get(row)
-    override def render(counter: AtomicInteger): Fragment = Fragment.const0(value)
+  sealed trait FieldLike[T, N[_], R] extends SqlExpr[T, N] with FieldLikeNoHkt[N[T], R] with Product {
+    val path: List[Path]
+    val name: String
+    val sqlReadCast: Option[String]
+    val sqlWriteCast: Option[String]
+    val get: R => N[T]
+    val set: (R, N[T]) => R
   }
 
   sealed trait FieldLikeNotId[T, N[_], R] extends FieldLike[T, N, R] with FieldLikeNotIdNoHkt[N[T], R]
 
   // connect a field `name` to a type `T` for a relation `R`
-  class Field[T, R](prefix: Option[String], name: String, sqlReadCast: Option[String] = None, sqlWriteCast: Option[String] = None)(get: R => T, set: (R, T) => R)
-      extends FieldLike[T, Required, R](prefix, name, sqlReadCast, sqlWriteCast)(get, set)
-      with FieldLikeNotId[T, Required, R]
+  case class Field[T, R](path: List[Path], name: String, sqlReadCast: Option[String], sqlWriteCast: Option[String], get: R => T, set: (R, T) => R) extends FieldLikeNotId[T, Required, R]
 
-  class IdField[T, R](prefix: Option[String], name: String, sqlReadCast: Option[String] = None, sqlWriteCast: Option[String] = None)(get: R => T, set: (R, T) => R)
-      extends FieldLike[T, Required, R](prefix, name, sqlReadCast, sqlWriteCast)(get, set)
+  case class IdField[T, R](path: List[Path], name: String, sqlReadCast: Option[String], sqlWriteCast: Option[String], get: R => T, set: (R, T) => R) extends FieldLike[T, Required, R]
 
-  class OptField[T, R](prefix: Option[String], name: String, sqlReadCast: Option[String] = None, sqlWriteCast: Option[String] = None)(get: R => Option[T], set: (R, Option[T]) => R)
-      extends FieldLike[T, Option, R](prefix, name, sqlReadCast, sqlWriteCast)(get, set)
-      with FieldLikeNotId[T, Option, R]
+  case class OptField[T, R](path: List[Path], name: String, sqlReadCast: Option[String], sqlWriteCast: Option[String], get: R => Option[T], set: (R, Option[T]) => R)
+      extends FieldLikeNotId[T, Option, R]
 
-  case class Const[T, N[_], R](value: N[T], P: Put[T], W: Write[N[T]]) extends SqlExpr[T, N, R] {
-    override def eval(row: R): N[T] =
-      value
-
-    override def render(counter: AtomicInteger): Fragment = {
+  case class Const[T, N[_]](value: N[T], P: Put[T], W: Write[N[T]]) extends SqlExpr[T, N] {
+    override def render(ctx: RenderCtx): Fragment = {
       val cast = P match {
         case _: Put.Basic[_]    => Fragment.empty
         case p: Put.Advanced[_] => Fragment.const0(s"::${p.schemaTypes.head}")
@@ -151,144 +141,115 @@ object SqlExpr {
       fr"${W.toFragment(value)}$cast"
     }
   }
+
   object Const {
-    trait As[T, N[_], R] {
-      def apply(value: N[T]): SqlExpr.Const[T, N, R]
+    trait As[T, N[_]] {
+      def apply(value: N[T]): SqlExpr.Const[T, N]
     }
 
     object As {
-      implicit def as[T, N[_], R](implicit P: Put[T], W: Write[N[T]]): As[T, N, R] =
+      implicit def as[T, N[_], R](implicit P: Put[T], W: Write[N[T]]): As[T, N] =
         (value: N[T]) => SqlExpr.Const(value, P, W)
     }
   }
 
-  case class ArrayIndex[T, N1[_], N2[_], R](arr: SqlExpr[Array[T], N1, R], idx: SqlExpr[Int, N2, R], N: Nullability2[N1, N2, Option]) extends SqlExpr[T, Option, R] {
-    override def eval(row: R): Option[T] = {
-      N.mapN(arr.eval(row), idx.eval(row)) { (arr, idx) =>
-        if (idx < 0 || idx >= arr.length) None
-        else Some(arr(idx))
-      }.flatten
-    }
-
-    override def render(counter: AtomicInteger): Fragment =
-      fr"${arr.render(counter)}[${idx.render(counter)}]"
+  case class ArrayIndex[T, N1[_], N2[_]](arr: SqlExpr[Array[T], N1], idx: SqlExpr[Int, N2], N: Nullability2[N1, N2, Option]) extends SqlExpr[T, Option] {
+    override def render(ctx: RenderCtx): Fragment =
+      fr"${arr.render(ctx)}[${idx.render(ctx)}]"
   }
 
-  case class Apply1[T1, O, N[_], R](f: SqlFunction1[T1, O], arg1: SqlExpr[T1, N, R], N: Nullability[N]) extends SqlExpr[O, N, R] {
-    override def eval(row: R): N[O] =
-      N.mapN(arg1.eval(row))(f.eval)
-    override def render(counter: AtomicInteger): Fragment =
-      fr"${Fragment.const0(f.name)}(${arg1.render(counter)})"
+  case class Apply1[T1, O, N[_]](f: SqlFunction1[T1, O], arg1: SqlExpr[T1, N], N: Nullability[N]) extends SqlExpr[O, N] {
+    override def render(ctx: RenderCtx): Fragment =
+      fr"${Fragment.const0(f.name)}(${arg1.render(ctx)})"
   }
 
-  case class Apply2[T1, T2, O, N1[_], N2[_], N[_], R](f: SqlFunction2[T1, T2, O], arg1: SqlExpr[T1, N1, R], arg2: SqlExpr[T2, N2, R], N: Nullability2[N1, N2, N]) extends SqlExpr[O, N, R] {
-    override def eval(row: R): N[O] =
-      N.mapN(arg1.eval(row), arg2.eval(row))(f.eval)
-    override def render(counter: AtomicInteger): Fragment =
-      fr"${Fragment.const0(f.name)}(${arg1.render(counter)}, ${arg2.render(counter)})"
+  case class Apply2[T1, T2, O, N1[_], N2[_], N[_]](f: SqlFunction2[T1, T2, O], arg1: SqlExpr[T1, N1], arg2: SqlExpr[T2, N2], N: Nullability2[N1, N2, N]) extends SqlExpr[O, N] {
+    override def render(ctx: RenderCtx): Fragment =
+      fr"${Fragment.const0(f.name)}(${arg1.render(ctx)}, ${arg2.render(ctx)})"
   }
 
-  case class Apply3[T1, T2, T3, N1[_], N2[_], N3[_], N[_], O, R](
+  case class Apply3[T1, T2, T3, N1[_], N2[_], N3[_], N[_], O](
       f: SqlFunction3[T1, T2, T3, O],
-      arg1: SqlExpr[T1, N1, R],
-      arg2: SqlExpr[T2, N2, R],
-      arg3: SqlExpr[T3, N3, R],
+      arg1: SqlExpr[T1, N1],
+      arg2: SqlExpr[T2, N2],
+      arg3: SqlExpr[T3, N3],
       N: Nullability3[N1, N2, N3, N]
-  ) extends SqlExpr[O, N, R] {
-    override def eval(row: R): N[O] =
-      N.mapN(arg1.eval(row), arg2.eval(row), arg3.eval(row))(f.eval)
-    override def render(counter: AtomicInteger): Fragment =
-      fr"${Fragment.const0(f.name)}(${arg1.render(counter)}, ${arg2.render(counter)}, ${arg3.render(counter)})"
+  ) extends SqlExpr[O, N] {
+    override def render(ctx: RenderCtx): Fragment =
+      fr"${Fragment.const0(f.name)}(${arg1.render(ctx)}, ${arg2.render(ctx)}, ${arg3.render(ctx)})"
   }
 
-  case class Binary[T1, T2, O, N1[_], N2[_], N[_], R](left: SqlExpr[T1, N1, R], op: SqlOperator[T1, T2, O], right: SqlExpr[T2, N2, R], N: Nullability2[N1, N2, N]) extends SqlExpr[O, N, R] {
-    override def eval(row: R): N[O] =
-      N.mapN(left.eval(row), right.eval(row))(op.eval)
-    override def render(counter: AtomicInteger): Fragment =
-      fr"(${left.render(counter)} ${Fragment.const0(op.name)} ${right.render(counter)})"
+  case class Binary[T1, T2, O, N1[_], N2[_], N[_]](left: SqlExpr[T1, N1], op: SqlOperator[T1, T2, O], right: SqlExpr[T2, N2], N: Nullability2[N1, N2, N]) extends SqlExpr[O, N] {
+    override def render(ctx: RenderCtx): Fragment =
+      fr"(${left.render(ctx)} ${Fragment.const0(op.name)} ${right.render(ctx)})"
   }
 
-  case class Underlying[T, TT, N[_], R](expr: SqlExpr[T, N, R], bijection: Bijection[T, TT], N: Nullability[N]) extends SqlExpr[TT, N, R] {
-    override def eval(row: R): N[TT] =
-      N.mapN(expr.eval(row))(bijection.underlying)
-    override def render(counter: AtomicInteger): Fragment =
-      expr.render(counter)
+  case class Underlying[T, TT, N[_]](expr: SqlExpr[T, N], bijection: Bijection[T, TT], N: Nullability[N]) extends SqlExpr[TT, N] {
+    override def render(ctx: RenderCtx): Fragment =
+      expr.render(ctx)
   }
 
-  case class Coalesce[T, R](expr: SqlExpr[T, Option, R], getOrElse: SqlExpr[T, Required, R]) extends SqlExpr[T, Required, R] {
-    override def eval(row: R): T =
-      expr.eval(row).getOrElse(getOrElse.eval(row))
-    override def render(counter: AtomicInteger): Fragment =
-      fr"coalesce(${expr.render(counter)}, ${getOrElse.render(counter)})"
+  case class Coalesce[T](expr: SqlExpr[T, Option], getOrElse: SqlExpr[T, Required]) extends SqlExpr[T, Required] {
+    override def render(ctx: RenderCtx): Fragment =
+      fr"coalesce(${expr.render(ctx)}, ${getOrElse.render(ctx)})"
   }
 
-  case class In[T, N[_], R](expr: SqlExpr[T, N, R], values: Array[T], ev: Put[Array[T]], N: Nullability[N]) extends SqlExpr[Boolean, N, R] {
-    override def eval(row: R): N[Boolean] =
-      N.mapN(expr.eval(row))(values.contains)
-
-    override def render(counter: AtomicInteger): Fragment =
-      fr"${expr.render(counter)} = ANY(${Write.fromPut(ev).toFragment(values)})"
+  case class In[T, N[_]](expr: SqlExpr[T, N], values: Array[T], ev: Put[Array[T]], N: Nullability[N]) extends SqlExpr[Boolean, N] {
+    override def render(ctx: RenderCtx): Fragment =
+      fr"${expr.render(ctx)} = ANY(${Write.fromPut(ev).toFragment(values)})"
   }
 
-  case class IsNull[T, R](expr: SqlExpr[T, Option, R]) extends SqlExpr[Boolean, Required, R] {
-    override def eval(row: R): Boolean =
-      expr.eval(row).isEmpty
-    override def render(counter: AtomicInteger): Fragment =
-      fr"${expr.render(counter)} IS NULL"
+  final case class IsNull[T](expr: SqlExpr[T, Option]) extends SqlExpr[Boolean, Required] {
+    override def render(ctx: RenderCtx): Fragment =
+      fr"${expr.render(ctx)} IS NULL"
   }
 
-  case class Not[T, N[_], R](expr: SqlExpr[T, N, R], B: Bijection[T, Boolean], N: Nullability[N]) extends SqlExpr[T, N, R] {
-    override def eval(row: R): N[T] =
-      N.mapN(expr.eval(row))(t => B.map(t)(b => !b))
-
-    override def render(counter: AtomicInteger): Fragment =
-      fr"NOT ${expr.render(counter)}"
+  case class Not[T, N[_]](expr: SqlExpr[T, N], B: Bijection[T, Boolean], N: Nullability[N]) extends SqlExpr[T, N] {
+    override def render(ctx: RenderCtx): Fragment =
+      fr"NOT ${expr.render(ctx)}"
   }
 
-  case class ToNullable[T, R, N1[_]](expr: SqlExpr[T, N1, R], N: Nullability[N1]) extends SqlExpr[T, Option, R] {
-    override def eval(row: R): Option[T] =
-      N.toOpt(expr.eval(row))
-    override def render(counter: AtomicInteger): Fragment =
-      expr.render(counter)
+  case class ToNullable[T, N[_]](expr: SqlExpr[T, N], N: Nullability[N]) extends SqlExpr[T, Option] {
+    override def render(ctx: RenderCtx): Fragment =
+      expr.render(ctx)
   }
 
   // automatically put values in a constant expression
-  implicit def asConstOpt[T, R](t: Option[T])(implicit P: Put[T]): SqlExpr.Const[T, Option, R] =
+  implicit def asConstOpt[T](t: Option[T])(implicit P: Put[T]): SqlExpr.Const[T, Option] =
     Const(t, P, Write.fromPutOption(using P))
 
-  implicit def asConstRequired[T, R](t: T)(implicit P: Put[T]): SqlExpr.Const[T, Required, R] =
-    Const[T, Required, R](t, P, Write.fromPut(using P))
+  implicit def asConstRequired[T](t: T)(implicit P: Put[T]): SqlExpr.Const[T, Required] =
+    Const[T, Required](t, P, Write.fromPut(using P))
 
   // some syntax to construct field sort order
-  implicit class SqlExprSortSyntax[T, N[_], R](private val expr: SqlExpr[T, N, R]) extends AnyVal {
-    def asc(implicit O: Ordering[T], N: Nullability[N]): SortOrder[T, N, R] = SortOrder(expr, ascending = true, nullsFirst = false)
-    def desc(implicit O: Ordering[T], N: Nullability[N]): SortOrder[T, N, R] = SortOrder(expr, ascending = false, nullsFirst = false)
+  implicit class SqlExprSortSyntax[T, N[_]](private val expr: SqlExpr[T, N]) extends AnyVal {
+    def asc(implicit O: Ordering[T], N: Nullability[N]): SortOrder[T, N] = SortOrder(expr, ascending = true, nullsFirst = false)
+    def desc(implicit O: Ordering[T], N: Nullability[N]): SortOrder[T, N] = SortOrder(expr, ascending = false, nullsFirst = false)
   }
 
-  final case class RowExpr[R](exprs: List[SqlExpr.SqlExprNoHkt[?, R]]) extends SqlExpr[List[?], Required, R] {
-    override def eval(row: R): List[?] = exprs.map(_.eval(row))
-    override def render(counter: AtomicInteger): Fragment = fr"(${exprs.map(_.render(counter)).intercalate(fr",")})"
+  final case class RowExpr(exprs: List[SqlExpr.SqlExprNoHkt[?]]) extends SqlExpr[List[?], Required] {
+    override def render(ctx: RenderCtx): Fragment = fr"(${exprs.map(_.render(ctx)).intercalate(fr",")})"
   }
 
-  implicit class SqlExprArraySyntax[T, N[_], R](private val expr: SqlExpr[Array[T], N, R]) extends AnyVal {
+  implicit class SqlExprArraySyntax[T, N[_]](private val expr: SqlExpr[Array[T], N]) extends AnyVal {
 
     /** look up an element in an array at index `idx` */
-    def arrayIndex[N2[_]](idx: SqlExpr[Int, N2, R])(implicit N: Nullability2[N, N2, Option]): SqlExpr[T, Option, R] =
-      SqlExpr.ArrayIndex[T, N, N2, R](expr, idx, N)
+    def arrayIndex[N2[_]](idx: SqlExpr[Int, N2])(implicit N: Nullability2[N, N2, Option]): SqlExpr[T, Option] =
+      SqlExpr.ArrayIndex[T, N, N2](expr, idx, N)
 
     /** concatenate two arrays */
-    def arrayConcat[N2[_], NC[_]](other: SqlExpr[Array[T], N2, R])(implicit C: ClassTag[T], N: Nullability2[N, N2, NC]): SqlExpr[Array[T], NC, R] =
+    def arrayConcat[N2[_], NC[_]](other: SqlExpr[Array[T], N2])(implicit C: ClassTag[T], N: Nullability2[N, N2, NC]): SqlExpr[Array[T], NC] =
       SqlExpr.Binary(expr, SqlOperator.arrayConcat, other, N)
 
     /** does arrays have elements in common */
-    def arrayOverlaps[N2[_], NC[_]](other: SqlExpr[Array[T], N2, R])(implicit N: Nullability2[N, N2, NC]): SqlExpr[Boolean, NC, R] =
+    def arrayOverlaps[N2[_], NC[_]](other: SqlExpr[Array[T], N2])(implicit N: Nullability2[N, N2, NC]): SqlExpr[Boolean, NC] =
       SqlExpr.Binary(expr, SqlOperator.arrayOverlaps[Array[T], T], other, N)
   }
 
-  implicit class SqlExprOptionalSyntax[T, R](private val expr: SqlExpr[T, Option, R]) extends AnyVal {
-    def isNull: SqlExpr[Boolean, Required, R] =
+  implicit class SqlExprOptionalSyntax[T](private val expr: SqlExpr[T, Option]) extends AnyVal {
+    def isNull: SqlExpr[Boolean, Required] =
       SqlExpr.IsNull(expr)
-    def coalesce(orElse: SqlExpr[T, Required, R]): SqlExpr[T, Required, R] =
+    def coalesce(orElse: SqlExpr[T, Required]): SqlExpr[T, Required] =
       SqlExpr.Coalesce(expr, orElse)
   }
 }

--- a/typo-dsl-doobie/src/scala/typo/dsl/UpdateBuilder.scala
+++ b/typo-dsl-doobie/src/scala/typo/dsl/UpdateBuilder.scala
@@ -8,25 +8,23 @@ import doobie.implicits.toSqlInterpolator
 import doobie.util.fragment.Fragment
 import doobie.util.{Put, Read, Write, fragments}
 
-import java.util.concurrent.atomic.AtomicInteger
-
-trait UpdateBuilder[Fields[_], Row] {
+trait UpdateBuilder[Fields, Row] {
   protected def params: UpdateParams[Fields, Row]
   protected def withParams(sqlParams: UpdateParams[Fields, Row]): UpdateBuilder[Fields, Row]
 
-  final def whereStrict(v: Fields[Row] => SqlExpr[Boolean, Required, Row]): UpdateBuilder[Fields, Row] =
+  final def whereStrict(v: Fields => SqlExpr[Boolean, Required]): UpdateBuilder[Fields, Row] =
     withParams(params.where(v))
 
-  final def where[N[_]: Nullability](v: Fields[Row] => SqlExpr[Boolean, N, Row]): UpdateBuilder[Fields, Row] =
+  final def where[N[_]: Nullability](v: Fields => SqlExpr[Boolean, N]): UpdateBuilder[Fields, Row] =
     withParams(params.where(f => v(f).?.coalesce(false)))
 
-  final def setValue[N[_], T](col: Fields[Row] => SqlExpr.FieldLikeNotId[T, N, Row])(value: N[T])(implicit P: Put[T], W: Write[N[T]]): UpdateBuilder[Fields, Row] =
-    withParams(params.set(col, _ => SqlExpr.Const[T, N, Row](value, P, W)))
+  final def setValue[N[_], T](col: Fields => SqlExpr.FieldLikeNotId[T, N, Row])(value: N[T])(implicit P: Put[T], W: Write[N[T]]): UpdateBuilder[Fields, Row] =
+    withParams(params.set(col, _ => SqlExpr.Const[T, N](value, P, W)))
 
-  final def setComputedValue[T, N[_]](col: Fields[Row] => SqlExpr.FieldLikeNotId[T, N, Row])(value: SqlExpr.FieldLikeNotId[T, N, Row] => SqlExpr[T, N, Row]): UpdateBuilder[Fields, Row] =
+  final def setComputedValue[T, N[_]](col: Fields => SqlExpr.FieldLikeNotId[T, N, Row])(value: SqlExpr.FieldLikeNotId[T, N, Row] => SqlExpr[T, N]): UpdateBuilder[Fields, Row] =
     withParams(params.set(col, fields => value(col(fields))))
 
-  final def setComputedValueFromRow[T, N[_]](col: Fields[Row] => SqlExpr.FieldLikeNotId[T, N, Row])(value: Fields[Row] => SqlExpr[T, N, Row]): UpdateBuilder[Fields, Row] =
+  final def setComputedValueFromRow[T, N[_]](col: Fields => SqlExpr.FieldLikeNotId[T, N, Row])(value: Fields => SqlExpr[T, N]): UpdateBuilder[Fields, Row] =
     withParams(params.set(col, value))
 
   def sql(returning: Boolean): Option[Fragment]
@@ -35,19 +33,22 @@ trait UpdateBuilder[Fields[_], Row] {
 }
 
 object UpdateBuilder {
-  def apply[Fields[_], Row](name: String, structure: Structure.Relation[Fields, ?, Row], rowParser: Read[Row]): UpdateBuilderSql[Fields, Row] =
+  def apply[Fields, Row](name: String, structure: Structure.Relation[Fields, Row], rowParser: Read[Row]): UpdateBuilderSql[Fields, Row] =
     UpdateBuilderSql(name, structure, rowParser, UpdateParams.empty)
 
-  case class UpdateBuilderSql[Fields[_], Row](
+  final case class UpdateBuilderSql[Fields, Row](
       name: String,
-      structure: Structure.Relation[Fields, ?, Row],
+      structure: Structure.Relation[Fields, Row],
       read: Read[Row],
       params: UpdateParams[Fields, Row]
   ) extends UpdateBuilder[Fields, Row] {
     override def withParams(sqlParams: UpdateParams[Fields, Row]): UpdateBuilder[Fields, Row] =
       copy(params = sqlParams)
 
-    def mkSql(counter: AtomicInteger, returning: Boolean): Fragment = {
+    def mkSql(returning: Boolean): Fragment =
+      mkSql(RenderCtx.Empty, returning)
+
+    def mkSql(ctx: RenderCtx, returning: Boolean): Fragment = {
       List[Option[Fragment]](
         Some(fr"update ${Fragment.const0(name)}"),
         NonEmptyList.fromList(params.setters) match {
@@ -57,21 +58,21 @@ object UpdateBuilder {
             val setFragments = setters.map { setter =>
               val fieldExpr = setter.col(structure.fields)
               val valueExpr = setter.value(structure.fields)
-              fr"${fieldExpr.render(counter)} = ${valueExpr.render(counter)}${fieldExpr.sqlWriteCast.fold(Fragment.empty)(cast => Fragment.const0(s"::$cast"))}"
+              fr"${fieldExpr.render(ctx)} = ${valueExpr.render(ctx)}${fieldExpr.sqlWriteCast.fold(Fragment.empty)(cast => Fragment.const0(s"::$cast"))}"
             }
             Some(fragments.set(setFragments))
         },
         NonEmptyList.fromList(params.where).map { wheres =>
           fragments.whereAnd(
             wheres.map { where =>
-              where(structure.fields).render(counter)
+              where(structure.fields).render(ctx)
             }
           )
         },
         if (returning) {
           val colFragments = fragments.comma(
             NonEmptyList.fromListUnsafe(structure.columns).map { col =>
-              Fragment.const0(col.sqlReadCast.foldLeft("\"" + col.value + "\"") { case (acc, cast) => s"$acc::$cast" })
+              Fragment.const0(col.sqlReadCast.foldLeft("\"" + col.value(ctx) + "\"") { case (acc, cast) => s"$acc::$cast" })
             }
           )
           Some(fr"returning $colFragments")
@@ -80,19 +81,19 @@ object UpdateBuilder {
     }
 
     override def sql(returning: Boolean): Option[Fragment] = {
-      Some(mkSql(new AtomicInteger(1), returning))
+      Some(mkSql(returning))
     }
 
     override def execute: ConnectionIO[Int] =
-      mkSql(new AtomicInteger(0), returning = false).update.run
+      mkSql(returning = false).update.run
 
     override def executeReturnChanged: ConnectionIO[List[Row]] = {
-      mkSql(new AtomicInteger(0), returning = true).query(using read).to[List]
+      mkSql(returning = true).query(using read).to[List]
     }
   }
-  case class UpdateBuilderMock[Id, Fields[_], Row](
+  final case class UpdateBuilderMock[Id, Fields, Row](
       params: UpdateParams[Fields, Row],
-      fields: Fields[Row],
+      structure: Structure[Fields, Row],
       map: scala.collection.mutable.Map[Id, Row]
   ) extends UpdateBuilder[Fields, Row] {
     override def withParams(sqlParams: UpdateParams[Fields, Row]): UpdateBuilder[Fields, Row] =
@@ -107,8 +108,12 @@ object UpdateBuilder {
     override def executeReturnChanged: ConnectionIO[List[Row]] = delay {
       val changed = List.newBuilder[Row]
       map.foreach { case (id, row) =>
-        if (params.where.forall(w => w(fields).eval(row))) {
-          val newRow = params.setters.foldLeft(row) { case (row, set) => set.transform(fields, row) }
+        if (params.where.forall(w => structure.untypedEval(w(structure.fields), row))) {
+          val newRow = params.setters.foldLeft(row) { case (row, set: UpdateParams.Setter[Fields, nt, Row]) =>
+            val field: SqlExpr.FieldLikeNotIdNoHkt[nt, Row] = set.col(structure.fields)
+            val newValue: nt = structure.untypedEval(set.value(structure.fields), row)
+            field.set(row, newValue)
+          }
           map.update(id, newRow)
           changed += newRow
         }

--- a/typo-dsl-doobie/src/scala/typo/dsl/pagination/SortOrderRepr.scala
+++ b/typo-dsl-doobie/src/scala/typo/dsl/pagination/SortOrderRepr.scala
@@ -1,8 +1,6 @@
 package typo.dsl.pagination
 
-import typo.dsl.SortOrderNoHkt
-
-import java.util.concurrent.atomic.AtomicInteger
+import typo.dsl.{RenderCtx, SortOrderNoHkt}
 
 /** A client cursor is inherently tied to a set of sort orderings.
   *
@@ -11,8 +9,8 @@ import java.util.concurrent.atomic.AtomicInteger
 case class SortOrderRepr(expr: String) extends AnyVal
 
 object SortOrderRepr {
-  def from[NT, R](x: SortOrderNoHkt[NT, R]): SortOrderRepr = {
-    val internals = x.expr.render(new AtomicInteger(0)).internals
+  def from[NT](x: SortOrderNoHkt[NT], ctx: RenderCtx): SortOrderRepr = {
+    val internals = x.expr.render(ctx).internals
     // todo: deconstructing the sql string and replacing `?` with the value would yield a more readable result
     val sql = internals.elements match {
       case Nil      => internals.sql

--- a/typo-dsl-shared/typo/dsl/DeleteParams.scala
+++ b/typo-dsl-shared/typo/dsl/DeleteParams.scala
@@ -1,18 +1,11 @@
 package typo.dsl
 
-case class DeleteParams[Fields[_], Row](
-    where: List[Fields[Row] => SqlExpr[Boolean, Required, Row]]
-) {
-  def where(v: Fields[Row] => SqlExpr[Boolean, Required, Row]): DeleteParams[Fields, Row] =
+case class DeleteParams[Fields](where: List[Fields => SqlExpr[Boolean, Required]]) {
+  def where(v: Fields => SqlExpr[Boolean, Required]): DeleteParams[Fields] =
     copy(where = where :+ v)
 }
 
 object DeleteParams {
-  def empty[Fields[_], Row]: DeleteParams[Fields, Row] =
-    DeleteParams[Fields, Row](List.empty)
-
-  def applyParams[Fields[_], Row](fields: Fields[Row], rows: List[Row], params: DeleteParams[Fields, Row]): List[Row] = {
-    val filtered = params.where.foldLeft(rows) { (acc, where) => acc.filter(o => where(fields).eval(o)) }
-    filtered
-  }
+  def empty[Fields]: DeleteParams[Fields] =
+    DeleteParams[Fields](List.empty)
 }

--- a/typo-dsl-shared/typo/dsl/Hidden.scala
+++ b/typo-dsl-shared/typo/dsl/Hidden.scala
@@ -1,4 +1,0 @@
-package typo.dsl
-
-/* make IDE integration look better with joined tables */
-trait Hidden

--- a/typo-dsl-shared/typo/dsl/OuterJoined.scala
+++ b/typo-dsl-shared/typo/dsl/OuterJoined.scala
@@ -1,6 +1,6 @@
 package typo.dsl
 
-class OuterJoined[Fields[_], Row](fields: Fields[Row]) {
-  def apply[T, N[_]: Nullability](f: Fields[Row] => SqlExpr[T, N, Row]): SqlExpr[T, Option, Row] =
+class OuterJoined[Fields](fields: Fields) {
+  def apply[T, N[_]: Nullability](f: Fields => SqlExpr[T, N]): SqlExpr[T, Option] =
     f(fields).?
 }

--- a/typo-dsl-shared/typo/dsl/Path.scala
+++ b/typo-dsl-shared/typo/dsl/Path.scala
@@ -1,0 +1,13 @@
+package typo.dsl
+
+sealed trait Path
+
+object Path {
+  implicit val ordering: Ordering[Path] = {
+    case (LeftInJoin, RightInJoin) => -1
+    case (RightInJoin, LeftInJoin) => 1
+    case _                         => 0
+  }
+  case object LeftInJoin extends Path
+  case object RightInJoin extends Path
+}

--- a/typo-dsl-shared/typo/dsl/RenderCtx.scala
+++ b/typo-dsl-shared/typo/dsl/RenderCtx.scala
@@ -1,0 +1,28 @@
+package typo.dsl
+
+import scala.math.Ordering.Implicits.seqOrdering
+
+/** Calculates aliases for all unique list of [[Path]]s in a select query. This is used to evaluate expressions from an [[SqlExpr]] when we have joined relations */
+class RenderCtx(val alias: Map[List[Path], String]) extends AnyVal
+
+object RenderCtx {
+  val Empty = new RenderCtx(Map.empty)
+
+  def from[F, R](s: SelectBuilderSql[F, R]): RenderCtx = {
+    def findPathsAndTableNames(s: SelectBuilderSql[?, ?]): List[(List[Path], String)] =
+      s match {
+        case SelectBuilderSql.Relation(name, structure, _, _)  => List(structure._path -> name)
+        case SelectBuilderSql.TableJoin(left, right, _, _)     => findPathsAndTableNames(left) ++ findPathsAndTableNames(right)
+        case SelectBuilderSql.TableLeftJoin(left, right, _, _) => findPathsAndTableNames(left) ++ findPathsAndTableNames(right)
+      }
+
+    val nameForPathsMap: Map[List[Path], String] =
+      findPathsAndTableNames(s)
+        .groupMap { case (_, name) => name.split('.').last } { case (path, _) => path }
+        .flatMap { case (sameName, paths) =>
+          paths.sorted.zipWithIndex.map { case (path, idx) => path -> s"$sameName$idx" }
+        }
+
+    new RenderCtx(nameForPathsMap)
+  }
+}

--- a/typo-dsl-shared/typo/dsl/Structure.scala
+++ b/typo-dsl-shared/typo/dsl/Structure.scala
@@ -53,8 +53,6 @@ trait Structure[Fields, Row] {
         x.N.mapN(untypedEval(x.expr, row))(t => x.B.map(t)(b => !b))
       case x: SqlExpr.ToNullable[t, n] =>
         x.N.toOpt(untypedEval(x.expr, row))
-      case x: SqlExpr.RowExpr =>
-        x.exprs.map(expr => untypedEval(expr, row))
     }
 
   final def join[Fields2, Row2](other: Structure[Fields2, Row2]): Structure[Joined[Fields, Fields2], (Row, Row2)] =

--- a/typo-dsl-shared/typo/dsl/Structure.scala
+++ b/typo-dsl-shared/typo/dsl/Structure.scala
@@ -53,6 +53,8 @@ trait Structure[Fields, Row] {
         x.N.mapN(untypedEval(x.expr, row))(t => x.B.map(t)(b => !b))
       case x: SqlExpr.ToNullable[t, n] =>
         x.N.toOpt(untypedEval(x.expr, row))
+      case x: SqlExpr.RowExpr =>
+        x.exprs.map(expr => untypedEval(expr, row))
     }
 
   final def join[Fields2, Row2](other: Structure[Fields2, Row2]): Structure[Joined[Fields, Fields2], (Row, Row2)] =

--- a/typo-dsl-shared/typo/dsl/UpdateParams.scala
+++ b/typo-dsl-shared/typo/dsl/UpdateParams.scala
@@ -1,30 +1,19 @@
 package typo.dsl
 
-case class UpdateParams[Fields[_], Row](
-    where: List[Fields[Row] => SqlExpr[Boolean, Required, Row]],
-    setters: List[UpdateParams.Setter[Fields, Row, ?]]
+case class UpdateParams[Fields, Row](
+    where: List[Fields => SqlExpr[Boolean, Required]],
+    setters: List[UpdateParams.Setter[Fields, ?, Row]]
 ) {
-  def where(v: Fields[Row] => SqlExpr[Boolean, Required, Row]): UpdateParams[Fields, Row] =
+  def where(v: Fields => SqlExpr[Boolean, Required]): UpdateParams[Fields, Row] =
     copy(where = where :+ v)
 
-  def set[NT](col: Fields[Row] => SqlExpr.FieldLikeNotIdNoHkt[NT, Row], value: Fields[Row] => SqlExpr.SqlExprNoHkt[NT, Row]): UpdateParams[Fields, Row] =
+  def set[NT](col: Fields => SqlExpr.FieldLikeNotIdNoHkt[NT, Row], value: Fields => SqlExpr.SqlExprNoHkt[NT]): UpdateParams[Fields, Row] =
     copy(setters = setters :+ UpdateParams.Setter(col, value))
 }
 
 object UpdateParams {
-  case class Setter[Fields[_], Row, NT](col: Fields[Row] => SqlExpr.FieldLikeNotIdNoHkt[NT, Row], value: Fields[Row] => SqlExpr.SqlExprNoHkt[NT, Row]) {
-    def transform(fields: Fields[Row], row: Row): Row = {
-      val field: SqlExpr.FieldLikeNotIdNoHkt[NT, Row] = col(fields)
-      val newValue: NT = value(fields).eval(row)
-      field.set(row, newValue)
-    }
-  }
+  case class Setter[Fields, NT, Row](col: Fields => SqlExpr.FieldLikeNotIdNoHkt[NT, Row], value: Fields => SqlExpr.SqlExprNoHkt[NT])
 
-  def empty[Fields[_], Row]: UpdateParams[Fields, Row] =
+  def empty[Fields, Row]: UpdateParams[Fields, Row] =
     UpdateParams[Fields, Row](List.empty, List.empty)
-
-  def applyParams[Fields[_], Row](fields: Fields[Row], rows: List[Row], params: UpdateParams[Fields, Row]): List[Row] = {
-    val filtered = params.where.foldLeft(rows) { (acc, where) => acc.filter(o => where(fields).eval(o)) }
-    filtered
-  }
 }

--- a/typo-dsl-shared/typo/dsl/internal/mocks.scala
+++ b/typo-dsl-shared/typo/dsl/internal/mocks.scala
@@ -1,14 +1,14 @@
 package typo.dsl.internal
 
-import typo.dsl.{SortOrder, SortOrderNoHkt}
+import typo.dsl.{SortOrder, SortOrderNoHkt, Structure}
 
 object mocks {
-  class RowOrdering[Row](sortOrderings: List[SortOrderNoHkt[?, Row]]) extends Ordering[Row] {
+  class RowOrdering[Fields, Row](structure: Structure[Fields, Row], sortOrderings: List[SortOrderNoHkt[?]]) extends Ordering[Row] {
     override def compare(leftRow: Row, rightRow: Row): Int =
       sortOrderings.iterator
-        .map { case so: SortOrder[t, n, Row] @unchecked /* for 2.13*/ =>
-          val left = so.expr.eval(leftRow)
-          val right = so.expr.eval(rightRow)
+        .map { case so: SortOrder[t, n] @unchecked /* for 2.13*/ =>
+          val left = structure.untypedEval(so.expr, leftRow)
+          val right = structure.untypedEval(so.expr, rightRow)
           val ordering: Ordering[Option[t]] = Ordering.Option(if (so.ascending) so.ordering else so.ordering.reverse)
           ordering.compare(so.nullability.toOpt(left), so.nullability.toOpt(right))
         }

--- a/typo-dsl-shared/typo/dsl/internal/seeks.scala
+++ b/typo-dsl-shared/typo/dsl/internal/seeks.scala
@@ -4,25 +4,25 @@ import typo.dsl.SelectParams.Seek
 import typo.dsl.*
 
 object seeks {
-  def expand[Fields[_], Row](fields: Fields[Row], params: SelectParams[Fields, Row]): (List[SqlExpr[Boolean, Option, Row]], List[SortOrderNoHkt[?, Row]]) =
+  def expand[Fields, Row](fields: Fields, params: SelectParams[Fields, Row]): (List[SqlExpr[Boolean, Option]], List[SortOrderNoHkt[?]]) =
     params.seeks match {
       case Nil => (params.where.map(_.apply(fields)), params.orderBy.map(_.apply(fields)))
       case nonEmpty =>
         require(params.orderBy.isEmpty, "Cannot have both seeks and orderBy")
-        val seekOrderBys: List[SortOrderNoHkt[?, Row]] =
-          nonEmpty.map { case seek: Seek[Fields, Row, _, _] @unchecked /* for 2.13*/ => seek.f(fields) }
+        val seekOrderBys: List[SortOrderNoHkt[?]] =
+          nonEmpty.map { case seek: Seek[Fields, _, _] @unchecked /* for 2.13*/ => seek.f(fields) }
 
-        val seekWhere: SqlExpr[Boolean, Option, Row] =
+        val seekWhere: SqlExpr[Boolean, Option] =
           seekOrderBys.map(_.ascending).distinct match {
             case List(uniformIsAscending) =>
               val dbTuple = SqlExpr.RowExpr(seekOrderBys.map(so => so.expr))
-              val valueTuple = SqlExpr.RowExpr(nonEmpty.map { case seek: Seek[Fields, Row, t, n] @unchecked /* for 2.13 */ => seek.value })
+              val valueTuple = SqlExpr.RowExpr(nonEmpty.map { case seek: Seek[Fields, t, n] @unchecked /* for 2.13 */ => seek.value })
               // this is for mock repositories. it's hard to separate it out from here
               implicit val ordering: Ordering[List[?]] = (leftRow: List[?], rightRow: List[?]) =>
                 leftRow.iterator
                   .zip(rightRow.iterator)
                   .zip(seekOrderBys.iterator)
-                  .map { case ((left, right), so: SortOrder[t, n, Row] @unchecked) /* for 2.13*/ =>
+                  .map { case ((left, right), so: SortOrder[t, n] @unchecked) /* for 2.13*/ =>
                     val ordering: Ordering[Option[t]] = Ordering.Option(if (so.ascending) so.ordering else so.ordering.reverse)
                     ordering.compare(so.nullability.toOpt(left.asInstanceOf[n[t]]), so.nullability.toOpt(right.asInstanceOf[n[t]]))
                   }
@@ -31,22 +31,22 @@ object seeks {
 
               if (uniformIsAscending) dbTuple > valueTuple else dbTuple < valueTuple
             case _ =>
-              val orConditions: Seq[SqlExpr[Boolean, Option, Row]] =
+              val orConditions: Seq[SqlExpr[Boolean, Option]] =
                 nonEmpty.indices.map { i =>
-                  val equals: List[SqlExpr[Boolean, Option, Row]] =
-                    nonEmpty.take(i).map { case seek: Seek[Fields, Row, t, n] @unchecked /* for 2.13*/ =>
-                      val so: SortOrder[t, n, Row] = seek.f(fields)
+                  val equals: List[SqlExpr[Boolean, Option]] =
+                    nonEmpty.take(i).map { case seek: Seek[Fields, t, n] @unchecked /* for 2.13*/ =>
+                      val so: SortOrder[t, n] = seek.f(fields)
                       implicit val n: Nullability2[n, n, Option] = Nullability2.opt(using so.nullability, so.nullability)
                       implicit val ordering: Ordering[t] = so.ordering
                       so.expr === seek.value
                     }
 
                   nonEmpty(i) match {
-                    case seek: Seek[Fields, Row, t, n] @unchecked /* for 2.13*/ =>
-                      val so: SortOrder[t, n, Row] = seek.f(fields)
+                    case seek: Seek[Fields, t, n] @unchecked /* for 2.13*/ =>
+                      val so: SortOrder[t, n] = seek.f(fields)
                       implicit val n: Nullability2[n, n, Option] = Nullability2.opt(using so.nullability, so.nullability)
                       implicit val ordering: Ordering[t] = so.ordering
-                      val predicate: SqlExpr[Boolean, Option, Row] =
+                      val predicate: SqlExpr[Boolean, Option] =
                         if (so.ascending) so.expr > seek.value else so.expr < seek.value
                       (equals :+ predicate).reduce(_ and _)
                   }

--- a/typo-dsl-shared/typo/dsl/package.scala
+++ b/typo-dsl-shared/typo/dsl/package.scala
@@ -1,9 +1,9 @@
 package typo
 
 package object dsl {
-  type Joined[Fields1[_], Fields2[_], T] = (Fields1[T], Fields2[T])
+  type Joined[Fields1, Fields2] = (Fields1, Fields2)
 
-  type LeftJoined[Fields1[_], Fields2[_], T] = (Fields1[T], OuterJoined[Fields2, T])
+  type LeftJoined[Fields1, Fields2] = (Fields1, OuterJoined[Fields2])
 
   type Required[T] = T
 

--- a/typo-dsl-shared/typo/dsl/pagination/PaginationQuery.scala
+++ b/typo-dsl-shared/typo/dsl/pagination/PaginationQuery.scala
@@ -2,35 +2,30 @@ package typo.dsl.pagination
 
 import typo.dsl.*
 
-import java.util.concurrent.atomic.AtomicInteger
-
 /** You'll typically use this behind a facade which accounts for your json library of choice.
   *
   * If you don't, you'll just have to fill in [[AbstractJsonCodec]] yourself.
   */
-class PaginationQuery[Fields[_], Row, E](
+class PaginationQuery[Fields, Row, E](
     query: SelectBuilder[Fields, Row],
-    part1s: List[ServerCursor.Part1NoHkt[Fields, Row, ?, E]]
+    parts: List[ServerCursor.PartNoHkt[Fields, Row, ?, E]]
 ) {
-  def andOn[T, N[_]](v: Fields[Row] => SortOrder[T, N, Row])(codec: AbstractJsonCodec[N[T], E])(implicit asConst: SqlExpr.Const.As[T, N, Row]): PaginationQuery[Fields, Row, E] =
-    new PaginationQuery(query, part1s :+ new ServerCursor.Part1(v, codec, asConst))
+
+  def andOn[T, N[_]](v: Fields => SortOrder[T, N])(codec: AbstractJsonCodec[N[T], E])(implicit asConst: SqlExpr.Const.As[T, N]): PaginationQuery[Fields, Row, E] = {
+    val sortOrder = v(query.structure.fields)
+    val sortOrderRepr = SortOrderRepr.from(sortOrder, query.renderCtx)
+    val newPart = new ServerCursor.Part[Fields, Row, T, N, E](v, sortOrder, sortOrderRepr, codec, asConst)
+    new PaginationQuery(query, parts :+ newPart)
+  }
 
   def done(limit: Int, continueFrom: Option[ClientCursor[E]]): Either[String, (SelectBuilder[Fields, Row], ServerCursor[Fields, Row, E])] = {
-    val initialCursor = {
-      // hack: improve DSL to avoid  instantiating structure twice
-      val structure: Structure[Fields, Row] = query match {
-        case mock: SelectBuilderMock[Fields, Row] => mock.structure
-        case sql: SelectBuilderSql[Fields, Row]   => sql.instantiate(new AtomicInteger(0)).structure
-        case _                                    => sys.error("unsupported query type")
-      }
-      new ServerCursor.Initial(part1s.map(_.asPart2(structure.fields)), limit)
-    }
+    val initialCursor = new ServerCursor.Initial(query.structure, parts, limit)
 
     continueFrom match {
       case None =>
-        val newQuery = initialCursor.part2s
-          .foldLeft(query) { case (q, part2: ServerCursor.Part2[Fields, Row, t, n, E] @unchecked /* for 2.13 */ ) =>
-            q.orderBy(part2.part1.v.asInstanceOf[Fields[Hidden] => SortOrder[t, n, Hidden]])
+        val newQuery = initialCursor.parts
+          .foldLeft(query) { case (q, part2: ServerCursor.Part[Fields, Row, t, n, E] @unchecked /* for 2.13 */ ) =>
+            q.orderBy(part2.v)
           }
           .limit(limit)
         Right((newQuery, initialCursor))
@@ -38,8 +33,8 @@ class PaginationQuery[Fields[_], Row, E](
       case Some(clientCursor) =>
         initialCursor.withTupleFrom(clientCursor).map { cursor =>
           val newQuery = cursor.part3s
-            .foldLeft(query) { case (q, part3: ServerCursor.Part3[Fields, Row, _, _, E] @unchecked /* for 2.13 */ ) =>
-              q.seek(part3.part2.part1.v)(part3.value)
+            .foldLeft(query) { case (q, partData: ServerCursor.PartWithData[Fields, Row, _, _, E] @unchecked /* for 2.13 */ ) =>
+              q.seek(partData.part.v)(partData.value)
             }
             .limit(limit)
           (newQuery, cursor)

--- a/typo-dsl-shared/typo/dsl/pagination/ServerCursor.scala
+++ b/typo-dsl-shared/typo/dsl/pagination/ServerCursor.scala
@@ -1,73 +1,57 @@
 package typo.dsl.pagination
 
-import typo.dsl.{SortOrder, SqlExpr}
 import typo.dsl.pagination.internal.ListOps
+import typo.dsl.{SortOrder, SqlExpr, Structure}
 
-sealed trait ServerCursor[Fields[_], Row, E] {
-  def part2s: List[ServerCursor.Part2NoHkt[Fields, Row, ?, E]]
+sealed trait ServerCursor[Fields, Row, E] {
+  def parts: List[ServerCursor.PartNoHkt[Fields, Row, ?, E]]
+  val structure: Structure[Fields, Row]
   val limit: Int
 
   final def withNewResults(rows: Seq[Row]): Option[ServerCursor.AtTuple[Fields, Row, E]] =
     if (rows.length < limit) None // no new cursor if we know we reached end
-    else rows.lastOption.map(lastRow => new ServerCursor.AtTuple(part2s.map(_.asPart3(lastRow)), limit))
+    else rows.lastOption.map(lastRow => new ServerCursor.AtTuple(structure, parts.map(_.withData(lastRow, structure)), limit))
 
   final def withTupleFrom(clientCursor: ClientCursor[E]): Either[String, ServerCursor.AtTuple[Fields, Row, E]] =
-    part2s.traverse(_.decodeDataFrom(clientCursor)).map(parts => new ServerCursor.AtTuple(parts, limit))
+    parts.traverse(_.decodeDataFrom(clientCursor)).map(parts => new ServerCursor.AtTuple(structure, parts, limit))
 }
 
 object ServerCursor {
-  class Initial[Fields[_], Row, E](val part2s: List[Part2NoHkt[Fields, Row, ?, E]], val limit: Int) extends ServerCursor[Fields, Row, E]
+  class Initial[Fields, Row, E](val structure: Structure[Fields, Row], val parts: List[PartNoHkt[Fields, Row, ?, E]], val limit: Int) extends ServerCursor[Fields, Row, E]
 
-  class AtTuple[Fields[_], Row, E](val part3s: List[Part3NoHkt[Fields, Row, ?, E]], val limit: Int) extends ServerCursor[Fields, Row, E] {
-    def part2s: List[Part2NoHkt[Fields, Row, ?, E]] = part3s.map(_.part2)
+  class AtTuple[Fields, Row, E](val structure: Structure[Fields, Row], val part3s: List[PartWithDataNoHkt[Fields, Row, ?, E]], val limit: Int) extends ServerCursor[Fields, Row, E] {
+    def parts: List[PartNoHkt[Fields, Row, ?, E]] = part3s.map(_.part)
     def clientCursor: ClientCursor[E] = ClientCursor(part3s.map(_.encoded).toMap)
   }
 
   /** A constituent in a server-side cursor.
-    *
-    * At this point we have a function from `Fields` to a [[SortOrder]], making it dependant on the *shape* of the query, but not an *instance* of a query.
-    *
-    * You very likely don't have to worry about this, as it is used internally.
     */
-  class Part1[Fields[_], Row, T, N[_], E](
-      val v: Fields[Row] => SortOrder[T, N, Row],
+  class Part[Fields, Row, T, N[_], E](
+      val v: Fields => SortOrder[T, N],
+      val sortOrder: SortOrder[T, N],
+      val sortOrderRepr: SortOrderRepr,
       val codec: AbstractJsonCodec[N[T], E],
-      val asConst: SqlExpr.Const.As[T, N, Row]
-  ) extends Part1NoHkt[Fields, Row, N[T], E] {
-    def asPart2(fields: Fields[Row]): ServerCursor.Part2[Fields, Row, T, N, E] =
-      new ServerCursor.Part2(this, v(fields))
-  }
-  sealed trait Part1NoHkt[Fields[_], Row, NT, E] { // for scala 2.13
-    def asPart2(fields: Fields[Row]): ServerCursor.Part2NoHkt[Fields, Row, NT, E]
-  }
+      val asConst: SqlExpr.Const.As[T, N]
+  ) extends PartNoHkt[Fields, Row, N[T], E] {
+    override def withData(row: Row, structure: Structure[Fields, Row]): PartWithData[Fields, Row, T, N, E] =
+      new ServerCursor.PartWithData[Fields, Row, T, N, E](this, asConst(structure.untypedEval(sortOrder.expr, row)))
 
-  /** A constituent in a server-side cursor.
-    *
-    * At this point we have extracted the [[SortOrder]] from a query, making the value somewhat depending on it. That dependency affects the rendering of columns only
-    *
-    * The benefit is that we can now render it to a [[SortOrderRepr]], so we can encode it in a [[ClientCursor]]
-    */
-  class Part2[Fields[_], Row, T, N[_], E](val part1: Part1[Fields, Row, T, N, E], val sortOrder: SortOrder[T, N, Row]) extends Part2NoHkt[Fields, Row, N[T], E] {
-    val sortOrderRepr: SortOrderRepr = SortOrderRepr.from(sortOrder)
-
-    override def asPart3(row: Row): Part3[Fields, Row, T, N, E] =
-      new ServerCursor.Part3[Fields, Row, T, N, E](this, part1.asConst(sortOrder.expr.eval(row)))
-
-    override def decodeDataFrom(clientCursor: ClientCursor[E]): Either[String, Part3[Fields, Row, T, N, E]] =
+    override def decodeDataFrom(clientCursor: ClientCursor[E]): Either[String, PartWithData[Fields, Row, T, N, E]] =
       clientCursor.parts.get(sortOrderRepr) match {
         case None => Left(s"Cursor is missing value for column '${sortOrderRepr.expr}'")
         case Some(value) =>
-          part1.codec.decode(value) match {
+          codec.decode(value) match {
             case Left(msg) =>
               Left(s"Cursor had invalid value '$value' for column '${sortOrderRepr.expr}': $msg")
             case Right(nt) =>
-              Right(new ServerCursor.Part3[Fields, Row, T, N, E](this, part1.asConst(nt)))
+              Right(new ServerCursor.PartWithData[Fields, Row, T, N, E](this, asConst(nt)))
           }
       }
   }
-  sealed trait Part2NoHkt[Fields[_], Row, NT, E] { // for scala 2.13
-    def asPart3(row: Row): Part3NoHkt[Fields, Row, NT, E]
-    def decodeDataFrom(clientCursor: ClientCursor[E]): Either[String, Part3NoHkt[Fields, Row, NT, E]]
+
+  sealed trait PartNoHkt[Fields, Row, NT, E] { // for scala 2.13
+    def withData(row: Row, structure: Structure[Fields, Row]): PartWithDataNoHkt[Fields, Row, NT, E]
+    def decodeDataFrom(clientCursor: ClientCursor[E]): Either[String, PartWithDataNoHkt[Fields, Row, NT, E]]
   }
 
   /** A constituent in a server-side cursor.
@@ -76,13 +60,13 @@ object ServerCursor {
     *
     * The data is wrapped in [[SqlExpr.Const]] so it's ready to embed into a query without threading through the type class instances
     */
-  class Part3[Fields[_], Row, T, N[_], E](val part2: Part2[Fields, Row, T, N, E], val value: SqlExpr.Const[T, N, Row]) extends Part3NoHkt[Fields, Row, N[T], E] {
+  class PartWithData[Fields, Row, T, N[_], E](val part: Part[Fields, Row, T, N, E], val value: SqlExpr.Const[T, N]) extends PartWithDataNoHkt[Fields, Row, N[T], E] {
     override def encoded: (SortOrderRepr, E) =
-      (part2.sortOrderRepr, part2.part1.codec.encode(value.value))
+      (part.sortOrderRepr, part.codec.encode(value.value))
   }
 
-  sealed trait Part3NoHkt[Fields[_], Row, NT, E] { // for scala 2.13
-    val part2: Part2NoHkt[Fields, Row, ?, E]
+  sealed trait PartWithDataNoHkt[Fields, Row, NT, E] { // for scala 2.13
+    val part: PartNoHkt[Fields, Row, ?, E]
     def encoded: (SortOrderRepr, E)
   }
 }

--- a/typo-dsl-zio-jdbc/src/scala/typo/dsl/DeleteBuilder.scala
+++ b/typo-dsl-zio-jdbc/src/scala/typo/dsl/DeleteBuilder.scala
@@ -3,17 +3,16 @@ package typo.dsl
 import zio.ZIO
 import zio.jdbc.*
 
-import java.util.concurrent.atomic.AtomicInteger
 import scala.annotation.nowarn
 
-trait DeleteBuilder[Fields[_], Row] {
-  protected def params: DeleteParams[Fields, Row]
-  protected def withParams(sqlParams: DeleteParams[Fields, Row]): DeleteBuilder[Fields, Row]
+trait DeleteBuilder[Fields, Row] {
+  protected def params: DeleteParams[Fields]
+  protected def withParams(sqlParams: DeleteParams[Fields]): DeleteBuilder[Fields, Row]
 
-  final def where[N[_]: Nullability](v: Fields[Row] => SqlExpr[Boolean, N, Row]): DeleteBuilder[Fields, Row] =
+  final def where[N[_]: Nullability](v: Fields => SqlExpr[Boolean, N]): DeleteBuilder[Fields, Row] =
     whereStrict(f => v(f).?.coalesce(false))
 
-  final def whereStrict(v: Fields[Row] => SqlExpr[Boolean, Required, Row]): DeleteBuilder[Fields, Row] =
+  final def whereStrict(v: Fields => SqlExpr[Boolean, Required]): DeleteBuilder[Fields, Row] =
     withParams(params.where(v))
 
   def sql: Option[SqlFragment]
@@ -21,40 +20,40 @@ trait DeleteBuilder[Fields[_], Row] {
 }
 
 object DeleteBuilder {
-  def apply[Fields[_], Row](name: String, structure: Structure.Relation[Fields, ?, Row]): DeleteBuilderSql[Fields, Row] =
+  def apply[Fields, Row](name: String, structure: Structure.Relation[Fields, Row]): DeleteBuilderSql[Fields, Row] =
     DeleteBuilderSql(name, structure, DeleteParams.empty)
 
-  final case class DeleteBuilderSql[Fields[_], Row](
+  final case class DeleteBuilderSql[Fields, Row](
       name: String,
-      structure: Structure.Relation[Fields, ?, Row],
-      params: DeleteParams[Fields, Row]
+      structure: Structure.Relation[Fields, Row],
+      params: DeleteParams[Fields]
   ) extends DeleteBuilder[Fields, Row] {
-    override def withParams(sqlParams: DeleteParams[Fields, Row]): DeleteBuilder[Fields, Row] =
+    override def withParams(sqlParams: DeleteParams[Fields]): DeleteBuilder[Fields, Row] =
       copy(params = sqlParams)
 
-    def mkSql(counter: AtomicInteger): SqlFragment = {
+    def mkSql(ctx: RenderCtx): SqlFragment = {
       List[Iterable[SqlFragment]](
         Some(SqlFragment.deleteFrom(name)),
         params.where
           .map(w => w(structure.fields))
           .reduceLeftOption(_.and(_))
-          .map { where => sql" where " ++ where.render(counter) }
+          .map { where => sql" where " ++ where.render(ctx) }
       ).flatten.reduce(_ ++ _)
     }
 
     override def sql: Option[SqlFragment] =
-      Some(mkSql(new AtomicInteger(1)))
+      Some(mkSql(RenderCtx.Empty))
 
     override def execute: ZIO[ZConnection, Throwable, Long] =
-      mkSql(new AtomicInteger(0)).update
+      mkSql(RenderCtx.Empty).update
   }
 
-  final case class DeleteBuilderMock[Id, Fields[_], Row](
-      params: DeleteParams[Fields, Row],
-      fields: Fields[Row],
+  final case class DeleteBuilderMock[Id, Fields, Row](
+      params: DeleteParams[Fields],
+      structure: Structure[Fields, Row],
       map: scala.collection.mutable.Map[Id, Row]
   ) extends DeleteBuilder[Fields, Row] {
-    override def withParams(sqlParams: DeleteParams[Fields, Row]): DeleteBuilder[Fields, Row] =
+    override def withParams(sqlParams: DeleteParams[Fields]): DeleteBuilder[Fields, Row] =
       copy(params = sqlParams)
 
     override def sql: Option[SqlFragment] = None
@@ -62,7 +61,7 @@ object DeleteBuilder {
     override def execute: ZIO[ZConnection, Throwable, Long] = ZIO.succeed {
       var changed: Long = 0L
       map.foreach { case (id, row) =>
-        if (params.where.forall(w => w(fields).eval(row))) {
+        if (params.where.forall(w => structure.untypedEval(w(structure.fields), row))) {
           map.remove(id): @nowarn
           changed += 1
         }

--- a/typo-dsl-zio-jdbc/src/scala/typo/dsl/SelectBuilder.scala
+++ b/typo-dsl-zio-jdbc/src/scala/typo/dsl/SelectBuilder.scala
@@ -3,7 +3,9 @@ package typo.dsl
 import zio.{Chunk, ZIO}
 import zio.jdbc.*
 
-trait SelectBuilder[Fields[_], Row] {
+trait SelectBuilder[Fields, Row] {
+  def renderCtx: RenderCtx
+  def structure: Structure[Fields, Row]
 
   /** Add a where clause to the query.
     *
@@ -16,18 +18,18 @@ trait SelectBuilder[Fields[_], Row] {
     *    .where(x => x.productline === "foo")
     * }}}
     */
-  final def where[N[_]: Nullability](v: Fields[Hidden] => SqlExpr[Boolean, N, Hidden]): SelectBuilder[Fields, Row] =
-    withParams(params.where(fields => v(fields.asInstanceOf[Fields[Hidden]]).asInstanceOf[SqlExpr[Boolean, N, Row]].?))
+  final def where[N[_]: Nullability](v: Fields => SqlExpr[Boolean, N]): SelectBuilder[Fields, Row] =
+    withParams(params.where(fields => v(fields).?))
 
-  final def maybeWhere[N[_]: Nullability, T](ot: Option[T])(v: (Fields[Hidden], T) => SqlExpr[Boolean, N, Hidden]): SelectBuilder[Fields, Row] =
+  final def maybeWhere[N[_]: Nullability, T](ot: Option[T])(v: (Fields, T) => SqlExpr[Boolean, N]): SelectBuilder[Fields, Row] =
     ot match {
       case Some(t) => where(fields => v(fields, t))
       case None    => this
     }
 
   /** Same as [[where]], but requires the expression to not be nullable */
-  final def whereStrict(v: Fields[Hidden] => SqlExpr[Boolean, Required, Hidden]): SelectBuilder[Fields, Row] =
-    withParams(params.where(fields => v(fields.asInstanceOf[Fields[Hidden]]).asInstanceOf[SqlExpr[Boolean, Required, Row]].?))
+  final def whereStrict(v: Fields => SqlExpr[Boolean, Required]): SelectBuilder[Fields, Row] =
+    withParams(params.where(fields => v(fields).?))
 
   /** Add an order by clause to the query.
     *
@@ -43,21 +45,22 @@ trait SelectBuilder[Fields[_], Row] {
     *        .orderBy { case ((_, _), productModel) => productModel(_.name).desc.withNullsFirst }
     * }}}
     */
-  final def orderBy[T, N[_]](v: Fields[Hidden] => SortOrder[T, N, Hidden]): SelectBuilder[Fields, Row] =
-    withParams(params.orderBy(v.asInstanceOf[Fields[Row] => SortOrderNoHkt[?, Row]]))
+  final def orderBy[T, N[_]](v: Fields => SortOrder[T, N]): SelectBuilder[Fields, Row] =
+    withParams(params.orderBy(v))
+
+  final def seek[T, N[_]](v: Fields => SortOrder[T, N])(value: SqlExpr.Const[T, N]): SelectBuilder[Fields, Row] =
+    withParams(params.seek(SelectParams.Seek[Fields, T, N](v, value)))
+
+  final def maybeSeek[T, N[_]](v: Fields => SortOrder[T, N])(maybeValue: Option[SqlExpr.Const[T, N]]): SelectBuilder[Fields, Row] =
+    maybeValue match {
+      case Some(value) => seek(v)(value)
+      case None        => orderBy(v)
+    }
+
   final def offset(v: Int): SelectBuilder[Fields, Row] =
     withParams(params.offset(v))
   final def limit(v: Int): SelectBuilder[Fields, Row] =
     withParams(params.limit(v))
-
-  final def seek[T, N[_]](v: Fields[Row] => SortOrder[T, N, Row])(value: SqlExpr.Const[T, N, Row]): SelectBuilder[Fields, Row] =
-    withParams(params.seek(SelectParams.Seek[Fields, Row, T, N](v, value)))
-
-  final def maybeSeek[T, N[_]](v: Fields[Row] => SortOrder[T, N, Row])(maybeValue: Option[SqlExpr.Const[T, N, Row]]): SelectBuilder[Fields, Row] =
-    maybeValue match {
-      case Some(value) => seek(v)(value)
-      case None        => orderBy(v.asInstanceOf[Fields[Hidden] => SortOrder[T, N, Hidden]])
-    }
 
   /** Execute the query and return the results as a list */
   def toChunk: ZIO[ZConnection, Throwable, Chunk[Row]]
@@ -66,10 +69,10 @@ trait SelectBuilder[Fields[_], Row] {
   def sql: Option[SqlFragment]
 
   /** start constructing a join */
-  final def join[F2[_], Row2](other: SelectBuilder[F2, Row2]): PartialJoin[F2, Row2] =
+  final def join[F2, Row2](other: SelectBuilder[F2, Row2]): PartialJoin[F2, Row2] =
     new PartialJoin[F2, Row2](other)
 
-  final class PartialJoin[Fields2[_], Row2](other: SelectBuilder[Fields2, Row2]) {
+  final class PartialJoin[Fields2, Row2](other: SelectBuilder[Fields2, Row2]) {
 
     /** inner join with the given predicate
       * {{{
@@ -78,12 +81,12 @@ trait SelectBuilder[Fields[_], Row] {
       *   .on { case (p, um) => p.sizeunitmeasurecode === um.unitmeasurecode }
       * }}}
       */
-    def on[N[_]: Nullability](pred: Joined[Fields, Fields2, Hidden] => SqlExpr[Boolean, N, Hidden]): SelectBuilder[Joined[Fields, Fields2, *], (Row, Row2)] =
-      joinOn(other)(pred.asInstanceOf[Joined[Fields, Fields2, (Row, Row2)] => SqlExpr[Boolean, N, (Row, Row2)]])
+    def on[N[_]: Nullability](pred: Joined[Fields, Fields2] => SqlExpr[Boolean, N]): SelectBuilder[Joined[Fields, Fields2], (Row, Row2)] =
+      joinOn(other)(pred)
 
     /** Variant of `on` that requires the join predicate to not be nullable */
-    def onStrict(pred: Joined[Fields, Fields2, Hidden] => SqlExpr[Boolean, Required, Hidden]): SelectBuilder[Joined[Fields, Fields2, *], (Row, Row2)] =
-      joinOn(other)(pred.asInstanceOf[Joined[Fields, Fields2, (Row, Row2)] => SqlExpr[Boolean, Required, (Row, Row2)]])
+    def onStrict(pred: Joined[Fields, Fields2] => SqlExpr[Boolean, Required]): SelectBuilder[Joined[Fields, Fields2], (Row, Row2)] =
+      joinOn(other)(pred)
 
     /** left join with the given predicate
       * {{{
@@ -92,23 +95,23 @@ trait SelectBuilder[Fields[_], Row] {
       * .leftOn { case (p, pm) => p.productmodelid === pm.productmodelid }
       * }}}
       */
-    def leftOn[N[_]: Nullability](pred: Joined[Fields, Fields2, Hidden] => SqlExpr[Boolean, N, Hidden]): SelectBuilder[LeftJoined[Fields, Fields2, *], (Row, Option[Row2])] =
-      leftJoinOn(other)(pred.asInstanceOf[Joined[Fields, Fields2, (Row, Row2)] => SqlExpr[Boolean, N, (Row, Row2)]])
+    def leftOn[N[_]: Nullability](pred: Joined[Fields, Fields2] => SqlExpr[Boolean, N]): SelectBuilder[LeftJoined[Fields, Fields2], (Row, Option[Row2])] =
+      leftJoinOn(other)(pred)
 
     /** Variant of `leftOn` that requires the join predicate to not be nullable */
-    def leftOnStrict(pred: Joined[Fields, Fields2, Hidden] => SqlExpr[Boolean, Required, Hidden]): SelectBuilder[LeftJoined[Fields, Fields2, *], (Row, Option[Row2])] =
-      leftJoinOn(other)(pred.asInstanceOf[Joined[Fields, Fields2, (Row, Row2)] => SqlExpr[Boolean, Required, (Row, Row2)]])
+    def leftOnStrict(pred: Joined[Fields, Fields2] => SqlExpr[Boolean, Required]): SelectBuilder[LeftJoined[Fields, Fields2], (Row, Option[Row2])] =
+      leftJoinOn(other)(pred)
   }
 
   protected def params: SelectParams[Fields, Row]
 
   protected def withParams(sqlParams: SelectParams[Fields, Row]): SelectBuilder[Fields, Row]
 
-  protected def joinOn[Fields2[_], N[_]: Nullability, Row2](other: SelectBuilder[Fields2, Row2])(
-      pred: Joined[Fields, Fields2, (Row, Row2)] => SqlExpr[Boolean, N, (Row, Row2)]
-  ): SelectBuilder[Joined[Fields, Fields2, *], (Row, Row2)]
+  protected def joinOn[Fields2, N[_]: Nullability, Row2](other: SelectBuilder[Fields2, Row2])(
+      pred: Joined[Fields, Fields2] => SqlExpr[Boolean, N]
+  ): SelectBuilder[Joined[Fields, Fields2], (Row, Row2)]
 
-  protected def leftJoinOn[Fields2[_], N[_]: Nullability, Row2](other: SelectBuilder[Fields2, Row2])(
-      pred: Joined[Fields, Fields2, (Row, Row2)] => SqlExpr[Boolean, N, (Row, Row2)]
-  ): SelectBuilder[LeftJoined[Fields, Fields2, *], (Row, Option[Row2])]
+  protected def leftJoinOn[Fields2, N[_]: Nullability, Row2](other: SelectBuilder[Fields2, Row2])(
+      pred: Joined[Fields, Fields2] => SqlExpr[Boolean, N]
+  ): SelectBuilder[LeftJoined[Fields, Fields2], (Row, Option[Row2])]
 }

--- a/typo-dsl-zio-jdbc/src/scala/typo/dsl/SelectBuilderMock.scala
+++ b/typo-dsl-zio-jdbc/src/scala/typo/dsl/SelectBuilderMock.scala
@@ -5,73 +5,81 @@ import typo.dsl.internal.mocks.RowOrdering
 import zio.{Chunk, ZIO}
 import zio.jdbc.*
 
-final case class SelectBuilderMock[Fields[_], Row](
+final case class SelectBuilderMock[Fields, Row](
     structure: Structure[Fields, Row],
     all: ZIO[ZConnection, Throwable, Chunk[Row]],
     params: SelectParams[Fields, Row]
 ) extends SelectBuilder[Fields, Row] {
+  def withPath(path: Path): SelectBuilderMock[Fields, Row] =
+    copy(structure = structure.withPath(path))
+
+  override val renderCtx: RenderCtx = RenderCtx.Empty
+
   override def withParams(sqlParams: SelectParams[Fields, Row]): SelectBuilder[Fields, Row] =
     copy(params = sqlParams)
 
   override def toChunk: ZIO[ZConnection, Throwable, Chunk[Row]] =
-    all.map(all => SelectBuilderMock.applyParams(structure.fields, all, params))
+    all.map(all => SelectBuilderMock.applyParams(structure, all, params))
 
-  override def joinOn[Fields2[_], N[_]: Nullability, Row2](
+  override def joinOn[Fields2, N[_]: Nullability, Row2](
       other: SelectBuilder[Fields2, Row2]
-  )(pred: Joined[Fields, Fields2, (Row, Row2)] => SqlExpr[Boolean, N, (Row, Row2)]): SelectBuilder[Joined[Fields, Fields2, *], (Row, Row2)] = {
-    def otherMock: SelectBuilderMock[Fields2, Row2] = other match {
-      case x: SelectBuilderMock[Fields2, Row2] => x
+  )(pred: Joined[Fields, Fields2] => SqlExpr[Boolean, N]): SelectBuilderMock[Joined[Fields, Fields2], (Row, Row2)] = {
+    val otherMock: SelectBuilderMock[Fields2, Row2] = other match {
+      case x: SelectBuilderMock[Fields2, Row2] => x.withPath(Path.RightInJoin)
       case _                                   => sys.error("you cannot mix mock and sql repos")
     }
 
-    val newStructure = structure.join(otherMock.structure)
+    val self = this.withPath(Path.LeftInJoin)
+    val newStructure = self.structure.join(otherMock.structure)
 
     val newRows: ZIO[ZConnection, Throwable, Chunk[(Row, Row2)]] =
       for {
-        lefts <- this.toChunk
+        lefts <- self.toChunk
         rights <- otherMock.toChunk
       } yield for {
         left <- lefts
         right <- rights
         newRow = (left, right)
-        if Nullability[N].toOpt(pred(newStructure.fields).eval(newRow)).getOrElse(false)
+        if Nullability[N].toOpt(newStructure.untypedEval(pred(newStructure.fields), newRow)).getOrElse(false)
       } yield newRow
 
-    SelectBuilderMock[Joined[Fields, Fields2, *], (Row, Row2)](newStructure, newRows, SelectParams.empty)
+    SelectBuilderMock[Joined[Fields, Fields2], (Row, Row2)](newStructure, newRows, SelectParams.empty)
   }
-  override def leftJoinOn[Fields2[_], N[_]: Nullability, Row2](other: SelectBuilder[Fields2, Row2])(
-      pred: Joined[Fields, Fields2, (Row, Row2)] => SqlExpr[Boolean, N, (Row, Row2)]
-  ): SelectBuilder[LeftJoined[Fields, Fields2, *], (Row, Option[Row2])] = {
-    def otherMock: SelectBuilderMock[Fields2, Row2] = other match {
-      case x: SelectBuilderMock[Fields2, Row2] => x
+  override def leftJoinOn[Fields2, N[_]: Nullability, Row2](
+      other: SelectBuilder[Fields2, Row2]
+  )(pred: Joined[Fields, Fields2] => SqlExpr[Boolean, N]): SelectBuilder[LeftJoined[Fields, Fields2], (Row, Option[Row2])] = {
+    val otherMock: SelectBuilderMock[Fields2, Row2] = other match {
+      case x: SelectBuilderMock[Fields2, Row2] => x.withPath(Path.RightInJoin)
       case _                                   => sys.error("you cannot mix mock and sql repos")
     }
+    val self = this.withPath(Path.LeftInJoin)
 
     val newRows: ZIO[ZConnection, Throwable, Chunk[(Row, Option[Row2])]] = {
       for {
-        lefts <- this.toChunk
+        lefts <- self.toChunk
         rights <- otherMock.toChunk
       } yield {
         lefts.map { left =>
           val maybeRight = rights.find { right =>
-            Nullability[N].toOpt(pred(structure.join(otherMock.structure).fields).eval((left, right))).getOrElse(false)
+            val newStructure = self.structure.join(otherMock.structure)
+            Nullability[N].toOpt(newStructure.untypedEval(pred(newStructure.fields), (left, right))).getOrElse(false)
           }
           (left, maybeRight)
         }
       }
     }
-    SelectBuilderMock[LeftJoined[Fields, Fields2, *], (Row, Option[Row2])](structure.leftJoin(otherMock.structure), newRows, SelectParams.empty)
+    SelectBuilderMock[LeftJoined[Fields, Fields2], (Row, Option[Row2])](structure.leftJoin(otherMock.structure), newRows, SelectParams.empty)
   }
 
   override def sql: Option[SqlFragment] = None
 }
 
 object SelectBuilderMock {
-  def applyParams[Fields[_], Row](fields: Fields[Row], rows: Chunk[Row], params: SelectParams[Fields, Row]): Chunk[Row] = {
-    val (filters, orderBys) = seeks.expand(fields, params)
-    implicit val rowOrdering: Ordering[Row] = new RowOrdering(orderBys)
+  def applyParams[Fields, R](structure: Structure[Fields, R], rows: Chunk[R], params: SelectParams[Fields, R]): Chunk[R] = {
+    val (filters, orderBys) = seeks.expand(structure.fields, params)
+    implicit val rowOrdering: Ordering[R] = new RowOrdering(structure, orderBys)
     rows
-      .filter(row => filters.forall(_.eval(row).getOrElse(false)))
+      .filter(row => filters.forall(expr => structure.untypedEval(expr, row).getOrElse(false)))
       .sorted
       .drop(params.offset.getOrElse(0))
       .take(params.limit.getOrElse(Int.MaxValue))

--- a/typo-dsl-zio-jdbc/src/scala/typo/dsl/SelectParams.scala
+++ b/typo-dsl-zio-jdbc/src/scala/typo/dsl/SelectParams.scala
@@ -4,41 +4,36 @@ import typo.dsl.internal.seeks
 import zio.NonEmptyChunk
 import zio.jdbc.*
 
-import java.util.concurrent.atomic.AtomicInteger
-
-final case class SelectParams[Fields[_], Row](
-    where: List[Fields[Row] => SqlExpr[Boolean, Option, Row]],
-    orderBy: List[Fields[Row] => SortOrderNoHkt[?, Row]],
-    seeks: List[SelectParams.SeekNoHkt[Fields, Row, ?]],
+final case class SelectParams[Fields, Row](
+    where: List[Fields => SqlExpr[Boolean, Option]],
+    orderBy: List[Fields => SortOrderNoHkt[?]],
+    seeks: List[SelectParams.SeekNoHkt[Fields, ?]],
     offset: Option[Int],
     limit: Option[Int]
 ) {
-  def where(v: Fields[Row] => SqlExpr[Boolean, Option, Row]): SelectParams[Fields, Row] = copy(where = where :+ v)
-  def orderBy(v: Fields[Row] => SortOrderNoHkt[?, Row]): SelectParams[Fields, Row] = copy(orderBy = orderBy :+ v)
-  def seek(v: SelectParams.SeekNoHkt[Fields, Row, ?]): SelectParams[Fields, Row] = copy(seeks = seeks :+ v)
+  def where(v: Fields => SqlExpr[Boolean, Option]): SelectParams[Fields, Row] = copy(where = where :+ v)
+  def orderBy(v: Fields => SortOrderNoHkt[?]): SelectParams[Fields, Row] = copy(orderBy = orderBy :+ v)
+  def seek(v: SelectParams.SeekNoHkt[Fields, ?]): SelectParams[Fields, Row] = copy(seeks = seeks :+ v)
   def offset(v: Int): SelectParams[Fields, Row] = copy(offset = Some(v))
   def limit(v: Int): SelectParams[Fields, Row] = copy(limit = Some(v))
 }
 
 object SelectParams {
-  sealed trait SeekNoHkt[Fields[_], Row, NT] {
-    val f: Fields[Row] => SortOrderNoHkt[NT, Row]
+  def empty[Fields, R]: SelectParams[Fields, R] =
+    SelectParams[Fields, R](List.empty, List.empty, List.empty, None, None)
+
+  sealed trait SeekNoHkt[Fields, NT] {
+    val f: Fields => SortOrderNoHkt[NT]
   }
 
-  case class Seek[Fields[_], Row, T, N[_]](
-      f: Fields[Row] => SortOrder[T, N, Row],
-      value: SqlExpr.Const[T, N, Row]
-  ) extends SeekNoHkt[Fields, Row, N[T]]
+  case class Seek[Fields, T, N[_]](f: Fields => SortOrder[T, N], value: SqlExpr.Const[T, N]) extends SeekNoHkt[Fields, N[T]]
 
-  def empty[Fields[_], Row]: SelectParams[Fields, Row] =
-    SelectParams[Fields, Row](List.empty, List.empty, List.empty, None, None)
-
-  def render[Row, Fields[_]](fields: Fields[Row], baseSql: SqlFragment, counter: AtomicInteger, params: SelectParams[Fields, Row]): SqlFragment = {
+  def render[Fields, R](fields: Fields, baseSql: SqlFragment, ctx: RenderCtx, params: SelectParams[Fields, R]): SqlFragment = {
     val (filters, orderBys) = seeks.expand(fields, params)
     List[Option[SqlFragment]](
       Some(baseSql),
-      NonEmptyChunk.fromIterableOption(filters.map(f => f.render(counter))).map(fs => fs.mkFragment(" WHERE ", " AND ", "")),
-      NonEmptyChunk.fromIterableOption(orderBys.map(f => f.render(counter))).map(fs => fs.mkFragment(" ORDER BY ", ", ", "")),
+      NonEmptyChunk.fromIterableOption(filters.map(f => f.render(ctx))).map(fs => fs.mkFragment(" WHERE ", " AND ", "")),
+      NonEmptyChunk.fromIterableOption(orderBys.map(f => f.render(ctx))).map(fs => fs.mkFragment(" ORDER BY ", ", ", "")),
       params.offset.map(value => sql" offset $value"),
       params.limit.map(value => sql" limit $value")
     ).flatten.reduce(_ ++ _)

--- a/typo-dsl-zio-jdbc/src/scala/typo/dsl/SqlExpr.scala
+++ b/typo-dsl-zio-jdbc/src/scala/typo/dsl/SqlExpr.scala
@@ -2,284 +2,238 @@ package typo.dsl
 
 import zio.jdbc.*
 
-import java.util.concurrent.atomic.AtomicInteger
 import scala.reflect.ClassTag
 
-trait SqlExpr[T, N[_], R] extends SqlExpr.SqlExprNoHkt[N[T], R] {
-  final def isEqual[N2[_], NC[_]](t: SqlExpr[T, N2, R])(implicit O: Ordering[T], N: Nullability2[N, N2, NC]): SqlExpr[Boolean, NC, R] =
+sealed trait SqlExpr[T, N[_]] extends SqlExpr.SqlExprNoHkt[N[T]] {
+  final def isEqual[N2[_], NC[_]](t: SqlExpr[T, N2])(implicit O: Ordering[T], N: Nullability2[N, N2, NC]): SqlExpr[Boolean, NC] =
     this === t
 
-  final def isNotEqual[N2[_], NC[_]](t: SqlExpr[T, N2, R])(implicit O: Ordering[T], N: Nullability2[N, N2, NC]): SqlExpr[Boolean, NC, R] =
+  final def isNotEqual[N2[_], NC[_]](t: SqlExpr[T, N2])(implicit O: Ordering[T], N: Nullability2[N, N2, NC]): SqlExpr[Boolean, NC] =
     this !== t
 
-  final def ===[N2[_], NC[_]](t: SqlExpr[T, N2, R])(implicit O: Ordering[T], N: Nullability2[N, N2, NC]): SqlExpr[Boolean, NC, R] =
+  final def ===[N2[_], NC[_]](t: SqlExpr[T, N2])(implicit O: Ordering[T], N: Nullability2[N, N2, NC]): SqlExpr[Boolean, NC] =
     SqlExpr.Binary(this, SqlOperator.eq, t, N)
 
-  final def !==[N2[_], NC[_]](t: SqlExpr[T, N2, R])(implicit O: Ordering[T], N: Nullability2[N, N2, NC]): SqlExpr[Boolean, NC, R] =
+  final def !==[N2[_], NC[_]](t: SqlExpr[T, N2])(implicit O: Ordering[T], N: Nullability2[N, N2, NC]): SqlExpr[Boolean, NC] =
     SqlExpr.Binary(this, SqlOperator.neq, t, N)
 
-  final def >[N2[_], NC[_]](t: SqlExpr[T, N2, R])(implicit O: Ordering[T], N: Nullability2[N, N2, NC]): SqlExpr[Boolean, NC, R] =
+  final def >[N2[_], NC[_]](t: SqlExpr[T, N2])(implicit O: Ordering[T], N: Nullability2[N, N2, NC]): SqlExpr[Boolean, NC] =
     SqlExpr.Binary(this, SqlOperator.gt, t, N)
 
-  final def >=[N2[_], NC[_]](t: SqlExpr[T, N2, R])(implicit O: Ordering[T], N: Nullability2[N, N2, NC]): SqlExpr[Boolean, NC, R] =
+  final def >=[N2[_], NC[_]](t: SqlExpr[T, N2])(implicit O: Ordering[T], N: Nullability2[N, N2, NC]): SqlExpr[Boolean, NC] =
     SqlExpr.Binary(this, SqlOperator.gte, t, N)
 
-  final def <[N2[_], NC[_]](t: SqlExpr[T, N2, R])(implicit O: Ordering[T], N: Nullability2[N, N2, NC]): SqlExpr[Boolean, NC, R] =
+  final def <[N2[_], NC[_]](t: SqlExpr[T, N2])(implicit O: Ordering[T], N: Nullability2[N, N2, NC]): SqlExpr[Boolean, NC] =
     SqlExpr.Binary(this, SqlOperator.lt, t, N)
 
-  final def <=[N2[_], NC[_]](t: SqlExpr[T, N2, R])(implicit O: Ordering[T], N: Nullability2[N, N2, NC]): SqlExpr[Boolean, NC, R] =
+  final def <=[N2[_], NC[_]](t: SqlExpr[T, N2])(implicit O: Ordering[T], N: Nullability2[N, N2, NC]): SqlExpr[Boolean, NC] =
     SqlExpr.Binary(this, SqlOperator.lte, t, N)
 
-  final infix def or[N2[_], NC[_]](other: SqlExpr[T, N2, R])(implicit B: Bijection[T, Boolean], N: Nullability2[N, N2, NC]): SqlExpr[T, NC, R] =
+  final infix def or[N2[_], NC[_]](other: SqlExpr[T, N2])(implicit B: Bijection[T, Boolean], N: Nullability2[N, N2, NC]): SqlExpr[T, NC] =
     SqlExpr.Binary(this, SqlOperator.or[T], other, N)
 
-  final infix def and[N2[_], NC[_]](other: SqlExpr[T, N2, R])(implicit B: Bijection[T, Boolean], N: Nullability2[N, N2, NC]): SqlExpr[T, NC, R] =
+  final infix def and[N2[_], NC[_]](other: SqlExpr[T, N2])(implicit B: Bijection[T, Boolean], N: Nullability2[N, N2, NC]): SqlExpr[T, NC] =
     SqlExpr.Binary(this, SqlOperator.and[T], other, N)
 
-  def unary_!(implicit B: Bijection[T, Boolean], N: Nullability[N]): SqlExpr[T, N, R] =
+  def unary_!(implicit B: Bijection[T, Boolean], N: Nullability[N]): SqlExpr[T, N] =
     SqlExpr.Not(this, B, N)
 
-  final def +[N2[_], NC[_]](t: SqlExpr[T, N2, R])(implicit Num: Numeric[T], N: Nullability2[N, N2, NC]): SqlExpr[T, NC, R] =
+  final def +[N2[_], NC[_]](t: SqlExpr[T, N2])(implicit Num: Numeric[T], N: Nullability2[N, N2, NC]): SqlExpr[T, NC] =
     plus(t)
-  final def plus[N2[_], NC[_]](t: SqlExpr[T, N2, R])(implicit Num: Numeric[T], N: Nullability2[N, N2, NC]): SqlExpr[T, NC, R] =
+  final def plus[N2[_], NC[_]](t: SqlExpr[T, N2])(implicit Num: Numeric[T], N: Nullability2[N, N2, NC]): SqlExpr[T, NC] =
     SqlExpr.Binary(this, SqlOperator.plus, t, N)
 
-  final def -[N2[_], NC[_]](t: SqlExpr[T, N2, R])(implicit Num: Numeric[T], N: Nullability2[N, N2, NC]): SqlExpr[T, NC, R] =
+  final def -[N2[_], NC[_]](t: SqlExpr[T, N2])(implicit Num: Numeric[T], N: Nullability2[N, N2, NC]): SqlExpr[T, NC] =
     sub(t)
-  final def sub[N2[_], NC[_]](t: SqlExpr[T, N2, R])(implicit Num: Numeric[T], N: Nullability2[N, N2, NC]): SqlExpr[T, NC, R] =
+  final def sub[N2[_], NC[_]](t: SqlExpr[T, N2])(implicit Num: Numeric[T], N: Nullability2[N, N2, NC]): SqlExpr[T, NC] =
     SqlExpr.Binary(this, SqlOperator.minus, t, N)
 
-  final def *[N2[_], NC[_]](t: SqlExpr[T, N2, R])(implicit Num: Numeric[T], N: Nullability2[N, N2, NC]): SqlExpr[T, NC, R] =
+  final def *[N2[_], NC[_]](t: SqlExpr[T, N2])(implicit Num: Numeric[T], N: Nullability2[N, N2, NC]): SqlExpr[T, NC] =
     mul(t)
-  final def mul[N2[_], NC[_]](t: SqlExpr[T, N2, R])(implicit Num: Numeric[T], N: Nullability2[N, N2, NC]): SqlExpr[T, NC, R] =
+  final def mul[N2[_], NC[_]](t: SqlExpr[T, N2])(implicit Num: Numeric[T], N: Nullability2[N, N2, NC]): SqlExpr[T, NC] =
     SqlExpr.Binary(this, SqlOperator.mul, t, N)
 
-  final def underlying[TT](implicit B: Bijection[T, TT], N: Nullability[N]): SqlExpr[TT, N, R] =
+  final def underlying[TT](implicit B: Bijection[T, TT], N: Nullability[N]): SqlExpr[TT, N] =
     SqlExpr.Underlying(this, B, N)
 
-  final def like(str: String)(implicit B: Bijection[T, String], N: Nullability[N]): SqlExpr[Boolean, N, R] =
+  final def like(str: String)(implicit B: Bijection[T, String], N: Nullability[N]): SqlExpr[Boolean, N] =
     SqlExpr.Binary(this, SqlOperator.like, SqlExpr.asConstRequired(str), N.withRequired)
 
-  final def ||[N2[_], NC[_]](other: SqlExpr[T, N2, R])(implicit B: Bijection[T, String], N: Nullability2[N, N2, NC]): SqlExpr[T, NC, R] =
+  final def ||[N2[_], NC[_]](other: SqlExpr[T, N2])(implicit B: Bijection[T, String], N: Nullability2[N, N2, NC]): SqlExpr[T, NC] =
     stringAppend(other)
-  final def stringAppend[N2[_], NC[_]](other: SqlExpr[T, N2, R])(implicit B: Bijection[T, String], N: Nullability2[N, N2, NC]): SqlExpr[T, NC, R] =
+  final def stringAppend[N2[_], NC[_]](other: SqlExpr[T, N2])(implicit B: Bijection[T, String], N: Nullability2[N, N2, NC]): SqlExpr[T, NC] =
     SqlExpr.Binary(this, SqlOperator.strAdd, other, N)
 
-  final def lower(implicit B: Bijection[T, String], N: Nullability[N]): SqlExpr[T, N, R] =
+  final def lower(implicit B: Bijection[T, String], N: Nullability[N]): SqlExpr[T, N] =
     SqlExpr.Apply1(SqlFunction1.lower, this, N)
 
-  final def reverse(implicit B: Bijection[T, String], N: Nullability[N]): SqlExpr[T, N, R] =
+  final def reverse(implicit B: Bijection[T, String], N: Nullability[N]): SqlExpr[T, N] =
     SqlExpr.Apply1(SqlFunction1.reverse, this, N)
 
-  final def upper(implicit B: Bijection[T, String], N: Nullability[N]): SqlExpr[T, N, R] =
+  final def upper(implicit B: Bijection[T, String], N: Nullability[N]): SqlExpr[T, N] =
     SqlExpr.Apply1(SqlFunction1.upper, this, N)
 
-  final def strpos[N2[_], NC[_]](substring: SqlExpr[String, N2, R])(implicit B: Bijection[T, String], N: Nullability2[N, N2, NC]): SqlExpr[Int, NC, R] =
+  final def strpos[N2[_], NC[_]](substring: SqlExpr[String, N2])(implicit B: Bijection[T, String], N: Nullability2[N, N2, NC]): SqlExpr[Int, NC] =
     SqlExpr.Apply2(SqlFunction2.strpos, this, substring, N)
 
-  final def strLength(implicit B: Bijection[T, String], N: Nullability[N]): SqlExpr[Int, N, R] =
+  final def strLength(implicit B: Bijection[T, String], N: Nullability[N]): SqlExpr[Int, N] =
     SqlExpr.Apply1(SqlFunction1.length, this, N)
 
-  final def substring[N2[_], N3[_], NC[_]](from: SqlExpr[Int, N2, R], count: SqlExpr[Int, N3, R])(implicit
+  final def substring[N2[_], N3[_], NC[_]](from: SqlExpr[Int, N2], count: SqlExpr[Int, N3])(implicit
       B: Bijection[T, String],
       N: Nullability3[N, N2, N3, NC]
-  ): SqlExpr[T, NC, R] =
+  ): SqlExpr[T, NC] =
     SqlExpr.Apply3(SqlFunction3.substring[T](), this, from, count, N)
 
-  final infix def in(ts: Array[T])(implicit ev: JdbcEncoder[Array[T]], N: Nullability[N]): SqlExpr[Boolean, N, R] =
+  final infix def in(ts: Array[T])(implicit ev: JdbcEncoder[Array[T]], N: Nullability[N]): SqlExpr[Boolean, N] =
     SqlExpr.In(this, ts, ev, N)
 
-  final def ?(implicit N: Nullability[N]): SqlExpr[T, Option, R] = opt
-  final def opt(implicit N: Nullability[N]): SqlExpr[T, Option, R] = SqlExpr.ToNullable(this, N)
+  final def ?(implicit N: Nullability[N]): SqlExpr[T, Option] = opt
+  final def opt(implicit N: Nullability[N]): SqlExpr[T, Option] = SqlExpr.ToNullable(this, N)
 }
 
 object SqlExpr {
-  trait SqlExprNoHkt[NT, R] {
-    def eval(row: R): NT
-
-    def render(counter: AtomicInteger): SqlFragment
+  sealed trait SqlExprNoHkt[NT] {
+    def render(ctx: RenderCtx): SqlFragment
   }
 
-  sealed trait FieldLikeNoHkt[NT, Row] extends SqlExprNoHkt[NT, Row] {
-    private[typo] val prefix: Option[String]
-    private[typo] val name: String
-    private[typo] val get: Row => NT
-    private[typo] val set: (Row, NT) => Row
-    private[typo] val sqlReadCast: Option[String]
-    private[typo] val sqlWriteCast: Option[String]
-
-    final def value: String = prefix.fold("")(_ + ".") + name
+  sealed trait FieldLikeNoHkt[NT, R] extends SqlExprNoHkt[NT] {
+    val path: List[Path]
+    val name: String
+    val get: R => NT
+    val set: (R, NT) => R
+    val sqlReadCast: Option[String]
+    val sqlWriteCast: Option[String]
+    final def value(ctx: RenderCtx): String = ctx.alias.get(path).fold("")(_ + ".") + name
+    final def render(ctx: RenderCtx): SqlFragment = SqlFragment(value(ctx))
   }
 
   sealed trait FieldLikeNotIdNoHkt[NT, R] extends FieldLikeNoHkt[NT, R]
 
-  sealed abstract class FieldLike[T, N[_], R](val prefix: Option[String], val name: String, val sqlReadCast: Option[String], val sqlWriteCast: Option[String])(
-      val get: R => N[T],
-      val set: (R, N[T]) => R
-  ) extends SqlExpr[T, N, R]
-      with FieldLikeNoHkt[N[T], R] {
-    override def eval(row: R): N[T] = get(row)
-    override def render(counter: AtomicInteger): SqlFragment = SqlFragment(value)
-  }
+  sealed trait FieldLike[T, N[_], R] extends SqlExpr[T, N] with FieldLikeNoHkt[N[T], R] with Product
 
   sealed trait FieldLikeNotId[T, N[_], R] extends FieldLike[T, N, R] with FieldLikeNotIdNoHkt[N[T], R]
 
   // connect a field `name` to a type `T` for a relation `R`
-  class Field[T, R](prefix: Option[String], name: String, sqlReadCast: Option[String] = None, sqlWriteCast: Option[String] = None)(get: R => T, set: (R, T) => R)
-      extends FieldLike[T, Required, R](prefix, name, sqlReadCast, sqlWriteCast)(get, set)
-      with FieldLikeNotId[T, Required, R]
+  case class Field[T, R](path: List[Path], name: String, sqlReadCast: Option[String], sqlWriteCast: Option[String], get: R => T, set: (R, T) => R) extends FieldLikeNotId[T, Required, R]
 
-  class IdField[T, R](prefix: Option[String], name: String, sqlReadCast: Option[String] = None, sqlWriteCast: Option[String] = None)(get: R => T, set: (R, T) => R)
-      extends FieldLike[T, Required, R](prefix, name, sqlReadCast, sqlWriteCast)(get, set)
+  case class IdField[T, R](path: List[Path], name: String, sqlReadCast: Option[String], sqlWriteCast: Option[String], get: R => T, set: (R, T) => R) extends FieldLike[T, Required, R]
 
-  class OptField[T, R](prefix: Option[String], name: String, sqlReadCast: Option[String] = None, sqlWriteCast: Option[String] = None)(get: R => Option[T], set: (R, Option[T]) => R)
-      extends FieldLike[T, Option, R](prefix, name, sqlReadCast, sqlWriteCast)(get, set)
-      with FieldLikeNotId[T, Option, R]
+  case class OptField[T, R](path: List[Path], name: String, sqlReadCast: Option[String], sqlWriteCast: Option[String], get: R => Option[T], set: (R, Option[T]) => R)
+      extends FieldLikeNotId[T, Option, R]
 
-  final case class Const[T, N[_], R](value: N[T], E: JdbcEncoder[N[T]], P: ParameterMetaData[T]) extends SqlExpr[T, N, R] {
-    override def eval(row: R): N[T] = value
-
-    override def render(counter: AtomicInteger): SqlFragment = sql"${E.encode(value)}" ++ s"::${P.sqlType}"
+  case class Const[T, N[_]](value: N[T], E: JdbcEncoder[N[T]], P: ParameterMetaData[T]) extends SqlExpr[T, N] {
+    override def render(ctx: RenderCtx): SqlFragment = sql"${E.encode(value)}" ++ s"::${P.sqlType}"
   }
 
   object Const {
-    trait As[T, N[_], R] {
-      def apply(value: N[T]): SqlExpr.Const[T, N, R]
+    trait As[T, N[_]] {
+      def apply(value: N[T]): SqlExpr.Const[T, N]
     }
 
     object As {
-      implicit def as[T, N[_], R](implicit E: JdbcEncoder[N[T]], P: ParameterMetaData[T]): As[T, N, R] =
+      implicit def as[T, N[_], R](implicit E: JdbcEncoder[N[T]], P: ParameterMetaData[T]): As[T, N] =
         (value: N[T]) => SqlExpr.Const(value, E, P)
     }
   }
 
-  final case class ArrayIndex[T, N1[_], N2[_], R](arr: SqlExpr[Array[T], N1, R], idx: SqlExpr[Int, N2, R], N: Nullability2[N1, N2, Option]) extends SqlExpr[T, Option, R] {
-    override def eval(row: R): Option[T] = {
-      N.mapN(arr.eval(row), idx.eval(row)) { (arr, idx) =>
-        if (idx < 0 || idx >= arr.length) None
-        else Some(arr(idx))
-      }.flatten
-    }
-
-    override def render(counter: AtomicInteger): SqlFragment =
-      sql"${arr.render(counter)}[${idx.render(counter)}]"
+  case class ArrayIndex[T, N1[_], N2[_]](arr: SqlExpr[Array[T], N1], idx: SqlExpr[Int, N2], N: Nullability2[N1, N2, Option]) extends SqlExpr[T, Option] {
+    override def render(ctx: RenderCtx): SqlFragment =
+      sql"${arr.render(ctx)}[${idx.render(ctx)}]"
   }
 
-  final case class Apply1[T1, O, N[_], R](f: SqlFunction1[T1, O], arg1: SqlExpr[T1, N, R], N: Nullability[N]) extends SqlExpr[O, N, R] {
-    override def eval(row: R): N[O] =
-      N.mapN(arg1.eval(row))(f.eval)
-    override def render(counter: AtomicInteger): SqlFragment =
-      sql"${SqlFragment(f.name)}(${arg1.render(counter)})"
+  case class Apply1[T1, O, N[_]](f: SqlFunction1[T1, O], arg1: SqlExpr[T1, N], N: Nullability[N]) extends SqlExpr[O, N] {
+    override def render(ctx: RenderCtx): SqlFragment =
+      sql"${SqlFragment(f.name)}(${arg1.render(ctx)})"
   }
 
-  final case class Apply2[T1, T2, O, N1[_], N2[_], N[_], R](f: SqlFunction2[T1, T2, O], arg1: SqlExpr[T1, N1, R], arg2: SqlExpr[T2, N2, R], N: Nullability2[N1, N2, N]) extends SqlExpr[O, N, R] {
-    override def eval(row: R): N[O] =
-      N.mapN(arg1.eval(row), arg2.eval(row))(f.eval)
-    override def render(counter: AtomicInteger): SqlFragment =
-      sql"${SqlFragment(f.name)}(${arg1.render(counter)}, ${arg2.render(counter)})"
+  case class Apply2[T1, T2, O, N1[_], N2[_], N[_]](f: SqlFunction2[T1, T2, O], arg1: SqlExpr[T1, N1], arg2: SqlExpr[T2, N2], N: Nullability2[N1, N2, N]) extends SqlExpr[O, N] {
+    override def render(ctx: RenderCtx): SqlFragment =
+      sql"${SqlFragment(f.name)}(${arg1.render(ctx)}, ${arg2.render(ctx)})"
   }
 
-  final case class Apply3[T1, T2, T3, N1[_], N2[_], N3[_], N[_], O, R](
+  case class Apply3[T1, T2, T3, N1[_], N2[_], N3[_], N[_], O](
       f: SqlFunction3[T1, T2, T3, O],
-      arg1: SqlExpr[T1, N1, R],
-      arg2: SqlExpr[T2, N2, R],
-      arg3: SqlExpr[T3, N3, R],
+      arg1: SqlExpr[T1, N1],
+      arg2: SqlExpr[T2, N2],
+      arg3: SqlExpr[T3, N3],
       N: Nullability3[N1, N2, N3, N]
-  ) extends SqlExpr[O, N, R] {
-    override def eval(row: R): N[O] =
-      N.mapN(arg1.eval(row), arg2.eval(row), arg3.eval(row))(f.eval)
-    override def render(counter: AtomicInteger): SqlFragment =
-      sql"${SqlFragment(f.name)}(${arg1.render(counter)}, ${arg2.render(counter)}, ${arg3.render(counter)})"
+  ) extends SqlExpr[O, N] {
+    override def render(ctx: RenderCtx): SqlFragment =
+      sql"${SqlFragment(f.name)}(${arg1.render(ctx)}, ${arg2.render(ctx)}, ${arg3.render(ctx)})"
   }
 
-  final case class Binary[T1, T2, O, N1[_], N2[_], N[_], R](left: SqlExpr[T1, N1, R], op: SqlOperator[T1, T2, O], right: SqlExpr[T2, N2, R], N: Nullability2[N1, N2, N]) extends SqlExpr[O, N, R] {
-    override def eval(row: R): N[O] =
-      N.mapN(left.eval(row), right.eval(row))(op.eval)
-    override def render(counter: AtomicInteger): SqlFragment =
-      sql"(${left.render(counter)} ${SqlFragment(op.name)} ${right.render(counter)})"
+  case class Binary[T1, T2, O, N1[_], N2[_], N[_]](left: SqlExpr[T1, N1], op: SqlOperator[T1, T2, O], right: SqlExpr[T2, N2], N: Nullability2[N1, N2, N]) extends SqlExpr[O, N] {
+    override def render(ctx: RenderCtx): SqlFragment =
+      sql"(${left.render(ctx)} ${SqlFragment(op.name)} ${right.render(ctx)})"
   }
 
-  final case class Underlying[T, TT, N[_], R](expr: SqlExpr[T, N, R], bijection: Bijection[T, TT], N: Nullability[N]) extends SqlExpr[TT, N, R] {
-    override def eval(row: R): N[TT] =
-      N.mapN(expr.eval(row))(bijection.underlying)
-    override def render(counter: AtomicInteger): SqlFragment =
-      expr.render(counter)
+  case class Underlying[T, TT, N[_]](expr: SqlExpr[T, N], bijection: Bijection[T, TT], N: Nullability[N]) extends SqlExpr[TT, N] {
+    override def render(ctx: RenderCtx): SqlFragment =
+      expr.render(ctx)
   }
 
-  final case class Coalesce[T, R](expr: SqlExpr[T, Option, R], getOrElse: SqlExpr[T, Required, R]) extends SqlExpr[T, Required, R] {
-    override def eval(row: R): T =
-      expr.eval(row).getOrElse(getOrElse.eval(row))
-    override def render(counter: AtomicInteger): SqlFragment =
-      sql"coalesce(${expr.render(counter)}, ${getOrElse.render(counter)})"
+  case class Coalesce[T](expr: SqlExpr[T, Option], getOrElse: SqlExpr[T, Required]) extends SqlExpr[T, Required] {
+    override def render(ctx: RenderCtx): SqlFragment =
+      sql"coalesce(${expr.render(ctx)}, ${getOrElse.render(ctx)})"
   }
 
-  final case class In[T, N[_], R](expr: SqlExpr[T, N, R], values: Array[T], ev: JdbcEncoder[Array[T]], N: Nullability[N]) extends SqlExpr[Boolean, N, R] {
-    override def eval(row: R): N[Boolean] =
-      N.mapN(expr.eval(row))(values.contains)
-
-    override def render(counter: AtomicInteger): SqlFragment =
-      sql"${expr.render(counter)} = ANY(${ev.encode(values)})"
+  case class In[T, N[_]](expr: SqlExpr[T, N], values: Array[T], ev: JdbcEncoder[Array[T]], N: Nullability[N]) extends SqlExpr[Boolean, N] {
+    override def render(ctx: RenderCtx): SqlFragment =
+      sql"${expr.render(ctx)} = ANY(${ev.encode(values)})"
   }
 
-  final case class IsNull[T, R](expr: SqlExpr[T, Option, R]) extends SqlExpr[Boolean, Required, R] {
-    override def eval(row: R): Boolean =
-      expr.eval(row).isEmpty
-    override def render(counter: AtomicInteger): SqlFragment =
-      sql"${expr.render(counter)} IS NULL"
+  case class IsNull[T](expr: SqlExpr[T, Option]) extends SqlExpr[Boolean, Required] {
+    override def render(ctx: RenderCtx): SqlFragment =
+      sql"${expr.render(ctx)} IS NULL"
   }
 
-  final case class Not[T, N[_], R](expr: SqlExpr[T, N, R], B: Bijection[T, Boolean], N: Nullability[N]) extends SqlExpr[T, N, R] {
-    override def eval(row: R): N[T] =
-      N.mapN(expr.eval(row))(t => B.map(t)(b => !b))
-
-    override def render(counter: AtomicInteger): SqlFragment =
-      sql"NOT ${expr.render(counter)}"
+  case class Not[T, N[_]](expr: SqlExpr[T, N], B: Bijection[T, Boolean], N: Nullability[N]) extends SqlExpr[T, N] {
+    override def render(ctx: RenderCtx): SqlFragment =
+      sql"NOT ${expr.render(ctx)}"
   }
 
-  final case class ToNullable[T, R, N1[_]](expr: SqlExpr[T, N1, R], N: Nullability[N1]) extends SqlExpr[T, Option, R] {
-    override def eval(row: R): Option[T] =
-      N.toOpt(expr.eval(row))
-    override def render(counter: AtomicInteger): SqlFragment =
-      expr.render(counter)
+  case class ToNullable[T, N[_]](expr: SqlExpr[T, N], N: Nullability[N]) extends SqlExpr[T, Option] {
+    override def render(ctx: RenderCtx): SqlFragment =
+      expr.render(ctx)
   }
 
   // automatically put values in a constant expression
-  implicit def asConstOpt[T, R](t: Option[T])(implicit E: JdbcEncoder[Option[T]], P: ParameterMetaData[T]): SqlExpr.Const[T, Option, R] =
+  implicit def asConstOpt[T](t: Option[T])(implicit E: JdbcEncoder[Option[T]], P: ParameterMetaData[T]): SqlExpr.Const[T, Option] =
     Const(t, E, P)
 
-  implicit def asConstRequired[T: JdbcEncoder: ParameterMetaData, R](t: T): SqlExpr.Const[T, Required, R] =
-    Const[T, Required, R](t, implicitly, implicitly)
+  implicit def asConstRequired[T: JdbcEncoder: ParameterMetaData](t: T): SqlExpr.Const[T, Required] =
+    Const[T, Required](t, implicitly, implicitly)
 
   // some syntax to construct field sort order
-  implicit class SqlExprSortSyntax[T, N[_], R](private val expr: SqlExpr[T, N, R]) extends AnyVal {
-    def asc(implicit O: Ordering[T], N: Nullability[N]): SortOrder[T, N, R] = SortOrder(expr, ascending = true, nullsFirst = false)
-    def desc(implicit O: Ordering[T], N: Nullability[N]): SortOrder[T, N, R] = SortOrder(expr, ascending = false, nullsFirst = false)
+  implicit class SqlExprSortSyntax[T, N[_]](private val expr: SqlExpr[T, N]) extends AnyVal {
+    def asc(implicit O: Ordering[T], N: Nullability[N]): SortOrder[T, N] = SortOrder(expr, ascending = true, nullsFirst = false)
+    def desc(implicit O: Ordering[T], N: Nullability[N]): SortOrder[T, N] = SortOrder(expr, ascending = false, nullsFirst = false)
   }
 
-  final case class RowExpr[R](exprs: List[SqlExpr.SqlExprNoHkt[?, R]]) extends SqlExpr[List[?], Required, R] {
-    override def eval(row: R): List[?] = exprs.map(_.eval(row))
+  final case class RowExpr[R](exprs: List[SqlExpr.SqlExprNoHkt[?]]) extends SqlExpr[List[?], Required] {
     override def render(counter: AtomicInteger): SqlFragment = exprs.map(_.render(counter)).mkFragment(sql"(", sql",", sql")")
   }
 
-  implicit class SqlExprArraySyntax[T, N[_], R](private val expr: SqlExpr[Array[T], N, R]) extends AnyVal {
+  implicit class SqlExprArraySyntax[T, N[_]](private val expr: SqlExpr[Array[T], N]) extends AnyVal {
 
     /** look up an element in an array at index `idx` */
-    def arrayIndex[N2[_]](idx: SqlExpr[Int, N2, R])(implicit N: Nullability2[N, N2, Option]): SqlExpr[T, Option, R] =
-      SqlExpr.ArrayIndex[T, N, N2, R](expr, idx, N)
+    def arrayIndex[N2[_]](idx: SqlExpr[Int, N2])(implicit N: Nullability2[N, N2, Option]): SqlExpr[T, Option] =
+      SqlExpr.ArrayIndex[T, N, N2](expr, idx, N)
 
     /** concatenate two arrays */
-    def arrayConcat[N2[_], NC[_]](other: SqlExpr[Array[T], N2, R])(implicit C: ClassTag[T], N: Nullability2[N, N2, NC]): SqlExpr[Array[T], NC, R] =
+    def arrayConcat[N2[_], NC[_]](other: SqlExpr[Array[T], N2])(implicit C: ClassTag[T], N: Nullability2[N, N2, NC]): SqlExpr[Array[T], NC] =
       SqlExpr.Binary(expr, SqlOperator.arrayConcat, other, N)
 
     /** does arrays have elements in common */
-    def arrayOverlaps[N2[_], NC[_]](other: SqlExpr[Array[T], N2, R])(implicit N: Nullability2[N, N2, NC]): SqlExpr[Boolean, NC, R] =
+    def arrayOverlaps[N2[_], NC[_]](other: SqlExpr[Array[T], N2])(implicit N: Nullability2[N, N2, NC]): SqlExpr[Boolean, NC] =
       SqlExpr.Binary(expr, SqlOperator.arrayOverlaps[Array[T], T], other, N)
   }
 
-  implicit class SqlExprOptionalSyntax[T, R](private val expr: SqlExpr[T, Option, R]) extends AnyVal {
-    def isNull: SqlExpr[Boolean, Required, R] =
+  implicit class SqlExprOptionalSyntax[T](private val expr: SqlExpr[T, Option]) extends AnyVal {
+    def isNull: SqlExpr[Boolean, Required] =
       SqlExpr.IsNull(expr)
-    def coalesce(orElse: SqlExpr[T, Required, R]): SqlExpr[T, Required, R] =
+    def coalesce(orElse: SqlExpr[T, Required]): SqlExpr[T, Required] =
       SqlExpr.Coalesce(expr, orElse)
   }
 }

--- a/typo-dsl-zio-jdbc/src/scala/typo/dsl/SqlExpr.scala
+++ b/typo-dsl-zio-jdbc/src/scala/typo/dsl/SqlExpr.scala
@@ -212,7 +212,7 @@ object SqlExpr {
   }
 
   final case class RowExpr[R](exprs: List[SqlExpr.SqlExprNoHkt[?]]) extends SqlExpr[List[?], Required] {
-    override def render(counter: AtomicInteger): SqlFragment = exprs.map(_.render(counter)).mkFragment(sql"(", sql",", sql")")
+    override def render(ctx: RenderCtx): SqlFragment = exprs.map(_.render(ctx)).mkFragment(sql"(", sql",", sql")")
   }
 
   implicit class SqlExprArraySyntax[T, N[_]](private val expr: SqlExpr[Array[T], N]) extends AnyVal {

--- a/typo-dsl-zio-jdbc/src/scala/typo/dsl/SqlExpr.scala
+++ b/typo-dsl-zio-jdbc/src/scala/typo/dsl/SqlExpr.scala
@@ -211,7 +211,7 @@ object SqlExpr {
     def desc(implicit O: Ordering[T], N: Nullability[N]): SortOrder[T, N] = SortOrder(expr, ascending = false, nullsFirst = false)
   }
 
-  final case class RowExpr[R](exprs: List[SqlExpr.SqlExprNoHkt[?]]) extends SqlExpr[List[?], Required] {
+  final case class RowExpr(exprs: List[SqlExpr.SqlExprNoHkt[?]]) extends SqlExpr[List[?], Required] {
     override def render(ctx: RenderCtx): SqlFragment = exprs.map(_.render(ctx)).mkFragment(sql"(", sql",", sql")")
   }
 

--- a/typo-dsl-zio-jdbc/src/scala/typo/dsl/pagination/SortOrderRepr.scala
+++ b/typo-dsl-zio-jdbc/src/scala/typo/dsl/pagination/SortOrderRepr.scala
@@ -1,9 +1,7 @@
 package typo.dsl.pagination
 
-import typo.dsl.SortOrderNoHkt
+import typo.dsl.{RenderCtx, SortOrderNoHkt}
 import zio.jdbc.SqlFragment
-
-import java.util.concurrent.atomic.AtomicInteger
 
 /** A client cursor is inherently tied to a set of sort orderings.
   *
@@ -12,7 +10,7 @@ import java.util.concurrent.atomic.AtomicInteger
 case class SortOrderRepr(expr: String) extends AnyVal
 
 object SortOrderRepr {
-  def from[NT, R](x: SortOrderNoHkt[NT, R]): SortOrderRepr = {
+  def from[NT](x: SortOrderNoHkt[NT], ctx: RenderCtx): SortOrderRepr = {
     val sql = new StringBuilder()
 
     // no usable way to just get the sql without parameters in zio-jdbc :(
@@ -25,7 +23,7 @@ object SortOrderRepr {
       }
 
     // note `x.expr`! the value is independent of ascending/descending and nulls first/last
-    recAdd(x.expr.render(new AtomicInteger(0)))
+    recAdd(x.expr.render(ctx))
 
     SortOrderRepr(sql.result().trim)
   }

--- a/typo-tester-anorm/generated-and-checked-in/adventureworks/customtypes/TypoShort.scala
+++ b/typo-tester-anorm/generated-and-checked-in/adventureworks/customtypes/TypoShort.scala
@@ -15,7 +15,6 @@ import java.sql.Types
 import org.postgresql.jdbc.PgArray
 import play.api.libs.json.Reads
 import play.api.libs.json.Writes
-import scala.math.Numeric
 import typo.dsl.Bijection
 
 /** Short primitive */

--- a/typo-tester-anorm/generated-and-checked-in/adventureworks/hr/d/DViewFields.scala
+++ b/typo-tester-anorm/generated-and-checked-in/adventureworks/hr/d/DViewFields.scala
@@ -10,38 +10,39 @@ package d
 import adventureworks.customtypes.TypoLocalDateTime
 import adventureworks.humanresources.department.DepartmentId
 import adventureworks.public.Name
+import typo.dsl.Path
 import typo.dsl.SqlExpr.Field
 import typo.dsl.SqlExpr.FieldLikeNoHkt
 import typo.dsl.Structure.Relation
 
-trait DViewFields[Row] {
-  val id: Field[DepartmentId, Row]
-  val departmentid: Field[DepartmentId, Row]
-  val name: Field[Name, Row]
-  val groupname: Field[Name, Row]
-  val modifieddate: Field[TypoLocalDateTime, Row]
+trait DViewFields {
+  def id: Field[DepartmentId, DViewRow]
+  def departmentid: Field[DepartmentId, DViewRow]
+  def name: Field[Name, DViewRow]
+  def groupname: Field[Name, DViewRow]
+  def modifieddate: Field[TypoLocalDateTime, DViewRow]
 }
 
 object DViewFields {
-  val structure: Relation[DViewFields, DViewRow, DViewRow] = 
-    new Impl(None, identity, (_, x) => x)
+  lazy val structure: Relation[DViewFields, DViewRow] =
+    new Impl(Nil)
     
-  private final class Impl[Row](val prefix: Option[String], val extract: Row => DViewRow, val merge: (Row, DViewRow) => Row)
-    extends Relation[DViewFields, DViewRow, Row] { 
+  private final class Impl(val _path: List[Path])
+    extends Relation[DViewFields, DViewRow] {
   
-    override val fields: DViewFields[Row] = new DViewFields[Row] {
-      override val id = new Field[DepartmentId, Row](prefix, "id", None, None)(x => extract(x).id, (row, value) => merge(row, extract(row).copy(id = value)))
-      override val departmentid = new Field[DepartmentId, Row](prefix, "departmentid", None, None)(x => extract(x).departmentid, (row, value) => merge(row, extract(row).copy(departmentid = value)))
-      override val name = new Field[Name, Row](prefix, "name", None, None)(x => extract(x).name, (row, value) => merge(row, extract(row).copy(name = value)))
-      override val groupname = new Field[Name, Row](prefix, "groupname", None, None)(x => extract(x).groupname, (row, value) => merge(row, extract(row).copy(groupname = value)))
-      override val modifieddate = new Field[TypoLocalDateTime, Row](prefix, "modifieddate", Some("text"), None)(x => extract(x).modifieddate, (row, value) => merge(row, extract(row).copy(modifieddate = value)))
+    override lazy val fields: DViewFields = new DViewFields {
+      override def id = Field[DepartmentId, DViewRow](_path, "id", None, None, x => x.id, (row, value) => row.copy(id = value))
+      override def departmentid = Field[DepartmentId, DViewRow](_path, "departmentid", None, None, x => x.departmentid, (row, value) => row.copy(departmentid = value))
+      override def name = Field[Name, DViewRow](_path, "name", None, None, x => x.name, (row, value) => row.copy(name = value))
+      override def groupname = Field[Name, DViewRow](_path, "groupname", None, None, x => x.groupname, (row, value) => row.copy(groupname = value))
+      override def modifieddate = Field[TypoLocalDateTime, DViewRow](_path, "modifieddate", Some("text"), None, x => x.modifieddate, (row, value) => row.copy(modifieddate = value))
     }
   
-    override val columns: List[FieldLikeNoHkt[?, Row]] =
-      List[FieldLikeNoHkt[?, Row]](fields.id, fields.departmentid, fields.name, fields.groupname, fields.modifieddate)
+    override lazy val columns: List[FieldLikeNoHkt[?, DViewRow]] =
+      List[FieldLikeNoHkt[?, DViewRow]](fields.id, fields.departmentid, fields.name, fields.groupname, fields.modifieddate)
   
-    override def copy[NewRow](prefix: Option[String], extract: NewRow => DViewRow, merge: (NewRow, DViewRow) => NewRow): Impl[NewRow] =
-      new Impl(prefix, extract, merge)
+    override def copy(path: List[Path]): Impl =
+      new Impl(path)
   }
   
 }

--- a/typo-tester-anorm/generated-and-checked-in/adventureworks/hr/e/EViewFields.scala
+++ b/typo-tester-anorm/generated-and-checked-in/adventureworks/hr/e/EViewFields.scala
@@ -13,61 +13,62 @@ import adventureworks.customtypes.TypoShort
 import adventureworks.customtypes.TypoUUID
 import adventureworks.person.businessentity.BusinessentityId
 import adventureworks.public.Flag
+import typo.dsl.Path
 import typo.dsl.SqlExpr.Field
 import typo.dsl.SqlExpr.FieldLikeNoHkt
 import typo.dsl.SqlExpr.OptField
 import typo.dsl.Structure.Relation
 
-trait EViewFields[Row] {
-  val id: Field[BusinessentityId, Row]
-  val businessentityid: Field[BusinessentityId, Row]
-  val nationalidnumber: Field[/* max 15 chars */ String, Row]
-  val loginid: Field[/* max 256 chars */ String, Row]
-  val jobtitle: Field[/* max 50 chars */ String, Row]
-  val birthdate: Field[TypoLocalDate, Row]
-  val maritalstatus: Field[/* bpchar, max 1 chars */ String, Row]
-  val gender: Field[/* bpchar, max 1 chars */ String, Row]
-  val hiredate: Field[TypoLocalDate, Row]
-  val salariedflag: Field[Flag, Row]
-  val vacationhours: Field[TypoShort, Row]
-  val sickleavehours: Field[TypoShort, Row]
-  val currentflag: Field[Flag, Row]
-  val rowguid: Field[TypoUUID, Row]
-  val modifieddate: Field[TypoLocalDateTime, Row]
-  val organizationnode: OptField[String, Row]
+trait EViewFields {
+  def id: Field[BusinessentityId, EViewRow]
+  def businessentityid: Field[BusinessentityId, EViewRow]
+  def nationalidnumber: Field[/* max 15 chars */ String, EViewRow]
+  def loginid: Field[/* max 256 chars */ String, EViewRow]
+  def jobtitle: Field[/* max 50 chars */ String, EViewRow]
+  def birthdate: Field[TypoLocalDate, EViewRow]
+  def maritalstatus: Field[/* bpchar, max 1 chars */ String, EViewRow]
+  def gender: Field[/* bpchar, max 1 chars */ String, EViewRow]
+  def hiredate: Field[TypoLocalDate, EViewRow]
+  def salariedflag: Field[Flag, EViewRow]
+  def vacationhours: Field[TypoShort, EViewRow]
+  def sickleavehours: Field[TypoShort, EViewRow]
+  def currentflag: Field[Flag, EViewRow]
+  def rowguid: Field[TypoUUID, EViewRow]
+  def modifieddate: Field[TypoLocalDateTime, EViewRow]
+  def organizationnode: OptField[String, EViewRow]
 }
 
 object EViewFields {
-  val structure: Relation[EViewFields, EViewRow, EViewRow] = 
-    new Impl(None, identity, (_, x) => x)
+  lazy val structure: Relation[EViewFields, EViewRow] =
+    new Impl(Nil)
     
-  private final class Impl[Row](val prefix: Option[String], val extract: Row => EViewRow, val merge: (Row, EViewRow) => Row)
-    extends Relation[EViewFields, EViewRow, Row] { 
+  private final class Impl(val _path: List[Path])
+    extends Relation[EViewFields, EViewRow] {
   
-    override val fields: EViewFields[Row] = new EViewFields[Row] {
-      override val id = new Field[BusinessentityId, Row](prefix, "id", None, None)(x => extract(x).id, (row, value) => merge(row, extract(row).copy(id = value)))
-      override val businessentityid = new Field[BusinessentityId, Row](prefix, "businessentityid", None, None)(x => extract(x).businessentityid, (row, value) => merge(row, extract(row).copy(businessentityid = value)))
-      override val nationalidnumber = new Field[/* max 15 chars */ String, Row](prefix, "nationalidnumber", None, None)(x => extract(x).nationalidnumber, (row, value) => merge(row, extract(row).copy(nationalidnumber = value)))
-      override val loginid = new Field[/* max 256 chars */ String, Row](prefix, "loginid", None, None)(x => extract(x).loginid, (row, value) => merge(row, extract(row).copy(loginid = value)))
-      override val jobtitle = new Field[/* max 50 chars */ String, Row](prefix, "jobtitle", None, None)(x => extract(x).jobtitle, (row, value) => merge(row, extract(row).copy(jobtitle = value)))
-      override val birthdate = new Field[TypoLocalDate, Row](prefix, "birthdate", Some("text"), None)(x => extract(x).birthdate, (row, value) => merge(row, extract(row).copy(birthdate = value)))
-      override val maritalstatus = new Field[/* bpchar, max 1 chars */ String, Row](prefix, "maritalstatus", None, None)(x => extract(x).maritalstatus, (row, value) => merge(row, extract(row).copy(maritalstatus = value)))
-      override val gender = new Field[/* bpchar, max 1 chars */ String, Row](prefix, "gender", None, None)(x => extract(x).gender, (row, value) => merge(row, extract(row).copy(gender = value)))
-      override val hiredate = new Field[TypoLocalDate, Row](prefix, "hiredate", Some("text"), None)(x => extract(x).hiredate, (row, value) => merge(row, extract(row).copy(hiredate = value)))
-      override val salariedflag = new Field[Flag, Row](prefix, "salariedflag", None, None)(x => extract(x).salariedflag, (row, value) => merge(row, extract(row).copy(salariedflag = value)))
-      override val vacationhours = new Field[TypoShort, Row](prefix, "vacationhours", None, None)(x => extract(x).vacationhours, (row, value) => merge(row, extract(row).copy(vacationhours = value)))
-      override val sickleavehours = new Field[TypoShort, Row](prefix, "sickleavehours", None, None)(x => extract(x).sickleavehours, (row, value) => merge(row, extract(row).copy(sickleavehours = value)))
-      override val currentflag = new Field[Flag, Row](prefix, "currentflag", None, None)(x => extract(x).currentflag, (row, value) => merge(row, extract(row).copy(currentflag = value)))
-      override val rowguid = new Field[TypoUUID, Row](prefix, "rowguid", None, None)(x => extract(x).rowguid, (row, value) => merge(row, extract(row).copy(rowguid = value)))
-      override val modifieddate = new Field[TypoLocalDateTime, Row](prefix, "modifieddate", Some("text"), None)(x => extract(x).modifieddate, (row, value) => merge(row, extract(row).copy(modifieddate = value)))
-      override val organizationnode = new OptField[String, Row](prefix, "organizationnode", None, None)(x => extract(x).organizationnode, (row, value) => merge(row, extract(row).copy(organizationnode = value)))
+    override lazy val fields: EViewFields = new EViewFields {
+      override def id = Field[BusinessentityId, EViewRow](_path, "id", None, None, x => x.id, (row, value) => row.copy(id = value))
+      override def businessentityid = Field[BusinessentityId, EViewRow](_path, "businessentityid", None, None, x => x.businessentityid, (row, value) => row.copy(businessentityid = value))
+      override def nationalidnumber = Field[/* max 15 chars */ String, EViewRow](_path, "nationalidnumber", None, None, x => x.nationalidnumber, (row, value) => row.copy(nationalidnumber = value))
+      override def loginid = Field[/* max 256 chars */ String, EViewRow](_path, "loginid", None, None, x => x.loginid, (row, value) => row.copy(loginid = value))
+      override def jobtitle = Field[/* max 50 chars */ String, EViewRow](_path, "jobtitle", None, None, x => x.jobtitle, (row, value) => row.copy(jobtitle = value))
+      override def birthdate = Field[TypoLocalDate, EViewRow](_path, "birthdate", Some("text"), None, x => x.birthdate, (row, value) => row.copy(birthdate = value))
+      override def maritalstatus = Field[/* bpchar, max 1 chars */ String, EViewRow](_path, "maritalstatus", None, None, x => x.maritalstatus, (row, value) => row.copy(maritalstatus = value))
+      override def gender = Field[/* bpchar, max 1 chars */ String, EViewRow](_path, "gender", None, None, x => x.gender, (row, value) => row.copy(gender = value))
+      override def hiredate = Field[TypoLocalDate, EViewRow](_path, "hiredate", Some("text"), None, x => x.hiredate, (row, value) => row.copy(hiredate = value))
+      override def salariedflag = Field[Flag, EViewRow](_path, "salariedflag", None, None, x => x.salariedflag, (row, value) => row.copy(salariedflag = value))
+      override def vacationhours = Field[TypoShort, EViewRow](_path, "vacationhours", None, None, x => x.vacationhours, (row, value) => row.copy(vacationhours = value))
+      override def sickleavehours = Field[TypoShort, EViewRow](_path, "sickleavehours", None, None, x => x.sickleavehours, (row, value) => row.copy(sickleavehours = value))
+      override def currentflag = Field[Flag, EViewRow](_path, "currentflag", None, None, x => x.currentflag, (row, value) => row.copy(currentflag = value))
+      override def rowguid = Field[TypoUUID, EViewRow](_path, "rowguid", None, None, x => x.rowguid, (row, value) => row.copy(rowguid = value))
+      override def modifieddate = Field[TypoLocalDateTime, EViewRow](_path, "modifieddate", Some("text"), None, x => x.modifieddate, (row, value) => row.copy(modifieddate = value))
+      override def organizationnode = OptField[String, EViewRow](_path, "organizationnode", None, None, x => x.organizationnode, (row, value) => row.copy(organizationnode = value))
     }
   
-    override val columns: List[FieldLikeNoHkt[?, Row]] =
-      List[FieldLikeNoHkt[?, Row]](fields.id, fields.businessentityid, fields.nationalidnumber, fields.loginid, fields.jobtitle, fields.birthdate, fields.maritalstatus, fields.gender, fields.hiredate, fields.salariedflag, fields.vacationhours, fields.sickleavehours, fields.currentflag, fields.rowguid, fields.modifieddate, fields.organizationnode)
+    override lazy val columns: List[FieldLikeNoHkt[?, EViewRow]] =
+      List[FieldLikeNoHkt[?, EViewRow]](fields.id, fields.businessentityid, fields.nationalidnumber, fields.loginid, fields.jobtitle, fields.birthdate, fields.maritalstatus, fields.gender, fields.hiredate, fields.salariedflag, fields.vacationhours, fields.sickleavehours, fields.currentflag, fields.rowguid, fields.modifieddate, fields.organizationnode)
   
-    override def copy[NewRow](prefix: Option[String], extract: NewRow => EViewRow, merge: (NewRow, EViewRow) => NewRow): Impl[NewRow] =
-      new Impl(prefix, extract, merge)
+    override def copy(path: List[Path]): Impl =
+      new Impl(path)
   }
   
 }

--- a/typo-tester-anorm/generated-and-checked-in/adventureworks/hr/edh/EdhViewFields.scala
+++ b/typo-tester-anorm/generated-and-checked-in/adventureworks/hr/edh/EdhViewFields.scala
@@ -12,43 +12,44 @@ import adventureworks.customtypes.TypoLocalDateTime
 import adventureworks.humanresources.department.DepartmentId
 import adventureworks.humanresources.shift.ShiftId
 import adventureworks.person.businessentity.BusinessentityId
+import typo.dsl.Path
 import typo.dsl.SqlExpr.Field
 import typo.dsl.SqlExpr.FieldLikeNoHkt
 import typo.dsl.SqlExpr.OptField
 import typo.dsl.Structure.Relation
 
-trait EdhViewFields[Row] {
-  val id: Field[BusinessentityId, Row]
-  val businessentityid: Field[BusinessentityId, Row]
-  val departmentid: Field[DepartmentId, Row]
-  val shiftid: Field[ShiftId, Row]
-  val startdate: Field[TypoLocalDate, Row]
-  val enddate: OptField[TypoLocalDate, Row]
-  val modifieddate: Field[TypoLocalDateTime, Row]
+trait EdhViewFields {
+  def id: Field[BusinessentityId, EdhViewRow]
+  def businessentityid: Field[BusinessentityId, EdhViewRow]
+  def departmentid: Field[DepartmentId, EdhViewRow]
+  def shiftid: Field[ShiftId, EdhViewRow]
+  def startdate: Field[TypoLocalDate, EdhViewRow]
+  def enddate: OptField[TypoLocalDate, EdhViewRow]
+  def modifieddate: Field[TypoLocalDateTime, EdhViewRow]
 }
 
 object EdhViewFields {
-  val structure: Relation[EdhViewFields, EdhViewRow, EdhViewRow] = 
-    new Impl(None, identity, (_, x) => x)
+  lazy val structure: Relation[EdhViewFields, EdhViewRow] =
+    new Impl(Nil)
     
-  private final class Impl[Row](val prefix: Option[String], val extract: Row => EdhViewRow, val merge: (Row, EdhViewRow) => Row)
-    extends Relation[EdhViewFields, EdhViewRow, Row] { 
+  private final class Impl(val _path: List[Path])
+    extends Relation[EdhViewFields, EdhViewRow] {
   
-    override val fields: EdhViewFields[Row] = new EdhViewFields[Row] {
-      override val id = new Field[BusinessentityId, Row](prefix, "id", None, None)(x => extract(x).id, (row, value) => merge(row, extract(row).copy(id = value)))
-      override val businessentityid = new Field[BusinessentityId, Row](prefix, "businessentityid", None, None)(x => extract(x).businessentityid, (row, value) => merge(row, extract(row).copy(businessentityid = value)))
-      override val departmentid = new Field[DepartmentId, Row](prefix, "departmentid", None, None)(x => extract(x).departmentid, (row, value) => merge(row, extract(row).copy(departmentid = value)))
-      override val shiftid = new Field[ShiftId, Row](prefix, "shiftid", None, None)(x => extract(x).shiftid, (row, value) => merge(row, extract(row).copy(shiftid = value)))
-      override val startdate = new Field[TypoLocalDate, Row](prefix, "startdate", Some("text"), None)(x => extract(x).startdate, (row, value) => merge(row, extract(row).copy(startdate = value)))
-      override val enddate = new OptField[TypoLocalDate, Row](prefix, "enddate", Some("text"), None)(x => extract(x).enddate, (row, value) => merge(row, extract(row).copy(enddate = value)))
-      override val modifieddate = new Field[TypoLocalDateTime, Row](prefix, "modifieddate", Some("text"), None)(x => extract(x).modifieddate, (row, value) => merge(row, extract(row).copy(modifieddate = value)))
+    override lazy val fields: EdhViewFields = new EdhViewFields {
+      override def id = Field[BusinessentityId, EdhViewRow](_path, "id", None, None, x => x.id, (row, value) => row.copy(id = value))
+      override def businessentityid = Field[BusinessentityId, EdhViewRow](_path, "businessentityid", None, None, x => x.businessentityid, (row, value) => row.copy(businessentityid = value))
+      override def departmentid = Field[DepartmentId, EdhViewRow](_path, "departmentid", None, None, x => x.departmentid, (row, value) => row.copy(departmentid = value))
+      override def shiftid = Field[ShiftId, EdhViewRow](_path, "shiftid", None, None, x => x.shiftid, (row, value) => row.copy(shiftid = value))
+      override def startdate = Field[TypoLocalDate, EdhViewRow](_path, "startdate", Some("text"), None, x => x.startdate, (row, value) => row.copy(startdate = value))
+      override def enddate = OptField[TypoLocalDate, EdhViewRow](_path, "enddate", Some("text"), None, x => x.enddate, (row, value) => row.copy(enddate = value))
+      override def modifieddate = Field[TypoLocalDateTime, EdhViewRow](_path, "modifieddate", Some("text"), None, x => x.modifieddate, (row, value) => row.copy(modifieddate = value))
     }
   
-    override val columns: List[FieldLikeNoHkt[?, Row]] =
-      List[FieldLikeNoHkt[?, Row]](fields.id, fields.businessentityid, fields.departmentid, fields.shiftid, fields.startdate, fields.enddate, fields.modifieddate)
+    override lazy val columns: List[FieldLikeNoHkt[?, EdhViewRow]] =
+      List[FieldLikeNoHkt[?, EdhViewRow]](fields.id, fields.businessentityid, fields.departmentid, fields.shiftid, fields.startdate, fields.enddate, fields.modifieddate)
   
-    override def copy[NewRow](prefix: Option[String], extract: NewRow => EdhViewRow, merge: (NewRow, EdhViewRow) => NewRow): Impl[NewRow] =
-      new Impl(prefix, extract, merge)
+    override def copy(path: List[Path]): Impl =
+      new Impl(path)
   }
   
 }

--- a/typo-tester-anorm/generated-and-checked-in/adventureworks/hr/eph/EphViewFields.scala
+++ b/typo-tester-anorm/generated-and-checked-in/adventureworks/hr/eph/EphViewFields.scala
@@ -10,40 +10,41 @@ package eph
 import adventureworks.customtypes.TypoLocalDateTime
 import adventureworks.customtypes.TypoShort
 import adventureworks.person.businessentity.BusinessentityId
+import typo.dsl.Path
 import typo.dsl.SqlExpr.Field
 import typo.dsl.SqlExpr.FieldLikeNoHkt
 import typo.dsl.Structure.Relation
 
-trait EphViewFields[Row] {
-  val id: Field[BusinessentityId, Row]
-  val businessentityid: Field[BusinessentityId, Row]
-  val ratechangedate: Field[TypoLocalDateTime, Row]
-  val rate: Field[BigDecimal, Row]
-  val payfrequency: Field[TypoShort, Row]
-  val modifieddate: Field[TypoLocalDateTime, Row]
+trait EphViewFields {
+  def id: Field[BusinessentityId, EphViewRow]
+  def businessentityid: Field[BusinessentityId, EphViewRow]
+  def ratechangedate: Field[TypoLocalDateTime, EphViewRow]
+  def rate: Field[BigDecimal, EphViewRow]
+  def payfrequency: Field[TypoShort, EphViewRow]
+  def modifieddate: Field[TypoLocalDateTime, EphViewRow]
 }
 
 object EphViewFields {
-  val structure: Relation[EphViewFields, EphViewRow, EphViewRow] = 
-    new Impl(None, identity, (_, x) => x)
+  lazy val structure: Relation[EphViewFields, EphViewRow] =
+    new Impl(Nil)
     
-  private final class Impl[Row](val prefix: Option[String], val extract: Row => EphViewRow, val merge: (Row, EphViewRow) => Row)
-    extends Relation[EphViewFields, EphViewRow, Row] { 
+  private final class Impl(val _path: List[Path])
+    extends Relation[EphViewFields, EphViewRow] {
   
-    override val fields: EphViewFields[Row] = new EphViewFields[Row] {
-      override val id = new Field[BusinessentityId, Row](prefix, "id", None, None)(x => extract(x).id, (row, value) => merge(row, extract(row).copy(id = value)))
-      override val businessentityid = new Field[BusinessentityId, Row](prefix, "businessentityid", None, None)(x => extract(x).businessentityid, (row, value) => merge(row, extract(row).copy(businessentityid = value)))
-      override val ratechangedate = new Field[TypoLocalDateTime, Row](prefix, "ratechangedate", Some("text"), None)(x => extract(x).ratechangedate, (row, value) => merge(row, extract(row).copy(ratechangedate = value)))
-      override val rate = new Field[BigDecimal, Row](prefix, "rate", None, None)(x => extract(x).rate, (row, value) => merge(row, extract(row).copy(rate = value)))
-      override val payfrequency = new Field[TypoShort, Row](prefix, "payfrequency", None, None)(x => extract(x).payfrequency, (row, value) => merge(row, extract(row).copy(payfrequency = value)))
-      override val modifieddate = new Field[TypoLocalDateTime, Row](prefix, "modifieddate", Some("text"), None)(x => extract(x).modifieddate, (row, value) => merge(row, extract(row).copy(modifieddate = value)))
+    override lazy val fields: EphViewFields = new EphViewFields {
+      override def id = Field[BusinessentityId, EphViewRow](_path, "id", None, None, x => x.id, (row, value) => row.copy(id = value))
+      override def businessentityid = Field[BusinessentityId, EphViewRow](_path, "businessentityid", None, None, x => x.businessentityid, (row, value) => row.copy(businessentityid = value))
+      override def ratechangedate = Field[TypoLocalDateTime, EphViewRow](_path, "ratechangedate", Some("text"), None, x => x.ratechangedate, (row, value) => row.copy(ratechangedate = value))
+      override def rate = Field[BigDecimal, EphViewRow](_path, "rate", None, None, x => x.rate, (row, value) => row.copy(rate = value))
+      override def payfrequency = Field[TypoShort, EphViewRow](_path, "payfrequency", None, None, x => x.payfrequency, (row, value) => row.copy(payfrequency = value))
+      override def modifieddate = Field[TypoLocalDateTime, EphViewRow](_path, "modifieddate", Some("text"), None, x => x.modifieddate, (row, value) => row.copy(modifieddate = value))
     }
   
-    override val columns: List[FieldLikeNoHkt[?, Row]] =
-      List[FieldLikeNoHkt[?, Row]](fields.id, fields.businessentityid, fields.ratechangedate, fields.rate, fields.payfrequency, fields.modifieddate)
+    override lazy val columns: List[FieldLikeNoHkt[?, EphViewRow]] =
+      List[FieldLikeNoHkt[?, EphViewRow]](fields.id, fields.businessentityid, fields.ratechangedate, fields.rate, fields.payfrequency, fields.modifieddate)
   
-    override def copy[NewRow](prefix: Option[String], extract: NewRow => EphViewRow, merge: (NewRow, EphViewRow) => NewRow): Impl[NewRow] =
-      new Impl(prefix, extract, merge)
+    override def copy(path: List[Path]): Impl =
+      new Impl(path)
   }
   
 }

--- a/typo-tester-anorm/generated-and-checked-in/adventureworks/hr/jc/JcViewFields.scala
+++ b/typo-tester-anorm/generated-and-checked-in/adventureworks/hr/jc/JcViewFields.scala
@@ -11,39 +11,40 @@ import adventureworks.customtypes.TypoLocalDateTime
 import adventureworks.customtypes.TypoXml
 import adventureworks.humanresources.jobcandidate.JobcandidateId
 import adventureworks.person.businessentity.BusinessentityId
+import typo.dsl.Path
 import typo.dsl.SqlExpr.Field
 import typo.dsl.SqlExpr.FieldLikeNoHkt
 import typo.dsl.SqlExpr.OptField
 import typo.dsl.Structure.Relation
 
-trait JcViewFields[Row] {
-  val id: Field[JobcandidateId, Row]
-  val jobcandidateid: Field[JobcandidateId, Row]
-  val businessentityid: OptField[BusinessentityId, Row]
-  val resume: OptField[TypoXml, Row]
-  val modifieddate: Field[TypoLocalDateTime, Row]
+trait JcViewFields {
+  def id: Field[JobcandidateId, JcViewRow]
+  def jobcandidateid: Field[JobcandidateId, JcViewRow]
+  def businessentityid: OptField[BusinessentityId, JcViewRow]
+  def resume: OptField[TypoXml, JcViewRow]
+  def modifieddate: Field[TypoLocalDateTime, JcViewRow]
 }
 
 object JcViewFields {
-  val structure: Relation[JcViewFields, JcViewRow, JcViewRow] = 
-    new Impl(None, identity, (_, x) => x)
+  lazy val structure: Relation[JcViewFields, JcViewRow] =
+    new Impl(Nil)
     
-  private final class Impl[Row](val prefix: Option[String], val extract: Row => JcViewRow, val merge: (Row, JcViewRow) => Row)
-    extends Relation[JcViewFields, JcViewRow, Row] { 
+  private final class Impl(val _path: List[Path])
+    extends Relation[JcViewFields, JcViewRow] {
   
-    override val fields: JcViewFields[Row] = new JcViewFields[Row] {
-      override val id = new Field[JobcandidateId, Row](prefix, "id", None, None)(x => extract(x).id, (row, value) => merge(row, extract(row).copy(id = value)))
-      override val jobcandidateid = new Field[JobcandidateId, Row](prefix, "jobcandidateid", None, None)(x => extract(x).jobcandidateid, (row, value) => merge(row, extract(row).copy(jobcandidateid = value)))
-      override val businessentityid = new OptField[BusinessentityId, Row](prefix, "businessentityid", None, None)(x => extract(x).businessentityid, (row, value) => merge(row, extract(row).copy(businessentityid = value)))
-      override val resume = new OptField[TypoXml, Row](prefix, "resume", None, None)(x => extract(x).resume, (row, value) => merge(row, extract(row).copy(resume = value)))
-      override val modifieddate = new Field[TypoLocalDateTime, Row](prefix, "modifieddate", Some("text"), None)(x => extract(x).modifieddate, (row, value) => merge(row, extract(row).copy(modifieddate = value)))
+    override lazy val fields: JcViewFields = new JcViewFields {
+      override def id = Field[JobcandidateId, JcViewRow](_path, "id", None, None, x => x.id, (row, value) => row.copy(id = value))
+      override def jobcandidateid = Field[JobcandidateId, JcViewRow](_path, "jobcandidateid", None, None, x => x.jobcandidateid, (row, value) => row.copy(jobcandidateid = value))
+      override def businessentityid = OptField[BusinessentityId, JcViewRow](_path, "businessentityid", None, None, x => x.businessentityid, (row, value) => row.copy(businessentityid = value))
+      override def resume = OptField[TypoXml, JcViewRow](_path, "resume", None, None, x => x.resume, (row, value) => row.copy(resume = value))
+      override def modifieddate = Field[TypoLocalDateTime, JcViewRow](_path, "modifieddate", Some("text"), None, x => x.modifieddate, (row, value) => row.copy(modifieddate = value))
     }
   
-    override val columns: List[FieldLikeNoHkt[?, Row]] =
-      List[FieldLikeNoHkt[?, Row]](fields.id, fields.jobcandidateid, fields.businessentityid, fields.resume, fields.modifieddate)
+    override lazy val columns: List[FieldLikeNoHkt[?, JcViewRow]] =
+      List[FieldLikeNoHkt[?, JcViewRow]](fields.id, fields.jobcandidateid, fields.businessentityid, fields.resume, fields.modifieddate)
   
-    override def copy[NewRow](prefix: Option[String], extract: NewRow => JcViewRow, merge: (NewRow, JcViewRow) => NewRow): Impl[NewRow] =
-      new Impl(prefix, extract, merge)
+    override def copy(path: List[Path]): Impl =
+      new Impl(path)
   }
   
 }

--- a/typo-tester-anorm/generated-and-checked-in/adventureworks/hr/s/SViewFields.scala
+++ b/typo-tester-anorm/generated-and-checked-in/adventureworks/hr/s/SViewFields.scala
@@ -11,40 +11,41 @@ import adventureworks.customtypes.TypoLocalDateTime
 import adventureworks.customtypes.TypoLocalTime
 import adventureworks.humanresources.shift.ShiftId
 import adventureworks.public.Name
+import typo.dsl.Path
 import typo.dsl.SqlExpr.Field
 import typo.dsl.SqlExpr.FieldLikeNoHkt
 import typo.dsl.Structure.Relation
 
-trait SViewFields[Row] {
-  val id: Field[ShiftId, Row]
-  val shiftid: Field[ShiftId, Row]
-  val name: Field[Name, Row]
-  val starttime: Field[TypoLocalTime, Row]
-  val endtime: Field[TypoLocalTime, Row]
-  val modifieddate: Field[TypoLocalDateTime, Row]
+trait SViewFields {
+  def id: Field[ShiftId, SViewRow]
+  def shiftid: Field[ShiftId, SViewRow]
+  def name: Field[Name, SViewRow]
+  def starttime: Field[TypoLocalTime, SViewRow]
+  def endtime: Field[TypoLocalTime, SViewRow]
+  def modifieddate: Field[TypoLocalDateTime, SViewRow]
 }
 
 object SViewFields {
-  val structure: Relation[SViewFields, SViewRow, SViewRow] = 
-    new Impl(None, identity, (_, x) => x)
+  lazy val structure: Relation[SViewFields, SViewRow] =
+    new Impl(Nil)
     
-  private final class Impl[Row](val prefix: Option[String], val extract: Row => SViewRow, val merge: (Row, SViewRow) => Row)
-    extends Relation[SViewFields, SViewRow, Row] { 
+  private final class Impl(val _path: List[Path])
+    extends Relation[SViewFields, SViewRow] {
   
-    override val fields: SViewFields[Row] = new SViewFields[Row] {
-      override val id = new Field[ShiftId, Row](prefix, "id", None, None)(x => extract(x).id, (row, value) => merge(row, extract(row).copy(id = value)))
-      override val shiftid = new Field[ShiftId, Row](prefix, "shiftid", None, None)(x => extract(x).shiftid, (row, value) => merge(row, extract(row).copy(shiftid = value)))
-      override val name = new Field[Name, Row](prefix, "name", None, None)(x => extract(x).name, (row, value) => merge(row, extract(row).copy(name = value)))
-      override val starttime = new Field[TypoLocalTime, Row](prefix, "starttime", Some("text"), None)(x => extract(x).starttime, (row, value) => merge(row, extract(row).copy(starttime = value)))
-      override val endtime = new Field[TypoLocalTime, Row](prefix, "endtime", Some("text"), None)(x => extract(x).endtime, (row, value) => merge(row, extract(row).copy(endtime = value)))
-      override val modifieddate = new Field[TypoLocalDateTime, Row](prefix, "modifieddate", Some("text"), None)(x => extract(x).modifieddate, (row, value) => merge(row, extract(row).copy(modifieddate = value)))
+    override lazy val fields: SViewFields = new SViewFields {
+      override def id = Field[ShiftId, SViewRow](_path, "id", None, None, x => x.id, (row, value) => row.copy(id = value))
+      override def shiftid = Field[ShiftId, SViewRow](_path, "shiftid", None, None, x => x.shiftid, (row, value) => row.copy(shiftid = value))
+      override def name = Field[Name, SViewRow](_path, "name", None, None, x => x.name, (row, value) => row.copy(name = value))
+      override def starttime = Field[TypoLocalTime, SViewRow](_path, "starttime", Some("text"), None, x => x.starttime, (row, value) => row.copy(starttime = value))
+      override def endtime = Field[TypoLocalTime, SViewRow](_path, "endtime", Some("text"), None, x => x.endtime, (row, value) => row.copy(endtime = value))
+      override def modifieddate = Field[TypoLocalDateTime, SViewRow](_path, "modifieddate", Some("text"), None, x => x.modifieddate, (row, value) => row.copy(modifieddate = value))
     }
   
-    override val columns: List[FieldLikeNoHkt[?, Row]] =
-      List[FieldLikeNoHkt[?, Row]](fields.id, fields.shiftid, fields.name, fields.starttime, fields.endtime, fields.modifieddate)
+    override lazy val columns: List[FieldLikeNoHkt[?, SViewRow]] =
+      List[FieldLikeNoHkt[?, SViewRow]](fields.id, fields.shiftid, fields.name, fields.starttime, fields.endtime, fields.modifieddate)
   
-    override def copy[NewRow](prefix: Option[String], extract: NewRow => SViewRow, merge: (NewRow, SViewRow) => NewRow): Impl[NewRow] =
-      new Impl(prefix, extract, merge)
+    override def copy(path: List[Path]): Impl =
+      new Impl(path)
   }
   
 }

--- a/typo-tester-anorm/generated-and-checked-in/adventureworks/humanresources/department/DepartmentFields.scala
+++ b/typo-tester-anorm/generated-and-checked-in/adventureworks/humanresources/department/DepartmentFields.scala
@@ -9,37 +9,38 @@ package department
 
 import adventureworks.customtypes.TypoLocalDateTime
 import adventureworks.public.Name
+import typo.dsl.Path
 import typo.dsl.SqlExpr.Field
 import typo.dsl.SqlExpr.FieldLikeNoHkt
 import typo.dsl.SqlExpr.IdField
 import typo.dsl.Structure.Relation
 
-trait DepartmentFields[Row] {
-  val departmentid: IdField[DepartmentId, Row]
-  val name: Field[Name, Row]
-  val groupname: Field[Name, Row]
-  val modifieddate: Field[TypoLocalDateTime, Row]
+trait DepartmentFields {
+  def departmentid: IdField[DepartmentId, DepartmentRow]
+  def name: Field[Name, DepartmentRow]
+  def groupname: Field[Name, DepartmentRow]
+  def modifieddate: Field[TypoLocalDateTime, DepartmentRow]
 }
 
 object DepartmentFields {
-  val structure: Relation[DepartmentFields, DepartmentRow, DepartmentRow] = 
-    new Impl(None, identity, (_, x) => x)
+  lazy val structure: Relation[DepartmentFields, DepartmentRow] =
+    new Impl(Nil)
     
-  private final class Impl[Row](val prefix: Option[String], val extract: Row => DepartmentRow, val merge: (Row, DepartmentRow) => Row)
-    extends Relation[DepartmentFields, DepartmentRow, Row] { 
+  private final class Impl(val _path: List[Path])
+    extends Relation[DepartmentFields, DepartmentRow] {
   
-    override val fields: DepartmentFields[Row] = new DepartmentFields[Row] {
-      override val departmentid = new IdField[DepartmentId, Row](prefix, "departmentid", None, Some("int4"))(x => extract(x).departmentid, (row, value) => merge(row, extract(row).copy(departmentid = value)))
-      override val name = new Field[Name, Row](prefix, "name", None, Some("varchar"))(x => extract(x).name, (row, value) => merge(row, extract(row).copy(name = value)))
-      override val groupname = new Field[Name, Row](prefix, "groupname", None, Some("varchar"))(x => extract(x).groupname, (row, value) => merge(row, extract(row).copy(groupname = value)))
-      override val modifieddate = new Field[TypoLocalDateTime, Row](prefix, "modifieddate", Some("text"), Some("timestamp"))(x => extract(x).modifieddate, (row, value) => merge(row, extract(row).copy(modifieddate = value)))
+    override lazy val fields: DepartmentFields = new DepartmentFields {
+      override def departmentid = IdField[DepartmentId, DepartmentRow](_path, "departmentid", None, Some("int4"), x => x.departmentid, (row, value) => row.copy(departmentid = value))
+      override def name = Field[Name, DepartmentRow](_path, "name", None, Some("varchar"), x => x.name, (row, value) => row.copy(name = value))
+      override def groupname = Field[Name, DepartmentRow](_path, "groupname", None, Some("varchar"), x => x.groupname, (row, value) => row.copy(groupname = value))
+      override def modifieddate = Field[TypoLocalDateTime, DepartmentRow](_path, "modifieddate", Some("text"), Some("timestamp"), x => x.modifieddate, (row, value) => row.copy(modifieddate = value))
     }
   
-    override val columns: List[FieldLikeNoHkt[?, Row]] =
-      List[FieldLikeNoHkt[?, Row]](fields.departmentid, fields.name, fields.groupname, fields.modifieddate)
+    override lazy val columns: List[FieldLikeNoHkt[?, DepartmentRow]] =
+      List[FieldLikeNoHkt[?, DepartmentRow]](fields.departmentid, fields.name, fields.groupname, fields.modifieddate)
   
-    override def copy[NewRow](prefix: Option[String], extract: NewRow => DepartmentRow, merge: (NewRow, DepartmentRow) => NewRow): Impl[NewRow] =
-      new Impl(prefix, extract, merge)
+    override def copy(path: List[Path]): Impl =
+      new Impl(path)
   }
   
 }

--- a/typo-tester-anorm/generated-and-checked-in/adventureworks/humanresources/department/DepartmentRepoMock.scala
+++ b/typo-tester-anorm/generated-and-checked-in/adventureworks/humanresources/department/DepartmentRepoMock.scala
@@ -22,7 +22,7 @@ import typo.dsl.UpdateParams
 class DepartmentRepoMock(toRow: Function1[DepartmentRowUnsaved, DepartmentRow],
                          map: scala.collection.mutable.Map[DepartmentId, DepartmentRow] = scala.collection.mutable.Map.empty) extends DepartmentRepo {
   override def delete: DeleteBuilder[DepartmentFields, DepartmentRow] = {
-    DeleteBuilderMock(DeleteParams.empty, DepartmentFields.structure.fields, map)
+    DeleteBuilderMock(DeleteParams.empty, DepartmentFields.structure, map)
   }
   override def deleteById(departmentid: DepartmentId)(implicit c: Connection): Boolean = {
     map.remove(departmentid).isDefined
@@ -72,7 +72,7 @@ class DepartmentRepoMock(toRow: Function1[DepartmentRowUnsaved, DepartmentRow],
     departmentids.view.flatMap(id => byId.get(id).map(x => (id, x))).toMap
   }
   override def update: UpdateBuilder[DepartmentFields, DepartmentRow] = {
-    UpdateBuilderMock(UpdateParams.empty, DepartmentFields.structure.fields, map)
+    UpdateBuilderMock(UpdateParams.empty, DepartmentFields.structure, map)
   }
   override def update(row: DepartmentRow)(implicit c: Connection): Boolean = {
     map.get(row.departmentid) match {

--- a/typo-tester-anorm/generated-and-checked-in/adventureworks/humanresources/employee/EmployeeFields.scala
+++ b/typo-tester-anorm/generated-and-checked-in/adventureworks/humanresources/employee/EmployeeFields.scala
@@ -13,60 +13,61 @@ import adventureworks.customtypes.TypoShort
 import adventureworks.customtypes.TypoUUID
 import adventureworks.person.businessentity.BusinessentityId
 import adventureworks.public.Flag
+import typo.dsl.Path
 import typo.dsl.SqlExpr.Field
 import typo.dsl.SqlExpr.FieldLikeNoHkt
 import typo.dsl.SqlExpr.IdField
 import typo.dsl.SqlExpr.OptField
 import typo.dsl.Structure.Relation
 
-trait EmployeeFields[Row] {
-  val businessentityid: IdField[BusinessentityId, Row]
-  val nationalidnumber: Field[/* max 15 chars */ String, Row]
-  val loginid: Field[/* max 256 chars */ String, Row]
-  val jobtitle: Field[/* max 50 chars */ String, Row]
-  val birthdate: Field[TypoLocalDate, Row]
-  val maritalstatus: Field[/* bpchar, max 1 chars */ String, Row]
-  val gender: Field[/* bpchar, max 1 chars */ String, Row]
-  val hiredate: Field[TypoLocalDate, Row]
-  val salariedflag: Field[Flag, Row]
-  val vacationhours: Field[TypoShort, Row]
-  val sickleavehours: Field[TypoShort, Row]
-  val currentflag: Field[Flag, Row]
-  val rowguid: Field[TypoUUID, Row]
-  val modifieddate: Field[TypoLocalDateTime, Row]
-  val organizationnode: OptField[String, Row]
+trait EmployeeFields {
+  def businessentityid: IdField[BusinessentityId, EmployeeRow]
+  def nationalidnumber: Field[/* max 15 chars */ String, EmployeeRow]
+  def loginid: Field[/* max 256 chars */ String, EmployeeRow]
+  def jobtitle: Field[/* max 50 chars */ String, EmployeeRow]
+  def birthdate: Field[TypoLocalDate, EmployeeRow]
+  def maritalstatus: Field[/* bpchar, max 1 chars */ String, EmployeeRow]
+  def gender: Field[/* bpchar, max 1 chars */ String, EmployeeRow]
+  def hiredate: Field[TypoLocalDate, EmployeeRow]
+  def salariedflag: Field[Flag, EmployeeRow]
+  def vacationhours: Field[TypoShort, EmployeeRow]
+  def sickleavehours: Field[TypoShort, EmployeeRow]
+  def currentflag: Field[Flag, EmployeeRow]
+  def rowguid: Field[TypoUUID, EmployeeRow]
+  def modifieddate: Field[TypoLocalDateTime, EmployeeRow]
+  def organizationnode: OptField[String, EmployeeRow]
 }
 
 object EmployeeFields {
-  val structure: Relation[EmployeeFields, EmployeeRow, EmployeeRow] = 
-    new Impl(None, identity, (_, x) => x)
+  lazy val structure: Relation[EmployeeFields, EmployeeRow] =
+    new Impl(Nil)
     
-  private final class Impl[Row](val prefix: Option[String], val extract: Row => EmployeeRow, val merge: (Row, EmployeeRow) => Row)
-    extends Relation[EmployeeFields, EmployeeRow, Row] { 
+  private final class Impl(val _path: List[Path])
+    extends Relation[EmployeeFields, EmployeeRow] {
   
-    override val fields: EmployeeFields[Row] = new EmployeeFields[Row] {
-      override val businessentityid = new IdField[BusinessentityId, Row](prefix, "businessentityid", None, Some("int4"))(x => extract(x).businessentityid, (row, value) => merge(row, extract(row).copy(businessentityid = value)))
-      override val nationalidnumber = new Field[/* max 15 chars */ String, Row](prefix, "nationalidnumber", None, None)(x => extract(x).nationalidnumber, (row, value) => merge(row, extract(row).copy(nationalidnumber = value)))
-      override val loginid = new Field[/* max 256 chars */ String, Row](prefix, "loginid", None, None)(x => extract(x).loginid, (row, value) => merge(row, extract(row).copy(loginid = value)))
-      override val jobtitle = new Field[/* max 50 chars */ String, Row](prefix, "jobtitle", None, None)(x => extract(x).jobtitle, (row, value) => merge(row, extract(row).copy(jobtitle = value)))
-      override val birthdate = new Field[TypoLocalDate, Row](prefix, "birthdate", Some("text"), Some("date"))(x => extract(x).birthdate, (row, value) => merge(row, extract(row).copy(birthdate = value)))
-      override val maritalstatus = new Field[/* bpchar, max 1 chars */ String, Row](prefix, "maritalstatus", None, Some("bpchar"))(x => extract(x).maritalstatus, (row, value) => merge(row, extract(row).copy(maritalstatus = value)))
-      override val gender = new Field[/* bpchar, max 1 chars */ String, Row](prefix, "gender", None, Some("bpchar"))(x => extract(x).gender, (row, value) => merge(row, extract(row).copy(gender = value)))
-      override val hiredate = new Field[TypoLocalDate, Row](prefix, "hiredate", Some("text"), Some("date"))(x => extract(x).hiredate, (row, value) => merge(row, extract(row).copy(hiredate = value)))
-      override val salariedflag = new Field[Flag, Row](prefix, "salariedflag", None, Some("bool"))(x => extract(x).salariedflag, (row, value) => merge(row, extract(row).copy(salariedflag = value)))
-      override val vacationhours = new Field[TypoShort, Row](prefix, "vacationhours", None, Some("int2"))(x => extract(x).vacationhours, (row, value) => merge(row, extract(row).copy(vacationhours = value)))
-      override val sickleavehours = new Field[TypoShort, Row](prefix, "sickleavehours", None, Some("int2"))(x => extract(x).sickleavehours, (row, value) => merge(row, extract(row).copy(sickleavehours = value)))
-      override val currentflag = new Field[Flag, Row](prefix, "currentflag", None, Some("bool"))(x => extract(x).currentflag, (row, value) => merge(row, extract(row).copy(currentflag = value)))
-      override val rowguid = new Field[TypoUUID, Row](prefix, "rowguid", None, Some("uuid"))(x => extract(x).rowguid, (row, value) => merge(row, extract(row).copy(rowguid = value)))
-      override val modifieddate = new Field[TypoLocalDateTime, Row](prefix, "modifieddate", Some("text"), Some("timestamp"))(x => extract(x).modifieddate, (row, value) => merge(row, extract(row).copy(modifieddate = value)))
-      override val organizationnode = new OptField[String, Row](prefix, "organizationnode", None, None)(x => extract(x).organizationnode, (row, value) => merge(row, extract(row).copy(organizationnode = value)))
+    override lazy val fields: EmployeeFields = new EmployeeFields {
+      override def businessentityid = IdField[BusinessentityId, EmployeeRow](_path, "businessentityid", None, Some("int4"), x => x.businessentityid, (row, value) => row.copy(businessentityid = value))
+      override def nationalidnumber = Field[/* max 15 chars */ String, EmployeeRow](_path, "nationalidnumber", None, None, x => x.nationalidnumber, (row, value) => row.copy(nationalidnumber = value))
+      override def loginid = Field[/* max 256 chars */ String, EmployeeRow](_path, "loginid", None, None, x => x.loginid, (row, value) => row.copy(loginid = value))
+      override def jobtitle = Field[/* max 50 chars */ String, EmployeeRow](_path, "jobtitle", None, None, x => x.jobtitle, (row, value) => row.copy(jobtitle = value))
+      override def birthdate = Field[TypoLocalDate, EmployeeRow](_path, "birthdate", Some("text"), Some("date"), x => x.birthdate, (row, value) => row.copy(birthdate = value))
+      override def maritalstatus = Field[/* bpchar, max 1 chars */ String, EmployeeRow](_path, "maritalstatus", None, Some("bpchar"), x => x.maritalstatus, (row, value) => row.copy(maritalstatus = value))
+      override def gender = Field[/* bpchar, max 1 chars */ String, EmployeeRow](_path, "gender", None, Some("bpchar"), x => x.gender, (row, value) => row.copy(gender = value))
+      override def hiredate = Field[TypoLocalDate, EmployeeRow](_path, "hiredate", Some("text"), Some("date"), x => x.hiredate, (row, value) => row.copy(hiredate = value))
+      override def salariedflag = Field[Flag, EmployeeRow](_path, "salariedflag", None, Some("bool"), x => x.salariedflag, (row, value) => row.copy(salariedflag = value))
+      override def vacationhours = Field[TypoShort, EmployeeRow](_path, "vacationhours", None, Some("int2"), x => x.vacationhours, (row, value) => row.copy(vacationhours = value))
+      override def sickleavehours = Field[TypoShort, EmployeeRow](_path, "sickleavehours", None, Some("int2"), x => x.sickleavehours, (row, value) => row.copy(sickleavehours = value))
+      override def currentflag = Field[Flag, EmployeeRow](_path, "currentflag", None, Some("bool"), x => x.currentflag, (row, value) => row.copy(currentflag = value))
+      override def rowguid = Field[TypoUUID, EmployeeRow](_path, "rowguid", None, Some("uuid"), x => x.rowguid, (row, value) => row.copy(rowguid = value))
+      override def modifieddate = Field[TypoLocalDateTime, EmployeeRow](_path, "modifieddate", Some("text"), Some("timestamp"), x => x.modifieddate, (row, value) => row.copy(modifieddate = value))
+      override def organizationnode = OptField[String, EmployeeRow](_path, "organizationnode", None, None, x => x.organizationnode, (row, value) => row.copy(organizationnode = value))
     }
   
-    override val columns: List[FieldLikeNoHkt[?, Row]] =
-      List[FieldLikeNoHkt[?, Row]](fields.businessentityid, fields.nationalidnumber, fields.loginid, fields.jobtitle, fields.birthdate, fields.maritalstatus, fields.gender, fields.hiredate, fields.salariedflag, fields.vacationhours, fields.sickleavehours, fields.currentflag, fields.rowguid, fields.modifieddate, fields.organizationnode)
+    override lazy val columns: List[FieldLikeNoHkt[?, EmployeeRow]] =
+      List[FieldLikeNoHkt[?, EmployeeRow]](fields.businessentityid, fields.nationalidnumber, fields.loginid, fields.jobtitle, fields.birthdate, fields.maritalstatus, fields.gender, fields.hiredate, fields.salariedflag, fields.vacationhours, fields.sickleavehours, fields.currentflag, fields.rowguid, fields.modifieddate, fields.organizationnode)
   
-    override def copy[NewRow](prefix: Option[String], extract: NewRow => EmployeeRow, merge: (NewRow, EmployeeRow) => NewRow): Impl[NewRow] =
-      new Impl(prefix, extract, merge)
+    override def copy(path: List[Path]): Impl =
+      new Impl(path)
   }
   
 }

--- a/typo-tester-anorm/generated-and-checked-in/adventureworks/humanresources/employee/EmployeeRepoMock.scala
+++ b/typo-tester-anorm/generated-and-checked-in/adventureworks/humanresources/employee/EmployeeRepoMock.scala
@@ -23,7 +23,7 @@ import typo.dsl.UpdateParams
 class EmployeeRepoMock(toRow: Function1[EmployeeRowUnsaved, EmployeeRow],
                        map: scala.collection.mutable.Map[BusinessentityId, EmployeeRow] = scala.collection.mutable.Map.empty) extends EmployeeRepo {
   override def delete: DeleteBuilder[EmployeeFields, EmployeeRow] = {
-    DeleteBuilderMock(DeleteParams.empty, EmployeeFields.structure.fields, map)
+    DeleteBuilderMock(DeleteParams.empty, EmployeeFields.structure, map)
   }
   override def deleteById(businessentityid: BusinessentityId)(implicit c: Connection): Boolean = {
     map.remove(businessentityid).isDefined
@@ -73,7 +73,7 @@ class EmployeeRepoMock(toRow: Function1[EmployeeRowUnsaved, EmployeeRow],
     businessentityids.view.flatMap(id => byId.get(id).map(x => (id, x))).toMap
   }
   override def update: UpdateBuilder[EmployeeFields, EmployeeRow] = {
-    UpdateBuilderMock(UpdateParams.empty, EmployeeFields.structure.fields, map)
+    UpdateBuilderMock(UpdateParams.empty, EmployeeFields.structure, map)
   }
   override def update(row: EmployeeRow)(implicit c: Connection): Boolean = {
     map.get(row.businessentityid) match {

--- a/typo-tester-anorm/generated-and-checked-in/adventureworks/humanresources/employeedepartmenthistory/EmployeedepartmenthistoryFields.scala
+++ b/typo-tester-anorm/generated-and-checked-in/adventureworks/humanresources/employeedepartmenthistory/EmployeedepartmenthistoryFields.scala
@@ -12,42 +12,43 @@ import adventureworks.customtypes.TypoLocalDateTime
 import adventureworks.humanresources.department.DepartmentId
 import adventureworks.humanresources.shift.ShiftId
 import adventureworks.person.businessentity.BusinessentityId
+import typo.dsl.Path
 import typo.dsl.SqlExpr.Field
 import typo.dsl.SqlExpr.FieldLikeNoHkt
 import typo.dsl.SqlExpr.IdField
 import typo.dsl.SqlExpr.OptField
 import typo.dsl.Structure.Relation
 
-trait EmployeedepartmenthistoryFields[Row] {
-  val businessentityid: IdField[BusinessentityId, Row]
-  val departmentid: IdField[DepartmentId, Row]
-  val shiftid: IdField[ShiftId, Row]
-  val startdate: IdField[TypoLocalDate, Row]
-  val enddate: OptField[TypoLocalDate, Row]
-  val modifieddate: Field[TypoLocalDateTime, Row]
+trait EmployeedepartmenthistoryFields {
+  def businessentityid: IdField[BusinessentityId, EmployeedepartmenthistoryRow]
+  def departmentid: IdField[DepartmentId, EmployeedepartmenthistoryRow]
+  def shiftid: IdField[ShiftId, EmployeedepartmenthistoryRow]
+  def startdate: IdField[TypoLocalDate, EmployeedepartmenthistoryRow]
+  def enddate: OptField[TypoLocalDate, EmployeedepartmenthistoryRow]
+  def modifieddate: Field[TypoLocalDateTime, EmployeedepartmenthistoryRow]
 }
 
 object EmployeedepartmenthistoryFields {
-  val structure: Relation[EmployeedepartmenthistoryFields, EmployeedepartmenthistoryRow, EmployeedepartmenthistoryRow] = 
-    new Impl(None, identity, (_, x) => x)
+  lazy val structure: Relation[EmployeedepartmenthistoryFields, EmployeedepartmenthistoryRow] =
+    new Impl(Nil)
     
-  private final class Impl[Row](val prefix: Option[String], val extract: Row => EmployeedepartmenthistoryRow, val merge: (Row, EmployeedepartmenthistoryRow) => Row)
-    extends Relation[EmployeedepartmenthistoryFields, EmployeedepartmenthistoryRow, Row] { 
+  private final class Impl(val _path: List[Path])
+    extends Relation[EmployeedepartmenthistoryFields, EmployeedepartmenthistoryRow] {
   
-    override val fields: EmployeedepartmenthistoryFields[Row] = new EmployeedepartmenthistoryFields[Row] {
-      override val businessentityid = new IdField[BusinessentityId, Row](prefix, "businessentityid", None, Some("int4"))(x => extract(x).businessentityid, (row, value) => merge(row, extract(row).copy(businessentityid = value)))
-      override val departmentid = new IdField[DepartmentId, Row](prefix, "departmentid", None, Some("int2"))(x => extract(x).departmentid, (row, value) => merge(row, extract(row).copy(departmentid = value)))
-      override val shiftid = new IdField[ShiftId, Row](prefix, "shiftid", None, Some("int2"))(x => extract(x).shiftid, (row, value) => merge(row, extract(row).copy(shiftid = value)))
-      override val startdate = new IdField[TypoLocalDate, Row](prefix, "startdate", Some("text"), Some("date"))(x => extract(x).startdate, (row, value) => merge(row, extract(row).copy(startdate = value)))
-      override val enddate = new OptField[TypoLocalDate, Row](prefix, "enddate", Some("text"), Some("date"))(x => extract(x).enddate, (row, value) => merge(row, extract(row).copy(enddate = value)))
-      override val modifieddate = new Field[TypoLocalDateTime, Row](prefix, "modifieddate", Some("text"), Some("timestamp"))(x => extract(x).modifieddate, (row, value) => merge(row, extract(row).copy(modifieddate = value)))
+    override lazy val fields: EmployeedepartmenthistoryFields = new EmployeedepartmenthistoryFields {
+      override def businessentityid = IdField[BusinessentityId, EmployeedepartmenthistoryRow](_path, "businessentityid", None, Some("int4"), x => x.businessentityid, (row, value) => row.copy(businessentityid = value))
+      override def departmentid = IdField[DepartmentId, EmployeedepartmenthistoryRow](_path, "departmentid", None, Some("int2"), x => x.departmentid, (row, value) => row.copy(departmentid = value))
+      override def shiftid = IdField[ShiftId, EmployeedepartmenthistoryRow](_path, "shiftid", None, Some("int2"), x => x.shiftid, (row, value) => row.copy(shiftid = value))
+      override def startdate = IdField[TypoLocalDate, EmployeedepartmenthistoryRow](_path, "startdate", Some("text"), Some("date"), x => x.startdate, (row, value) => row.copy(startdate = value))
+      override def enddate = OptField[TypoLocalDate, EmployeedepartmenthistoryRow](_path, "enddate", Some("text"), Some("date"), x => x.enddate, (row, value) => row.copy(enddate = value))
+      override def modifieddate = Field[TypoLocalDateTime, EmployeedepartmenthistoryRow](_path, "modifieddate", Some("text"), Some("timestamp"), x => x.modifieddate, (row, value) => row.copy(modifieddate = value))
     }
   
-    override val columns: List[FieldLikeNoHkt[?, Row]] =
-      List[FieldLikeNoHkt[?, Row]](fields.businessentityid, fields.departmentid, fields.shiftid, fields.startdate, fields.enddate, fields.modifieddate)
+    override lazy val columns: List[FieldLikeNoHkt[?, EmployeedepartmenthistoryRow]] =
+      List[FieldLikeNoHkt[?, EmployeedepartmenthistoryRow]](fields.businessentityid, fields.departmentid, fields.shiftid, fields.startdate, fields.enddate, fields.modifieddate)
   
-    override def copy[NewRow](prefix: Option[String], extract: NewRow => EmployeedepartmenthistoryRow, merge: (NewRow, EmployeedepartmenthistoryRow) => NewRow): Impl[NewRow] =
-      new Impl(prefix, extract, merge)
+    override def copy(path: List[Path]): Impl =
+      new Impl(path)
   }
   
 }

--- a/typo-tester-anorm/generated-and-checked-in/adventureworks/humanresources/employeedepartmenthistory/EmployeedepartmenthistoryRepoMock.scala
+++ b/typo-tester-anorm/generated-and-checked-in/adventureworks/humanresources/employeedepartmenthistory/EmployeedepartmenthistoryRepoMock.scala
@@ -22,7 +22,7 @@ import typo.dsl.UpdateParams
 class EmployeedepartmenthistoryRepoMock(toRow: Function1[EmployeedepartmenthistoryRowUnsaved, EmployeedepartmenthistoryRow],
                                         map: scala.collection.mutable.Map[EmployeedepartmenthistoryId, EmployeedepartmenthistoryRow] = scala.collection.mutable.Map.empty) extends EmployeedepartmenthistoryRepo {
   override def delete: DeleteBuilder[EmployeedepartmenthistoryFields, EmployeedepartmenthistoryRow] = {
-    DeleteBuilderMock(DeleteParams.empty, EmployeedepartmenthistoryFields.structure.fields, map)
+    DeleteBuilderMock(DeleteParams.empty, EmployeedepartmenthistoryFields.structure, map)
   }
   override def deleteById(compositeId: EmployeedepartmenthistoryId)(implicit c: Connection): Boolean = {
     map.remove(compositeId).isDefined
@@ -72,7 +72,7 @@ class EmployeedepartmenthistoryRepoMock(toRow: Function1[Employeedepartmenthisto
     compositeIds.view.flatMap(id => byId.get(id).map(x => (id, x))).toMap
   }
   override def update: UpdateBuilder[EmployeedepartmenthistoryFields, EmployeedepartmenthistoryRow] = {
-    UpdateBuilderMock(UpdateParams.empty, EmployeedepartmenthistoryFields.structure.fields, map)
+    UpdateBuilderMock(UpdateParams.empty, EmployeedepartmenthistoryFields.structure, map)
   }
   override def update(row: EmployeedepartmenthistoryRow)(implicit c: Connection): Boolean = {
     map.get(row.compositeId) match {

--- a/typo-tester-anorm/generated-and-checked-in/adventureworks/humanresources/employeepayhistory/EmployeepayhistoryFields.scala
+++ b/typo-tester-anorm/generated-and-checked-in/adventureworks/humanresources/employeepayhistory/EmployeepayhistoryFields.scala
@@ -10,39 +10,40 @@ package employeepayhistory
 import adventureworks.customtypes.TypoLocalDateTime
 import adventureworks.customtypes.TypoShort
 import adventureworks.person.businessentity.BusinessentityId
+import typo.dsl.Path
 import typo.dsl.SqlExpr.Field
 import typo.dsl.SqlExpr.FieldLikeNoHkt
 import typo.dsl.SqlExpr.IdField
 import typo.dsl.Structure.Relation
 
-trait EmployeepayhistoryFields[Row] {
-  val businessentityid: IdField[BusinessentityId, Row]
-  val ratechangedate: IdField[TypoLocalDateTime, Row]
-  val rate: Field[BigDecimal, Row]
-  val payfrequency: Field[TypoShort, Row]
-  val modifieddate: Field[TypoLocalDateTime, Row]
+trait EmployeepayhistoryFields {
+  def businessentityid: IdField[BusinessentityId, EmployeepayhistoryRow]
+  def ratechangedate: IdField[TypoLocalDateTime, EmployeepayhistoryRow]
+  def rate: Field[BigDecimal, EmployeepayhistoryRow]
+  def payfrequency: Field[TypoShort, EmployeepayhistoryRow]
+  def modifieddate: Field[TypoLocalDateTime, EmployeepayhistoryRow]
 }
 
 object EmployeepayhistoryFields {
-  val structure: Relation[EmployeepayhistoryFields, EmployeepayhistoryRow, EmployeepayhistoryRow] = 
-    new Impl(None, identity, (_, x) => x)
+  lazy val structure: Relation[EmployeepayhistoryFields, EmployeepayhistoryRow] =
+    new Impl(Nil)
     
-  private final class Impl[Row](val prefix: Option[String], val extract: Row => EmployeepayhistoryRow, val merge: (Row, EmployeepayhistoryRow) => Row)
-    extends Relation[EmployeepayhistoryFields, EmployeepayhistoryRow, Row] { 
+  private final class Impl(val _path: List[Path])
+    extends Relation[EmployeepayhistoryFields, EmployeepayhistoryRow] {
   
-    override val fields: EmployeepayhistoryFields[Row] = new EmployeepayhistoryFields[Row] {
-      override val businessentityid = new IdField[BusinessentityId, Row](prefix, "businessentityid", None, Some("int4"))(x => extract(x).businessentityid, (row, value) => merge(row, extract(row).copy(businessentityid = value)))
-      override val ratechangedate = new IdField[TypoLocalDateTime, Row](prefix, "ratechangedate", Some("text"), Some("timestamp"))(x => extract(x).ratechangedate, (row, value) => merge(row, extract(row).copy(ratechangedate = value)))
-      override val rate = new Field[BigDecimal, Row](prefix, "rate", None, Some("numeric"))(x => extract(x).rate, (row, value) => merge(row, extract(row).copy(rate = value)))
-      override val payfrequency = new Field[TypoShort, Row](prefix, "payfrequency", None, Some("int2"))(x => extract(x).payfrequency, (row, value) => merge(row, extract(row).copy(payfrequency = value)))
-      override val modifieddate = new Field[TypoLocalDateTime, Row](prefix, "modifieddate", Some("text"), Some("timestamp"))(x => extract(x).modifieddate, (row, value) => merge(row, extract(row).copy(modifieddate = value)))
+    override lazy val fields: EmployeepayhistoryFields = new EmployeepayhistoryFields {
+      override def businessentityid = IdField[BusinessentityId, EmployeepayhistoryRow](_path, "businessentityid", None, Some("int4"), x => x.businessentityid, (row, value) => row.copy(businessentityid = value))
+      override def ratechangedate = IdField[TypoLocalDateTime, EmployeepayhistoryRow](_path, "ratechangedate", Some("text"), Some("timestamp"), x => x.ratechangedate, (row, value) => row.copy(ratechangedate = value))
+      override def rate = Field[BigDecimal, EmployeepayhistoryRow](_path, "rate", None, Some("numeric"), x => x.rate, (row, value) => row.copy(rate = value))
+      override def payfrequency = Field[TypoShort, EmployeepayhistoryRow](_path, "payfrequency", None, Some("int2"), x => x.payfrequency, (row, value) => row.copy(payfrequency = value))
+      override def modifieddate = Field[TypoLocalDateTime, EmployeepayhistoryRow](_path, "modifieddate", Some("text"), Some("timestamp"), x => x.modifieddate, (row, value) => row.copy(modifieddate = value))
     }
   
-    override val columns: List[FieldLikeNoHkt[?, Row]] =
-      List[FieldLikeNoHkt[?, Row]](fields.businessentityid, fields.ratechangedate, fields.rate, fields.payfrequency, fields.modifieddate)
+    override lazy val columns: List[FieldLikeNoHkt[?, EmployeepayhistoryRow]] =
+      List[FieldLikeNoHkt[?, EmployeepayhistoryRow]](fields.businessentityid, fields.ratechangedate, fields.rate, fields.payfrequency, fields.modifieddate)
   
-    override def copy[NewRow](prefix: Option[String], extract: NewRow => EmployeepayhistoryRow, merge: (NewRow, EmployeepayhistoryRow) => NewRow): Impl[NewRow] =
-      new Impl(prefix, extract, merge)
+    override def copy(path: List[Path]): Impl =
+      new Impl(path)
   }
   
 }

--- a/typo-tester-anorm/generated-and-checked-in/adventureworks/humanresources/employeepayhistory/EmployeepayhistoryRepoMock.scala
+++ b/typo-tester-anorm/generated-and-checked-in/adventureworks/humanresources/employeepayhistory/EmployeepayhistoryRepoMock.scala
@@ -22,7 +22,7 @@ import typo.dsl.UpdateParams
 class EmployeepayhistoryRepoMock(toRow: Function1[EmployeepayhistoryRowUnsaved, EmployeepayhistoryRow],
                                  map: scala.collection.mutable.Map[EmployeepayhistoryId, EmployeepayhistoryRow] = scala.collection.mutable.Map.empty) extends EmployeepayhistoryRepo {
   override def delete: DeleteBuilder[EmployeepayhistoryFields, EmployeepayhistoryRow] = {
-    DeleteBuilderMock(DeleteParams.empty, EmployeepayhistoryFields.structure.fields, map)
+    DeleteBuilderMock(DeleteParams.empty, EmployeepayhistoryFields.structure, map)
   }
   override def deleteById(compositeId: EmployeepayhistoryId)(implicit c: Connection): Boolean = {
     map.remove(compositeId).isDefined
@@ -72,7 +72,7 @@ class EmployeepayhistoryRepoMock(toRow: Function1[EmployeepayhistoryRowUnsaved, 
     compositeIds.view.flatMap(id => byId.get(id).map(x => (id, x))).toMap
   }
   override def update: UpdateBuilder[EmployeepayhistoryFields, EmployeepayhistoryRow] = {
-    UpdateBuilderMock(UpdateParams.empty, EmployeepayhistoryFields.structure.fields, map)
+    UpdateBuilderMock(UpdateParams.empty, EmployeepayhistoryFields.structure, map)
   }
   override def update(row: EmployeepayhistoryRow)(implicit c: Connection): Boolean = {
     map.get(row.compositeId) match {

--- a/typo-tester-anorm/generated-and-checked-in/adventureworks/humanresources/jobcandidate/JobcandidateFields.scala
+++ b/typo-tester-anorm/generated-and-checked-in/adventureworks/humanresources/jobcandidate/JobcandidateFields.scala
@@ -10,38 +10,39 @@ package jobcandidate
 import adventureworks.customtypes.TypoLocalDateTime
 import adventureworks.customtypes.TypoXml
 import adventureworks.person.businessentity.BusinessentityId
+import typo.dsl.Path
 import typo.dsl.SqlExpr.Field
 import typo.dsl.SqlExpr.FieldLikeNoHkt
 import typo.dsl.SqlExpr.IdField
 import typo.dsl.SqlExpr.OptField
 import typo.dsl.Structure.Relation
 
-trait JobcandidateFields[Row] {
-  val jobcandidateid: IdField[JobcandidateId, Row]
-  val businessentityid: OptField[BusinessentityId, Row]
-  val resume: OptField[TypoXml, Row]
-  val modifieddate: Field[TypoLocalDateTime, Row]
+trait JobcandidateFields {
+  def jobcandidateid: IdField[JobcandidateId, JobcandidateRow]
+  def businessentityid: OptField[BusinessentityId, JobcandidateRow]
+  def resume: OptField[TypoXml, JobcandidateRow]
+  def modifieddate: Field[TypoLocalDateTime, JobcandidateRow]
 }
 
 object JobcandidateFields {
-  val structure: Relation[JobcandidateFields, JobcandidateRow, JobcandidateRow] = 
-    new Impl(None, identity, (_, x) => x)
+  lazy val structure: Relation[JobcandidateFields, JobcandidateRow] =
+    new Impl(Nil)
     
-  private final class Impl[Row](val prefix: Option[String], val extract: Row => JobcandidateRow, val merge: (Row, JobcandidateRow) => Row)
-    extends Relation[JobcandidateFields, JobcandidateRow, Row] { 
+  private final class Impl(val _path: List[Path])
+    extends Relation[JobcandidateFields, JobcandidateRow] {
   
-    override val fields: JobcandidateFields[Row] = new JobcandidateFields[Row] {
-      override val jobcandidateid = new IdField[JobcandidateId, Row](prefix, "jobcandidateid", None, Some("int4"))(x => extract(x).jobcandidateid, (row, value) => merge(row, extract(row).copy(jobcandidateid = value)))
-      override val businessentityid = new OptField[BusinessentityId, Row](prefix, "businessentityid", None, Some("int4"))(x => extract(x).businessentityid, (row, value) => merge(row, extract(row).copy(businessentityid = value)))
-      override val resume = new OptField[TypoXml, Row](prefix, "resume", None, Some("xml"))(x => extract(x).resume, (row, value) => merge(row, extract(row).copy(resume = value)))
-      override val modifieddate = new Field[TypoLocalDateTime, Row](prefix, "modifieddate", Some("text"), Some("timestamp"))(x => extract(x).modifieddate, (row, value) => merge(row, extract(row).copy(modifieddate = value)))
+    override lazy val fields: JobcandidateFields = new JobcandidateFields {
+      override def jobcandidateid = IdField[JobcandidateId, JobcandidateRow](_path, "jobcandidateid", None, Some("int4"), x => x.jobcandidateid, (row, value) => row.copy(jobcandidateid = value))
+      override def businessentityid = OptField[BusinessentityId, JobcandidateRow](_path, "businessentityid", None, Some("int4"), x => x.businessentityid, (row, value) => row.copy(businessentityid = value))
+      override def resume = OptField[TypoXml, JobcandidateRow](_path, "resume", None, Some("xml"), x => x.resume, (row, value) => row.copy(resume = value))
+      override def modifieddate = Field[TypoLocalDateTime, JobcandidateRow](_path, "modifieddate", Some("text"), Some("timestamp"), x => x.modifieddate, (row, value) => row.copy(modifieddate = value))
     }
   
-    override val columns: List[FieldLikeNoHkt[?, Row]] =
-      List[FieldLikeNoHkt[?, Row]](fields.jobcandidateid, fields.businessentityid, fields.resume, fields.modifieddate)
+    override lazy val columns: List[FieldLikeNoHkt[?, JobcandidateRow]] =
+      List[FieldLikeNoHkt[?, JobcandidateRow]](fields.jobcandidateid, fields.businessentityid, fields.resume, fields.modifieddate)
   
-    override def copy[NewRow](prefix: Option[String], extract: NewRow => JobcandidateRow, merge: (NewRow, JobcandidateRow) => NewRow): Impl[NewRow] =
-      new Impl(prefix, extract, merge)
+    override def copy(path: List[Path]): Impl =
+      new Impl(path)
   }
   
 }

--- a/typo-tester-anorm/generated-and-checked-in/adventureworks/humanresources/jobcandidate/JobcandidateRepoMock.scala
+++ b/typo-tester-anorm/generated-and-checked-in/adventureworks/humanresources/jobcandidate/JobcandidateRepoMock.scala
@@ -22,7 +22,7 @@ import typo.dsl.UpdateParams
 class JobcandidateRepoMock(toRow: Function1[JobcandidateRowUnsaved, JobcandidateRow],
                            map: scala.collection.mutable.Map[JobcandidateId, JobcandidateRow] = scala.collection.mutable.Map.empty) extends JobcandidateRepo {
   override def delete: DeleteBuilder[JobcandidateFields, JobcandidateRow] = {
-    DeleteBuilderMock(DeleteParams.empty, JobcandidateFields.structure.fields, map)
+    DeleteBuilderMock(DeleteParams.empty, JobcandidateFields.structure, map)
   }
   override def deleteById(jobcandidateid: JobcandidateId)(implicit c: Connection): Boolean = {
     map.remove(jobcandidateid).isDefined
@@ -72,7 +72,7 @@ class JobcandidateRepoMock(toRow: Function1[JobcandidateRowUnsaved, Jobcandidate
     jobcandidateids.view.flatMap(id => byId.get(id).map(x => (id, x))).toMap
   }
   override def update: UpdateBuilder[JobcandidateFields, JobcandidateRow] = {
-    UpdateBuilderMock(UpdateParams.empty, JobcandidateFields.structure.fields, map)
+    UpdateBuilderMock(UpdateParams.empty, JobcandidateFields.structure, map)
   }
   override def update(row: JobcandidateRow)(implicit c: Connection): Boolean = {
     map.get(row.jobcandidateid) match {

--- a/typo-tester-anorm/generated-and-checked-in/adventureworks/humanresources/shift/ShiftFields.scala
+++ b/typo-tester-anorm/generated-and-checked-in/adventureworks/humanresources/shift/ShiftFields.scala
@@ -10,39 +10,40 @@ package shift
 import adventureworks.customtypes.TypoLocalDateTime
 import adventureworks.customtypes.TypoLocalTime
 import adventureworks.public.Name
+import typo.dsl.Path
 import typo.dsl.SqlExpr.Field
 import typo.dsl.SqlExpr.FieldLikeNoHkt
 import typo.dsl.SqlExpr.IdField
 import typo.dsl.Structure.Relation
 
-trait ShiftFields[Row] {
-  val shiftid: IdField[ShiftId, Row]
-  val name: Field[Name, Row]
-  val starttime: Field[TypoLocalTime, Row]
-  val endtime: Field[TypoLocalTime, Row]
-  val modifieddate: Field[TypoLocalDateTime, Row]
+trait ShiftFields {
+  def shiftid: IdField[ShiftId, ShiftRow]
+  def name: Field[Name, ShiftRow]
+  def starttime: Field[TypoLocalTime, ShiftRow]
+  def endtime: Field[TypoLocalTime, ShiftRow]
+  def modifieddate: Field[TypoLocalDateTime, ShiftRow]
 }
 
 object ShiftFields {
-  val structure: Relation[ShiftFields, ShiftRow, ShiftRow] = 
-    new Impl(None, identity, (_, x) => x)
+  lazy val structure: Relation[ShiftFields, ShiftRow] =
+    new Impl(Nil)
     
-  private final class Impl[Row](val prefix: Option[String], val extract: Row => ShiftRow, val merge: (Row, ShiftRow) => Row)
-    extends Relation[ShiftFields, ShiftRow, Row] { 
+  private final class Impl(val _path: List[Path])
+    extends Relation[ShiftFields, ShiftRow] {
   
-    override val fields: ShiftFields[Row] = new ShiftFields[Row] {
-      override val shiftid = new IdField[ShiftId, Row](prefix, "shiftid", None, Some("int4"))(x => extract(x).shiftid, (row, value) => merge(row, extract(row).copy(shiftid = value)))
-      override val name = new Field[Name, Row](prefix, "name", None, Some("varchar"))(x => extract(x).name, (row, value) => merge(row, extract(row).copy(name = value)))
-      override val starttime = new Field[TypoLocalTime, Row](prefix, "starttime", Some("text"), Some("time"))(x => extract(x).starttime, (row, value) => merge(row, extract(row).copy(starttime = value)))
-      override val endtime = new Field[TypoLocalTime, Row](prefix, "endtime", Some("text"), Some("time"))(x => extract(x).endtime, (row, value) => merge(row, extract(row).copy(endtime = value)))
-      override val modifieddate = new Field[TypoLocalDateTime, Row](prefix, "modifieddate", Some("text"), Some("timestamp"))(x => extract(x).modifieddate, (row, value) => merge(row, extract(row).copy(modifieddate = value)))
+    override lazy val fields: ShiftFields = new ShiftFields {
+      override def shiftid = IdField[ShiftId, ShiftRow](_path, "shiftid", None, Some("int4"), x => x.shiftid, (row, value) => row.copy(shiftid = value))
+      override def name = Field[Name, ShiftRow](_path, "name", None, Some("varchar"), x => x.name, (row, value) => row.copy(name = value))
+      override def starttime = Field[TypoLocalTime, ShiftRow](_path, "starttime", Some("text"), Some("time"), x => x.starttime, (row, value) => row.copy(starttime = value))
+      override def endtime = Field[TypoLocalTime, ShiftRow](_path, "endtime", Some("text"), Some("time"), x => x.endtime, (row, value) => row.copy(endtime = value))
+      override def modifieddate = Field[TypoLocalDateTime, ShiftRow](_path, "modifieddate", Some("text"), Some("timestamp"), x => x.modifieddate, (row, value) => row.copy(modifieddate = value))
     }
   
-    override val columns: List[FieldLikeNoHkt[?, Row]] =
-      List[FieldLikeNoHkt[?, Row]](fields.shiftid, fields.name, fields.starttime, fields.endtime, fields.modifieddate)
+    override lazy val columns: List[FieldLikeNoHkt[?, ShiftRow]] =
+      List[FieldLikeNoHkt[?, ShiftRow]](fields.shiftid, fields.name, fields.starttime, fields.endtime, fields.modifieddate)
   
-    override def copy[NewRow](prefix: Option[String], extract: NewRow => ShiftRow, merge: (NewRow, ShiftRow) => NewRow): Impl[NewRow] =
-      new Impl(prefix, extract, merge)
+    override def copy(path: List[Path]): Impl =
+      new Impl(path)
   }
   
 }

--- a/typo-tester-anorm/generated-and-checked-in/adventureworks/humanresources/shift/ShiftRepoMock.scala
+++ b/typo-tester-anorm/generated-and-checked-in/adventureworks/humanresources/shift/ShiftRepoMock.scala
@@ -22,7 +22,7 @@ import typo.dsl.UpdateParams
 class ShiftRepoMock(toRow: Function1[ShiftRowUnsaved, ShiftRow],
                     map: scala.collection.mutable.Map[ShiftId, ShiftRow] = scala.collection.mutable.Map.empty) extends ShiftRepo {
   override def delete: DeleteBuilder[ShiftFields, ShiftRow] = {
-    DeleteBuilderMock(DeleteParams.empty, ShiftFields.structure.fields, map)
+    DeleteBuilderMock(DeleteParams.empty, ShiftFields.structure, map)
   }
   override def deleteById(shiftid: ShiftId)(implicit c: Connection): Boolean = {
     map.remove(shiftid).isDefined
@@ -72,7 +72,7 @@ class ShiftRepoMock(toRow: Function1[ShiftRowUnsaved, ShiftRow],
     shiftids.view.flatMap(id => byId.get(id).map(x => (id, x))).toMap
   }
   override def update: UpdateBuilder[ShiftFields, ShiftRow] = {
-    UpdateBuilderMock(UpdateParams.empty, ShiftFields.structure.fields, map)
+    UpdateBuilderMock(UpdateParams.empty, ShiftFields.structure, map)
   }
   override def update(row: ShiftRow)(implicit c: Connection): Boolean = {
     map.get(row.shiftid) match {

--- a/typo-tester-anorm/generated-and-checked-in/adventureworks/humanresources/vemployee/VemployeeViewFields.scala
+++ b/typo-tester-anorm/generated-and-checked-in/adventureworks/humanresources/vemployee/VemployeeViewFields.scala
@@ -12,65 +12,66 @@ import adventureworks.person.businessentity.BusinessentityId
 import adventureworks.public.Name
 import adventureworks.public.Phone
 import adventureworks.userdefined.FirstName
+import typo.dsl.Path
 import typo.dsl.SqlExpr.Field
 import typo.dsl.SqlExpr.FieldLikeNoHkt
 import typo.dsl.SqlExpr.OptField
 import typo.dsl.Structure.Relation
 
-trait VemployeeViewFields[Row] {
-  val businessentityid: Field[BusinessentityId, Row]
-  val title: OptField[/* max 8 chars */ String, Row]
-  val firstname: Field[/* user-picked */ FirstName, Row]
-  val middlename: OptField[Name, Row]
-  val lastname: Field[Name, Row]
-  val suffix: OptField[/* max 10 chars */ String, Row]
-  val jobtitle: Field[/* max 50 chars */ String, Row]
-  val phonenumber: OptField[Phone, Row]
-  val phonenumbertype: OptField[Name, Row]
-  val emailaddress: OptField[/* max 50 chars */ String, Row]
-  val emailpromotion: Field[Int, Row]
-  val addressline1: Field[/* max 60 chars */ String, Row]
-  val addressline2: OptField[/* max 60 chars */ String, Row]
-  val city: Field[/* max 30 chars */ String, Row]
-  val stateprovincename: Field[Name, Row]
-  val postalcode: Field[/* max 15 chars */ String, Row]
-  val countryregionname: Field[Name, Row]
-  val additionalcontactinfo: OptField[TypoXml, Row]
+trait VemployeeViewFields {
+  def businessentityid: Field[BusinessentityId, VemployeeViewRow]
+  def title: OptField[/* max 8 chars */ String, VemployeeViewRow]
+  def firstname: Field[/* user-picked */ FirstName, VemployeeViewRow]
+  def middlename: OptField[Name, VemployeeViewRow]
+  def lastname: Field[Name, VemployeeViewRow]
+  def suffix: OptField[/* max 10 chars */ String, VemployeeViewRow]
+  def jobtitle: Field[/* max 50 chars */ String, VemployeeViewRow]
+  def phonenumber: OptField[Phone, VemployeeViewRow]
+  def phonenumbertype: OptField[Name, VemployeeViewRow]
+  def emailaddress: OptField[/* max 50 chars */ String, VemployeeViewRow]
+  def emailpromotion: Field[Int, VemployeeViewRow]
+  def addressline1: Field[/* max 60 chars */ String, VemployeeViewRow]
+  def addressline2: OptField[/* max 60 chars */ String, VemployeeViewRow]
+  def city: Field[/* max 30 chars */ String, VemployeeViewRow]
+  def stateprovincename: Field[Name, VemployeeViewRow]
+  def postalcode: Field[/* max 15 chars */ String, VemployeeViewRow]
+  def countryregionname: Field[Name, VemployeeViewRow]
+  def additionalcontactinfo: OptField[TypoXml, VemployeeViewRow]
 }
 
 object VemployeeViewFields {
-  val structure: Relation[VemployeeViewFields, VemployeeViewRow, VemployeeViewRow] = 
-    new Impl(None, identity, (_, x) => x)
+  lazy val structure: Relation[VemployeeViewFields, VemployeeViewRow] =
+    new Impl(Nil)
     
-  private final class Impl[Row](val prefix: Option[String], val extract: Row => VemployeeViewRow, val merge: (Row, VemployeeViewRow) => Row)
-    extends Relation[VemployeeViewFields, VemployeeViewRow, Row] { 
+  private final class Impl(val _path: List[Path])
+    extends Relation[VemployeeViewFields, VemployeeViewRow] {
   
-    override val fields: VemployeeViewFields[Row] = new VemployeeViewFields[Row] {
-      override val businessentityid = new Field[BusinessentityId, Row](prefix, "businessentityid", None, None)(x => extract(x).businessentityid, (row, value) => merge(row, extract(row).copy(businessentityid = value)))
-      override val title = new OptField[/* max 8 chars */ String, Row](prefix, "title", None, None)(x => extract(x).title, (row, value) => merge(row, extract(row).copy(title = value)))
-      override val firstname = new Field[/* user-picked */ FirstName, Row](prefix, "firstname", None, None)(x => extract(x).firstname, (row, value) => merge(row, extract(row).copy(firstname = value)))
-      override val middlename = new OptField[Name, Row](prefix, "middlename", None, None)(x => extract(x).middlename, (row, value) => merge(row, extract(row).copy(middlename = value)))
-      override val lastname = new Field[Name, Row](prefix, "lastname", None, None)(x => extract(x).lastname, (row, value) => merge(row, extract(row).copy(lastname = value)))
-      override val suffix = new OptField[/* max 10 chars */ String, Row](prefix, "suffix", None, None)(x => extract(x).suffix, (row, value) => merge(row, extract(row).copy(suffix = value)))
-      override val jobtitle = new Field[/* max 50 chars */ String, Row](prefix, "jobtitle", None, None)(x => extract(x).jobtitle, (row, value) => merge(row, extract(row).copy(jobtitle = value)))
-      override val phonenumber = new OptField[Phone, Row](prefix, "phonenumber", None, None)(x => extract(x).phonenumber, (row, value) => merge(row, extract(row).copy(phonenumber = value)))
-      override val phonenumbertype = new OptField[Name, Row](prefix, "phonenumbertype", None, None)(x => extract(x).phonenumbertype, (row, value) => merge(row, extract(row).copy(phonenumbertype = value)))
-      override val emailaddress = new OptField[/* max 50 chars */ String, Row](prefix, "emailaddress", None, None)(x => extract(x).emailaddress, (row, value) => merge(row, extract(row).copy(emailaddress = value)))
-      override val emailpromotion = new Field[Int, Row](prefix, "emailpromotion", None, None)(x => extract(x).emailpromotion, (row, value) => merge(row, extract(row).copy(emailpromotion = value)))
-      override val addressline1 = new Field[/* max 60 chars */ String, Row](prefix, "addressline1", None, None)(x => extract(x).addressline1, (row, value) => merge(row, extract(row).copy(addressline1 = value)))
-      override val addressline2 = new OptField[/* max 60 chars */ String, Row](prefix, "addressline2", None, None)(x => extract(x).addressline2, (row, value) => merge(row, extract(row).copy(addressline2 = value)))
-      override val city = new Field[/* max 30 chars */ String, Row](prefix, "city", None, None)(x => extract(x).city, (row, value) => merge(row, extract(row).copy(city = value)))
-      override val stateprovincename = new Field[Name, Row](prefix, "stateprovincename", None, None)(x => extract(x).stateprovincename, (row, value) => merge(row, extract(row).copy(stateprovincename = value)))
-      override val postalcode = new Field[/* max 15 chars */ String, Row](prefix, "postalcode", None, None)(x => extract(x).postalcode, (row, value) => merge(row, extract(row).copy(postalcode = value)))
-      override val countryregionname = new Field[Name, Row](prefix, "countryregionname", None, None)(x => extract(x).countryregionname, (row, value) => merge(row, extract(row).copy(countryregionname = value)))
-      override val additionalcontactinfo = new OptField[TypoXml, Row](prefix, "additionalcontactinfo", None, None)(x => extract(x).additionalcontactinfo, (row, value) => merge(row, extract(row).copy(additionalcontactinfo = value)))
+    override lazy val fields: VemployeeViewFields = new VemployeeViewFields {
+      override def businessentityid = Field[BusinessentityId, VemployeeViewRow](_path, "businessentityid", None, None, x => x.businessentityid, (row, value) => row.copy(businessentityid = value))
+      override def title = OptField[/* max 8 chars */ String, VemployeeViewRow](_path, "title", None, None, x => x.title, (row, value) => row.copy(title = value))
+      override def firstname = Field[/* user-picked */ FirstName, VemployeeViewRow](_path, "firstname", None, None, x => x.firstname, (row, value) => row.copy(firstname = value))
+      override def middlename = OptField[Name, VemployeeViewRow](_path, "middlename", None, None, x => x.middlename, (row, value) => row.copy(middlename = value))
+      override def lastname = Field[Name, VemployeeViewRow](_path, "lastname", None, None, x => x.lastname, (row, value) => row.copy(lastname = value))
+      override def suffix = OptField[/* max 10 chars */ String, VemployeeViewRow](_path, "suffix", None, None, x => x.suffix, (row, value) => row.copy(suffix = value))
+      override def jobtitle = Field[/* max 50 chars */ String, VemployeeViewRow](_path, "jobtitle", None, None, x => x.jobtitle, (row, value) => row.copy(jobtitle = value))
+      override def phonenumber = OptField[Phone, VemployeeViewRow](_path, "phonenumber", None, None, x => x.phonenumber, (row, value) => row.copy(phonenumber = value))
+      override def phonenumbertype = OptField[Name, VemployeeViewRow](_path, "phonenumbertype", None, None, x => x.phonenumbertype, (row, value) => row.copy(phonenumbertype = value))
+      override def emailaddress = OptField[/* max 50 chars */ String, VemployeeViewRow](_path, "emailaddress", None, None, x => x.emailaddress, (row, value) => row.copy(emailaddress = value))
+      override def emailpromotion = Field[Int, VemployeeViewRow](_path, "emailpromotion", None, None, x => x.emailpromotion, (row, value) => row.copy(emailpromotion = value))
+      override def addressline1 = Field[/* max 60 chars */ String, VemployeeViewRow](_path, "addressline1", None, None, x => x.addressline1, (row, value) => row.copy(addressline1 = value))
+      override def addressline2 = OptField[/* max 60 chars */ String, VemployeeViewRow](_path, "addressline2", None, None, x => x.addressline2, (row, value) => row.copy(addressline2 = value))
+      override def city = Field[/* max 30 chars */ String, VemployeeViewRow](_path, "city", None, None, x => x.city, (row, value) => row.copy(city = value))
+      override def stateprovincename = Field[Name, VemployeeViewRow](_path, "stateprovincename", None, None, x => x.stateprovincename, (row, value) => row.copy(stateprovincename = value))
+      override def postalcode = Field[/* max 15 chars */ String, VemployeeViewRow](_path, "postalcode", None, None, x => x.postalcode, (row, value) => row.copy(postalcode = value))
+      override def countryregionname = Field[Name, VemployeeViewRow](_path, "countryregionname", None, None, x => x.countryregionname, (row, value) => row.copy(countryregionname = value))
+      override def additionalcontactinfo = OptField[TypoXml, VemployeeViewRow](_path, "additionalcontactinfo", None, None, x => x.additionalcontactinfo, (row, value) => row.copy(additionalcontactinfo = value))
     }
   
-    override val columns: List[FieldLikeNoHkt[?, Row]] =
-      List[FieldLikeNoHkt[?, Row]](fields.businessentityid, fields.title, fields.firstname, fields.middlename, fields.lastname, fields.suffix, fields.jobtitle, fields.phonenumber, fields.phonenumbertype, fields.emailaddress, fields.emailpromotion, fields.addressline1, fields.addressline2, fields.city, fields.stateprovincename, fields.postalcode, fields.countryregionname, fields.additionalcontactinfo)
+    override lazy val columns: List[FieldLikeNoHkt[?, VemployeeViewRow]] =
+      List[FieldLikeNoHkt[?, VemployeeViewRow]](fields.businessentityid, fields.title, fields.firstname, fields.middlename, fields.lastname, fields.suffix, fields.jobtitle, fields.phonenumber, fields.phonenumbertype, fields.emailaddress, fields.emailpromotion, fields.addressline1, fields.addressline2, fields.city, fields.stateprovincename, fields.postalcode, fields.countryregionname, fields.additionalcontactinfo)
   
-    override def copy[NewRow](prefix: Option[String], extract: NewRow => VemployeeViewRow, merge: (NewRow, VemployeeViewRow) => NewRow): Impl[NewRow] =
-      new Impl(prefix, extract, merge)
+    override def copy(path: List[Path]): Impl =
+      new Impl(path)
   }
   
 }

--- a/typo-tester-anorm/generated-and-checked-in/adventureworks/humanresources/vemployeedepartment/VemployeedepartmentViewFields.scala
+++ b/typo-tester-anorm/generated-and-checked-in/adventureworks/humanresources/vemployeedepartment/VemployeedepartmentViewFields.scala
@@ -11,49 +11,50 @@ import adventureworks.customtypes.TypoLocalDate
 import adventureworks.person.businessentity.BusinessentityId
 import adventureworks.public.Name
 import adventureworks.userdefined.FirstName
+import typo.dsl.Path
 import typo.dsl.SqlExpr.Field
 import typo.dsl.SqlExpr.FieldLikeNoHkt
 import typo.dsl.SqlExpr.OptField
 import typo.dsl.Structure.Relation
 
-trait VemployeedepartmentViewFields[Row] {
-  val businessentityid: Field[BusinessentityId, Row]
-  val title: OptField[/* max 8 chars */ String, Row]
-  val firstname: Field[/* user-picked */ FirstName, Row]
-  val middlename: OptField[Name, Row]
-  val lastname: Field[Name, Row]
-  val suffix: OptField[/* max 10 chars */ String, Row]
-  val jobtitle: Field[/* max 50 chars */ String, Row]
-  val department: Field[Name, Row]
-  val groupname: Field[Name, Row]
-  val startdate: Field[TypoLocalDate, Row]
+trait VemployeedepartmentViewFields {
+  def businessentityid: Field[BusinessentityId, VemployeedepartmentViewRow]
+  def title: OptField[/* max 8 chars */ String, VemployeedepartmentViewRow]
+  def firstname: Field[/* user-picked */ FirstName, VemployeedepartmentViewRow]
+  def middlename: OptField[Name, VemployeedepartmentViewRow]
+  def lastname: Field[Name, VemployeedepartmentViewRow]
+  def suffix: OptField[/* max 10 chars */ String, VemployeedepartmentViewRow]
+  def jobtitle: Field[/* max 50 chars */ String, VemployeedepartmentViewRow]
+  def department: Field[Name, VemployeedepartmentViewRow]
+  def groupname: Field[Name, VemployeedepartmentViewRow]
+  def startdate: Field[TypoLocalDate, VemployeedepartmentViewRow]
 }
 
 object VemployeedepartmentViewFields {
-  val structure: Relation[VemployeedepartmentViewFields, VemployeedepartmentViewRow, VemployeedepartmentViewRow] = 
-    new Impl(None, identity, (_, x) => x)
+  lazy val structure: Relation[VemployeedepartmentViewFields, VemployeedepartmentViewRow] =
+    new Impl(Nil)
     
-  private final class Impl[Row](val prefix: Option[String], val extract: Row => VemployeedepartmentViewRow, val merge: (Row, VemployeedepartmentViewRow) => Row)
-    extends Relation[VemployeedepartmentViewFields, VemployeedepartmentViewRow, Row] { 
+  private final class Impl(val _path: List[Path])
+    extends Relation[VemployeedepartmentViewFields, VemployeedepartmentViewRow] {
   
-    override val fields: VemployeedepartmentViewFields[Row] = new VemployeedepartmentViewFields[Row] {
-      override val businessentityid = new Field[BusinessentityId, Row](prefix, "businessentityid", None, None)(x => extract(x).businessentityid, (row, value) => merge(row, extract(row).copy(businessentityid = value)))
-      override val title = new OptField[/* max 8 chars */ String, Row](prefix, "title", None, None)(x => extract(x).title, (row, value) => merge(row, extract(row).copy(title = value)))
-      override val firstname = new Field[/* user-picked */ FirstName, Row](prefix, "firstname", None, None)(x => extract(x).firstname, (row, value) => merge(row, extract(row).copy(firstname = value)))
-      override val middlename = new OptField[Name, Row](prefix, "middlename", None, None)(x => extract(x).middlename, (row, value) => merge(row, extract(row).copy(middlename = value)))
-      override val lastname = new Field[Name, Row](prefix, "lastname", None, None)(x => extract(x).lastname, (row, value) => merge(row, extract(row).copy(lastname = value)))
-      override val suffix = new OptField[/* max 10 chars */ String, Row](prefix, "suffix", None, None)(x => extract(x).suffix, (row, value) => merge(row, extract(row).copy(suffix = value)))
-      override val jobtitle = new Field[/* max 50 chars */ String, Row](prefix, "jobtitle", None, None)(x => extract(x).jobtitle, (row, value) => merge(row, extract(row).copy(jobtitle = value)))
-      override val department = new Field[Name, Row](prefix, "department", None, None)(x => extract(x).department, (row, value) => merge(row, extract(row).copy(department = value)))
-      override val groupname = new Field[Name, Row](prefix, "groupname", None, None)(x => extract(x).groupname, (row, value) => merge(row, extract(row).copy(groupname = value)))
-      override val startdate = new Field[TypoLocalDate, Row](prefix, "startdate", Some("text"), None)(x => extract(x).startdate, (row, value) => merge(row, extract(row).copy(startdate = value)))
+    override lazy val fields: VemployeedepartmentViewFields = new VemployeedepartmentViewFields {
+      override def businessentityid = Field[BusinessentityId, VemployeedepartmentViewRow](_path, "businessentityid", None, None, x => x.businessentityid, (row, value) => row.copy(businessentityid = value))
+      override def title = OptField[/* max 8 chars */ String, VemployeedepartmentViewRow](_path, "title", None, None, x => x.title, (row, value) => row.copy(title = value))
+      override def firstname = Field[/* user-picked */ FirstName, VemployeedepartmentViewRow](_path, "firstname", None, None, x => x.firstname, (row, value) => row.copy(firstname = value))
+      override def middlename = OptField[Name, VemployeedepartmentViewRow](_path, "middlename", None, None, x => x.middlename, (row, value) => row.copy(middlename = value))
+      override def lastname = Field[Name, VemployeedepartmentViewRow](_path, "lastname", None, None, x => x.lastname, (row, value) => row.copy(lastname = value))
+      override def suffix = OptField[/* max 10 chars */ String, VemployeedepartmentViewRow](_path, "suffix", None, None, x => x.suffix, (row, value) => row.copy(suffix = value))
+      override def jobtitle = Field[/* max 50 chars */ String, VemployeedepartmentViewRow](_path, "jobtitle", None, None, x => x.jobtitle, (row, value) => row.copy(jobtitle = value))
+      override def department = Field[Name, VemployeedepartmentViewRow](_path, "department", None, None, x => x.department, (row, value) => row.copy(department = value))
+      override def groupname = Field[Name, VemployeedepartmentViewRow](_path, "groupname", None, None, x => x.groupname, (row, value) => row.copy(groupname = value))
+      override def startdate = Field[TypoLocalDate, VemployeedepartmentViewRow](_path, "startdate", Some("text"), None, x => x.startdate, (row, value) => row.copy(startdate = value))
     }
   
-    override val columns: List[FieldLikeNoHkt[?, Row]] =
-      List[FieldLikeNoHkt[?, Row]](fields.businessentityid, fields.title, fields.firstname, fields.middlename, fields.lastname, fields.suffix, fields.jobtitle, fields.department, fields.groupname, fields.startdate)
+    override lazy val columns: List[FieldLikeNoHkt[?, VemployeedepartmentViewRow]] =
+      List[FieldLikeNoHkt[?, VemployeedepartmentViewRow]](fields.businessentityid, fields.title, fields.firstname, fields.middlename, fields.lastname, fields.suffix, fields.jobtitle, fields.department, fields.groupname, fields.startdate)
   
-    override def copy[NewRow](prefix: Option[String], extract: NewRow => VemployeedepartmentViewRow, merge: (NewRow, VemployeedepartmentViewRow) => NewRow): Impl[NewRow] =
-      new Impl(prefix, extract, merge)
+    override def copy(path: List[Path]): Impl =
+      new Impl(path)
   }
   
 }

--- a/typo-tester-anorm/generated-and-checked-in/adventureworks/humanresources/vemployeedepartmenthistory/VemployeedepartmenthistoryViewFields.scala
+++ b/typo-tester-anorm/generated-and-checked-in/adventureworks/humanresources/vemployeedepartmenthistory/VemployeedepartmenthistoryViewFields.scala
@@ -11,51 +11,52 @@ import adventureworks.customtypes.TypoLocalDate
 import adventureworks.person.businessentity.BusinessentityId
 import adventureworks.public.Name
 import adventureworks.userdefined.FirstName
+import typo.dsl.Path
 import typo.dsl.SqlExpr.Field
 import typo.dsl.SqlExpr.FieldLikeNoHkt
 import typo.dsl.SqlExpr.OptField
 import typo.dsl.Structure.Relation
 
-trait VemployeedepartmenthistoryViewFields[Row] {
-  val businessentityid: Field[BusinessentityId, Row]
-  val title: OptField[/* max 8 chars */ String, Row]
-  val firstname: Field[/* user-picked */ FirstName, Row]
-  val middlename: OptField[Name, Row]
-  val lastname: Field[Name, Row]
-  val suffix: OptField[/* max 10 chars */ String, Row]
-  val shift: Field[Name, Row]
-  val department: Field[Name, Row]
-  val groupname: Field[Name, Row]
-  val startdate: Field[TypoLocalDate, Row]
-  val enddate: OptField[TypoLocalDate, Row]
+trait VemployeedepartmenthistoryViewFields {
+  def businessentityid: Field[BusinessentityId, VemployeedepartmenthistoryViewRow]
+  def title: OptField[/* max 8 chars */ String, VemployeedepartmenthistoryViewRow]
+  def firstname: Field[/* user-picked */ FirstName, VemployeedepartmenthistoryViewRow]
+  def middlename: OptField[Name, VemployeedepartmenthistoryViewRow]
+  def lastname: Field[Name, VemployeedepartmenthistoryViewRow]
+  def suffix: OptField[/* max 10 chars */ String, VemployeedepartmenthistoryViewRow]
+  def shift: Field[Name, VemployeedepartmenthistoryViewRow]
+  def department: Field[Name, VemployeedepartmenthistoryViewRow]
+  def groupname: Field[Name, VemployeedepartmenthistoryViewRow]
+  def startdate: Field[TypoLocalDate, VemployeedepartmenthistoryViewRow]
+  def enddate: OptField[TypoLocalDate, VemployeedepartmenthistoryViewRow]
 }
 
 object VemployeedepartmenthistoryViewFields {
-  val structure: Relation[VemployeedepartmenthistoryViewFields, VemployeedepartmenthistoryViewRow, VemployeedepartmenthistoryViewRow] = 
-    new Impl(None, identity, (_, x) => x)
+  lazy val structure: Relation[VemployeedepartmenthistoryViewFields, VemployeedepartmenthistoryViewRow] =
+    new Impl(Nil)
     
-  private final class Impl[Row](val prefix: Option[String], val extract: Row => VemployeedepartmenthistoryViewRow, val merge: (Row, VemployeedepartmenthistoryViewRow) => Row)
-    extends Relation[VemployeedepartmenthistoryViewFields, VemployeedepartmenthistoryViewRow, Row] { 
+  private final class Impl(val _path: List[Path])
+    extends Relation[VemployeedepartmenthistoryViewFields, VemployeedepartmenthistoryViewRow] {
   
-    override val fields: VemployeedepartmenthistoryViewFields[Row] = new VemployeedepartmenthistoryViewFields[Row] {
-      override val businessentityid = new Field[BusinessentityId, Row](prefix, "businessentityid", None, None)(x => extract(x).businessentityid, (row, value) => merge(row, extract(row).copy(businessentityid = value)))
-      override val title = new OptField[/* max 8 chars */ String, Row](prefix, "title", None, None)(x => extract(x).title, (row, value) => merge(row, extract(row).copy(title = value)))
-      override val firstname = new Field[/* user-picked */ FirstName, Row](prefix, "firstname", None, None)(x => extract(x).firstname, (row, value) => merge(row, extract(row).copy(firstname = value)))
-      override val middlename = new OptField[Name, Row](prefix, "middlename", None, None)(x => extract(x).middlename, (row, value) => merge(row, extract(row).copy(middlename = value)))
-      override val lastname = new Field[Name, Row](prefix, "lastname", None, None)(x => extract(x).lastname, (row, value) => merge(row, extract(row).copy(lastname = value)))
-      override val suffix = new OptField[/* max 10 chars */ String, Row](prefix, "suffix", None, None)(x => extract(x).suffix, (row, value) => merge(row, extract(row).copy(suffix = value)))
-      override val shift = new Field[Name, Row](prefix, "shift", None, None)(x => extract(x).shift, (row, value) => merge(row, extract(row).copy(shift = value)))
-      override val department = new Field[Name, Row](prefix, "department", None, None)(x => extract(x).department, (row, value) => merge(row, extract(row).copy(department = value)))
-      override val groupname = new Field[Name, Row](prefix, "groupname", None, None)(x => extract(x).groupname, (row, value) => merge(row, extract(row).copy(groupname = value)))
-      override val startdate = new Field[TypoLocalDate, Row](prefix, "startdate", Some("text"), None)(x => extract(x).startdate, (row, value) => merge(row, extract(row).copy(startdate = value)))
-      override val enddate = new OptField[TypoLocalDate, Row](prefix, "enddate", Some("text"), None)(x => extract(x).enddate, (row, value) => merge(row, extract(row).copy(enddate = value)))
+    override lazy val fields: VemployeedepartmenthistoryViewFields = new VemployeedepartmenthistoryViewFields {
+      override def businessentityid = Field[BusinessentityId, VemployeedepartmenthistoryViewRow](_path, "businessentityid", None, None, x => x.businessentityid, (row, value) => row.copy(businessentityid = value))
+      override def title = OptField[/* max 8 chars */ String, VemployeedepartmenthistoryViewRow](_path, "title", None, None, x => x.title, (row, value) => row.copy(title = value))
+      override def firstname = Field[/* user-picked */ FirstName, VemployeedepartmenthistoryViewRow](_path, "firstname", None, None, x => x.firstname, (row, value) => row.copy(firstname = value))
+      override def middlename = OptField[Name, VemployeedepartmenthistoryViewRow](_path, "middlename", None, None, x => x.middlename, (row, value) => row.copy(middlename = value))
+      override def lastname = Field[Name, VemployeedepartmenthistoryViewRow](_path, "lastname", None, None, x => x.lastname, (row, value) => row.copy(lastname = value))
+      override def suffix = OptField[/* max 10 chars */ String, VemployeedepartmenthistoryViewRow](_path, "suffix", None, None, x => x.suffix, (row, value) => row.copy(suffix = value))
+      override def shift = Field[Name, VemployeedepartmenthistoryViewRow](_path, "shift", None, None, x => x.shift, (row, value) => row.copy(shift = value))
+      override def department = Field[Name, VemployeedepartmenthistoryViewRow](_path, "department", None, None, x => x.department, (row, value) => row.copy(department = value))
+      override def groupname = Field[Name, VemployeedepartmenthistoryViewRow](_path, "groupname", None, None, x => x.groupname, (row, value) => row.copy(groupname = value))
+      override def startdate = Field[TypoLocalDate, VemployeedepartmenthistoryViewRow](_path, "startdate", Some("text"), None, x => x.startdate, (row, value) => row.copy(startdate = value))
+      override def enddate = OptField[TypoLocalDate, VemployeedepartmenthistoryViewRow](_path, "enddate", Some("text"), None, x => x.enddate, (row, value) => row.copy(enddate = value))
     }
   
-    override val columns: List[FieldLikeNoHkt[?, Row]] =
-      List[FieldLikeNoHkt[?, Row]](fields.businessentityid, fields.title, fields.firstname, fields.middlename, fields.lastname, fields.suffix, fields.shift, fields.department, fields.groupname, fields.startdate, fields.enddate)
+    override lazy val columns: List[FieldLikeNoHkt[?, VemployeedepartmenthistoryViewRow]] =
+      List[FieldLikeNoHkt[?, VemployeedepartmenthistoryViewRow]](fields.businessentityid, fields.title, fields.firstname, fields.middlename, fields.lastname, fields.suffix, fields.shift, fields.department, fields.groupname, fields.startdate, fields.enddate)
   
-    override def copy[NewRow](prefix: Option[String], extract: NewRow => VemployeedepartmenthistoryViewRow, merge: (NewRow, VemployeedepartmenthistoryViewRow) => NewRow): Impl[NewRow] =
-      new Impl(prefix, extract, merge)
+    override def copy(path: List[Path]): Impl =
+      new Impl(path)
   }
   
 }

--- a/typo-tester-anorm/generated-and-checked-in/adventureworks/humanresources/vjobcandidate/VjobcandidateViewFields.scala
+++ b/typo-tester-anorm/generated-and-checked-in/adventureworks/humanresources/vjobcandidate/VjobcandidateViewFields.scala
@@ -10,61 +10,62 @@ package vjobcandidate
 import adventureworks.customtypes.TypoLocalDateTime
 import adventureworks.humanresources.jobcandidate.JobcandidateId
 import adventureworks.person.businessentity.BusinessentityId
+import typo.dsl.Path
 import typo.dsl.SqlExpr.Field
 import typo.dsl.SqlExpr.FieldLikeNoHkt
 import typo.dsl.SqlExpr.OptField
 import typo.dsl.Structure.Relation
 
-trait VjobcandidateViewFields[Row] {
-  val jobcandidateid: Field[JobcandidateId, Row]
-  val businessentityid: OptField[BusinessentityId, Row]
-  val NamePrefix: OptField[/* max 30 chars */ String, Row]
-  val NameFirst: OptField[/* max 30 chars */ String, Row]
-  val NameMiddle: OptField[/* max 30 chars */ String, Row]
-  val NameLast: OptField[/* max 30 chars */ String, Row]
-  val NameSuffix: OptField[/* max 30 chars */ String, Row]
-  val Skills: OptField[String, Row]
-  val AddrType: OptField[/* max 30 chars */ String, Row]
-  val AddrLocCountryRegion: OptField[/* max 100 chars */ String, Row]
-  val AddrLocState: OptField[/* max 100 chars */ String, Row]
-  val AddrLocCity: OptField[/* max 100 chars */ String, Row]
-  val AddrPostalCode: OptField[/* max 20 chars */ String, Row]
-  val EMail: OptField[String, Row]
-  val WebSite: OptField[String, Row]
-  val modifieddate: Field[TypoLocalDateTime, Row]
+trait VjobcandidateViewFields {
+  def jobcandidateid: Field[JobcandidateId, VjobcandidateViewRow]
+  def businessentityid: OptField[BusinessentityId, VjobcandidateViewRow]
+  def NamePrefix: OptField[/* max 30 chars */ String, VjobcandidateViewRow]
+  def NameFirst: OptField[/* max 30 chars */ String, VjobcandidateViewRow]
+  def NameMiddle: OptField[/* max 30 chars */ String, VjobcandidateViewRow]
+  def NameLast: OptField[/* max 30 chars */ String, VjobcandidateViewRow]
+  def NameSuffix: OptField[/* max 30 chars */ String, VjobcandidateViewRow]
+  def Skills: OptField[String, VjobcandidateViewRow]
+  def AddrType: OptField[/* max 30 chars */ String, VjobcandidateViewRow]
+  def AddrLocCountryRegion: OptField[/* max 100 chars */ String, VjobcandidateViewRow]
+  def AddrLocState: OptField[/* max 100 chars */ String, VjobcandidateViewRow]
+  def AddrLocCity: OptField[/* max 100 chars */ String, VjobcandidateViewRow]
+  def AddrPostalCode: OptField[/* max 20 chars */ String, VjobcandidateViewRow]
+  def EMail: OptField[String, VjobcandidateViewRow]
+  def WebSite: OptField[String, VjobcandidateViewRow]
+  def modifieddate: Field[TypoLocalDateTime, VjobcandidateViewRow]
 }
 
 object VjobcandidateViewFields {
-  val structure: Relation[VjobcandidateViewFields, VjobcandidateViewRow, VjobcandidateViewRow] = 
-    new Impl(None, identity, (_, x) => x)
+  lazy val structure: Relation[VjobcandidateViewFields, VjobcandidateViewRow] =
+    new Impl(Nil)
     
-  private final class Impl[Row](val prefix: Option[String], val extract: Row => VjobcandidateViewRow, val merge: (Row, VjobcandidateViewRow) => Row)
-    extends Relation[VjobcandidateViewFields, VjobcandidateViewRow, Row] { 
+  private final class Impl(val _path: List[Path])
+    extends Relation[VjobcandidateViewFields, VjobcandidateViewRow] {
   
-    override val fields: VjobcandidateViewFields[Row] = new VjobcandidateViewFields[Row] {
-      override val jobcandidateid = new Field[JobcandidateId, Row](prefix, "jobcandidateid", None, None)(x => extract(x).jobcandidateid, (row, value) => merge(row, extract(row).copy(jobcandidateid = value)))
-      override val businessentityid = new OptField[BusinessentityId, Row](prefix, "businessentityid", None, None)(x => extract(x).businessentityid, (row, value) => merge(row, extract(row).copy(businessentityid = value)))
-      override val NamePrefix = new OptField[/* max 30 chars */ String, Row](prefix, "Name.Prefix", None, None)(x => extract(x).NamePrefix, (row, value) => merge(row, extract(row).copy(NamePrefix = value)))
-      override val NameFirst = new OptField[/* max 30 chars */ String, Row](prefix, "Name.First", None, None)(x => extract(x).NameFirst, (row, value) => merge(row, extract(row).copy(NameFirst = value)))
-      override val NameMiddle = new OptField[/* max 30 chars */ String, Row](prefix, "Name.Middle", None, None)(x => extract(x).NameMiddle, (row, value) => merge(row, extract(row).copy(NameMiddle = value)))
-      override val NameLast = new OptField[/* max 30 chars */ String, Row](prefix, "Name.Last", None, None)(x => extract(x).NameLast, (row, value) => merge(row, extract(row).copy(NameLast = value)))
-      override val NameSuffix = new OptField[/* max 30 chars */ String, Row](prefix, "Name.Suffix", None, None)(x => extract(x).NameSuffix, (row, value) => merge(row, extract(row).copy(NameSuffix = value)))
-      override val Skills = new OptField[String, Row](prefix, "Skills", None, None)(x => extract(x).Skills, (row, value) => merge(row, extract(row).copy(Skills = value)))
-      override val AddrType = new OptField[/* max 30 chars */ String, Row](prefix, "Addr.Type", None, None)(x => extract(x).AddrType, (row, value) => merge(row, extract(row).copy(AddrType = value)))
-      override val AddrLocCountryRegion = new OptField[/* max 100 chars */ String, Row](prefix, "Addr.Loc.CountryRegion", None, None)(x => extract(x).AddrLocCountryRegion, (row, value) => merge(row, extract(row).copy(AddrLocCountryRegion = value)))
-      override val AddrLocState = new OptField[/* max 100 chars */ String, Row](prefix, "Addr.Loc.State", None, None)(x => extract(x).AddrLocState, (row, value) => merge(row, extract(row).copy(AddrLocState = value)))
-      override val AddrLocCity = new OptField[/* max 100 chars */ String, Row](prefix, "Addr.Loc.City", None, None)(x => extract(x).AddrLocCity, (row, value) => merge(row, extract(row).copy(AddrLocCity = value)))
-      override val AddrPostalCode = new OptField[/* max 20 chars */ String, Row](prefix, "Addr.PostalCode", None, None)(x => extract(x).AddrPostalCode, (row, value) => merge(row, extract(row).copy(AddrPostalCode = value)))
-      override val EMail = new OptField[String, Row](prefix, "EMail", None, None)(x => extract(x).EMail, (row, value) => merge(row, extract(row).copy(EMail = value)))
-      override val WebSite = new OptField[String, Row](prefix, "WebSite", None, None)(x => extract(x).WebSite, (row, value) => merge(row, extract(row).copy(WebSite = value)))
-      override val modifieddate = new Field[TypoLocalDateTime, Row](prefix, "modifieddate", Some("text"), None)(x => extract(x).modifieddate, (row, value) => merge(row, extract(row).copy(modifieddate = value)))
+    override lazy val fields: VjobcandidateViewFields = new VjobcandidateViewFields {
+      override def jobcandidateid = Field[JobcandidateId, VjobcandidateViewRow](_path, "jobcandidateid", None, None, x => x.jobcandidateid, (row, value) => row.copy(jobcandidateid = value))
+      override def businessentityid = OptField[BusinessentityId, VjobcandidateViewRow](_path, "businessentityid", None, None, x => x.businessentityid, (row, value) => row.copy(businessentityid = value))
+      override def NamePrefix = OptField[/* max 30 chars */ String, VjobcandidateViewRow](_path, "Name.Prefix", None, None, x => x.NamePrefix, (row, value) => row.copy(NamePrefix = value))
+      override def NameFirst = OptField[/* max 30 chars */ String, VjobcandidateViewRow](_path, "Name.First", None, None, x => x.NameFirst, (row, value) => row.copy(NameFirst = value))
+      override def NameMiddle = OptField[/* max 30 chars */ String, VjobcandidateViewRow](_path, "Name.Middle", None, None, x => x.NameMiddle, (row, value) => row.copy(NameMiddle = value))
+      override def NameLast = OptField[/* max 30 chars */ String, VjobcandidateViewRow](_path, "Name.Last", None, None, x => x.NameLast, (row, value) => row.copy(NameLast = value))
+      override def NameSuffix = OptField[/* max 30 chars */ String, VjobcandidateViewRow](_path, "Name.Suffix", None, None, x => x.NameSuffix, (row, value) => row.copy(NameSuffix = value))
+      override def Skills = OptField[String, VjobcandidateViewRow](_path, "Skills", None, None, x => x.Skills, (row, value) => row.copy(Skills = value))
+      override def AddrType = OptField[/* max 30 chars */ String, VjobcandidateViewRow](_path, "Addr.Type", None, None, x => x.AddrType, (row, value) => row.copy(AddrType = value))
+      override def AddrLocCountryRegion = OptField[/* max 100 chars */ String, VjobcandidateViewRow](_path, "Addr.Loc.CountryRegion", None, None, x => x.AddrLocCountryRegion, (row, value) => row.copy(AddrLocCountryRegion = value))
+      override def AddrLocState = OptField[/* max 100 chars */ String, VjobcandidateViewRow](_path, "Addr.Loc.State", None, None, x => x.AddrLocState, (row, value) => row.copy(AddrLocState = value))
+      override def AddrLocCity = OptField[/* max 100 chars */ String, VjobcandidateViewRow](_path, "Addr.Loc.City", None, None, x => x.AddrLocCity, (row, value) => row.copy(AddrLocCity = value))
+      override def AddrPostalCode = OptField[/* max 20 chars */ String, VjobcandidateViewRow](_path, "Addr.PostalCode", None, None, x => x.AddrPostalCode, (row, value) => row.copy(AddrPostalCode = value))
+      override def EMail = OptField[String, VjobcandidateViewRow](_path, "EMail", None, None, x => x.EMail, (row, value) => row.copy(EMail = value))
+      override def WebSite = OptField[String, VjobcandidateViewRow](_path, "WebSite", None, None, x => x.WebSite, (row, value) => row.copy(WebSite = value))
+      override def modifieddate = Field[TypoLocalDateTime, VjobcandidateViewRow](_path, "modifieddate", Some("text"), None, x => x.modifieddate, (row, value) => row.copy(modifieddate = value))
     }
   
-    override val columns: List[FieldLikeNoHkt[?, Row]] =
-      List[FieldLikeNoHkt[?, Row]](fields.jobcandidateid, fields.businessentityid, fields.NamePrefix, fields.NameFirst, fields.NameMiddle, fields.NameLast, fields.NameSuffix, fields.Skills, fields.AddrType, fields.AddrLocCountryRegion, fields.AddrLocState, fields.AddrLocCity, fields.AddrPostalCode, fields.EMail, fields.WebSite, fields.modifieddate)
+    override lazy val columns: List[FieldLikeNoHkt[?, VjobcandidateViewRow]] =
+      List[FieldLikeNoHkt[?, VjobcandidateViewRow]](fields.jobcandidateid, fields.businessentityid, fields.NamePrefix, fields.NameFirst, fields.NameMiddle, fields.NameLast, fields.NameSuffix, fields.Skills, fields.AddrType, fields.AddrLocCountryRegion, fields.AddrLocState, fields.AddrLocCity, fields.AddrPostalCode, fields.EMail, fields.WebSite, fields.modifieddate)
   
-    override def copy[NewRow](prefix: Option[String], extract: NewRow => VjobcandidateViewRow, merge: (NewRow, VjobcandidateViewRow) => NewRow): Impl[NewRow] =
-      new Impl(prefix, extract, merge)
+    override def copy(path: List[Path]): Impl =
+      new Impl(path)
   }
   
 }

--- a/typo-tester-anorm/generated-and-checked-in/adventureworks/humanresources/vjobcandidateeducation/VjobcandidateeducationViewFields.scala
+++ b/typo-tester-anorm/generated-and-checked-in/adventureworks/humanresources/vjobcandidateeducation/VjobcandidateeducationViewFields.scala
@@ -9,55 +9,56 @@ package vjobcandidateeducation
 
 import adventureworks.customtypes.TypoLocalDate
 import adventureworks.humanresources.jobcandidate.JobcandidateId
+import typo.dsl.Path
 import typo.dsl.SqlExpr.Field
 import typo.dsl.SqlExpr.FieldLikeNoHkt
 import typo.dsl.SqlExpr.OptField
 import typo.dsl.Structure.Relation
 
-trait VjobcandidateeducationViewFields[Row] {
-  val jobcandidateid: Field[JobcandidateId, Row]
-  val EduLevel: OptField[/* max 50 chars */ String, Row]
-  val EduStartDate: OptField[TypoLocalDate, Row]
-  val EduEndDate: OptField[TypoLocalDate, Row]
-  val EduDegree: OptField[/* max 50 chars */ String, Row]
-  val EduMajor: OptField[/* max 50 chars */ String, Row]
-  val EduMinor: OptField[/* max 50 chars */ String, Row]
-  val EduGPA: OptField[/* max 5 chars */ String, Row]
-  val EduGPAScale: OptField[/* max 5 chars */ String, Row]
-  val EduSchool: OptField[/* max 100 chars */ String, Row]
-  val EduLocCountryRegion: OptField[/* max 100 chars */ String, Row]
-  val EduLocState: OptField[/* max 100 chars */ String, Row]
-  val EduLocCity: OptField[/* max 100 chars */ String, Row]
+trait VjobcandidateeducationViewFields {
+  def jobcandidateid: Field[JobcandidateId, VjobcandidateeducationViewRow]
+  def EduLevel: OptField[/* max 50 chars */ String, VjobcandidateeducationViewRow]
+  def EduStartDate: OptField[TypoLocalDate, VjobcandidateeducationViewRow]
+  def EduEndDate: OptField[TypoLocalDate, VjobcandidateeducationViewRow]
+  def EduDegree: OptField[/* max 50 chars */ String, VjobcandidateeducationViewRow]
+  def EduMajor: OptField[/* max 50 chars */ String, VjobcandidateeducationViewRow]
+  def EduMinor: OptField[/* max 50 chars */ String, VjobcandidateeducationViewRow]
+  def EduGPA: OptField[/* max 5 chars */ String, VjobcandidateeducationViewRow]
+  def EduGPAScale: OptField[/* max 5 chars */ String, VjobcandidateeducationViewRow]
+  def EduSchool: OptField[/* max 100 chars */ String, VjobcandidateeducationViewRow]
+  def EduLocCountryRegion: OptField[/* max 100 chars */ String, VjobcandidateeducationViewRow]
+  def EduLocState: OptField[/* max 100 chars */ String, VjobcandidateeducationViewRow]
+  def EduLocCity: OptField[/* max 100 chars */ String, VjobcandidateeducationViewRow]
 }
 
 object VjobcandidateeducationViewFields {
-  val structure: Relation[VjobcandidateeducationViewFields, VjobcandidateeducationViewRow, VjobcandidateeducationViewRow] = 
-    new Impl(None, identity, (_, x) => x)
+  lazy val structure: Relation[VjobcandidateeducationViewFields, VjobcandidateeducationViewRow] =
+    new Impl(Nil)
     
-  private final class Impl[Row](val prefix: Option[String], val extract: Row => VjobcandidateeducationViewRow, val merge: (Row, VjobcandidateeducationViewRow) => Row)
-    extends Relation[VjobcandidateeducationViewFields, VjobcandidateeducationViewRow, Row] { 
+  private final class Impl(val _path: List[Path])
+    extends Relation[VjobcandidateeducationViewFields, VjobcandidateeducationViewRow] {
   
-    override val fields: VjobcandidateeducationViewFields[Row] = new VjobcandidateeducationViewFields[Row] {
-      override val jobcandidateid = new Field[JobcandidateId, Row](prefix, "jobcandidateid", None, None)(x => extract(x).jobcandidateid, (row, value) => merge(row, extract(row).copy(jobcandidateid = value)))
-      override val EduLevel = new OptField[/* max 50 chars */ String, Row](prefix, "Edu.Level", None, None)(x => extract(x).EduLevel, (row, value) => merge(row, extract(row).copy(EduLevel = value)))
-      override val EduStartDate = new OptField[TypoLocalDate, Row](prefix, "Edu.StartDate", Some("text"), None)(x => extract(x).EduStartDate, (row, value) => merge(row, extract(row).copy(EduStartDate = value)))
-      override val EduEndDate = new OptField[TypoLocalDate, Row](prefix, "Edu.EndDate", Some("text"), None)(x => extract(x).EduEndDate, (row, value) => merge(row, extract(row).copy(EduEndDate = value)))
-      override val EduDegree = new OptField[/* max 50 chars */ String, Row](prefix, "Edu.Degree", None, None)(x => extract(x).EduDegree, (row, value) => merge(row, extract(row).copy(EduDegree = value)))
-      override val EduMajor = new OptField[/* max 50 chars */ String, Row](prefix, "Edu.Major", None, None)(x => extract(x).EduMajor, (row, value) => merge(row, extract(row).copy(EduMajor = value)))
-      override val EduMinor = new OptField[/* max 50 chars */ String, Row](prefix, "Edu.Minor", None, None)(x => extract(x).EduMinor, (row, value) => merge(row, extract(row).copy(EduMinor = value)))
-      override val EduGPA = new OptField[/* max 5 chars */ String, Row](prefix, "Edu.GPA", None, None)(x => extract(x).EduGPA, (row, value) => merge(row, extract(row).copy(EduGPA = value)))
-      override val EduGPAScale = new OptField[/* max 5 chars */ String, Row](prefix, "Edu.GPAScale", None, None)(x => extract(x).EduGPAScale, (row, value) => merge(row, extract(row).copy(EduGPAScale = value)))
-      override val EduSchool = new OptField[/* max 100 chars */ String, Row](prefix, "Edu.School", None, None)(x => extract(x).EduSchool, (row, value) => merge(row, extract(row).copy(EduSchool = value)))
-      override val EduLocCountryRegion = new OptField[/* max 100 chars */ String, Row](prefix, "Edu.Loc.CountryRegion", None, None)(x => extract(x).EduLocCountryRegion, (row, value) => merge(row, extract(row).copy(EduLocCountryRegion = value)))
-      override val EduLocState = new OptField[/* max 100 chars */ String, Row](prefix, "Edu.Loc.State", None, None)(x => extract(x).EduLocState, (row, value) => merge(row, extract(row).copy(EduLocState = value)))
-      override val EduLocCity = new OptField[/* max 100 chars */ String, Row](prefix, "Edu.Loc.City", None, None)(x => extract(x).EduLocCity, (row, value) => merge(row, extract(row).copy(EduLocCity = value)))
+    override lazy val fields: VjobcandidateeducationViewFields = new VjobcandidateeducationViewFields {
+      override def jobcandidateid = Field[JobcandidateId, VjobcandidateeducationViewRow](_path, "jobcandidateid", None, None, x => x.jobcandidateid, (row, value) => row.copy(jobcandidateid = value))
+      override def EduLevel = OptField[/* max 50 chars */ String, VjobcandidateeducationViewRow](_path, "Edu.Level", None, None, x => x.EduLevel, (row, value) => row.copy(EduLevel = value))
+      override def EduStartDate = OptField[TypoLocalDate, VjobcandidateeducationViewRow](_path, "Edu.StartDate", Some("text"), None, x => x.EduStartDate, (row, value) => row.copy(EduStartDate = value))
+      override def EduEndDate = OptField[TypoLocalDate, VjobcandidateeducationViewRow](_path, "Edu.EndDate", Some("text"), None, x => x.EduEndDate, (row, value) => row.copy(EduEndDate = value))
+      override def EduDegree = OptField[/* max 50 chars */ String, VjobcandidateeducationViewRow](_path, "Edu.Degree", None, None, x => x.EduDegree, (row, value) => row.copy(EduDegree = value))
+      override def EduMajor = OptField[/* max 50 chars */ String, VjobcandidateeducationViewRow](_path, "Edu.Major", None, None, x => x.EduMajor, (row, value) => row.copy(EduMajor = value))
+      override def EduMinor = OptField[/* max 50 chars */ String, VjobcandidateeducationViewRow](_path, "Edu.Minor", None, None, x => x.EduMinor, (row, value) => row.copy(EduMinor = value))
+      override def EduGPA = OptField[/* max 5 chars */ String, VjobcandidateeducationViewRow](_path, "Edu.GPA", None, None, x => x.EduGPA, (row, value) => row.copy(EduGPA = value))
+      override def EduGPAScale = OptField[/* max 5 chars */ String, VjobcandidateeducationViewRow](_path, "Edu.GPAScale", None, None, x => x.EduGPAScale, (row, value) => row.copy(EduGPAScale = value))
+      override def EduSchool = OptField[/* max 100 chars */ String, VjobcandidateeducationViewRow](_path, "Edu.School", None, None, x => x.EduSchool, (row, value) => row.copy(EduSchool = value))
+      override def EduLocCountryRegion = OptField[/* max 100 chars */ String, VjobcandidateeducationViewRow](_path, "Edu.Loc.CountryRegion", None, None, x => x.EduLocCountryRegion, (row, value) => row.copy(EduLocCountryRegion = value))
+      override def EduLocState = OptField[/* max 100 chars */ String, VjobcandidateeducationViewRow](_path, "Edu.Loc.State", None, None, x => x.EduLocState, (row, value) => row.copy(EduLocState = value))
+      override def EduLocCity = OptField[/* max 100 chars */ String, VjobcandidateeducationViewRow](_path, "Edu.Loc.City", None, None, x => x.EduLocCity, (row, value) => row.copy(EduLocCity = value))
     }
   
-    override val columns: List[FieldLikeNoHkt[?, Row]] =
-      List[FieldLikeNoHkt[?, Row]](fields.jobcandidateid, fields.EduLevel, fields.EduStartDate, fields.EduEndDate, fields.EduDegree, fields.EduMajor, fields.EduMinor, fields.EduGPA, fields.EduGPAScale, fields.EduSchool, fields.EduLocCountryRegion, fields.EduLocState, fields.EduLocCity)
+    override lazy val columns: List[FieldLikeNoHkt[?, VjobcandidateeducationViewRow]] =
+      List[FieldLikeNoHkt[?, VjobcandidateeducationViewRow]](fields.jobcandidateid, fields.EduLevel, fields.EduStartDate, fields.EduEndDate, fields.EduDegree, fields.EduMajor, fields.EduMinor, fields.EduGPA, fields.EduGPAScale, fields.EduSchool, fields.EduLocCountryRegion, fields.EduLocState, fields.EduLocCity)
   
-    override def copy[NewRow](prefix: Option[String], extract: NewRow => VjobcandidateeducationViewRow, merge: (NewRow, VjobcandidateeducationViewRow) => NewRow): Impl[NewRow] =
-      new Impl(prefix, extract, merge)
+    override def copy(path: List[Path]): Impl =
+      new Impl(path)
   }
   
 }

--- a/typo-tester-anorm/generated-and-checked-in/adventureworks/humanresources/vjobcandidateemployment/VjobcandidateemploymentViewFields.scala
+++ b/typo-tester-anorm/generated-and-checked-in/adventureworks/humanresources/vjobcandidateemployment/VjobcandidateemploymentViewFields.scala
@@ -9,51 +9,52 @@ package vjobcandidateemployment
 
 import adventureworks.customtypes.TypoLocalDate
 import adventureworks.humanresources.jobcandidate.JobcandidateId
+import typo.dsl.Path
 import typo.dsl.SqlExpr.Field
 import typo.dsl.SqlExpr.FieldLikeNoHkt
 import typo.dsl.SqlExpr.OptField
 import typo.dsl.Structure.Relation
 
-trait VjobcandidateemploymentViewFields[Row] {
-  val jobcandidateid: Field[JobcandidateId, Row]
-  val EmpStartDate: OptField[TypoLocalDate, Row]
-  val EmpEndDate: OptField[TypoLocalDate, Row]
-  val EmpOrgName: OptField[/* max 100 chars */ String, Row]
-  val EmpJobTitle: OptField[/* max 100 chars */ String, Row]
-  val EmpResponsibility: OptField[String, Row]
-  val EmpFunctionCategory: OptField[String, Row]
-  val EmpIndustryCategory: OptField[String, Row]
-  val EmpLocCountryRegion: OptField[String, Row]
-  val EmpLocState: OptField[String, Row]
-  val EmpLocCity: OptField[String, Row]
+trait VjobcandidateemploymentViewFields {
+  def jobcandidateid: Field[JobcandidateId, VjobcandidateemploymentViewRow]
+  def EmpStartDate: OptField[TypoLocalDate, VjobcandidateemploymentViewRow]
+  def EmpEndDate: OptField[TypoLocalDate, VjobcandidateemploymentViewRow]
+  def EmpOrgName: OptField[/* max 100 chars */ String, VjobcandidateemploymentViewRow]
+  def EmpJobTitle: OptField[/* max 100 chars */ String, VjobcandidateemploymentViewRow]
+  def EmpResponsibility: OptField[String, VjobcandidateemploymentViewRow]
+  def EmpFunctionCategory: OptField[String, VjobcandidateemploymentViewRow]
+  def EmpIndustryCategory: OptField[String, VjobcandidateemploymentViewRow]
+  def EmpLocCountryRegion: OptField[String, VjobcandidateemploymentViewRow]
+  def EmpLocState: OptField[String, VjobcandidateemploymentViewRow]
+  def EmpLocCity: OptField[String, VjobcandidateemploymentViewRow]
 }
 
 object VjobcandidateemploymentViewFields {
-  val structure: Relation[VjobcandidateemploymentViewFields, VjobcandidateemploymentViewRow, VjobcandidateemploymentViewRow] = 
-    new Impl(None, identity, (_, x) => x)
+  lazy val structure: Relation[VjobcandidateemploymentViewFields, VjobcandidateemploymentViewRow] =
+    new Impl(Nil)
     
-  private final class Impl[Row](val prefix: Option[String], val extract: Row => VjobcandidateemploymentViewRow, val merge: (Row, VjobcandidateemploymentViewRow) => Row)
-    extends Relation[VjobcandidateemploymentViewFields, VjobcandidateemploymentViewRow, Row] { 
+  private final class Impl(val _path: List[Path])
+    extends Relation[VjobcandidateemploymentViewFields, VjobcandidateemploymentViewRow] {
   
-    override val fields: VjobcandidateemploymentViewFields[Row] = new VjobcandidateemploymentViewFields[Row] {
-      override val jobcandidateid = new Field[JobcandidateId, Row](prefix, "jobcandidateid", None, None)(x => extract(x).jobcandidateid, (row, value) => merge(row, extract(row).copy(jobcandidateid = value)))
-      override val EmpStartDate = new OptField[TypoLocalDate, Row](prefix, "Emp.StartDate", Some("text"), None)(x => extract(x).EmpStartDate, (row, value) => merge(row, extract(row).copy(EmpStartDate = value)))
-      override val EmpEndDate = new OptField[TypoLocalDate, Row](prefix, "Emp.EndDate", Some("text"), None)(x => extract(x).EmpEndDate, (row, value) => merge(row, extract(row).copy(EmpEndDate = value)))
-      override val EmpOrgName = new OptField[/* max 100 chars */ String, Row](prefix, "Emp.OrgName", None, None)(x => extract(x).EmpOrgName, (row, value) => merge(row, extract(row).copy(EmpOrgName = value)))
-      override val EmpJobTitle = new OptField[/* max 100 chars */ String, Row](prefix, "Emp.JobTitle", None, None)(x => extract(x).EmpJobTitle, (row, value) => merge(row, extract(row).copy(EmpJobTitle = value)))
-      override val EmpResponsibility = new OptField[String, Row](prefix, "Emp.Responsibility", None, None)(x => extract(x).EmpResponsibility, (row, value) => merge(row, extract(row).copy(EmpResponsibility = value)))
-      override val EmpFunctionCategory = new OptField[String, Row](prefix, "Emp.FunctionCategory", None, None)(x => extract(x).EmpFunctionCategory, (row, value) => merge(row, extract(row).copy(EmpFunctionCategory = value)))
-      override val EmpIndustryCategory = new OptField[String, Row](prefix, "Emp.IndustryCategory", None, None)(x => extract(x).EmpIndustryCategory, (row, value) => merge(row, extract(row).copy(EmpIndustryCategory = value)))
-      override val EmpLocCountryRegion = new OptField[String, Row](prefix, "Emp.Loc.CountryRegion", None, None)(x => extract(x).EmpLocCountryRegion, (row, value) => merge(row, extract(row).copy(EmpLocCountryRegion = value)))
-      override val EmpLocState = new OptField[String, Row](prefix, "Emp.Loc.State", None, None)(x => extract(x).EmpLocState, (row, value) => merge(row, extract(row).copy(EmpLocState = value)))
-      override val EmpLocCity = new OptField[String, Row](prefix, "Emp.Loc.City", None, None)(x => extract(x).EmpLocCity, (row, value) => merge(row, extract(row).copy(EmpLocCity = value)))
+    override lazy val fields: VjobcandidateemploymentViewFields = new VjobcandidateemploymentViewFields {
+      override def jobcandidateid = Field[JobcandidateId, VjobcandidateemploymentViewRow](_path, "jobcandidateid", None, None, x => x.jobcandidateid, (row, value) => row.copy(jobcandidateid = value))
+      override def EmpStartDate = OptField[TypoLocalDate, VjobcandidateemploymentViewRow](_path, "Emp.StartDate", Some("text"), None, x => x.EmpStartDate, (row, value) => row.copy(EmpStartDate = value))
+      override def EmpEndDate = OptField[TypoLocalDate, VjobcandidateemploymentViewRow](_path, "Emp.EndDate", Some("text"), None, x => x.EmpEndDate, (row, value) => row.copy(EmpEndDate = value))
+      override def EmpOrgName = OptField[/* max 100 chars */ String, VjobcandidateemploymentViewRow](_path, "Emp.OrgName", None, None, x => x.EmpOrgName, (row, value) => row.copy(EmpOrgName = value))
+      override def EmpJobTitle = OptField[/* max 100 chars */ String, VjobcandidateemploymentViewRow](_path, "Emp.JobTitle", None, None, x => x.EmpJobTitle, (row, value) => row.copy(EmpJobTitle = value))
+      override def EmpResponsibility = OptField[String, VjobcandidateemploymentViewRow](_path, "Emp.Responsibility", None, None, x => x.EmpResponsibility, (row, value) => row.copy(EmpResponsibility = value))
+      override def EmpFunctionCategory = OptField[String, VjobcandidateemploymentViewRow](_path, "Emp.FunctionCategory", None, None, x => x.EmpFunctionCategory, (row, value) => row.copy(EmpFunctionCategory = value))
+      override def EmpIndustryCategory = OptField[String, VjobcandidateemploymentViewRow](_path, "Emp.IndustryCategory", None, None, x => x.EmpIndustryCategory, (row, value) => row.copy(EmpIndustryCategory = value))
+      override def EmpLocCountryRegion = OptField[String, VjobcandidateemploymentViewRow](_path, "Emp.Loc.CountryRegion", None, None, x => x.EmpLocCountryRegion, (row, value) => row.copy(EmpLocCountryRegion = value))
+      override def EmpLocState = OptField[String, VjobcandidateemploymentViewRow](_path, "Emp.Loc.State", None, None, x => x.EmpLocState, (row, value) => row.copy(EmpLocState = value))
+      override def EmpLocCity = OptField[String, VjobcandidateemploymentViewRow](_path, "Emp.Loc.City", None, None, x => x.EmpLocCity, (row, value) => row.copy(EmpLocCity = value))
     }
   
-    override val columns: List[FieldLikeNoHkt[?, Row]] =
-      List[FieldLikeNoHkt[?, Row]](fields.jobcandidateid, fields.EmpStartDate, fields.EmpEndDate, fields.EmpOrgName, fields.EmpJobTitle, fields.EmpResponsibility, fields.EmpFunctionCategory, fields.EmpIndustryCategory, fields.EmpLocCountryRegion, fields.EmpLocState, fields.EmpLocCity)
+    override lazy val columns: List[FieldLikeNoHkt[?, VjobcandidateemploymentViewRow]] =
+      List[FieldLikeNoHkt[?, VjobcandidateemploymentViewRow]](fields.jobcandidateid, fields.EmpStartDate, fields.EmpEndDate, fields.EmpOrgName, fields.EmpJobTitle, fields.EmpResponsibility, fields.EmpFunctionCategory, fields.EmpIndustryCategory, fields.EmpLocCountryRegion, fields.EmpLocState, fields.EmpLocCity)
   
-    override def copy[NewRow](prefix: Option[String], extract: NewRow => VjobcandidateemploymentViewRow, merge: (NewRow, VjobcandidateemploymentViewRow) => NewRow): Impl[NewRow] =
-      new Impl(prefix, extract, merge)
+    override def copy(path: List[Path]): Impl =
+      new Impl(path)
   }
   
 }

--- a/typo-tester-anorm/generated-and-checked-in/adventureworks/pe/a/AViewFields.scala
+++ b/typo-tester-anorm/generated-and-checked-in/adventureworks/pe/a/AViewFields.scala
@@ -12,49 +12,50 @@ import adventureworks.customtypes.TypoLocalDateTime
 import adventureworks.customtypes.TypoUUID
 import adventureworks.person.address.AddressId
 import adventureworks.person.stateprovince.StateprovinceId
+import typo.dsl.Path
 import typo.dsl.SqlExpr.Field
 import typo.dsl.SqlExpr.FieldLikeNoHkt
 import typo.dsl.SqlExpr.OptField
 import typo.dsl.Structure.Relation
 
-trait AViewFields[Row] {
-  val id: Field[AddressId, Row]
-  val addressid: Field[AddressId, Row]
-  val addressline1: Field[/* max 60 chars */ String, Row]
-  val addressline2: OptField[/* max 60 chars */ String, Row]
-  val city: Field[/* max 30 chars */ String, Row]
-  val stateprovinceid: Field[StateprovinceId, Row]
-  val postalcode: Field[/* max 15 chars */ String, Row]
-  val spatiallocation: OptField[TypoBytea, Row]
-  val rowguid: Field[TypoUUID, Row]
-  val modifieddate: Field[TypoLocalDateTime, Row]
+trait AViewFields {
+  def id: Field[AddressId, AViewRow]
+  def addressid: Field[AddressId, AViewRow]
+  def addressline1: Field[/* max 60 chars */ String, AViewRow]
+  def addressline2: OptField[/* max 60 chars */ String, AViewRow]
+  def city: Field[/* max 30 chars */ String, AViewRow]
+  def stateprovinceid: Field[StateprovinceId, AViewRow]
+  def postalcode: Field[/* max 15 chars */ String, AViewRow]
+  def spatiallocation: OptField[TypoBytea, AViewRow]
+  def rowguid: Field[TypoUUID, AViewRow]
+  def modifieddate: Field[TypoLocalDateTime, AViewRow]
 }
 
 object AViewFields {
-  val structure: Relation[AViewFields, AViewRow, AViewRow] = 
-    new Impl(None, identity, (_, x) => x)
+  lazy val structure: Relation[AViewFields, AViewRow] =
+    new Impl(Nil)
     
-  private final class Impl[Row](val prefix: Option[String], val extract: Row => AViewRow, val merge: (Row, AViewRow) => Row)
-    extends Relation[AViewFields, AViewRow, Row] { 
+  private final class Impl(val _path: List[Path])
+    extends Relation[AViewFields, AViewRow] {
   
-    override val fields: AViewFields[Row] = new AViewFields[Row] {
-      override val id = new Field[AddressId, Row](prefix, "id", None, None)(x => extract(x).id, (row, value) => merge(row, extract(row).copy(id = value)))
-      override val addressid = new Field[AddressId, Row](prefix, "addressid", None, None)(x => extract(x).addressid, (row, value) => merge(row, extract(row).copy(addressid = value)))
-      override val addressline1 = new Field[/* max 60 chars */ String, Row](prefix, "addressline1", None, None)(x => extract(x).addressline1, (row, value) => merge(row, extract(row).copy(addressline1 = value)))
-      override val addressline2 = new OptField[/* max 60 chars */ String, Row](prefix, "addressline2", None, None)(x => extract(x).addressline2, (row, value) => merge(row, extract(row).copy(addressline2 = value)))
-      override val city = new Field[/* max 30 chars */ String, Row](prefix, "city", None, None)(x => extract(x).city, (row, value) => merge(row, extract(row).copy(city = value)))
-      override val stateprovinceid = new Field[StateprovinceId, Row](prefix, "stateprovinceid", None, None)(x => extract(x).stateprovinceid, (row, value) => merge(row, extract(row).copy(stateprovinceid = value)))
-      override val postalcode = new Field[/* max 15 chars */ String, Row](prefix, "postalcode", None, None)(x => extract(x).postalcode, (row, value) => merge(row, extract(row).copy(postalcode = value)))
-      override val spatiallocation = new OptField[TypoBytea, Row](prefix, "spatiallocation", None, None)(x => extract(x).spatiallocation, (row, value) => merge(row, extract(row).copy(spatiallocation = value)))
-      override val rowguid = new Field[TypoUUID, Row](prefix, "rowguid", None, None)(x => extract(x).rowguid, (row, value) => merge(row, extract(row).copy(rowguid = value)))
-      override val modifieddate = new Field[TypoLocalDateTime, Row](prefix, "modifieddate", Some("text"), None)(x => extract(x).modifieddate, (row, value) => merge(row, extract(row).copy(modifieddate = value)))
+    override lazy val fields: AViewFields = new AViewFields {
+      override def id = Field[AddressId, AViewRow](_path, "id", None, None, x => x.id, (row, value) => row.copy(id = value))
+      override def addressid = Field[AddressId, AViewRow](_path, "addressid", None, None, x => x.addressid, (row, value) => row.copy(addressid = value))
+      override def addressline1 = Field[/* max 60 chars */ String, AViewRow](_path, "addressline1", None, None, x => x.addressline1, (row, value) => row.copy(addressline1 = value))
+      override def addressline2 = OptField[/* max 60 chars */ String, AViewRow](_path, "addressline2", None, None, x => x.addressline2, (row, value) => row.copy(addressline2 = value))
+      override def city = Field[/* max 30 chars */ String, AViewRow](_path, "city", None, None, x => x.city, (row, value) => row.copy(city = value))
+      override def stateprovinceid = Field[StateprovinceId, AViewRow](_path, "stateprovinceid", None, None, x => x.stateprovinceid, (row, value) => row.copy(stateprovinceid = value))
+      override def postalcode = Field[/* max 15 chars */ String, AViewRow](_path, "postalcode", None, None, x => x.postalcode, (row, value) => row.copy(postalcode = value))
+      override def spatiallocation = OptField[TypoBytea, AViewRow](_path, "spatiallocation", None, None, x => x.spatiallocation, (row, value) => row.copy(spatiallocation = value))
+      override def rowguid = Field[TypoUUID, AViewRow](_path, "rowguid", None, None, x => x.rowguid, (row, value) => row.copy(rowguid = value))
+      override def modifieddate = Field[TypoLocalDateTime, AViewRow](_path, "modifieddate", Some("text"), None, x => x.modifieddate, (row, value) => row.copy(modifieddate = value))
     }
   
-    override val columns: List[FieldLikeNoHkt[?, Row]] =
-      List[FieldLikeNoHkt[?, Row]](fields.id, fields.addressid, fields.addressline1, fields.addressline2, fields.city, fields.stateprovinceid, fields.postalcode, fields.spatiallocation, fields.rowguid, fields.modifieddate)
+    override lazy val columns: List[FieldLikeNoHkt[?, AViewRow]] =
+      List[FieldLikeNoHkt[?, AViewRow]](fields.id, fields.addressid, fields.addressline1, fields.addressline2, fields.city, fields.stateprovinceid, fields.postalcode, fields.spatiallocation, fields.rowguid, fields.modifieddate)
   
-    override def copy[NewRow](prefix: Option[String], extract: NewRow => AViewRow, merge: (NewRow, AViewRow) => NewRow): Impl[NewRow] =
-      new Impl(prefix, extract, merge)
+    override def copy(path: List[Path]): Impl =
+      new Impl(path)
   }
   
 }

--- a/typo-tester-anorm/generated-and-checked-in/adventureworks/pe/at/AtViewFields.scala
+++ b/typo-tester-anorm/generated-and-checked-in/adventureworks/pe/at/AtViewFields.scala
@@ -11,38 +11,39 @@ import adventureworks.customtypes.TypoLocalDateTime
 import adventureworks.customtypes.TypoUUID
 import adventureworks.person.addresstype.AddresstypeId
 import adventureworks.public.Name
+import typo.dsl.Path
 import typo.dsl.SqlExpr.Field
 import typo.dsl.SqlExpr.FieldLikeNoHkt
 import typo.dsl.Structure.Relation
 
-trait AtViewFields[Row] {
-  val id: Field[AddresstypeId, Row]
-  val addresstypeid: Field[AddresstypeId, Row]
-  val name: Field[Name, Row]
-  val rowguid: Field[TypoUUID, Row]
-  val modifieddate: Field[TypoLocalDateTime, Row]
+trait AtViewFields {
+  def id: Field[AddresstypeId, AtViewRow]
+  def addresstypeid: Field[AddresstypeId, AtViewRow]
+  def name: Field[Name, AtViewRow]
+  def rowguid: Field[TypoUUID, AtViewRow]
+  def modifieddate: Field[TypoLocalDateTime, AtViewRow]
 }
 
 object AtViewFields {
-  val structure: Relation[AtViewFields, AtViewRow, AtViewRow] = 
-    new Impl(None, identity, (_, x) => x)
+  lazy val structure: Relation[AtViewFields, AtViewRow] =
+    new Impl(Nil)
     
-  private final class Impl[Row](val prefix: Option[String], val extract: Row => AtViewRow, val merge: (Row, AtViewRow) => Row)
-    extends Relation[AtViewFields, AtViewRow, Row] { 
+  private final class Impl(val _path: List[Path])
+    extends Relation[AtViewFields, AtViewRow] {
   
-    override val fields: AtViewFields[Row] = new AtViewFields[Row] {
-      override val id = new Field[AddresstypeId, Row](prefix, "id", None, None)(x => extract(x).id, (row, value) => merge(row, extract(row).copy(id = value)))
-      override val addresstypeid = new Field[AddresstypeId, Row](prefix, "addresstypeid", None, None)(x => extract(x).addresstypeid, (row, value) => merge(row, extract(row).copy(addresstypeid = value)))
-      override val name = new Field[Name, Row](prefix, "name", None, None)(x => extract(x).name, (row, value) => merge(row, extract(row).copy(name = value)))
-      override val rowguid = new Field[TypoUUID, Row](prefix, "rowguid", None, None)(x => extract(x).rowguid, (row, value) => merge(row, extract(row).copy(rowguid = value)))
-      override val modifieddate = new Field[TypoLocalDateTime, Row](prefix, "modifieddate", Some("text"), None)(x => extract(x).modifieddate, (row, value) => merge(row, extract(row).copy(modifieddate = value)))
+    override lazy val fields: AtViewFields = new AtViewFields {
+      override def id = Field[AddresstypeId, AtViewRow](_path, "id", None, None, x => x.id, (row, value) => row.copy(id = value))
+      override def addresstypeid = Field[AddresstypeId, AtViewRow](_path, "addresstypeid", None, None, x => x.addresstypeid, (row, value) => row.copy(addresstypeid = value))
+      override def name = Field[Name, AtViewRow](_path, "name", None, None, x => x.name, (row, value) => row.copy(name = value))
+      override def rowguid = Field[TypoUUID, AtViewRow](_path, "rowguid", None, None, x => x.rowguid, (row, value) => row.copy(rowguid = value))
+      override def modifieddate = Field[TypoLocalDateTime, AtViewRow](_path, "modifieddate", Some("text"), None, x => x.modifieddate, (row, value) => row.copy(modifieddate = value))
     }
   
-    override val columns: List[FieldLikeNoHkt[?, Row]] =
-      List[FieldLikeNoHkt[?, Row]](fields.id, fields.addresstypeid, fields.name, fields.rowguid, fields.modifieddate)
+    override lazy val columns: List[FieldLikeNoHkt[?, AtViewRow]] =
+      List[FieldLikeNoHkt[?, AtViewRow]](fields.id, fields.addresstypeid, fields.name, fields.rowguid, fields.modifieddate)
   
-    override def copy[NewRow](prefix: Option[String], extract: NewRow => AtViewRow, merge: (NewRow, AtViewRow) => NewRow): Impl[NewRow] =
-      new Impl(prefix, extract, merge)
+    override def copy(path: List[Path]): Impl =
+      new Impl(path)
   }
   
 }

--- a/typo-tester-anorm/generated-and-checked-in/adventureworks/pe/be/BeViewFields.scala
+++ b/typo-tester-anorm/generated-and-checked-in/adventureworks/pe/be/BeViewFields.scala
@@ -10,36 +10,37 @@ package be
 import adventureworks.customtypes.TypoLocalDateTime
 import adventureworks.customtypes.TypoUUID
 import adventureworks.person.businessentity.BusinessentityId
+import typo.dsl.Path
 import typo.dsl.SqlExpr.Field
 import typo.dsl.SqlExpr.FieldLikeNoHkt
 import typo.dsl.Structure.Relation
 
-trait BeViewFields[Row] {
-  val id: Field[BusinessentityId, Row]
-  val businessentityid: Field[BusinessentityId, Row]
-  val rowguid: Field[TypoUUID, Row]
-  val modifieddate: Field[TypoLocalDateTime, Row]
+trait BeViewFields {
+  def id: Field[BusinessentityId, BeViewRow]
+  def businessentityid: Field[BusinessentityId, BeViewRow]
+  def rowguid: Field[TypoUUID, BeViewRow]
+  def modifieddate: Field[TypoLocalDateTime, BeViewRow]
 }
 
 object BeViewFields {
-  val structure: Relation[BeViewFields, BeViewRow, BeViewRow] = 
-    new Impl(None, identity, (_, x) => x)
+  lazy val structure: Relation[BeViewFields, BeViewRow] =
+    new Impl(Nil)
     
-  private final class Impl[Row](val prefix: Option[String], val extract: Row => BeViewRow, val merge: (Row, BeViewRow) => Row)
-    extends Relation[BeViewFields, BeViewRow, Row] { 
+  private final class Impl(val _path: List[Path])
+    extends Relation[BeViewFields, BeViewRow] {
   
-    override val fields: BeViewFields[Row] = new BeViewFields[Row] {
-      override val id = new Field[BusinessentityId, Row](prefix, "id", None, None)(x => extract(x).id, (row, value) => merge(row, extract(row).copy(id = value)))
-      override val businessentityid = new Field[BusinessentityId, Row](prefix, "businessentityid", None, None)(x => extract(x).businessentityid, (row, value) => merge(row, extract(row).copy(businessentityid = value)))
-      override val rowguid = new Field[TypoUUID, Row](prefix, "rowguid", None, None)(x => extract(x).rowguid, (row, value) => merge(row, extract(row).copy(rowguid = value)))
-      override val modifieddate = new Field[TypoLocalDateTime, Row](prefix, "modifieddate", Some("text"), None)(x => extract(x).modifieddate, (row, value) => merge(row, extract(row).copy(modifieddate = value)))
+    override lazy val fields: BeViewFields = new BeViewFields {
+      override def id = Field[BusinessentityId, BeViewRow](_path, "id", None, None, x => x.id, (row, value) => row.copy(id = value))
+      override def businessentityid = Field[BusinessentityId, BeViewRow](_path, "businessentityid", None, None, x => x.businessentityid, (row, value) => row.copy(businessentityid = value))
+      override def rowguid = Field[TypoUUID, BeViewRow](_path, "rowguid", None, None, x => x.rowguid, (row, value) => row.copy(rowguid = value))
+      override def modifieddate = Field[TypoLocalDateTime, BeViewRow](_path, "modifieddate", Some("text"), None, x => x.modifieddate, (row, value) => row.copy(modifieddate = value))
     }
   
-    override val columns: List[FieldLikeNoHkt[?, Row]] =
-      List[FieldLikeNoHkt[?, Row]](fields.id, fields.businessentityid, fields.rowguid, fields.modifieddate)
+    override lazy val columns: List[FieldLikeNoHkt[?, BeViewRow]] =
+      List[FieldLikeNoHkt[?, BeViewRow]](fields.id, fields.businessentityid, fields.rowguid, fields.modifieddate)
   
-    override def copy[NewRow](prefix: Option[String], extract: NewRow => BeViewRow, merge: (NewRow, BeViewRow) => NewRow): Impl[NewRow] =
-      new Impl(prefix, extract, merge)
+    override def copy(path: List[Path]): Impl =
+      new Impl(path)
   }
   
 }

--- a/typo-tester-anorm/generated-and-checked-in/adventureworks/pe/bea/BeaViewFields.scala
+++ b/typo-tester-anorm/generated-and-checked-in/adventureworks/pe/bea/BeaViewFields.scala
@@ -12,40 +12,41 @@ import adventureworks.customtypes.TypoUUID
 import adventureworks.person.address.AddressId
 import adventureworks.person.addresstype.AddresstypeId
 import adventureworks.person.businessentity.BusinessentityId
+import typo.dsl.Path
 import typo.dsl.SqlExpr.Field
 import typo.dsl.SqlExpr.FieldLikeNoHkt
 import typo.dsl.Structure.Relation
 
-trait BeaViewFields[Row] {
-  val id: Field[BusinessentityId, Row]
-  val businessentityid: Field[BusinessentityId, Row]
-  val addressid: Field[AddressId, Row]
-  val addresstypeid: Field[AddresstypeId, Row]
-  val rowguid: Field[TypoUUID, Row]
-  val modifieddate: Field[TypoLocalDateTime, Row]
+trait BeaViewFields {
+  def id: Field[BusinessentityId, BeaViewRow]
+  def businessentityid: Field[BusinessentityId, BeaViewRow]
+  def addressid: Field[AddressId, BeaViewRow]
+  def addresstypeid: Field[AddresstypeId, BeaViewRow]
+  def rowguid: Field[TypoUUID, BeaViewRow]
+  def modifieddate: Field[TypoLocalDateTime, BeaViewRow]
 }
 
 object BeaViewFields {
-  val structure: Relation[BeaViewFields, BeaViewRow, BeaViewRow] = 
-    new Impl(None, identity, (_, x) => x)
+  lazy val structure: Relation[BeaViewFields, BeaViewRow] =
+    new Impl(Nil)
     
-  private final class Impl[Row](val prefix: Option[String], val extract: Row => BeaViewRow, val merge: (Row, BeaViewRow) => Row)
-    extends Relation[BeaViewFields, BeaViewRow, Row] { 
+  private final class Impl(val _path: List[Path])
+    extends Relation[BeaViewFields, BeaViewRow] {
   
-    override val fields: BeaViewFields[Row] = new BeaViewFields[Row] {
-      override val id = new Field[BusinessentityId, Row](prefix, "id", None, None)(x => extract(x).id, (row, value) => merge(row, extract(row).copy(id = value)))
-      override val businessentityid = new Field[BusinessentityId, Row](prefix, "businessentityid", None, None)(x => extract(x).businessentityid, (row, value) => merge(row, extract(row).copy(businessentityid = value)))
-      override val addressid = new Field[AddressId, Row](prefix, "addressid", None, None)(x => extract(x).addressid, (row, value) => merge(row, extract(row).copy(addressid = value)))
-      override val addresstypeid = new Field[AddresstypeId, Row](prefix, "addresstypeid", None, None)(x => extract(x).addresstypeid, (row, value) => merge(row, extract(row).copy(addresstypeid = value)))
-      override val rowguid = new Field[TypoUUID, Row](prefix, "rowguid", None, None)(x => extract(x).rowguid, (row, value) => merge(row, extract(row).copy(rowguid = value)))
-      override val modifieddate = new Field[TypoLocalDateTime, Row](prefix, "modifieddate", Some("text"), None)(x => extract(x).modifieddate, (row, value) => merge(row, extract(row).copy(modifieddate = value)))
+    override lazy val fields: BeaViewFields = new BeaViewFields {
+      override def id = Field[BusinessentityId, BeaViewRow](_path, "id", None, None, x => x.id, (row, value) => row.copy(id = value))
+      override def businessentityid = Field[BusinessentityId, BeaViewRow](_path, "businessentityid", None, None, x => x.businessentityid, (row, value) => row.copy(businessentityid = value))
+      override def addressid = Field[AddressId, BeaViewRow](_path, "addressid", None, None, x => x.addressid, (row, value) => row.copy(addressid = value))
+      override def addresstypeid = Field[AddresstypeId, BeaViewRow](_path, "addresstypeid", None, None, x => x.addresstypeid, (row, value) => row.copy(addresstypeid = value))
+      override def rowguid = Field[TypoUUID, BeaViewRow](_path, "rowguid", None, None, x => x.rowguid, (row, value) => row.copy(rowguid = value))
+      override def modifieddate = Field[TypoLocalDateTime, BeaViewRow](_path, "modifieddate", Some("text"), None, x => x.modifieddate, (row, value) => row.copy(modifieddate = value))
     }
   
-    override val columns: List[FieldLikeNoHkt[?, Row]] =
-      List[FieldLikeNoHkt[?, Row]](fields.id, fields.businessentityid, fields.addressid, fields.addresstypeid, fields.rowguid, fields.modifieddate)
+    override lazy val columns: List[FieldLikeNoHkt[?, BeaViewRow]] =
+      List[FieldLikeNoHkt[?, BeaViewRow]](fields.id, fields.businessentityid, fields.addressid, fields.addresstypeid, fields.rowguid, fields.modifieddate)
   
-    override def copy[NewRow](prefix: Option[String], extract: NewRow => BeaViewRow, merge: (NewRow, BeaViewRow) => NewRow): Impl[NewRow] =
-      new Impl(prefix, extract, merge)
+    override def copy(path: List[Path]): Impl =
+      new Impl(path)
   }
   
 }

--- a/typo-tester-anorm/generated-and-checked-in/adventureworks/pe/bec/BecViewFields.scala
+++ b/typo-tester-anorm/generated-and-checked-in/adventureworks/pe/bec/BecViewFields.scala
@@ -11,40 +11,41 @@ import adventureworks.customtypes.TypoLocalDateTime
 import adventureworks.customtypes.TypoUUID
 import adventureworks.person.businessentity.BusinessentityId
 import adventureworks.person.contacttype.ContacttypeId
+import typo.dsl.Path
 import typo.dsl.SqlExpr.Field
 import typo.dsl.SqlExpr.FieldLikeNoHkt
 import typo.dsl.Structure.Relation
 
-trait BecViewFields[Row] {
-  val id: Field[BusinessentityId, Row]
-  val businessentityid: Field[BusinessentityId, Row]
-  val personid: Field[BusinessentityId, Row]
-  val contacttypeid: Field[ContacttypeId, Row]
-  val rowguid: Field[TypoUUID, Row]
-  val modifieddate: Field[TypoLocalDateTime, Row]
+trait BecViewFields {
+  def id: Field[BusinessentityId, BecViewRow]
+  def businessentityid: Field[BusinessentityId, BecViewRow]
+  def personid: Field[BusinessentityId, BecViewRow]
+  def contacttypeid: Field[ContacttypeId, BecViewRow]
+  def rowguid: Field[TypoUUID, BecViewRow]
+  def modifieddate: Field[TypoLocalDateTime, BecViewRow]
 }
 
 object BecViewFields {
-  val structure: Relation[BecViewFields, BecViewRow, BecViewRow] = 
-    new Impl(None, identity, (_, x) => x)
+  lazy val structure: Relation[BecViewFields, BecViewRow] =
+    new Impl(Nil)
     
-  private final class Impl[Row](val prefix: Option[String], val extract: Row => BecViewRow, val merge: (Row, BecViewRow) => Row)
-    extends Relation[BecViewFields, BecViewRow, Row] { 
+  private final class Impl(val _path: List[Path])
+    extends Relation[BecViewFields, BecViewRow] {
   
-    override val fields: BecViewFields[Row] = new BecViewFields[Row] {
-      override val id = new Field[BusinessentityId, Row](prefix, "id", None, None)(x => extract(x).id, (row, value) => merge(row, extract(row).copy(id = value)))
-      override val businessentityid = new Field[BusinessentityId, Row](prefix, "businessentityid", None, None)(x => extract(x).businessentityid, (row, value) => merge(row, extract(row).copy(businessentityid = value)))
-      override val personid = new Field[BusinessentityId, Row](prefix, "personid", None, None)(x => extract(x).personid, (row, value) => merge(row, extract(row).copy(personid = value)))
-      override val contacttypeid = new Field[ContacttypeId, Row](prefix, "contacttypeid", None, None)(x => extract(x).contacttypeid, (row, value) => merge(row, extract(row).copy(contacttypeid = value)))
-      override val rowguid = new Field[TypoUUID, Row](prefix, "rowguid", None, None)(x => extract(x).rowguid, (row, value) => merge(row, extract(row).copy(rowguid = value)))
-      override val modifieddate = new Field[TypoLocalDateTime, Row](prefix, "modifieddate", Some("text"), None)(x => extract(x).modifieddate, (row, value) => merge(row, extract(row).copy(modifieddate = value)))
+    override lazy val fields: BecViewFields = new BecViewFields {
+      override def id = Field[BusinessentityId, BecViewRow](_path, "id", None, None, x => x.id, (row, value) => row.copy(id = value))
+      override def businessentityid = Field[BusinessentityId, BecViewRow](_path, "businessentityid", None, None, x => x.businessentityid, (row, value) => row.copy(businessentityid = value))
+      override def personid = Field[BusinessentityId, BecViewRow](_path, "personid", None, None, x => x.personid, (row, value) => row.copy(personid = value))
+      override def contacttypeid = Field[ContacttypeId, BecViewRow](_path, "contacttypeid", None, None, x => x.contacttypeid, (row, value) => row.copy(contacttypeid = value))
+      override def rowguid = Field[TypoUUID, BecViewRow](_path, "rowguid", None, None, x => x.rowguid, (row, value) => row.copy(rowguid = value))
+      override def modifieddate = Field[TypoLocalDateTime, BecViewRow](_path, "modifieddate", Some("text"), None, x => x.modifieddate, (row, value) => row.copy(modifieddate = value))
     }
   
-    override val columns: List[FieldLikeNoHkt[?, Row]] =
-      List[FieldLikeNoHkt[?, Row]](fields.id, fields.businessentityid, fields.personid, fields.contacttypeid, fields.rowguid, fields.modifieddate)
+    override lazy val columns: List[FieldLikeNoHkt[?, BecViewRow]] =
+      List[FieldLikeNoHkt[?, BecViewRow]](fields.id, fields.businessentityid, fields.personid, fields.contacttypeid, fields.rowguid, fields.modifieddate)
   
-    override def copy[NewRow](prefix: Option[String], extract: NewRow => BecViewRow, merge: (NewRow, BecViewRow) => NewRow): Impl[NewRow] =
-      new Impl(prefix, extract, merge)
+    override def copy(path: List[Path]): Impl =
+      new Impl(path)
   }
   
 }

--- a/typo-tester-anorm/generated-and-checked-in/adventureworks/pe/ct/CtViewFields.scala
+++ b/typo-tester-anorm/generated-and-checked-in/adventureworks/pe/ct/CtViewFields.scala
@@ -10,36 +10,37 @@ package ct
 import adventureworks.customtypes.TypoLocalDateTime
 import adventureworks.person.contacttype.ContacttypeId
 import adventureworks.public.Name
+import typo.dsl.Path
 import typo.dsl.SqlExpr.Field
 import typo.dsl.SqlExpr.FieldLikeNoHkt
 import typo.dsl.Structure.Relation
 
-trait CtViewFields[Row] {
-  val id: Field[ContacttypeId, Row]
-  val contacttypeid: Field[ContacttypeId, Row]
-  val name: Field[Name, Row]
-  val modifieddate: Field[TypoLocalDateTime, Row]
+trait CtViewFields {
+  def id: Field[ContacttypeId, CtViewRow]
+  def contacttypeid: Field[ContacttypeId, CtViewRow]
+  def name: Field[Name, CtViewRow]
+  def modifieddate: Field[TypoLocalDateTime, CtViewRow]
 }
 
 object CtViewFields {
-  val structure: Relation[CtViewFields, CtViewRow, CtViewRow] = 
-    new Impl(None, identity, (_, x) => x)
+  lazy val structure: Relation[CtViewFields, CtViewRow] =
+    new Impl(Nil)
     
-  private final class Impl[Row](val prefix: Option[String], val extract: Row => CtViewRow, val merge: (Row, CtViewRow) => Row)
-    extends Relation[CtViewFields, CtViewRow, Row] { 
+  private final class Impl(val _path: List[Path])
+    extends Relation[CtViewFields, CtViewRow] {
   
-    override val fields: CtViewFields[Row] = new CtViewFields[Row] {
-      override val id = new Field[ContacttypeId, Row](prefix, "id", None, None)(x => extract(x).id, (row, value) => merge(row, extract(row).copy(id = value)))
-      override val contacttypeid = new Field[ContacttypeId, Row](prefix, "contacttypeid", None, None)(x => extract(x).contacttypeid, (row, value) => merge(row, extract(row).copy(contacttypeid = value)))
-      override val name = new Field[Name, Row](prefix, "name", None, None)(x => extract(x).name, (row, value) => merge(row, extract(row).copy(name = value)))
-      override val modifieddate = new Field[TypoLocalDateTime, Row](prefix, "modifieddate", Some("text"), None)(x => extract(x).modifieddate, (row, value) => merge(row, extract(row).copy(modifieddate = value)))
+    override lazy val fields: CtViewFields = new CtViewFields {
+      override def id = Field[ContacttypeId, CtViewRow](_path, "id", None, None, x => x.id, (row, value) => row.copy(id = value))
+      override def contacttypeid = Field[ContacttypeId, CtViewRow](_path, "contacttypeid", None, None, x => x.contacttypeid, (row, value) => row.copy(contacttypeid = value))
+      override def name = Field[Name, CtViewRow](_path, "name", None, None, x => x.name, (row, value) => row.copy(name = value))
+      override def modifieddate = Field[TypoLocalDateTime, CtViewRow](_path, "modifieddate", Some("text"), None, x => x.modifieddate, (row, value) => row.copy(modifieddate = value))
     }
   
-    override val columns: List[FieldLikeNoHkt[?, Row]] =
-      List[FieldLikeNoHkt[?, Row]](fields.id, fields.contacttypeid, fields.name, fields.modifieddate)
+    override lazy val columns: List[FieldLikeNoHkt[?, CtViewRow]] =
+      List[FieldLikeNoHkt[?, CtViewRow]](fields.id, fields.contacttypeid, fields.name, fields.modifieddate)
   
-    override def copy[NewRow](prefix: Option[String], extract: NewRow => CtViewRow, merge: (NewRow, CtViewRow) => NewRow): Impl[NewRow] =
-      new Impl(prefix, extract, merge)
+    override def copy(path: List[Path]): Impl =
+      new Impl(path)
   }
   
 }

--- a/typo-tester-anorm/generated-and-checked-in/adventureworks/pe/e/EViewFields.scala
+++ b/typo-tester-anorm/generated-and-checked-in/adventureworks/pe/e/EViewFields.scala
@@ -10,41 +10,42 @@ package e
 import adventureworks.customtypes.TypoLocalDateTime
 import adventureworks.customtypes.TypoUUID
 import adventureworks.person.businessentity.BusinessentityId
+import typo.dsl.Path
 import typo.dsl.SqlExpr.Field
 import typo.dsl.SqlExpr.FieldLikeNoHkt
 import typo.dsl.SqlExpr.OptField
 import typo.dsl.Structure.Relation
 
-trait EViewFields[Row] {
-  val id: Field[Int, Row]
-  val businessentityid: Field[BusinessentityId, Row]
-  val emailaddressid: Field[Int, Row]
-  val emailaddress: OptField[/* max 50 chars */ String, Row]
-  val rowguid: Field[TypoUUID, Row]
-  val modifieddate: Field[TypoLocalDateTime, Row]
+trait EViewFields {
+  def id: Field[Int, EViewRow]
+  def businessentityid: Field[BusinessentityId, EViewRow]
+  def emailaddressid: Field[Int, EViewRow]
+  def emailaddress: OptField[/* max 50 chars */ String, EViewRow]
+  def rowguid: Field[TypoUUID, EViewRow]
+  def modifieddate: Field[TypoLocalDateTime, EViewRow]
 }
 
 object EViewFields {
-  val structure: Relation[EViewFields, EViewRow, EViewRow] = 
-    new Impl(None, identity, (_, x) => x)
+  lazy val structure: Relation[EViewFields, EViewRow] =
+    new Impl(Nil)
     
-  private final class Impl[Row](val prefix: Option[String], val extract: Row => EViewRow, val merge: (Row, EViewRow) => Row)
-    extends Relation[EViewFields, EViewRow, Row] { 
+  private final class Impl(val _path: List[Path])
+    extends Relation[EViewFields, EViewRow] {
   
-    override val fields: EViewFields[Row] = new EViewFields[Row] {
-      override val id = new Field[Int, Row](prefix, "id", None, None)(x => extract(x).id, (row, value) => merge(row, extract(row).copy(id = value)))
-      override val businessentityid = new Field[BusinessentityId, Row](prefix, "businessentityid", None, None)(x => extract(x).businessentityid, (row, value) => merge(row, extract(row).copy(businessentityid = value)))
-      override val emailaddressid = new Field[Int, Row](prefix, "emailaddressid", None, None)(x => extract(x).emailaddressid, (row, value) => merge(row, extract(row).copy(emailaddressid = value)))
-      override val emailaddress = new OptField[/* max 50 chars */ String, Row](prefix, "emailaddress", None, None)(x => extract(x).emailaddress, (row, value) => merge(row, extract(row).copy(emailaddress = value)))
-      override val rowguid = new Field[TypoUUID, Row](prefix, "rowguid", None, None)(x => extract(x).rowguid, (row, value) => merge(row, extract(row).copy(rowguid = value)))
-      override val modifieddate = new Field[TypoLocalDateTime, Row](prefix, "modifieddate", Some("text"), None)(x => extract(x).modifieddate, (row, value) => merge(row, extract(row).copy(modifieddate = value)))
+    override lazy val fields: EViewFields = new EViewFields {
+      override def id = Field[Int, EViewRow](_path, "id", None, None, x => x.id, (row, value) => row.copy(id = value))
+      override def businessentityid = Field[BusinessentityId, EViewRow](_path, "businessentityid", None, None, x => x.businessentityid, (row, value) => row.copy(businessentityid = value))
+      override def emailaddressid = Field[Int, EViewRow](_path, "emailaddressid", None, None, x => x.emailaddressid, (row, value) => row.copy(emailaddressid = value))
+      override def emailaddress = OptField[/* max 50 chars */ String, EViewRow](_path, "emailaddress", None, None, x => x.emailaddress, (row, value) => row.copy(emailaddress = value))
+      override def rowguid = Field[TypoUUID, EViewRow](_path, "rowguid", None, None, x => x.rowguid, (row, value) => row.copy(rowguid = value))
+      override def modifieddate = Field[TypoLocalDateTime, EViewRow](_path, "modifieddate", Some("text"), None, x => x.modifieddate, (row, value) => row.copy(modifieddate = value))
     }
   
-    override val columns: List[FieldLikeNoHkt[?, Row]] =
-      List[FieldLikeNoHkt[?, Row]](fields.id, fields.businessentityid, fields.emailaddressid, fields.emailaddress, fields.rowguid, fields.modifieddate)
+    override lazy val columns: List[FieldLikeNoHkt[?, EViewRow]] =
+      List[FieldLikeNoHkt[?, EViewRow]](fields.id, fields.businessentityid, fields.emailaddressid, fields.emailaddress, fields.rowguid, fields.modifieddate)
   
-    override def copy[NewRow](prefix: Option[String], extract: NewRow => EViewRow, merge: (NewRow, EViewRow) => NewRow): Impl[NewRow] =
-      new Impl(prefix, extract, merge)
+    override def copy(path: List[Path]): Impl =
+      new Impl(path)
   }
   
 }

--- a/typo-tester-anorm/generated-and-checked-in/adventureworks/pe/p/PViewFields.scala
+++ b/typo-tester-anorm/generated-and-checked-in/adventureworks/pe/p/PViewFields.scala
@@ -14,57 +14,58 @@ import adventureworks.person.businessentity.BusinessentityId
 import adventureworks.public.Name
 import adventureworks.public.NameStyle
 import adventureworks.userdefined.FirstName
+import typo.dsl.Path
 import typo.dsl.SqlExpr.Field
 import typo.dsl.SqlExpr.FieldLikeNoHkt
 import typo.dsl.SqlExpr.OptField
 import typo.dsl.Structure.Relation
 
-trait PViewFields[Row] {
-  val id: Field[BusinessentityId, Row]
-  val businessentityid: Field[BusinessentityId, Row]
-  val persontype: Field[/* bpchar, max 2 chars */ String, Row]
-  val namestyle: Field[NameStyle, Row]
-  val title: OptField[/* max 8 chars */ String, Row]
-  val firstname: Field[/* user-picked */ FirstName, Row]
-  val middlename: OptField[Name, Row]
-  val lastname: Field[Name, Row]
-  val suffix: OptField[/* max 10 chars */ String, Row]
-  val emailpromotion: Field[Int, Row]
-  val additionalcontactinfo: OptField[TypoXml, Row]
-  val demographics: OptField[TypoXml, Row]
-  val rowguid: Field[TypoUUID, Row]
-  val modifieddate: Field[TypoLocalDateTime, Row]
+trait PViewFields {
+  def id: Field[BusinessentityId, PViewRow]
+  def businessentityid: Field[BusinessentityId, PViewRow]
+  def persontype: Field[/* bpchar, max 2 chars */ String, PViewRow]
+  def namestyle: Field[NameStyle, PViewRow]
+  def title: OptField[/* max 8 chars */ String, PViewRow]
+  def firstname: Field[/* user-picked */ FirstName, PViewRow]
+  def middlename: OptField[Name, PViewRow]
+  def lastname: Field[Name, PViewRow]
+  def suffix: OptField[/* max 10 chars */ String, PViewRow]
+  def emailpromotion: Field[Int, PViewRow]
+  def additionalcontactinfo: OptField[TypoXml, PViewRow]
+  def demographics: OptField[TypoXml, PViewRow]
+  def rowguid: Field[TypoUUID, PViewRow]
+  def modifieddate: Field[TypoLocalDateTime, PViewRow]
 }
 
 object PViewFields {
-  val structure: Relation[PViewFields, PViewRow, PViewRow] = 
-    new Impl(None, identity, (_, x) => x)
+  lazy val structure: Relation[PViewFields, PViewRow] =
+    new Impl(Nil)
     
-  private final class Impl[Row](val prefix: Option[String], val extract: Row => PViewRow, val merge: (Row, PViewRow) => Row)
-    extends Relation[PViewFields, PViewRow, Row] { 
+  private final class Impl(val _path: List[Path])
+    extends Relation[PViewFields, PViewRow] {
   
-    override val fields: PViewFields[Row] = new PViewFields[Row] {
-      override val id = new Field[BusinessentityId, Row](prefix, "id", None, None)(x => extract(x).id, (row, value) => merge(row, extract(row).copy(id = value)))
-      override val businessentityid = new Field[BusinessentityId, Row](prefix, "businessentityid", None, None)(x => extract(x).businessentityid, (row, value) => merge(row, extract(row).copy(businessentityid = value)))
-      override val persontype = new Field[/* bpchar, max 2 chars */ String, Row](prefix, "persontype", None, None)(x => extract(x).persontype, (row, value) => merge(row, extract(row).copy(persontype = value)))
-      override val namestyle = new Field[NameStyle, Row](prefix, "namestyle", None, None)(x => extract(x).namestyle, (row, value) => merge(row, extract(row).copy(namestyle = value)))
-      override val title = new OptField[/* max 8 chars */ String, Row](prefix, "title", None, None)(x => extract(x).title, (row, value) => merge(row, extract(row).copy(title = value)))
-      override val firstname = new Field[/* user-picked */ FirstName, Row](prefix, "firstname", None, None)(x => extract(x).firstname, (row, value) => merge(row, extract(row).copy(firstname = value)))
-      override val middlename = new OptField[Name, Row](prefix, "middlename", None, None)(x => extract(x).middlename, (row, value) => merge(row, extract(row).copy(middlename = value)))
-      override val lastname = new Field[Name, Row](prefix, "lastname", None, None)(x => extract(x).lastname, (row, value) => merge(row, extract(row).copy(lastname = value)))
-      override val suffix = new OptField[/* max 10 chars */ String, Row](prefix, "suffix", None, None)(x => extract(x).suffix, (row, value) => merge(row, extract(row).copy(suffix = value)))
-      override val emailpromotion = new Field[Int, Row](prefix, "emailpromotion", None, None)(x => extract(x).emailpromotion, (row, value) => merge(row, extract(row).copy(emailpromotion = value)))
-      override val additionalcontactinfo = new OptField[TypoXml, Row](prefix, "additionalcontactinfo", None, None)(x => extract(x).additionalcontactinfo, (row, value) => merge(row, extract(row).copy(additionalcontactinfo = value)))
-      override val demographics = new OptField[TypoXml, Row](prefix, "demographics", None, None)(x => extract(x).demographics, (row, value) => merge(row, extract(row).copy(demographics = value)))
-      override val rowguid = new Field[TypoUUID, Row](prefix, "rowguid", None, None)(x => extract(x).rowguid, (row, value) => merge(row, extract(row).copy(rowguid = value)))
-      override val modifieddate = new Field[TypoLocalDateTime, Row](prefix, "modifieddate", Some("text"), None)(x => extract(x).modifieddate, (row, value) => merge(row, extract(row).copy(modifieddate = value)))
+    override lazy val fields: PViewFields = new PViewFields {
+      override def id = Field[BusinessentityId, PViewRow](_path, "id", None, None, x => x.id, (row, value) => row.copy(id = value))
+      override def businessentityid = Field[BusinessentityId, PViewRow](_path, "businessentityid", None, None, x => x.businessentityid, (row, value) => row.copy(businessentityid = value))
+      override def persontype = Field[/* bpchar, max 2 chars */ String, PViewRow](_path, "persontype", None, None, x => x.persontype, (row, value) => row.copy(persontype = value))
+      override def namestyle = Field[NameStyle, PViewRow](_path, "namestyle", None, None, x => x.namestyle, (row, value) => row.copy(namestyle = value))
+      override def title = OptField[/* max 8 chars */ String, PViewRow](_path, "title", None, None, x => x.title, (row, value) => row.copy(title = value))
+      override def firstname = Field[/* user-picked */ FirstName, PViewRow](_path, "firstname", None, None, x => x.firstname, (row, value) => row.copy(firstname = value))
+      override def middlename = OptField[Name, PViewRow](_path, "middlename", None, None, x => x.middlename, (row, value) => row.copy(middlename = value))
+      override def lastname = Field[Name, PViewRow](_path, "lastname", None, None, x => x.lastname, (row, value) => row.copy(lastname = value))
+      override def suffix = OptField[/* max 10 chars */ String, PViewRow](_path, "suffix", None, None, x => x.suffix, (row, value) => row.copy(suffix = value))
+      override def emailpromotion = Field[Int, PViewRow](_path, "emailpromotion", None, None, x => x.emailpromotion, (row, value) => row.copy(emailpromotion = value))
+      override def additionalcontactinfo = OptField[TypoXml, PViewRow](_path, "additionalcontactinfo", None, None, x => x.additionalcontactinfo, (row, value) => row.copy(additionalcontactinfo = value))
+      override def demographics = OptField[TypoXml, PViewRow](_path, "demographics", None, None, x => x.demographics, (row, value) => row.copy(demographics = value))
+      override def rowguid = Field[TypoUUID, PViewRow](_path, "rowguid", None, None, x => x.rowguid, (row, value) => row.copy(rowguid = value))
+      override def modifieddate = Field[TypoLocalDateTime, PViewRow](_path, "modifieddate", Some("text"), None, x => x.modifieddate, (row, value) => row.copy(modifieddate = value))
     }
   
-    override val columns: List[FieldLikeNoHkt[?, Row]] =
-      List[FieldLikeNoHkt[?, Row]](fields.id, fields.businessentityid, fields.persontype, fields.namestyle, fields.title, fields.firstname, fields.middlename, fields.lastname, fields.suffix, fields.emailpromotion, fields.additionalcontactinfo, fields.demographics, fields.rowguid, fields.modifieddate)
+    override lazy val columns: List[FieldLikeNoHkt[?, PViewRow]] =
+      List[FieldLikeNoHkt[?, PViewRow]](fields.id, fields.businessentityid, fields.persontype, fields.namestyle, fields.title, fields.firstname, fields.middlename, fields.lastname, fields.suffix, fields.emailpromotion, fields.additionalcontactinfo, fields.demographics, fields.rowguid, fields.modifieddate)
   
-    override def copy[NewRow](prefix: Option[String], extract: NewRow => PViewRow, merge: (NewRow, PViewRow) => NewRow): Impl[NewRow] =
-      new Impl(prefix, extract, merge)
+    override def copy(path: List[Path]): Impl =
+      new Impl(path)
   }
   
 }

--- a/typo-tester-anorm/generated-and-checked-in/adventureworks/pe/pa/PaViewFields.scala
+++ b/typo-tester-anorm/generated-and-checked-in/adventureworks/pe/pa/PaViewFields.scala
@@ -10,40 +10,41 @@ package pa
 import adventureworks.customtypes.TypoLocalDateTime
 import adventureworks.customtypes.TypoUUID
 import adventureworks.person.businessentity.BusinessentityId
+import typo.dsl.Path
 import typo.dsl.SqlExpr.Field
 import typo.dsl.SqlExpr.FieldLikeNoHkt
 import typo.dsl.Structure.Relation
 
-trait PaViewFields[Row] {
-  val id: Field[BusinessentityId, Row]
-  val businessentityid: Field[BusinessentityId, Row]
-  val passwordhash: Field[/* max 128 chars */ String, Row]
-  val passwordsalt: Field[/* max 10 chars */ String, Row]
-  val rowguid: Field[TypoUUID, Row]
-  val modifieddate: Field[TypoLocalDateTime, Row]
+trait PaViewFields {
+  def id: Field[BusinessentityId, PaViewRow]
+  def businessentityid: Field[BusinessentityId, PaViewRow]
+  def passwordhash: Field[/* max 128 chars */ String, PaViewRow]
+  def passwordsalt: Field[/* max 10 chars */ String, PaViewRow]
+  def rowguid: Field[TypoUUID, PaViewRow]
+  def modifieddate: Field[TypoLocalDateTime, PaViewRow]
 }
 
 object PaViewFields {
-  val structure: Relation[PaViewFields, PaViewRow, PaViewRow] = 
-    new Impl(None, identity, (_, x) => x)
+  lazy val structure: Relation[PaViewFields, PaViewRow] =
+    new Impl(Nil)
     
-  private final class Impl[Row](val prefix: Option[String], val extract: Row => PaViewRow, val merge: (Row, PaViewRow) => Row)
-    extends Relation[PaViewFields, PaViewRow, Row] { 
+  private final class Impl(val _path: List[Path])
+    extends Relation[PaViewFields, PaViewRow] {
   
-    override val fields: PaViewFields[Row] = new PaViewFields[Row] {
-      override val id = new Field[BusinessentityId, Row](prefix, "id", None, None)(x => extract(x).id, (row, value) => merge(row, extract(row).copy(id = value)))
-      override val businessentityid = new Field[BusinessentityId, Row](prefix, "businessentityid", None, None)(x => extract(x).businessentityid, (row, value) => merge(row, extract(row).copy(businessentityid = value)))
-      override val passwordhash = new Field[/* max 128 chars */ String, Row](prefix, "passwordhash", None, None)(x => extract(x).passwordhash, (row, value) => merge(row, extract(row).copy(passwordhash = value)))
-      override val passwordsalt = new Field[/* max 10 chars */ String, Row](prefix, "passwordsalt", None, None)(x => extract(x).passwordsalt, (row, value) => merge(row, extract(row).copy(passwordsalt = value)))
-      override val rowguid = new Field[TypoUUID, Row](prefix, "rowguid", None, None)(x => extract(x).rowguid, (row, value) => merge(row, extract(row).copy(rowguid = value)))
-      override val modifieddate = new Field[TypoLocalDateTime, Row](prefix, "modifieddate", Some("text"), None)(x => extract(x).modifieddate, (row, value) => merge(row, extract(row).copy(modifieddate = value)))
+    override lazy val fields: PaViewFields = new PaViewFields {
+      override def id = Field[BusinessentityId, PaViewRow](_path, "id", None, None, x => x.id, (row, value) => row.copy(id = value))
+      override def businessentityid = Field[BusinessentityId, PaViewRow](_path, "businessentityid", None, None, x => x.businessentityid, (row, value) => row.copy(businessentityid = value))
+      override def passwordhash = Field[/* max 128 chars */ String, PaViewRow](_path, "passwordhash", None, None, x => x.passwordhash, (row, value) => row.copy(passwordhash = value))
+      override def passwordsalt = Field[/* max 10 chars */ String, PaViewRow](_path, "passwordsalt", None, None, x => x.passwordsalt, (row, value) => row.copy(passwordsalt = value))
+      override def rowguid = Field[TypoUUID, PaViewRow](_path, "rowguid", None, None, x => x.rowguid, (row, value) => row.copy(rowguid = value))
+      override def modifieddate = Field[TypoLocalDateTime, PaViewRow](_path, "modifieddate", Some("text"), None, x => x.modifieddate, (row, value) => row.copy(modifieddate = value))
     }
   
-    override val columns: List[FieldLikeNoHkt[?, Row]] =
-      List[FieldLikeNoHkt[?, Row]](fields.id, fields.businessentityid, fields.passwordhash, fields.passwordsalt, fields.rowguid, fields.modifieddate)
+    override lazy val columns: List[FieldLikeNoHkt[?, PaViewRow]] =
+      List[FieldLikeNoHkt[?, PaViewRow]](fields.id, fields.businessentityid, fields.passwordhash, fields.passwordsalt, fields.rowguid, fields.modifieddate)
   
-    override def copy[NewRow](prefix: Option[String], extract: NewRow => PaViewRow, merge: (NewRow, PaViewRow) => NewRow): Impl[NewRow] =
-      new Impl(prefix, extract, merge)
+    override def copy(path: List[Path]): Impl =
+      new Impl(path)
   }
   
 }

--- a/typo-tester-anorm/generated-and-checked-in/adventureworks/pe/pnt/PntViewFields.scala
+++ b/typo-tester-anorm/generated-and-checked-in/adventureworks/pe/pnt/PntViewFields.scala
@@ -10,36 +10,37 @@ package pnt
 import adventureworks.customtypes.TypoLocalDateTime
 import adventureworks.person.phonenumbertype.PhonenumbertypeId
 import adventureworks.public.Name
+import typo.dsl.Path
 import typo.dsl.SqlExpr.Field
 import typo.dsl.SqlExpr.FieldLikeNoHkt
 import typo.dsl.Structure.Relation
 
-trait PntViewFields[Row] {
-  val id: Field[PhonenumbertypeId, Row]
-  val phonenumbertypeid: Field[PhonenumbertypeId, Row]
-  val name: Field[Name, Row]
-  val modifieddate: Field[TypoLocalDateTime, Row]
+trait PntViewFields {
+  def id: Field[PhonenumbertypeId, PntViewRow]
+  def phonenumbertypeid: Field[PhonenumbertypeId, PntViewRow]
+  def name: Field[Name, PntViewRow]
+  def modifieddate: Field[TypoLocalDateTime, PntViewRow]
 }
 
 object PntViewFields {
-  val structure: Relation[PntViewFields, PntViewRow, PntViewRow] = 
-    new Impl(None, identity, (_, x) => x)
+  lazy val structure: Relation[PntViewFields, PntViewRow] =
+    new Impl(Nil)
     
-  private final class Impl[Row](val prefix: Option[String], val extract: Row => PntViewRow, val merge: (Row, PntViewRow) => Row)
-    extends Relation[PntViewFields, PntViewRow, Row] { 
+  private final class Impl(val _path: List[Path])
+    extends Relation[PntViewFields, PntViewRow] {
   
-    override val fields: PntViewFields[Row] = new PntViewFields[Row] {
-      override val id = new Field[PhonenumbertypeId, Row](prefix, "id", None, None)(x => extract(x).id, (row, value) => merge(row, extract(row).copy(id = value)))
-      override val phonenumbertypeid = new Field[PhonenumbertypeId, Row](prefix, "phonenumbertypeid", None, None)(x => extract(x).phonenumbertypeid, (row, value) => merge(row, extract(row).copy(phonenumbertypeid = value)))
-      override val name = new Field[Name, Row](prefix, "name", None, None)(x => extract(x).name, (row, value) => merge(row, extract(row).copy(name = value)))
-      override val modifieddate = new Field[TypoLocalDateTime, Row](prefix, "modifieddate", Some("text"), None)(x => extract(x).modifieddate, (row, value) => merge(row, extract(row).copy(modifieddate = value)))
+    override lazy val fields: PntViewFields = new PntViewFields {
+      override def id = Field[PhonenumbertypeId, PntViewRow](_path, "id", None, None, x => x.id, (row, value) => row.copy(id = value))
+      override def phonenumbertypeid = Field[PhonenumbertypeId, PntViewRow](_path, "phonenumbertypeid", None, None, x => x.phonenumbertypeid, (row, value) => row.copy(phonenumbertypeid = value))
+      override def name = Field[Name, PntViewRow](_path, "name", None, None, x => x.name, (row, value) => row.copy(name = value))
+      override def modifieddate = Field[TypoLocalDateTime, PntViewRow](_path, "modifieddate", Some("text"), None, x => x.modifieddate, (row, value) => row.copy(modifieddate = value))
     }
   
-    override val columns: List[FieldLikeNoHkt[?, Row]] =
-      List[FieldLikeNoHkt[?, Row]](fields.id, fields.phonenumbertypeid, fields.name, fields.modifieddate)
+    override lazy val columns: List[FieldLikeNoHkt[?, PntViewRow]] =
+      List[FieldLikeNoHkt[?, PntViewRow]](fields.id, fields.phonenumbertypeid, fields.name, fields.modifieddate)
   
-    override def copy[NewRow](prefix: Option[String], extract: NewRow => PntViewRow, merge: (NewRow, PntViewRow) => NewRow): Impl[NewRow] =
-      new Impl(prefix, extract, merge)
+    override def copy(path: List[Path]): Impl =
+      new Impl(path)
   }
   
 }

--- a/typo-tester-anorm/generated-and-checked-in/adventureworks/pe/pp/PpViewFields.scala
+++ b/typo-tester-anorm/generated-and-checked-in/adventureworks/pe/pp/PpViewFields.scala
@@ -11,38 +11,39 @@ import adventureworks.customtypes.TypoLocalDateTime
 import adventureworks.person.businessentity.BusinessentityId
 import adventureworks.person.phonenumbertype.PhonenumbertypeId
 import adventureworks.public.Phone
+import typo.dsl.Path
 import typo.dsl.SqlExpr.Field
 import typo.dsl.SqlExpr.FieldLikeNoHkt
 import typo.dsl.Structure.Relation
 
-trait PpViewFields[Row] {
-  val id: Field[BusinessentityId, Row]
-  val businessentityid: Field[BusinessentityId, Row]
-  val phonenumber: Field[Phone, Row]
-  val phonenumbertypeid: Field[PhonenumbertypeId, Row]
-  val modifieddate: Field[TypoLocalDateTime, Row]
+trait PpViewFields {
+  def id: Field[BusinessentityId, PpViewRow]
+  def businessentityid: Field[BusinessentityId, PpViewRow]
+  def phonenumber: Field[Phone, PpViewRow]
+  def phonenumbertypeid: Field[PhonenumbertypeId, PpViewRow]
+  def modifieddate: Field[TypoLocalDateTime, PpViewRow]
 }
 
 object PpViewFields {
-  val structure: Relation[PpViewFields, PpViewRow, PpViewRow] = 
-    new Impl(None, identity, (_, x) => x)
+  lazy val structure: Relation[PpViewFields, PpViewRow] =
+    new Impl(Nil)
     
-  private final class Impl[Row](val prefix: Option[String], val extract: Row => PpViewRow, val merge: (Row, PpViewRow) => Row)
-    extends Relation[PpViewFields, PpViewRow, Row] { 
+  private final class Impl(val _path: List[Path])
+    extends Relation[PpViewFields, PpViewRow] {
   
-    override val fields: PpViewFields[Row] = new PpViewFields[Row] {
-      override val id = new Field[BusinessentityId, Row](prefix, "id", None, None)(x => extract(x).id, (row, value) => merge(row, extract(row).copy(id = value)))
-      override val businessentityid = new Field[BusinessentityId, Row](prefix, "businessentityid", None, None)(x => extract(x).businessentityid, (row, value) => merge(row, extract(row).copy(businessentityid = value)))
-      override val phonenumber = new Field[Phone, Row](prefix, "phonenumber", None, None)(x => extract(x).phonenumber, (row, value) => merge(row, extract(row).copy(phonenumber = value)))
-      override val phonenumbertypeid = new Field[PhonenumbertypeId, Row](prefix, "phonenumbertypeid", None, None)(x => extract(x).phonenumbertypeid, (row, value) => merge(row, extract(row).copy(phonenumbertypeid = value)))
-      override val modifieddate = new Field[TypoLocalDateTime, Row](prefix, "modifieddate", Some("text"), None)(x => extract(x).modifieddate, (row, value) => merge(row, extract(row).copy(modifieddate = value)))
+    override lazy val fields: PpViewFields = new PpViewFields {
+      override def id = Field[BusinessentityId, PpViewRow](_path, "id", None, None, x => x.id, (row, value) => row.copy(id = value))
+      override def businessentityid = Field[BusinessentityId, PpViewRow](_path, "businessentityid", None, None, x => x.businessentityid, (row, value) => row.copy(businessentityid = value))
+      override def phonenumber = Field[Phone, PpViewRow](_path, "phonenumber", None, None, x => x.phonenumber, (row, value) => row.copy(phonenumber = value))
+      override def phonenumbertypeid = Field[PhonenumbertypeId, PpViewRow](_path, "phonenumbertypeid", None, None, x => x.phonenumbertypeid, (row, value) => row.copy(phonenumbertypeid = value))
+      override def modifieddate = Field[TypoLocalDateTime, PpViewRow](_path, "modifieddate", Some("text"), None, x => x.modifieddate, (row, value) => row.copy(modifieddate = value))
     }
   
-    override val columns: List[FieldLikeNoHkt[?, Row]] =
-      List[FieldLikeNoHkt[?, Row]](fields.id, fields.businessentityid, fields.phonenumber, fields.phonenumbertypeid, fields.modifieddate)
+    override lazy val columns: List[FieldLikeNoHkt[?, PpViewRow]] =
+      List[FieldLikeNoHkt[?, PpViewRow]](fields.id, fields.businessentityid, fields.phonenumber, fields.phonenumbertypeid, fields.modifieddate)
   
-    override def copy[NewRow](prefix: Option[String], extract: NewRow => PpViewRow, merge: (NewRow, PpViewRow) => NewRow): Impl[NewRow] =
-      new Impl(prefix, extract, merge)
+    override def copy(path: List[Path]): Impl =
+      new Impl(path)
   }
   
 }

--- a/typo-tester-anorm/generated-and-checked-in/adventureworks/pe/sp/SpViewFields.scala
+++ b/typo-tester-anorm/generated-and-checked-in/adventureworks/pe/sp/SpViewFields.scala
@@ -14,46 +14,47 @@ import adventureworks.person.stateprovince.StateprovinceId
 import adventureworks.public.Flag
 import adventureworks.public.Name
 import adventureworks.sales.salesterritory.SalesterritoryId
+import typo.dsl.Path
 import typo.dsl.SqlExpr.Field
 import typo.dsl.SqlExpr.FieldLikeNoHkt
 import typo.dsl.Structure.Relation
 
-trait SpViewFields[Row] {
-  val id: Field[StateprovinceId, Row]
-  val stateprovinceid: Field[StateprovinceId, Row]
-  val stateprovincecode: Field[/* bpchar, max 3 chars */ String, Row]
-  val countryregioncode: Field[CountryregionId, Row]
-  val isonlystateprovinceflag: Field[Flag, Row]
-  val name: Field[Name, Row]
-  val territoryid: Field[SalesterritoryId, Row]
-  val rowguid: Field[TypoUUID, Row]
-  val modifieddate: Field[TypoLocalDateTime, Row]
+trait SpViewFields {
+  def id: Field[StateprovinceId, SpViewRow]
+  def stateprovinceid: Field[StateprovinceId, SpViewRow]
+  def stateprovincecode: Field[/* bpchar, max 3 chars */ String, SpViewRow]
+  def countryregioncode: Field[CountryregionId, SpViewRow]
+  def isonlystateprovinceflag: Field[Flag, SpViewRow]
+  def name: Field[Name, SpViewRow]
+  def territoryid: Field[SalesterritoryId, SpViewRow]
+  def rowguid: Field[TypoUUID, SpViewRow]
+  def modifieddate: Field[TypoLocalDateTime, SpViewRow]
 }
 
 object SpViewFields {
-  val structure: Relation[SpViewFields, SpViewRow, SpViewRow] = 
-    new Impl(None, identity, (_, x) => x)
+  lazy val structure: Relation[SpViewFields, SpViewRow] =
+    new Impl(Nil)
     
-  private final class Impl[Row](val prefix: Option[String], val extract: Row => SpViewRow, val merge: (Row, SpViewRow) => Row)
-    extends Relation[SpViewFields, SpViewRow, Row] { 
+  private final class Impl(val _path: List[Path])
+    extends Relation[SpViewFields, SpViewRow] {
   
-    override val fields: SpViewFields[Row] = new SpViewFields[Row] {
-      override val id = new Field[StateprovinceId, Row](prefix, "id", None, None)(x => extract(x).id, (row, value) => merge(row, extract(row).copy(id = value)))
-      override val stateprovinceid = new Field[StateprovinceId, Row](prefix, "stateprovinceid", None, None)(x => extract(x).stateprovinceid, (row, value) => merge(row, extract(row).copy(stateprovinceid = value)))
-      override val stateprovincecode = new Field[/* bpchar, max 3 chars */ String, Row](prefix, "stateprovincecode", None, None)(x => extract(x).stateprovincecode, (row, value) => merge(row, extract(row).copy(stateprovincecode = value)))
-      override val countryregioncode = new Field[CountryregionId, Row](prefix, "countryregioncode", None, None)(x => extract(x).countryregioncode, (row, value) => merge(row, extract(row).copy(countryregioncode = value)))
-      override val isonlystateprovinceflag = new Field[Flag, Row](prefix, "isonlystateprovinceflag", None, None)(x => extract(x).isonlystateprovinceflag, (row, value) => merge(row, extract(row).copy(isonlystateprovinceflag = value)))
-      override val name = new Field[Name, Row](prefix, "name", None, None)(x => extract(x).name, (row, value) => merge(row, extract(row).copy(name = value)))
-      override val territoryid = new Field[SalesterritoryId, Row](prefix, "territoryid", None, None)(x => extract(x).territoryid, (row, value) => merge(row, extract(row).copy(territoryid = value)))
-      override val rowguid = new Field[TypoUUID, Row](prefix, "rowguid", None, None)(x => extract(x).rowguid, (row, value) => merge(row, extract(row).copy(rowguid = value)))
-      override val modifieddate = new Field[TypoLocalDateTime, Row](prefix, "modifieddate", Some("text"), None)(x => extract(x).modifieddate, (row, value) => merge(row, extract(row).copy(modifieddate = value)))
+    override lazy val fields: SpViewFields = new SpViewFields {
+      override def id = Field[StateprovinceId, SpViewRow](_path, "id", None, None, x => x.id, (row, value) => row.copy(id = value))
+      override def stateprovinceid = Field[StateprovinceId, SpViewRow](_path, "stateprovinceid", None, None, x => x.stateprovinceid, (row, value) => row.copy(stateprovinceid = value))
+      override def stateprovincecode = Field[/* bpchar, max 3 chars */ String, SpViewRow](_path, "stateprovincecode", None, None, x => x.stateprovincecode, (row, value) => row.copy(stateprovincecode = value))
+      override def countryregioncode = Field[CountryregionId, SpViewRow](_path, "countryregioncode", None, None, x => x.countryregioncode, (row, value) => row.copy(countryregioncode = value))
+      override def isonlystateprovinceflag = Field[Flag, SpViewRow](_path, "isonlystateprovinceflag", None, None, x => x.isonlystateprovinceflag, (row, value) => row.copy(isonlystateprovinceflag = value))
+      override def name = Field[Name, SpViewRow](_path, "name", None, None, x => x.name, (row, value) => row.copy(name = value))
+      override def territoryid = Field[SalesterritoryId, SpViewRow](_path, "territoryid", None, None, x => x.territoryid, (row, value) => row.copy(territoryid = value))
+      override def rowguid = Field[TypoUUID, SpViewRow](_path, "rowguid", None, None, x => x.rowguid, (row, value) => row.copy(rowguid = value))
+      override def modifieddate = Field[TypoLocalDateTime, SpViewRow](_path, "modifieddate", Some("text"), None, x => x.modifieddate, (row, value) => row.copy(modifieddate = value))
     }
   
-    override val columns: List[FieldLikeNoHkt[?, Row]] =
-      List[FieldLikeNoHkt[?, Row]](fields.id, fields.stateprovinceid, fields.stateprovincecode, fields.countryregioncode, fields.isonlystateprovinceflag, fields.name, fields.territoryid, fields.rowguid, fields.modifieddate)
+    override lazy val columns: List[FieldLikeNoHkt[?, SpViewRow]] =
+      List[FieldLikeNoHkt[?, SpViewRow]](fields.id, fields.stateprovinceid, fields.stateprovincecode, fields.countryregioncode, fields.isonlystateprovinceflag, fields.name, fields.territoryid, fields.rowguid, fields.modifieddate)
   
-    override def copy[NewRow](prefix: Option[String], extract: NewRow => SpViewRow, merge: (NewRow, SpViewRow) => NewRow): Impl[NewRow] =
-      new Impl(prefix, extract, merge)
+    override def copy(path: List[Path]): Impl =
+      new Impl(path)
   }
   
 }

--- a/typo-tester-anorm/generated-and-checked-in/adventureworks/person/address/AddressFields.scala
+++ b/typo-tester-anorm/generated-and-checked-in/adventureworks/person/address/AddressFields.scala
@@ -11,48 +11,49 @@ import adventureworks.customtypes.TypoBytea
 import adventureworks.customtypes.TypoLocalDateTime
 import adventureworks.customtypes.TypoUUID
 import adventureworks.person.stateprovince.StateprovinceId
+import typo.dsl.Path
 import typo.dsl.SqlExpr.Field
 import typo.dsl.SqlExpr.FieldLikeNoHkt
 import typo.dsl.SqlExpr.IdField
 import typo.dsl.SqlExpr.OptField
 import typo.dsl.Structure.Relation
 
-trait AddressFields[Row] {
-  val addressid: IdField[AddressId, Row]
-  val addressline1: Field[/* max 60 chars */ String, Row]
-  val addressline2: OptField[/* max 60 chars */ String, Row]
-  val city: Field[/* max 30 chars */ String, Row]
-  val stateprovinceid: Field[StateprovinceId, Row]
-  val postalcode: Field[/* max 15 chars */ String, Row]
-  val spatiallocation: OptField[TypoBytea, Row]
-  val rowguid: Field[TypoUUID, Row]
-  val modifieddate: Field[TypoLocalDateTime, Row]
+trait AddressFields {
+  def addressid: IdField[AddressId, AddressRow]
+  def addressline1: Field[/* max 60 chars */ String, AddressRow]
+  def addressline2: OptField[/* max 60 chars */ String, AddressRow]
+  def city: Field[/* max 30 chars */ String, AddressRow]
+  def stateprovinceid: Field[StateprovinceId, AddressRow]
+  def postalcode: Field[/* max 15 chars */ String, AddressRow]
+  def spatiallocation: OptField[TypoBytea, AddressRow]
+  def rowguid: Field[TypoUUID, AddressRow]
+  def modifieddate: Field[TypoLocalDateTime, AddressRow]
 }
 
 object AddressFields {
-  val structure: Relation[AddressFields, AddressRow, AddressRow] = 
-    new Impl(None, identity, (_, x) => x)
+  lazy val structure: Relation[AddressFields, AddressRow] =
+    new Impl(Nil)
     
-  private final class Impl[Row](val prefix: Option[String], val extract: Row => AddressRow, val merge: (Row, AddressRow) => Row)
-    extends Relation[AddressFields, AddressRow, Row] { 
+  private final class Impl(val _path: List[Path])
+    extends Relation[AddressFields, AddressRow] {
   
-    override val fields: AddressFields[Row] = new AddressFields[Row] {
-      override val addressid = new IdField[AddressId, Row](prefix, "addressid", None, Some("int4"))(x => extract(x).addressid, (row, value) => merge(row, extract(row).copy(addressid = value)))
-      override val addressline1 = new Field[/* max 60 chars */ String, Row](prefix, "addressline1", None, None)(x => extract(x).addressline1, (row, value) => merge(row, extract(row).copy(addressline1 = value)))
-      override val addressline2 = new OptField[/* max 60 chars */ String, Row](prefix, "addressline2", None, None)(x => extract(x).addressline2, (row, value) => merge(row, extract(row).copy(addressline2 = value)))
-      override val city = new Field[/* max 30 chars */ String, Row](prefix, "city", None, None)(x => extract(x).city, (row, value) => merge(row, extract(row).copy(city = value)))
-      override val stateprovinceid = new Field[StateprovinceId, Row](prefix, "stateprovinceid", None, Some("int4"))(x => extract(x).stateprovinceid, (row, value) => merge(row, extract(row).copy(stateprovinceid = value)))
-      override val postalcode = new Field[/* max 15 chars */ String, Row](prefix, "postalcode", None, None)(x => extract(x).postalcode, (row, value) => merge(row, extract(row).copy(postalcode = value)))
-      override val spatiallocation = new OptField[TypoBytea, Row](prefix, "spatiallocation", None, Some("bytea"))(x => extract(x).spatiallocation, (row, value) => merge(row, extract(row).copy(spatiallocation = value)))
-      override val rowguid = new Field[TypoUUID, Row](prefix, "rowguid", None, Some("uuid"))(x => extract(x).rowguid, (row, value) => merge(row, extract(row).copy(rowguid = value)))
-      override val modifieddate = new Field[TypoLocalDateTime, Row](prefix, "modifieddate", Some("text"), Some("timestamp"))(x => extract(x).modifieddate, (row, value) => merge(row, extract(row).copy(modifieddate = value)))
+    override lazy val fields: AddressFields = new AddressFields {
+      override def addressid = IdField[AddressId, AddressRow](_path, "addressid", None, Some("int4"), x => x.addressid, (row, value) => row.copy(addressid = value))
+      override def addressline1 = Field[/* max 60 chars */ String, AddressRow](_path, "addressline1", None, None, x => x.addressline1, (row, value) => row.copy(addressline1 = value))
+      override def addressline2 = OptField[/* max 60 chars */ String, AddressRow](_path, "addressline2", None, None, x => x.addressline2, (row, value) => row.copy(addressline2 = value))
+      override def city = Field[/* max 30 chars */ String, AddressRow](_path, "city", None, None, x => x.city, (row, value) => row.copy(city = value))
+      override def stateprovinceid = Field[StateprovinceId, AddressRow](_path, "stateprovinceid", None, Some("int4"), x => x.stateprovinceid, (row, value) => row.copy(stateprovinceid = value))
+      override def postalcode = Field[/* max 15 chars */ String, AddressRow](_path, "postalcode", None, None, x => x.postalcode, (row, value) => row.copy(postalcode = value))
+      override def spatiallocation = OptField[TypoBytea, AddressRow](_path, "spatiallocation", None, Some("bytea"), x => x.spatiallocation, (row, value) => row.copy(spatiallocation = value))
+      override def rowguid = Field[TypoUUID, AddressRow](_path, "rowguid", None, Some("uuid"), x => x.rowguid, (row, value) => row.copy(rowguid = value))
+      override def modifieddate = Field[TypoLocalDateTime, AddressRow](_path, "modifieddate", Some("text"), Some("timestamp"), x => x.modifieddate, (row, value) => row.copy(modifieddate = value))
     }
   
-    override val columns: List[FieldLikeNoHkt[?, Row]] =
-      List[FieldLikeNoHkt[?, Row]](fields.addressid, fields.addressline1, fields.addressline2, fields.city, fields.stateprovinceid, fields.postalcode, fields.spatiallocation, fields.rowguid, fields.modifieddate)
+    override lazy val columns: List[FieldLikeNoHkt[?, AddressRow]] =
+      List[FieldLikeNoHkt[?, AddressRow]](fields.addressid, fields.addressline1, fields.addressline2, fields.city, fields.stateprovinceid, fields.postalcode, fields.spatiallocation, fields.rowguid, fields.modifieddate)
   
-    override def copy[NewRow](prefix: Option[String], extract: NewRow => AddressRow, merge: (NewRow, AddressRow) => NewRow): Impl[NewRow] =
-      new Impl(prefix, extract, merge)
+    override def copy(path: List[Path]): Impl =
+      new Impl(path)
   }
   
 }

--- a/typo-tester-anorm/generated-and-checked-in/adventureworks/person/address/AddressRepoMock.scala
+++ b/typo-tester-anorm/generated-and-checked-in/adventureworks/person/address/AddressRepoMock.scala
@@ -22,7 +22,7 @@ import typo.dsl.UpdateParams
 class AddressRepoMock(toRow: Function1[AddressRowUnsaved, AddressRow],
                       map: scala.collection.mutable.Map[AddressId, AddressRow] = scala.collection.mutable.Map.empty) extends AddressRepo {
   override def delete: DeleteBuilder[AddressFields, AddressRow] = {
-    DeleteBuilderMock(DeleteParams.empty, AddressFields.structure.fields, map)
+    DeleteBuilderMock(DeleteParams.empty, AddressFields.structure, map)
   }
   override def deleteById(addressid: AddressId)(implicit c: Connection): Boolean = {
     map.remove(addressid).isDefined
@@ -72,7 +72,7 @@ class AddressRepoMock(toRow: Function1[AddressRowUnsaved, AddressRow],
     addressids.view.flatMap(id => byId.get(id).map(x => (id, x))).toMap
   }
   override def update: UpdateBuilder[AddressFields, AddressRow] = {
-    UpdateBuilderMock(UpdateParams.empty, AddressFields.structure.fields, map)
+    UpdateBuilderMock(UpdateParams.empty, AddressFields.structure, map)
   }
   override def update(row: AddressRow)(implicit c: Connection): Boolean = {
     map.get(row.addressid) match {

--- a/typo-tester-anorm/generated-and-checked-in/adventureworks/person/addresstype/AddresstypeFields.scala
+++ b/typo-tester-anorm/generated-and-checked-in/adventureworks/person/addresstype/AddresstypeFields.scala
@@ -10,37 +10,38 @@ package addresstype
 import adventureworks.customtypes.TypoLocalDateTime
 import adventureworks.customtypes.TypoUUID
 import adventureworks.public.Name
+import typo.dsl.Path
 import typo.dsl.SqlExpr.Field
 import typo.dsl.SqlExpr.FieldLikeNoHkt
 import typo.dsl.SqlExpr.IdField
 import typo.dsl.Structure.Relation
 
-trait AddresstypeFields[Row] {
-  val addresstypeid: IdField[AddresstypeId, Row]
-  val name: Field[Name, Row]
-  val rowguid: Field[TypoUUID, Row]
-  val modifieddate: Field[TypoLocalDateTime, Row]
+trait AddresstypeFields {
+  def addresstypeid: IdField[AddresstypeId, AddresstypeRow]
+  def name: Field[Name, AddresstypeRow]
+  def rowguid: Field[TypoUUID, AddresstypeRow]
+  def modifieddate: Field[TypoLocalDateTime, AddresstypeRow]
 }
 
 object AddresstypeFields {
-  val structure: Relation[AddresstypeFields, AddresstypeRow, AddresstypeRow] = 
-    new Impl(None, identity, (_, x) => x)
+  lazy val structure: Relation[AddresstypeFields, AddresstypeRow] =
+    new Impl(Nil)
     
-  private final class Impl[Row](val prefix: Option[String], val extract: Row => AddresstypeRow, val merge: (Row, AddresstypeRow) => Row)
-    extends Relation[AddresstypeFields, AddresstypeRow, Row] { 
+  private final class Impl(val _path: List[Path])
+    extends Relation[AddresstypeFields, AddresstypeRow] {
   
-    override val fields: AddresstypeFields[Row] = new AddresstypeFields[Row] {
-      override val addresstypeid = new IdField[AddresstypeId, Row](prefix, "addresstypeid", None, Some("int4"))(x => extract(x).addresstypeid, (row, value) => merge(row, extract(row).copy(addresstypeid = value)))
-      override val name = new Field[Name, Row](prefix, "name", None, Some("varchar"))(x => extract(x).name, (row, value) => merge(row, extract(row).copy(name = value)))
-      override val rowguid = new Field[TypoUUID, Row](prefix, "rowguid", None, Some("uuid"))(x => extract(x).rowguid, (row, value) => merge(row, extract(row).copy(rowguid = value)))
-      override val modifieddate = new Field[TypoLocalDateTime, Row](prefix, "modifieddate", Some("text"), Some("timestamp"))(x => extract(x).modifieddate, (row, value) => merge(row, extract(row).copy(modifieddate = value)))
+    override lazy val fields: AddresstypeFields = new AddresstypeFields {
+      override def addresstypeid = IdField[AddresstypeId, AddresstypeRow](_path, "addresstypeid", None, Some("int4"), x => x.addresstypeid, (row, value) => row.copy(addresstypeid = value))
+      override def name = Field[Name, AddresstypeRow](_path, "name", None, Some("varchar"), x => x.name, (row, value) => row.copy(name = value))
+      override def rowguid = Field[TypoUUID, AddresstypeRow](_path, "rowguid", None, Some("uuid"), x => x.rowguid, (row, value) => row.copy(rowguid = value))
+      override def modifieddate = Field[TypoLocalDateTime, AddresstypeRow](_path, "modifieddate", Some("text"), Some("timestamp"), x => x.modifieddate, (row, value) => row.copy(modifieddate = value))
     }
   
-    override val columns: List[FieldLikeNoHkt[?, Row]] =
-      List[FieldLikeNoHkt[?, Row]](fields.addresstypeid, fields.name, fields.rowguid, fields.modifieddate)
+    override lazy val columns: List[FieldLikeNoHkt[?, AddresstypeRow]] =
+      List[FieldLikeNoHkt[?, AddresstypeRow]](fields.addresstypeid, fields.name, fields.rowguid, fields.modifieddate)
   
-    override def copy[NewRow](prefix: Option[String], extract: NewRow => AddresstypeRow, merge: (NewRow, AddresstypeRow) => NewRow): Impl[NewRow] =
-      new Impl(prefix, extract, merge)
+    override def copy(path: List[Path]): Impl =
+      new Impl(path)
   }
   
 }

--- a/typo-tester-anorm/generated-and-checked-in/adventureworks/person/addresstype/AddresstypeRepoMock.scala
+++ b/typo-tester-anorm/generated-and-checked-in/adventureworks/person/addresstype/AddresstypeRepoMock.scala
@@ -22,7 +22,7 @@ import typo.dsl.UpdateParams
 class AddresstypeRepoMock(toRow: Function1[AddresstypeRowUnsaved, AddresstypeRow],
                           map: scala.collection.mutable.Map[AddresstypeId, AddresstypeRow] = scala.collection.mutable.Map.empty) extends AddresstypeRepo {
   override def delete: DeleteBuilder[AddresstypeFields, AddresstypeRow] = {
-    DeleteBuilderMock(DeleteParams.empty, AddresstypeFields.structure.fields, map)
+    DeleteBuilderMock(DeleteParams.empty, AddresstypeFields.structure, map)
   }
   override def deleteById(addresstypeid: AddresstypeId)(implicit c: Connection): Boolean = {
     map.remove(addresstypeid).isDefined
@@ -72,7 +72,7 @@ class AddresstypeRepoMock(toRow: Function1[AddresstypeRowUnsaved, AddresstypeRow
     addresstypeids.view.flatMap(id => byId.get(id).map(x => (id, x))).toMap
   }
   override def update: UpdateBuilder[AddresstypeFields, AddresstypeRow] = {
-    UpdateBuilderMock(UpdateParams.empty, AddresstypeFields.structure.fields, map)
+    UpdateBuilderMock(UpdateParams.empty, AddresstypeFields.structure, map)
   }
   override def update(row: AddresstypeRow)(implicit c: Connection): Boolean = {
     map.get(row.addresstypeid) match {

--- a/typo-tester-anorm/generated-and-checked-in/adventureworks/person/businessentity/BusinessentityRepoMock.scala
+++ b/typo-tester-anorm/generated-and-checked-in/adventureworks/person/businessentity/BusinessentityRepoMock.scala
@@ -22,7 +22,7 @@ import typo.dsl.UpdateParams
 class BusinessentityRepoMock(toRow: Function1[BusinessentityRowUnsaved, BusinessentityRow],
                              map: scala.collection.mutable.Map[BusinessentityId, BusinessentityRow] = scala.collection.mutable.Map.empty) extends BusinessentityRepo {
   override def delete: DeleteBuilder[BusinessentityFields, BusinessentityRow] = {
-    DeleteBuilderMock(DeleteParams.empty, BusinessentityFields.structure.fields, map)
+    DeleteBuilderMock(DeleteParams.empty, BusinessentityFields.structure, map)
   }
   override def deleteById(businessentityid: BusinessentityId)(implicit c: Connection): Boolean = {
     map.remove(businessentityid).isDefined
@@ -72,7 +72,7 @@ class BusinessentityRepoMock(toRow: Function1[BusinessentityRowUnsaved, Business
     businessentityids.view.flatMap(id => byId.get(id).map(x => (id, x))).toMap
   }
   override def update: UpdateBuilder[BusinessentityFields, BusinessentityRow] = {
-    UpdateBuilderMock(UpdateParams.empty, BusinessentityFields.structure.fields, map)
+    UpdateBuilderMock(UpdateParams.empty, BusinessentityFields.structure, map)
   }
   override def update(row: BusinessentityRow)(implicit c: Connection): Boolean = {
     map.get(row.businessentityid) match {

--- a/typo-tester-anorm/generated-and-checked-in/adventureworks/person/businessentityaddress/BusinessentityaddressFields.scala
+++ b/typo-tester-anorm/generated-and-checked-in/adventureworks/person/businessentityaddress/BusinessentityaddressFields.scala
@@ -12,39 +12,40 @@ import adventureworks.customtypes.TypoUUID
 import adventureworks.person.address.AddressId
 import adventureworks.person.addresstype.AddresstypeId
 import adventureworks.person.businessentity.BusinessentityId
+import typo.dsl.Path
 import typo.dsl.SqlExpr.Field
 import typo.dsl.SqlExpr.FieldLikeNoHkt
 import typo.dsl.SqlExpr.IdField
 import typo.dsl.Structure.Relation
 
-trait BusinessentityaddressFields[Row] {
-  val businessentityid: IdField[BusinessentityId, Row]
-  val addressid: IdField[AddressId, Row]
-  val addresstypeid: IdField[AddresstypeId, Row]
-  val rowguid: Field[TypoUUID, Row]
-  val modifieddate: Field[TypoLocalDateTime, Row]
+trait BusinessentityaddressFields {
+  def businessentityid: IdField[BusinessentityId, BusinessentityaddressRow]
+  def addressid: IdField[AddressId, BusinessentityaddressRow]
+  def addresstypeid: IdField[AddresstypeId, BusinessentityaddressRow]
+  def rowguid: Field[TypoUUID, BusinessentityaddressRow]
+  def modifieddate: Field[TypoLocalDateTime, BusinessentityaddressRow]
 }
 
 object BusinessentityaddressFields {
-  val structure: Relation[BusinessentityaddressFields, BusinessentityaddressRow, BusinessentityaddressRow] = 
-    new Impl(None, identity, (_, x) => x)
+  lazy val structure: Relation[BusinessentityaddressFields, BusinessentityaddressRow] =
+    new Impl(Nil)
     
-  private final class Impl[Row](val prefix: Option[String], val extract: Row => BusinessentityaddressRow, val merge: (Row, BusinessentityaddressRow) => Row)
-    extends Relation[BusinessentityaddressFields, BusinessentityaddressRow, Row] { 
+  private final class Impl(val _path: List[Path])
+    extends Relation[BusinessentityaddressFields, BusinessentityaddressRow] {
   
-    override val fields: BusinessentityaddressFields[Row] = new BusinessentityaddressFields[Row] {
-      override val businessentityid = new IdField[BusinessentityId, Row](prefix, "businessentityid", None, Some("int4"))(x => extract(x).businessentityid, (row, value) => merge(row, extract(row).copy(businessentityid = value)))
-      override val addressid = new IdField[AddressId, Row](prefix, "addressid", None, Some("int4"))(x => extract(x).addressid, (row, value) => merge(row, extract(row).copy(addressid = value)))
-      override val addresstypeid = new IdField[AddresstypeId, Row](prefix, "addresstypeid", None, Some("int4"))(x => extract(x).addresstypeid, (row, value) => merge(row, extract(row).copy(addresstypeid = value)))
-      override val rowguid = new Field[TypoUUID, Row](prefix, "rowguid", None, Some("uuid"))(x => extract(x).rowguid, (row, value) => merge(row, extract(row).copy(rowguid = value)))
-      override val modifieddate = new Field[TypoLocalDateTime, Row](prefix, "modifieddate", Some("text"), Some("timestamp"))(x => extract(x).modifieddate, (row, value) => merge(row, extract(row).copy(modifieddate = value)))
+    override lazy val fields: BusinessentityaddressFields = new BusinessentityaddressFields {
+      override def businessentityid = IdField[BusinessentityId, BusinessentityaddressRow](_path, "businessentityid", None, Some("int4"), x => x.businessentityid, (row, value) => row.copy(businessentityid = value))
+      override def addressid = IdField[AddressId, BusinessentityaddressRow](_path, "addressid", None, Some("int4"), x => x.addressid, (row, value) => row.copy(addressid = value))
+      override def addresstypeid = IdField[AddresstypeId, BusinessentityaddressRow](_path, "addresstypeid", None, Some("int4"), x => x.addresstypeid, (row, value) => row.copy(addresstypeid = value))
+      override def rowguid = Field[TypoUUID, BusinessentityaddressRow](_path, "rowguid", None, Some("uuid"), x => x.rowguid, (row, value) => row.copy(rowguid = value))
+      override def modifieddate = Field[TypoLocalDateTime, BusinessentityaddressRow](_path, "modifieddate", Some("text"), Some("timestamp"), x => x.modifieddate, (row, value) => row.copy(modifieddate = value))
     }
   
-    override val columns: List[FieldLikeNoHkt[?, Row]] =
-      List[FieldLikeNoHkt[?, Row]](fields.businessentityid, fields.addressid, fields.addresstypeid, fields.rowguid, fields.modifieddate)
+    override lazy val columns: List[FieldLikeNoHkt[?, BusinessentityaddressRow]] =
+      List[FieldLikeNoHkt[?, BusinessentityaddressRow]](fields.businessentityid, fields.addressid, fields.addresstypeid, fields.rowguid, fields.modifieddate)
   
-    override def copy[NewRow](prefix: Option[String], extract: NewRow => BusinessentityaddressRow, merge: (NewRow, BusinessentityaddressRow) => NewRow): Impl[NewRow] =
-      new Impl(prefix, extract, merge)
+    override def copy(path: List[Path]): Impl =
+      new Impl(path)
   }
   
 }

--- a/typo-tester-anorm/generated-and-checked-in/adventureworks/person/businessentityaddress/BusinessentityaddressRepoMock.scala
+++ b/typo-tester-anorm/generated-and-checked-in/adventureworks/person/businessentityaddress/BusinessentityaddressRepoMock.scala
@@ -22,7 +22,7 @@ import typo.dsl.UpdateParams
 class BusinessentityaddressRepoMock(toRow: Function1[BusinessentityaddressRowUnsaved, BusinessentityaddressRow],
                                     map: scala.collection.mutable.Map[BusinessentityaddressId, BusinessentityaddressRow] = scala.collection.mutable.Map.empty) extends BusinessentityaddressRepo {
   override def delete: DeleteBuilder[BusinessentityaddressFields, BusinessentityaddressRow] = {
-    DeleteBuilderMock(DeleteParams.empty, BusinessentityaddressFields.structure.fields, map)
+    DeleteBuilderMock(DeleteParams.empty, BusinessentityaddressFields.structure, map)
   }
   override def deleteById(compositeId: BusinessentityaddressId)(implicit c: Connection): Boolean = {
     map.remove(compositeId).isDefined
@@ -72,7 +72,7 @@ class BusinessentityaddressRepoMock(toRow: Function1[BusinessentityaddressRowUns
     compositeIds.view.flatMap(id => byId.get(id).map(x => (id, x))).toMap
   }
   override def update: UpdateBuilder[BusinessentityaddressFields, BusinessentityaddressRow] = {
-    UpdateBuilderMock(UpdateParams.empty, BusinessentityaddressFields.structure.fields, map)
+    UpdateBuilderMock(UpdateParams.empty, BusinessentityaddressFields.structure, map)
   }
   override def update(row: BusinessentityaddressRow)(implicit c: Connection): Boolean = {
     map.get(row.compositeId) match {

--- a/typo-tester-anorm/generated-and-checked-in/adventureworks/person/businessentitycontact/BusinessentitycontactFields.scala
+++ b/typo-tester-anorm/generated-and-checked-in/adventureworks/person/businessentitycontact/BusinessentitycontactFields.scala
@@ -11,39 +11,40 @@ import adventureworks.customtypes.TypoLocalDateTime
 import adventureworks.customtypes.TypoUUID
 import adventureworks.person.businessentity.BusinessentityId
 import adventureworks.person.contacttype.ContacttypeId
+import typo.dsl.Path
 import typo.dsl.SqlExpr.Field
 import typo.dsl.SqlExpr.FieldLikeNoHkt
 import typo.dsl.SqlExpr.IdField
 import typo.dsl.Structure.Relation
 
-trait BusinessentitycontactFields[Row] {
-  val businessentityid: IdField[BusinessentityId, Row]
-  val personid: IdField[BusinessentityId, Row]
-  val contacttypeid: IdField[ContacttypeId, Row]
-  val rowguid: Field[TypoUUID, Row]
-  val modifieddate: Field[TypoLocalDateTime, Row]
+trait BusinessentitycontactFields {
+  def businessentityid: IdField[BusinessentityId, BusinessentitycontactRow]
+  def personid: IdField[BusinessentityId, BusinessentitycontactRow]
+  def contacttypeid: IdField[ContacttypeId, BusinessentitycontactRow]
+  def rowguid: Field[TypoUUID, BusinessentitycontactRow]
+  def modifieddate: Field[TypoLocalDateTime, BusinessentitycontactRow]
 }
 
 object BusinessentitycontactFields {
-  val structure: Relation[BusinessentitycontactFields, BusinessentitycontactRow, BusinessentitycontactRow] = 
-    new Impl(None, identity, (_, x) => x)
+  lazy val structure: Relation[BusinessentitycontactFields, BusinessentitycontactRow] =
+    new Impl(Nil)
     
-  private final class Impl[Row](val prefix: Option[String], val extract: Row => BusinessentitycontactRow, val merge: (Row, BusinessentitycontactRow) => Row)
-    extends Relation[BusinessentitycontactFields, BusinessentitycontactRow, Row] { 
+  private final class Impl(val _path: List[Path])
+    extends Relation[BusinessentitycontactFields, BusinessentitycontactRow] {
   
-    override val fields: BusinessentitycontactFields[Row] = new BusinessentitycontactFields[Row] {
-      override val businessentityid = new IdField[BusinessentityId, Row](prefix, "businessentityid", None, Some("int4"))(x => extract(x).businessentityid, (row, value) => merge(row, extract(row).copy(businessentityid = value)))
-      override val personid = new IdField[BusinessentityId, Row](prefix, "personid", None, Some("int4"))(x => extract(x).personid, (row, value) => merge(row, extract(row).copy(personid = value)))
-      override val contacttypeid = new IdField[ContacttypeId, Row](prefix, "contacttypeid", None, Some("int4"))(x => extract(x).contacttypeid, (row, value) => merge(row, extract(row).copy(contacttypeid = value)))
-      override val rowguid = new Field[TypoUUID, Row](prefix, "rowguid", None, Some("uuid"))(x => extract(x).rowguid, (row, value) => merge(row, extract(row).copy(rowguid = value)))
-      override val modifieddate = new Field[TypoLocalDateTime, Row](prefix, "modifieddate", Some("text"), Some("timestamp"))(x => extract(x).modifieddate, (row, value) => merge(row, extract(row).copy(modifieddate = value)))
+    override lazy val fields: BusinessentitycontactFields = new BusinessentitycontactFields {
+      override def businessentityid = IdField[BusinessentityId, BusinessentitycontactRow](_path, "businessentityid", None, Some("int4"), x => x.businessentityid, (row, value) => row.copy(businessentityid = value))
+      override def personid = IdField[BusinessentityId, BusinessentitycontactRow](_path, "personid", None, Some("int4"), x => x.personid, (row, value) => row.copy(personid = value))
+      override def contacttypeid = IdField[ContacttypeId, BusinessentitycontactRow](_path, "contacttypeid", None, Some("int4"), x => x.contacttypeid, (row, value) => row.copy(contacttypeid = value))
+      override def rowguid = Field[TypoUUID, BusinessentitycontactRow](_path, "rowguid", None, Some("uuid"), x => x.rowguid, (row, value) => row.copy(rowguid = value))
+      override def modifieddate = Field[TypoLocalDateTime, BusinessentitycontactRow](_path, "modifieddate", Some("text"), Some("timestamp"), x => x.modifieddate, (row, value) => row.copy(modifieddate = value))
     }
   
-    override val columns: List[FieldLikeNoHkt[?, Row]] =
-      List[FieldLikeNoHkt[?, Row]](fields.businessentityid, fields.personid, fields.contacttypeid, fields.rowguid, fields.modifieddate)
+    override lazy val columns: List[FieldLikeNoHkt[?, BusinessentitycontactRow]] =
+      List[FieldLikeNoHkt[?, BusinessentitycontactRow]](fields.businessentityid, fields.personid, fields.contacttypeid, fields.rowguid, fields.modifieddate)
   
-    override def copy[NewRow](prefix: Option[String], extract: NewRow => BusinessentitycontactRow, merge: (NewRow, BusinessentitycontactRow) => NewRow): Impl[NewRow] =
-      new Impl(prefix, extract, merge)
+    override def copy(path: List[Path]): Impl =
+      new Impl(path)
   }
   
 }

--- a/typo-tester-anorm/generated-and-checked-in/adventureworks/person/businessentitycontact/BusinessentitycontactRepoMock.scala
+++ b/typo-tester-anorm/generated-and-checked-in/adventureworks/person/businessentitycontact/BusinessentitycontactRepoMock.scala
@@ -22,7 +22,7 @@ import typo.dsl.UpdateParams
 class BusinessentitycontactRepoMock(toRow: Function1[BusinessentitycontactRowUnsaved, BusinessentitycontactRow],
                                     map: scala.collection.mutable.Map[BusinessentitycontactId, BusinessentitycontactRow] = scala.collection.mutable.Map.empty) extends BusinessentitycontactRepo {
   override def delete: DeleteBuilder[BusinessentitycontactFields, BusinessentitycontactRow] = {
-    DeleteBuilderMock(DeleteParams.empty, BusinessentitycontactFields.structure.fields, map)
+    DeleteBuilderMock(DeleteParams.empty, BusinessentitycontactFields.structure, map)
   }
   override def deleteById(compositeId: BusinessentitycontactId)(implicit c: Connection): Boolean = {
     map.remove(compositeId).isDefined
@@ -72,7 +72,7 @@ class BusinessentitycontactRepoMock(toRow: Function1[BusinessentitycontactRowUns
     compositeIds.view.flatMap(id => byId.get(id).map(x => (id, x))).toMap
   }
   override def update: UpdateBuilder[BusinessentitycontactFields, BusinessentitycontactRow] = {
-    UpdateBuilderMock(UpdateParams.empty, BusinessentitycontactFields.structure.fields, map)
+    UpdateBuilderMock(UpdateParams.empty, BusinessentitycontactFields.structure, map)
   }
   override def update(row: BusinessentitycontactRow)(implicit c: Connection): Boolean = {
     map.get(row.compositeId) match {

--- a/typo-tester-anorm/generated-and-checked-in/adventureworks/person/contacttype/ContacttypeFields.scala
+++ b/typo-tester-anorm/generated-and-checked-in/adventureworks/person/contacttype/ContacttypeFields.scala
@@ -9,35 +9,36 @@ package contacttype
 
 import adventureworks.customtypes.TypoLocalDateTime
 import adventureworks.public.Name
+import typo.dsl.Path
 import typo.dsl.SqlExpr.Field
 import typo.dsl.SqlExpr.FieldLikeNoHkt
 import typo.dsl.SqlExpr.IdField
 import typo.dsl.Structure.Relation
 
-trait ContacttypeFields[Row] {
-  val contacttypeid: IdField[ContacttypeId, Row]
-  val name: Field[Name, Row]
-  val modifieddate: Field[TypoLocalDateTime, Row]
+trait ContacttypeFields {
+  def contacttypeid: IdField[ContacttypeId, ContacttypeRow]
+  def name: Field[Name, ContacttypeRow]
+  def modifieddate: Field[TypoLocalDateTime, ContacttypeRow]
 }
 
 object ContacttypeFields {
-  val structure: Relation[ContacttypeFields, ContacttypeRow, ContacttypeRow] = 
-    new Impl(None, identity, (_, x) => x)
+  lazy val structure: Relation[ContacttypeFields, ContacttypeRow] =
+    new Impl(Nil)
     
-  private final class Impl[Row](val prefix: Option[String], val extract: Row => ContacttypeRow, val merge: (Row, ContacttypeRow) => Row)
-    extends Relation[ContacttypeFields, ContacttypeRow, Row] { 
+  private final class Impl(val _path: List[Path])
+    extends Relation[ContacttypeFields, ContacttypeRow] {
   
-    override val fields: ContacttypeFields[Row] = new ContacttypeFields[Row] {
-      override val contacttypeid = new IdField[ContacttypeId, Row](prefix, "contacttypeid", None, Some("int4"))(x => extract(x).contacttypeid, (row, value) => merge(row, extract(row).copy(contacttypeid = value)))
-      override val name = new Field[Name, Row](prefix, "name", None, Some("varchar"))(x => extract(x).name, (row, value) => merge(row, extract(row).copy(name = value)))
-      override val modifieddate = new Field[TypoLocalDateTime, Row](prefix, "modifieddate", Some("text"), Some("timestamp"))(x => extract(x).modifieddate, (row, value) => merge(row, extract(row).copy(modifieddate = value)))
+    override lazy val fields: ContacttypeFields = new ContacttypeFields {
+      override def contacttypeid = IdField[ContacttypeId, ContacttypeRow](_path, "contacttypeid", None, Some("int4"), x => x.contacttypeid, (row, value) => row.copy(contacttypeid = value))
+      override def name = Field[Name, ContacttypeRow](_path, "name", None, Some("varchar"), x => x.name, (row, value) => row.copy(name = value))
+      override def modifieddate = Field[TypoLocalDateTime, ContacttypeRow](_path, "modifieddate", Some("text"), Some("timestamp"), x => x.modifieddate, (row, value) => row.copy(modifieddate = value))
     }
   
-    override val columns: List[FieldLikeNoHkt[?, Row]] =
-      List[FieldLikeNoHkt[?, Row]](fields.contacttypeid, fields.name, fields.modifieddate)
+    override lazy val columns: List[FieldLikeNoHkt[?, ContacttypeRow]] =
+      List[FieldLikeNoHkt[?, ContacttypeRow]](fields.contacttypeid, fields.name, fields.modifieddate)
   
-    override def copy[NewRow](prefix: Option[String], extract: NewRow => ContacttypeRow, merge: (NewRow, ContacttypeRow) => NewRow): Impl[NewRow] =
-      new Impl(prefix, extract, merge)
+    override def copy(path: List[Path]): Impl =
+      new Impl(path)
   }
   
 }

--- a/typo-tester-anorm/generated-and-checked-in/adventureworks/person/contacttype/ContacttypeRepoMock.scala
+++ b/typo-tester-anorm/generated-and-checked-in/adventureworks/person/contacttype/ContacttypeRepoMock.scala
@@ -22,7 +22,7 @@ import typo.dsl.UpdateParams
 class ContacttypeRepoMock(toRow: Function1[ContacttypeRowUnsaved, ContacttypeRow],
                           map: scala.collection.mutable.Map[ContacttypeId, ContacttypeRow] = scala.collection.mutable.Map.empty) extends ContacttypeRepo {
   override def delete: DeleteBuilder[ContacttypeFields, ContacttypeRow] = {
-    DeleteBuilderMock(DeleteParams.empty, ContacttypeFields.structure.fields, map)
+    DeleteBuilderMock(DeleteParams.empty, ContacttypeFields.structure, map)
   }
   override def deleteById(contacttypeid: ContacttypeId)(implicit c: Connection): Boolean = {
     map.remove(contacttypeid).isDefined
@@ -72,7 +72,7 @@ class ContacttypeRepoMock(toRow: Function1[ContacttypeRowUnsaved, ContacttypeRow
     contacttypeids.view.flatMap(id => byId.get(id).map(x => (id, x))).toMap
   }
   override def update: UpdateBuilder[ContacttypeFields, ContacttypeRow] = {
-    UpdateBuilderMock(UpdateParams.empty, ContacttypeFields.structure.fields, map)
+    UpdateBuilderMock(UpdateParams.empty, ContacttypeFields.structure, map)
   }
   override def update(row: ContacttypeRow)(implicit c: Connection): Boolean = {
     map.get(row.contacttypeid) match {

--- a/typo-tester-anorm/generated-and-checked-in/adventureworks/person/countryregion/CountryregionFields.scala
+++ b/typo-tester-anorm/generated-and-checked-in/adventureworks/person/countryregion/CountryregionFields.scala
@@ -9,35 +9,36 @@ package countryregion
 
 import adventureworks.customtypes.TypoLocalDateTime
 import adventureworks.public.Name
+import typo.dsl.Path
 import typo.dsl.SqlExpr.Field
 import typo.dsl.SqlExpr.FieldLikeNoHkt
 import typo.dsl.SqlExpr.IdField
 import typo.dsl.Structure.Relation
 
-trait CountryregionFields[Row] {
-  val countryregioncode: IdField[CountryregionId, Row]
-  val name: Field[Name, Row]
-  val modifieddate: Field[TypoLocalDateTime, Row]
+trait CountryregionFields {
+  def countryregioncode: IdField[CountryregionId, CountryregionRow]
+  def name: Field[Name, CountryregionRow]
+  def modifieddate: Field[TypoLocalDateTime, CountryregionRow]
 }
 
 object CountryregionFields {
-  val structure: Relation[CountryregionFields, CountryregionRow, CountryregionRow] = 
-    new Impl(None, identity, (_, x) => x)
+  lazy val structure: Relation[CountryregionFields, CountryregionRow] =
+    new Impl(Nil)
     
-  private final class Impl[Row](val prefix: Option[String], val extract: Row => CountryregionRow, val merge: (Row, CountryregionRow) => Row)
-    extends Relation[CountryregionFields, CountryregionRow, Row] { 
+  private final class Impl(val _path: List[Path])
+    extends Relation[CountryregionFields, CountryregionRow] {
   
-    override val fields: CountryregionFields[Row] = new CountryregionFields[Row] {
-      override val countryregioncode = new IdField[CountryregionId, Row](prefix, "countryregioncode", None, None)(x => extract(x).countryregioncode, (row, value) => merge(row, extract(row).copy(countryregioncode = value)))
-      override val name = new Field[Name, Row](prefix, "name", None, Some("varchar"))(x => extract(x).name, (row, value) => merge(row, extract(row).copy(name = value)))
-      override val modifieddate = new Field[TypoLocalDateTime, Row](prefix, "modifieddate", Some("text"), Some("timestamp"))(x => extract(x).modifieddate, (row, value) => merge(row, extract(row).copy(modifieddate = value)))
+    override lazy val fields: CountryregionFields = new CountryregionFields {
+      override def countryregioncode = IdField[CountryregionId, CountryregionRow](_path, "countryregioncode", None, None, x => x.countryregioncode, (row, value) => row.copy(countryregioncode = value))
+      override def name = Field[Name, CountryregionRow](_path, "name", None, Some("varchar"), x => x.name, (row, value) => row.copy(name = value))
+      override def modifieddate = Field[TypoLocalDateTime, CountryregionRow](_path, "modifieddate", Some("text"), Some("timestamp"), x => x.modifieddate, (row, value) => row.copy(modifieddate = value))
     }
   
-    override val columns: List[FieldLikeNoHkt[?, Row]] =
-      List[FieldLikeNoHkt[?, Row]](fields.countryregioncode, fields.name, fields.modifieddate)
+    override lazy val columns: List[FieldLikeNoHkt[?, CountryregionRow]] =
+      List[FieldLikeNoHkt[?, CountryregionRow]](fields.countryregioncode, fields.name, fields.modifieddate)
   
-    override def copy[NewRow](prefix: Option[String], extract: NewRow => CountryregionRow, merge: (NewRow, CountryregionRow) => NewRow): Impl[NewRow] =
-      new Impl(prefix, extract, merge)
+    override def copy(path: List[Path]): Impl =
+      new Impl(path)
   }
   
 }

--- a/typo-tester-anorm/generated-and-checked-in/adventureworks/person/countryregion/CountryregionRepoMock.scala
+++ b/typo-tester-anorm/generated-and-checked-in/adventureworks/person/countryregion/CountryregionRepoMock.scala
@@ -22,7 +22,7 @@ import typo.dsl.UpdateParams
 class CountryregionRepoMock(toRow: Function1[CountryregionRowUnsaved, CountryregionRow],
                             map: scala.collection.mutable.Map[CountryregionId, CountryregionRow] = scala.collection.mutable.Map.empty) extends CountryregionRepo {
   override def delete: DeleteBuilder[CountryregionFields, CountryregionRow] = {
-    DeleteBuilderMock(DeleteParams.empty, CountryregionFields.structure.fields, map)
+    DeleteBuilderMock(DeleteParams.empty, CountryregionFields.structure, map)
   }
   override def deleteById(countryregioncode: CountryregionId)(implicit c: Connection): Boolean = {
     map.remove(countryregioncode).isDefined
@@ -72,7 +72,7 @@ class CountryregionRepoMock(toRow: Function1[CountryregionRowUnsaved, Countryreg
     countryregioncodes.view.flatMap(id => byId.get(id).map(x => (id, x))).toMap
   }
   override def update: UpdateBuilder[CountryregionFields, CountryregionRow] = {
-    UpdateBuilderMock(UpdateParams.empty, CountryregionFields.structure.fields, map)
+    UpdateBuilderMock(UpdateParams.empty, CountryregionFields.structure, map)
   }
   override def update(row: CountryregionRow)(implicit c: Connection): Boolean = {
     map.get(row.countryregioncode) match {

--- a/typo-tester-anorm/generated-and-checked-in/adventureworks/person/emailaddress/EmailaddressFields.scala
+++ b/typo-tester-anorm/generated-and-checked-in/adventureworks/person/emailaddress/EmailaddressFields.scala
@@ -10,40 +10,41 @@ package emailaddress
 import adventureworks.customtypes.TypoLocalDateTime
 import adventureworks.customtypes.TypoUUID
 import adventureworks.person.businessentity.BusinessentityId
+import typo.dsl.Path
 import typo.dsl.SqlExpr.Field
 import typo.dsl.SqlExpr.FieldLikeNoHkt
 import typo.dsl.SqlExpr.IdField
 import typo.dsl.SqlExpr.OptField
 import typo.dsl.Structure.Relation
 
-trait EmailaddressFields[Row] {
-  val businessentityid: IdField[BusinessentityId, Row]
-  val emailaddressid: IdField[Int, Row]
-  val emailaddress: OptField[/* max 50 chars */ String, Row]
-  val rowguid: Field[TypoUUID, Row]
-  val modifieddate: Field[TypoLocalDateTime, Row]
+trait EmailaddressFields {
+  def businessentityid: IdField[BusinessentityId, EmailaddressRow]
+  def emailaddressid: IdField[Int, EmailaddressRow]
+  def emailaddress: OptField[/* max 50 chars */ String, EmailaddressRow]
+  def rowguid: Field[TypoUUID, EmailaddressRow]
+  def modifieddate: Field[TypoLocalDateTime, EmailaddressRow]
 }
 
 object EmailaddressFields {
-  val structure: Relation[EmailaddressFields, EmailaddressRow, EmailaddressRow] = 
-    new Impl(None, identity, (_, x) => x)
+  lazy val structure: Relation[EmailaddressFields, EmailaddressRow] =
+    new Impl(Nil)
     
-  private final class Impl[Row](val prefix: Option[String], val extract: Row => EmailaddressRow, val merge: (Row, EmailaddressRow) => Row)
-    extends Relation[EmailaddressFields, EmailaddressRow, Row] { 
+  private final class Impl(val _path: List[Path])
+    extends Relation[EmailaddressFields, EmailaddressRow] {
   
-    override val fields: EmailaddressFields[Row] = new EmailaddressFields[Row] {
-      override val businessentityid = new IdField[BusinessentityId, Row](prefix, "businessentityid", None, Some("int4"))(x => extract(x).businessentityid, (row, value) => merge(row, extract(row).copy(businessentityid = value)))
-      override val emailaddressid = new IdField[Int, Row](prefix, "emailaddressid", None, Some("int4"))(x => extract(x).emailaddressid, (row, value) => merge(row, extract(row).copy(emailaddressid = value)))
-      override val emailaddress = new OptField[/* max 50 chars */ String, Row](prefix, "emailaddress", None, None)(x => extract(x).emailaddress, (row, value) => merge(row, extract(row).copy(emailaddress = value)))
-      override val rowguid = new Field[TypoUUID, Row](prefix, "rowguid", None, Some("uuid"))(x => extract(x).rowguid, (row, value) => merge(row, extract(row).copy(rowguid = value)))
-      override val modifieddate = new Field[TypoLocalDateTime, Row](prefix, "modifieddate", Some("text"), Some("timestamp"))(x => extract(x).modifieddate, (row, value) => merge(row, extract(row).copy(modifieddate = value)))
+    override lazy val fields: EmailaddressFields = new EmailaddressFields {
+      override def businessentityid = IdField[BusinessentityId, EmailaddressRow](_path, "businessentityid", None, Some("int4"), x => x.businessentityid, (row, value) => row.copy(businessentityid = value))
+      override def emailaddressid = IdField[Int, EmailaddressRow](_path, "emailaddressid", None, Some("int4"), x => x.emailaddressid, (row, value) => row.copy(emailaddressid = value))
+      override def emailaddress = OptField[/* max 50 chars */ String, EmailaddressRow](_path, "emailaddress", None, None, x => x.emailaddress, (row, value) => row.copy(emailaddress = value))
+      override def rowguid = Field[TypoUUID, EmailaddressRow](_path, "rowguid", None, Some("uuid"), x => x.rowguid, (row, value) => row.copy(rowguid = value))
+      override def modifieddate = Field[TypoLocalDateTime, EmailaddressRow](_path, "modifieddate", Some("text"), Some("timestamp"), x => x.modifieddate, (row, value) => row.copy(modifieddate = value))
     }
   
-    override val columns: List[FieldLikeNoHkt[?, Row]] =
-      List[FieldLikeNoHkt[?, Row]](fields.businessentityid, fields.emailaddressid, fields.emailaddress, fields.rowguid, fields.modifieddate)
+    override lazy val columns: List[FieldLikeNoHkt[?, EmailaddressRow]] =
+      List[FieldLikeNoHkt[?, EmailaddressRow]](fields.businessentityid, fields.emailaddressid, fields.emailaddress, fields.rowguid, fields.modifieddate)
   
-    override def copy[NewRow](prefix: Option[String], extract: NewRow => EmailaddressRow, merge: (NewRow, EmailaddressRow) => NewRow): Impl[NewRow] =
-      new Impl(prefix, extract, merge)
+    override def copy(path: List[Path]): Impl =
+      new Impl(path)
   }
   
 }

--- a/typo-tester-anorm/generated-and-checked-in/adventureworks/person/emailaddress/EmailaddressRepoMock.scala
+++ b/typo-tester-anorm/generated-and-checked-in/adventureworks/person/emailaddress/EmailaddressRepoMock.scala
@@ -22,7 +22,7 @@ import typo.dsl.UpdateParams
 class EmailaddressRepoMock(toRow: Function1[EmailaddressRowUnsaved, EmailaddressRow],
                            map: scala.collection.mutable.Map[EmailaddressId, EmailaddressRow] = scala.collection.mutable.Map.empty) extends EmailaddressRepo {
   override def delete: DeleteBuilder[EmailaddressFields, EmailaddressRow] = {
-    DeleteBuilderMock(DeleteParams.empty, EmailaddressFields.structure.fields, map)
+    DeleteBuilderMock(DeleteParams.empty, EmailaddressFields.structure, map)
   }
   override def deleteById(compositeId: EmailaddressId)(implicit c: Connection): Boolean = {
     map.remove(compositeId).isDefined
@@ -72,7 +72,7 @@ class EmailaddressRepoMock(toRow: Function1[EmailaddressRowUnsaved, Emailaddress
     compositeIds.view.flatMap(id => byId.get(id).map(x => (id, x))).toMap
   }
   override def update: UpdateBuilder[EmailaddressFields, EmailaddressRow] = {
-    UpdateBuilderMock(UpdateParams.empty, EmailaddressFields.structure.fields, map)
+    UpdateBuilderMock(UpdateParams.empty, EmailaddressFields.structure, map)
   }
   override def update(row: EmailaddressRow)(implicit c: Connection): Boolean = {
     map.get(row.compositeId) match {

--- a/typo-tester-anorm/generated-and-checked-in/adventureworks/person/password/PasswordFields.scala
+++ b/typo-tester-anorm/generated-and-checked-in/adventureworks/person/password/PasswordFields.scala
@@ -10,39 +10,40 @@ package password
 import adventureworks.customtypes.TypoLocalDateTime
 import adventureworks.customtypes.TypoUUID
 import adventureworks.person.businessentity.BusinessentityId
+import typo.dsl.Path
 import typo.dsl.SqlExpr.Field
 import typo.dsl.SqlExpr.FieldLikeNoHkt
 import typo.dsl.SqlExpr.IdField
 import typo.dsl.Structure.Relation
 
-trait PasswordFields[Row] {
-  val businessentityid: IdField[BusinessentityId, Row]
-  val passwordhash: Field[/* max 128 chars */ String, Row]
-  val passwordsalt: Field[/* max 10 chars */ String, Row]
-  val rowguid: Field[TypoUUID, Row]
-  val modifieddate: Field[TypoLocalDateTime, Row]
+trait PasswordFields {
+  def businessentityid: IdField[BusinessentityId, PasswordRow]
+  def passwordhash: Field[/* max 128 chars */ String, PasswordRow]
+  def passwordsalt: Field[/* max 10 chars */ String, PasswordRow]
+  def rowguid: Field[TypoUUID, PasswordRow]
+  def modifieddate: Field[TypoLocalDateTime, PasswordRow]
 }
 
 object PasswordFields {
-  val structure: Relation[PasswordFields, PasswordRow, PasswordRow] = 
-    new Impl(None, identity, (_, x) => x)
+  lazy val structure: Relation[PasswordFields, PasswordRow] =
+    new Impl(Nil)
     
-  private final class Impl[Row](val prefix: Option[String], val extract: Row => PasswordRow, val merge: (Row, PasswordRow) => Row)
-    extends Relation[PasswordFields, PasswordRow, Row] { 
+  private final class Impl(val _path: List[Path])
+    extends Relation[PasswordFields, PasswordRow] {
   
-    override val fields: PasswordFields[Row] = new PasswordFields[Row] {
-      override val businessentityid = new IdField[BusinessentityId, Row](prefix, "businessentityid", None, Some("int4"))(x => extract(x).businessentityid, (row, value) => merge(row, extract(row).copy(businessentityid = value)))
-      override val passwordhash = new Field[/* max 128 chars */ String, Row](prefix, "passwordhash", None, None)(x => extract(x).passwordhash, (row, value) => merge(row, extract(row).copy(passwordhash = value)))
-      override val passwordsalt = new Field[/* max 10 chars */ String, Row](prefix, "passwordsalt", None, None)(x => extract(x).passwordsalt, (row, value) => merge(row, extract(row).copy(passwordsalt = value)))
-      override val rowguid = new Field[TypoUUID, Row](prefix, "rowguid", None, Some("uuid"))(x => extract(x).rowguid, (row, value) => merge(row, extract(row).copy(rowguid = value)))
-      override val modifieddate = new Field[TypoLocalDateTime, Row](prefix, "modifieddate", Some("text"), Some("timestamp"))(x => extract(x).modifieddate, (row, value) => merge(row, extract(row).copy(modifieddate = value)))
+    override lazy val fields: PasswordFields = new PasswordFields {
+      override def businessentityid = IdField[BusinessentityId, PasswordRow](_path, "businessentityid", None, Some("int4"), x => x.businessentityid, (row, value) => row.copy(businessentityid = value))
+      override def passwordhash = Field[/* max 128 chars */ String, PasswordRow](_path, "passwordhash", None, None, x => x.passwordhash, (row, value) => row.copy(passwordhash = value))
+      override def passwordsalt = Field[/* max 10 chars */ String, PasswordRow](_path, "passwordsalt", None, None, x => x.passwordsalt, (row, value) => row.copy(passwordsalt = value))
+      override def rowguid = Field[TypoUUID, PasswordRow](_path, "rowguid", None, Some("uuid"), x => x.rowguid, (row, value) => row.copy(rowguid = value))
+      override def modifieddate = Field[TypoLocalDateTime, PasswordRow](_path, "modifieddate", Some("text"), Some("timestamp"), x => x.modifieddate, (row, value) => row.copy(modifieddate = value))
     }
   
-    override val columns: List[FieldLikeNoHkt[?, Row]] =
-      List[FieldLikeNoHkt[?, Row]](fields.businessentityid, fields.passwordhash, fields.passwordsalt, fields.rowguid, fields.modifieddate)
+    override lazy val columns: List[FieldLikeNoHkt[?, PasswordRow]] =
+      List[FieldLikeNoHkt[?, PasswordRow]](fields.businessentityid, fields.passwordhash, fields.passwordsalt, fields.rowguid, fields.modifieddate)
   
-    override def copy[NewRow](prefix: Option[String], extract: NewRow => PasswordRow, merge: (NewRow, PasswordRow) => NewRow): Impl[NewRow] =
-      new Impl(prefix, extract, merge)
+    override def copy(path: List[Path]): Impl =
+      new Impl(path)
   }
   
 }

--- a/typo-tester-anorm/generated-and-checked-in/adventureworks/person/password/PasswordRepoMock.scala
+++ b/typo-tester-anorm/generated-and-checked-in/adventureworks/person/password/PasswordRepoMock.scala
@@ -23,7 +23,7 @@ import typo.dsl.UpdateParams
 class PasswordRepoMock(toRow: Function1[PasswordRowUnsaved, PasswordRow],
                        map: scala.collection.mutable.Map[BusinessentityId, PasswordRow] = scala.collection.mutable.Map.empty) extends PasswordRepo {
   override def delete: DeleteBuilder[PasswordFields, PasswordRow] = {
-    DeleteBuilderMock(DeleteParams.empty, PasswordFields.structure.fields, map)
+    DeleteBuilderMock(DeleteParams.empty, PasswordFields.structure, map)
   }
   override def deleteById(businessentityid: BusinessentityId)(implicit c: Connection): Boolean = {
     map.remove(businessentityid).isDefined
@@ -73,7 +73,7 @@ class PasswordRepoMock(toRow: Function1[PasswordRowUnsaved, PasswordRow],
     businessentityids.view.flatMap(id => byId.get(id).map(x => (id, x))).toMap
   }
   override def update: UpdateBuilder[PasswordFields, PasswordRow] = {
-    UpdateBuilderMock(UpdateParams.empty, PasswordFields.structure.fields, map)
+    UpdateBuilderMock(UpdateParams.empty, PasswordFields.structure, map)
   }
   override def update(row: PasswordRow)(implicit c: Connection): Boolean = {
     map.get(row.businessentityid) match {

--- a/typo-tester-anorm/generated-and-checked-in/adventureworks/person/person/PersonFields.scala
+++ b/typo-tester-anorm/generated-and-checked-in/adventureworks/person/person/PersonFields.scala
@@ -14,56 +14,57 @@ import adventureworks.person.businessentity.BusinessentityId
 import adventureworks.public.Name
 import adventureworks.public.NameStyle
 import adventureworks.userdefined.FirstName
+import typo.dsl.Path
 import typo.dsl.SqlExpr.Field
 import typo.dsl.SqlExpr.FieldLikeNoHkt
 import typo.dsl.SqlExpr.IdField
 import typo.dsl.SqlExpr.OptField
 import typo.dsl.Structure.Relation
 
-trait PersonFields[Row] {
-  val businessentityid: IdField[BusinessentityId, Row]
-  val persontype: Field[/* bpchar, max 2 chars */ String, Row]
-  val namestyle: Field[NameStyle, Row]
-  val title: OptField[/* max 8 chars */ String, Row]
-  val firstname: Field[/* user-picked */ FirstName, Row]
-  val middlename: OptField[Name, Row]
-  val lastname: Field[Name, Row]
-  val suffix: OptField[/* max 10 chars */ String, Row]
-  val emailpromotion: Field[Int, Row]
-  val additionalcontactinfo: OptField[TypoXml, Row]
-  val demographics: OptField[TypoXml, Row]
-  val rowguid: Field[TypoUUID, Row]
-  val modifieddate: Field[TypoLocalDateTime, Row]
+trait PersonFields {
+  def businessentityid: IdField[BusinessentityId, PersonRow]
+  def persontype: Field[/* bpchar, max 2 chars */ String, PersonRow]
+  def namestyle: Field[NameStyle, PersonRow]
+  def title: OptField[/* max 8 chars */ String, PersonRow]
+  def firstname: Field[/* user-picked */ FirstName, PersonRow]
+  def middlename: OptField[Name, PersonRow]
+  def lastname: Field[Name, PersonRow]
+  def suffix: OptField[/* max 10 chars */ String, PersonRow]
+  def emailpromotion: Field[Int, PersonRow]
+  def additionalcontactinfo: OptField[TypoXml, PersonRow]
+  def demographics: OptField[TypoXml, PersonRow]
+  def rowguid: Field[TypoUUID, PersonRow]
+  def modifieddate: Field[TypoLocalDateTime, PersonRow]
 }
 
 object PersonFields {
-  val structure: Relation[PersonFields, PersonRow, PersonRow] = 
-    new Impl(None, identity, (_, x) => x)
+  lazy val structure: Relation[PersonFields, PersonRow] =
+    new Impl(Nil)
     
-  private final class Impl[Row](val prefix: Option[String], val extract: Row => PersonRow, val merge: (Row, PersonRow) => Row)
-    extends Relation[PersonFields, PersonRow, Row] { 
+  private final class Impl(val _path: List[Path])
+    extends Relation[PersonFields, PersonRow] {
   
-    override val fields: PersonFields[Row] = new PersonFields[Row] {
-      override val businessentityid = new IdField[BusinessentityId, Row](prefix, "businessentityid", None, Some("int4"))(x => extract(x).businessentityid, (row, value) => merge(row, extract(row).copy(businessentityid = value)))
-      override val persontype = new Field[/* bpchar, max 2 chars */ String, Row](prefix, "persontype", None, Some("bpchar"))(x => extract(x).persontype, (row, value) => merge(row, extract(row).copy(persontype = value)))
-      override val namestyle = new Field[NameStyle, Row](prefix, "namestyle", None, Some("bool"))(x => extract(x).namestyle, (row, value) => merge(row, extract(row).copy(namestyle = value)))
-      override val title = new OptField[/* max 8 chars */ String, Row](prefix, "title", None, None)(x => extract(x).title, (row, value) => merge(row, extract(row).copy(title = value)))
-      override val firstname = new Field[/* user-picked */ FirstName, Row](prefix, "firstname", None, Some("varchar"))(x => extract(x).firstname, (row, value) => merge(row, extract(row).copy(firstname = value)))
-      override val middlename = new OptField[Name, Row](prefix, "middlename", None, Some("varchar"))(x => extract(x).middlename, (row, value) => merge(row, extract(row).copy(middlename = value)))
-      override val lastname = new Field[Name, Row](prefix, "lastname", None, Some("varchar"))(x => extract(x).lastname, (row, value) => merge(row, extract(row).copy(lastname = value)))
-      override val suffix = new OptField[/* max 10 chars */ String, Row](prefix, "suffix", None, None)(x => extract(x).suffix, (row, value) => merge(row, extract(row).copy(suffix = value)))
-      override val emailpromotion = new Field[Int, Row](prefix, "emailpromotion", None, Some("int4"))(x => extract(x).emailpromotion, (row, value) => merge(row, extract(row).copy(emailpromotion = value)))
-      override val additionalcontactinfo = new OptField[TypoXml, Row](prefix, "additionalcontactinfo", None, Some("xml"))(x => extract(x).additionalcontactinfo, (row, value) => merge(row, extract(row).copy(additionalcontactinfo = value)))
-      override val demographics = new OptField[TypoXml, Row](prefix, "demographics", None, Some("xml"))(x => extract(x).demographics, (row, value) => merge(row, extract(row).copy(demographics = value)))
-      override val rowguid = new Field[TypoUUID, Row](prefix, "rowguid", None, Some("uuid"))(x => extract(x).rowguid, (row, value) => merge(row, extract(row).copy(rowguid = value)))
-      override val modifieddate = new Field[TypoLocalDateTime, Row](prefix, "modifieddate", Some("text"), Some("timestamp"))(x => extract(x).modifieddate, (row, value) => merge(row, extract(row).copy(modifieddate = value)))
+    override lazy val fields: PersonFields = new PersonFields {
+      override def businessentityid = IdField[BusinessentityId, PersonRow](_path, "businessentityid", None, Some("int4"), x => x.businessentityid, (row, value) => row.copy(businessentityid = value))
+      override def persontype = Field[/* bpchar, max 2 chars */ String, PersonRow](_path, "persontype", None, Some("bpchar"), x => x.persontype, (row, value) => row.copy(persontype = value))
+      override def namestyle = Field[NameStyle, PersonRow](_path, "namestyle", None, Some("bool"), x => x.namestyle, (row, value) => row.copy(namestyle = value))
+      override def title = OptField[/* max 8 chars */ String, PersonRow](_path, "title", None, None, x => x.title, (row, value) => row.copy(title = value))
+      override def firstname = Field[/* user-picked */ FirstName, PersonRow](_path, "firstname", None, Some("varchar"), x => x.firstname, (row, value) => row.copy(firstname = value))
+      override def middlename = OptField[Name, PersonRow](_path, "middlename", None, Some("varchar"), x => x.middlename, (row, value) => row.copy(middlename = value))
+      override def lastname = Field[Name, PersonRow](_path, "lastname", None, Some("varchar"), x => x.lastname, (row, value) => row.copy(lastname = value))
+      override def suffix = OptField[/* max 10 chars */ String, PersonRow](_path, "suffix", None, None, x => x.suffix, (row, value) => row.copy(suffix = value))
+      override def emailpromotion = Field[Int, PersonRow](_path, "emailpromotion", None, Some("int4"), x => x.emailpromotion, (row, value) => row.copy(emailpromotion = value))
+      override def additionalcontactinfo = OptField[TypoXml, PersonRow](_path, "additionalcontactinfo", None, Some("xml"), x => x.additionalcontactinfo, (row, value) => row.copy(additionalcontactinfo = value))
+      override def demographics = OptField[TypoXml, PersonRow](_path, "demographics", None, Some("xml"), x => x.demographics, (row, value) => row.copy(demographics = value))
+      override def rowguid = Field[TypoUUID, PersonRow](_path, "rowguid", None, Some("uuid"), x => x.rowguid, (row, value) => row.copy(rowguid = value))
+      override def modifieddate = Field[TypoLocalDateTime, PersonRow](_path, "modifieddate", Some("text"), Some("timestamp"), x => x.modifieddate, (row, value) => row.copy(modifieddate = value))
     }
   
-    override val columns: List[FieldLikeNoHkt[?, Row]] =
-      List[FieldLikeNoHkt[?, Row]](fields.businessentityid, fields.persontype, fields.namestyle, fields.title, fields.firstname, fields.middlename, fields.lastname, fields.suffix, fields.emailpromotion, fields.additionalcontactinfo, fields.demographics, fields.rowguid, fields.modifieddate)
+    override lazy val columns: List[FieldLikeNoHkt[?, PersonRow]] =
+      List[FieldLikeNoHkt[?, PersonRow]](fields.businessentityid, fields.persontype, fields.namestyle, fields.title, fields.firstname, fields.middlename, fields.lastname, fields.suffix, fields.emailpromotion, fields.additionalcontactinfo, fields.demographics, fields.rowguid, fields.modifieddate)
   
-    override def copy[NewRow](prefix: Option[String], extract: NewRow => PersonRow, merge: (NewRow, PersonRow) => NewRow): Impl[NewRow] =
-      new Impl(prefix, extract, merge)
+    override def copy(path: List[Path]): Impl =
+      new Impl(path)
   }
   
 }

--- a/typo-tester-anorm/generated-and-checked-in/adventureworks/person/person/PersonRepoMock.scala
+++ b/typo-tester-anorm/generated-and-checked-in/adventureworks/person/person/PersonRepoMock.scala
@@ -23,7 +23,7 @@ import typo.dsl.UpdateParams
 class PersonRepoMock(toRow: Function1[PersonRowUnsaved, PersonRow],
                      map: scala.collection.mutable.Map[BusinessentityId, PersonRow] = scala.collection.mutable.Map.empty) extends PersonRepo {
   override def delete: DeleteBuilder[PersonFields, PersonRow] = {
-    DeleteBuilderMock(DeleteParams.empty, PersonFields.structure.fields, map)
+    DeleteBuilderMock(DeleteParams.empty, PersonFields.structure, map)
   }
   override def deleteById(businessentityid: BusinessentityId)(implicit c: Connection): Boolean = {
     map.remove(businessentityid).isDefined
@@ -73,7 +73,7 @@ class PersonRepoMock(toRow: Function1[PersonRowUnsaved, PersonRow],
     businessentityids.view.flatMap(id => byId.get(id).map(x => (id, x))).toMap
   }
   override def update: UpdateBuilder[PersonFields, PersonRow] = {
-    UpdateBuilderMock(UpdateParams.empty, PersonFields.structure.fields, map)
+    UpdateBuilderMock(UpdateParams.empty, PersonFields.structure, map)
   }
   override def update(row: PersonRow)(implicit c: Connection): Boolean = {
     map.get(row.businessentityid) match {

--- a/typo-tester-anorm/generated-and-checked-in/adventureworks/person/personphone/PersonphoneFields.scala
+++ b/typo-tester-anorm/generated-and-checked-in/adventureworks/person/personphone/PersonphoneFields.scala
@@ -11,37 +11,38 @@ import adventureworks.customtypes.TypoLocalDateTime
 import adventureworks.person.businessentity.BusinessentityId
 import adventureworks.person.phonenumbertype.PhonenumbertypeId
 import adventureworks.public.Phone
+import typo.dsl.Path
 import typo.dsl.SqlExpr.Field
 import typo.dsl.SqlExpr.FieldLikeNoHkt
 import typo.dsl.SqlExpr.IdField
 import typo.dsl.Structure.Relation
 
-trait PersonphoneFields[Row] {
-  val businessentityid: IdField[BusinessentityId, Row]
-  val phonenumber: IdField[Phone, Row]
-  val phonenumbertypeid: IdField[PhonenumbertypeId, Row]
-  val modifieddate: Field[TypoLocalDateTime, Row]
+trait PersonphoneFields {
+  def businessentityid: IdField[BusinessentityId, PersonphoneRow]
+  def phonenumber: IdField[Phone, PersonphoneRow]
+  def phonenumbertypeid: IdField[PhonenumbertypeId, PersonphoneRow]
+  def modifieddate: Field[TypoLocalDateTime, PersonphoneRow]
 }
 
 object PersonphoneFields {
-  val structure: Relation[PersonphoneFields, PersonphoneRow, PersonphoneRow] = 
-    new Impl(None, identity, (_, x) => x)
+  lazy val structure: Relation[PersonphoneFields, PersonphoneRow] =
+    new Impl(Nil)
     
-  private final class Impl[Row](val prefix: Option[String], val extract: Row => PersonphoneRow, val merge: (Row, PersonphoneRow) => Row)
-    extends Relation[PersonphoneFields, PersonphoneRow, Row] { 
+  private final class Impl(val _path: List[Path])
+    extends Relation[PersonphoneFields, PersonphoneRow] {
   
-    override val fields: PersonphoneFields[Row] = new PersonphoneFields[Row] {
-      override val businessentityid = new IdField[BusinessentityId, Row](prefix, "businessentityid", None, Some("int4"))(x => extract(x).businessentityid, (row, value) => merge(row, extract(row).copy(businessentityid = value)))
-      override val phonenumber = new IdField[Phone, Row](prefix, "phonenumber", None, Some("varchar"))(x => extract(x).phonenumber, (row, value) => merge(row, extract(row).copy(phonenumber = value)))
-      override val phonenumbertypeid = new IdField[PhonenumbertypeId, Row](prefix, "phonenumbertypeid", None, Some("int4"))(x => extract(x).phonenumbertypeid, (row, value) => merge(row, extract(row).copy(phonenumbertypeid = value)))
-      override val modifieddate = new Field[TypoLocalDateTime, Row](prefix, "modifieddate", Some("text"), Some("timestamp"))(x => extract(x).modifieddate, (row, value) => merge(row, extract(row).copy(modifieddate = value)))
+    override lazy val fields: PersonphoneFields = new PersonphoneFields {
+      override def businessentityid = IdField[BusinessentityId, PersonphoneRow](_path, "businessentityid", None, Some("int4"), x => x.businessentityid, (row, value) => row.copy(businessentityid = value))
+      override def phonenumber = IdField[Phone, PersonphoneRow](_path, "phonenumber", None, Some("varchar"), x => x.phonenumber, (row, value) => row.copy(phonenumber = value))
+      override def phonenumbertypeid = IdField[PhonenumbertypeId, PersonphoneRow](_path, "phonenumbertypeid", None, Some("int4"), x => x.phonenumbertypeid, (row, value) => row.copy(phonenumbertypeid = value))
+      override def modifieddate = Field[TypoLocalDateTime, PersonphoneRow](_path, "modifieddate", Some("text"), Some("timestamp"), x => x.modifieddate, (row, value) => row.copy(modifieddate = value))
     }
   
-    override val columns: List[FieldLikeNoHkt[?, Row]] =
-      List[FieldLikeNoHkt[?, Row]](fields.businessentityid, fields.phonenumber, fields.phonenumbertypeid, fields.modifieddate)
+    override lazy val columns: List[FieldLikeNoHkt[?, PersonphoneRow]] =
+      List[FieldLikeNoHkt[?, PersonphoneRow]](fields.businessentityid, fields.phonenumber, fields.phonenumbertypeid, fields.modifieddate)
   
-    override def copy[NewRow](prefix: Option[String], extract: NewRow => PersonphoneRow, merge: (NewRow, PersonphoneRow) => NewRow): Impl[NewRow] =
-      new Impl(prefix, extract, merge)
+    override def copy(path: List[Path]): Impl =
+      new Impl(path)
   }
   
 }

--- a/typo-tester-anorm/generated-and-checked-in/adventureworks/person/personphone/PersonphoneRepoMock.scala
+++ b/typo-tester-anorm/generated-and-checked-in/adventureworks/person/personphone/PersonphoneRepoMock.scala
@@ -22,7 +22,7 @@ import typo.dsl.UpdateParams
 class PersonphoneRepoMock(toRow: Function1[PersonphoneRowUnsaved, PersonphoneRow],
                           map: scala.collection.mutable.Map[PersonphoneId, PersonphoneRow] = scala.collection.mutable.Map.empty) extends PersonphoneRepo {
   override def delete: DeleteBuilder[PersonphoneFields, PersonphoneRow] = {
-    DeleteBuilderMock(DeleteParams.empty, PersonphoneFields.structure.fields, map)
+    DeleteBuilderMock(DeleteParams.empty, PersonphoneFields.structure, map)
   }
   override def deleteById(compositeId: PersonphoneId)(implicit c: Connection): Boolean = {
     map.remove(compositeId).isDefined
@@ -72,7 +72,7 @@ class PersonphoneRepoMock(toRow: Function1[PersonphoneRowUnsaved, PersonphoneRow
     compositeIds.view.flatMap(id => byId.get(id).map(x => (id, x))).toMap
   }
   override def update: UpdateBuilder[PersonphoneFields, PersonphoneRow] = {
-    UpdateBuilderMock(UpdateParams.empty, PersonphoneFields.structure.fields, map)
+    UpdateBuilderMock(UpdateParams.empty, PersonphoneFields.structure, map)
   }
   override def update(row: PersonphoneRow)(implicit c: Connection): Boolean = {
     map.get(row.compositeId) match {

--- a/typo-tester-anorm/generated-and-checked-in/adventureworks/person/phonenumbertype/PhonenumbertypeFields.scala
+++ b/typo-tester-anorm/generated-and-checked-in/adventureworks/person/phonenumbertype/PhonenumbertypeFields.scala
@@ -9,35 +9,36 @@ package phonenumbertype
 
 import adventureworks.customtypes.TypoLocalDateTime
 import adventureworks.public.Name
+import typo.dsl.Path
 import typo.dsl.SqlExpr.Field
 import typo.dsl.SqlExpr.FieldLikeNoHkt
 import typo.dsl.SqlExpr.IdField
 import typo.dsl.Structure.Relation
 
-trait PhonenumbertypeFields[Row] {
-  val phonenumbertypeid: IdField[PhonenumbertypeId, Row]
-  val name: Field[Name, Row]
-  val modifieddate: Field[TypoLocalDateTime, Row]
+trait PhonenumbertypeFields {
+  def phonenumbertypeid: IdField[PhonenumbertypeId, PhonenumbertypeRow]
+  def name: Field[Name, PhonenumbertypeRow]
+  def modifieddate: Field[TypoLocalDateTime, PhonenumbertypeRow]
 }
 
 object PhonenumbertypeFields {
-  val structure: Relation[PhonenumbertypeFields, PhonenumbertypeRow, PhonenumbertypeRow] = 
-    new Impl(None, identity, (_, x) => x)
+  lazy val structure: Relation[PhonenumbertypeFields, PhonenumbertypeRow] =
+    new Impl(Nil)
     
-  private final class Impl[Row](val prefix: Option[String], val extract: Row => PhonenumbertypeRow, val merge: (Row, PhonenumbertypeRow) => Row)
-    extends Relation[PhonenumbertypeFields, PhonenumbertypeRow, Row] { 
+  private final class Impl(val _path: List[Path])
+    extends Relation[PhonenumbertypeFields, PhonenumbertypeRow] {
   
-    override val fields: PhonenumbertypeFields[Row] = new PhonenumbertypeFields[Row] {
-      override val phonenumbertypeid = new IdField[PhonenumbertypeId, Row](prefix, "phonenumbertypeid", None, Some("int4"))(x => extract(x).phonenumbertypeid, (row, value) => merge(row, extract(row).copy(phonenumbertypeid = value)))
-      override val name = new Field[Name, Row](prefix, "name", None, Some("varchar"))(x => extract(x).name, (row, value) => merge(row, extract(row).copy(name = value)))
-      override val modifieddate = new Field[TypoLocalDateTime, Row](prefix, "modifieddate", Some("text"), Some("timestamp"))(x => extract(x).modifieddate, (row, value) => merge(row, extract(row).copy(modifieddate = value)))
+    override lazy val fields: PhonenumbertypeFields = new PhonenumbertypeFields {
+      override def phonenumbertypeid = IdField[PhonenumbertypeId, PhonenumbertypeRow](_path, "phonenumbertypeid", None, Some("int4"), x => x.phonenumbertypeid, (row, value) => row.copy(phonenumbertypeid = value))
+      override def name = Field[Name, PhonenumbertypeRow](_path, "name", None, Some("varchar"), x => x.name, (row, value) => row.copy(name = value))
+      override def modifieddate = Field[TypoLocalDateTime, PhonenumbertypeRow](_path, "modifieddate", Some("text"), Some("timestamp"), x => x.modifieddate, (row, value) => row.copy(modifieddate = value))
     }
   
-    override val columns: List[FieldLikeNoHkt[?, Row]] =
-      List[FieldLikeNoHkt[?, Row]](fields.phonenumbertypeid, fields.name, fields.modifieddate)
+    override lazy val columns: List[FieldLikeNoHkt[?, PhonenumbertypeRow]] =
+      List[FieldLikeNoHkt[?, PhonenumbertypeRow]](fields.phonenumbertypeid, fields.name, fields.modifieddate)
   
-    override def copy[NewRow](prefix: Option[String], extract: NewRow => PhonenumbertypeRow, merge: (NewRow, PhonenumbertypeRow) => NewRow): Impl[NewRow] =
-      new Impl(prefix, extract, merge)
+    override def copy(path: List[Path]): Impl =
+      new Impl(path)
   }
   
 }

--- a/typo-tester-anorm/generated-and-checked-in/adventureworks/person/phonenumbertype/PhonenumbertypeRepoMock.scala
+++ b/typo-tester-anorm/generated-and-checked-in/adventureworks/person/phonenumbertype/PhonenumbertypeRepoMock.scala
@@ -22,7 +22,7 @@ import typo.dsl.UpdateParams
 class PhonenumbertypeRepoMock(toRow: Function1[PhonenumbertypeRowUnsaved, PhonenumbertypeRow],
                               map: scala.collection.mutable.Map[PhonenumbertypeId, PhonenumbertypeRow] = scala.collection.mutable.Map.empty) extends PhonenumbertypeRepo {
   override def delete: DeleteBuilder[PhonenumbertypeFields, PhonenumbertypeRow] = {
-    DeleteBuilderMock(DeleteParams.empty, PhonenumbertypeFields.structure.fields, map)
+    DeleteBuilderMock(DeleteParams.empty, PhonenumbertypeFields.structure, map)
   }
   override def deleteById(phonenumbertypeid: PhonenumbertypeId)(implicit c: Connection): Boolean = {
     map.remove(phonenumbertypeid).isDefined
@@ -72,7 +72,7 @@ class PhonenumbertypeRepoMock(toRow: Function1[PhonenumbertypeRowUnsaved, Phonen
     phonenumbertypeids.view.flatMap(id => byId.get(id).map(x => (id, x))).toMap
   }
   override def update: UpdateBuilder[PhonenumbertypeFields, PhonenumbertypeRow] = {
-    UpdateBuilderMock(UpdateParams.empty, PhonenumbertypeFields.structure.fields, map)
+    UpdateBuilderMock(UpdateParams.empty, PhonenumbertypeFields.structure, map)
   }
   override def update(row: PhonenumbertypeRow)(implicit c: Connection): Boolean = {
     map.get(row.phonenumbertypeid) match {

--- a/typo-tester-anorm/generated-and-checked-in/adventureworks/person/stateprovince/StateprovinceFields.scala
+++ b/typo-tester-anorm/generated-and-checked-in/adventureworks/person/stateprovince/StateprovinceFields.scala
@@ -13,45 +13,46 @@ import adventureworks.person.countryregion.CountryregionId
 import adventureworks.public.Flag
 import adventureworks.public.Name
 import adventureworks.sales.salesterritory.SalesterritoryId
+import typo.dsl.Path
 import typo.dsl.SqlExpr.Field
 import typo.dsl.SqlExpr.FieldLikeNoHkt
 import typo.dsl.SqlExpr.IdField
 import typo.dsl.Structure.Relation
 
-trait StateprovinceFields[Row] {
-  val stateprovinceid: IdField[StateprovinceId, Row]
-  val stateprovincecode: Field[/* bpchar, max 3 chars */ String, Row]
-  val countryregioncode: Field[CountryregionId, Row]
-  val isonlystateprovinceflag: Field[Flag, Row]
-  val name: Field[Name, Row]
-  val territoryid: Field[SalesterritoryId, Row]
-  val rowguid: Field[TypoUUID, Row]
-  val modifieddate: Field[TypoLocalDateTime, Row]
+trait StateprovinceFields {
+  def stateprovinceid: IdField[StateprovinceId, StateprovinceRow]
+  def stateprovincecode: Field[/* bpchar, max 3 chars */ String, StateprovinceRow]
+  def countryregioncode: Field[CountryregionId, StateprovinceRow]
+  def isonlystateprovinceflag: Field[Flag, StateprovinceRow]
+  def name: Field[Name, StateprovinceRow]
+  def territoryid: Field[SalesterritoryId, StateprovinceRow]
+  def rowguid: Field[TypoUUID, StateprovinceRow]
+  def modifieddate: Field[TypoLocalDateTime, StateprovinceRow]
 }
 
 object StateprovinceFields {
-  val structure: Relation[StateprovinceFields, StateprovinceRow, StateprovinceRow] = 
-    new Impl(None, identity, (_, x) => x)
+  lazy val structure: Relation[StateprovinceFields, StateprovinceRow] =
+    new Impl(Nil)
     
-  private final class Impl[Row](val prefix: Option[String], val extract: Row => StateprovinceRow, val merge: (Row, StateprovinceRow) => Row)
-    extends Relation[StateprovinceFields, StateprovinceRow, Row] { 
+  private final class Impl(val _path: List[Path])
+    extends Relation[StateprovinceFields, StateprovinceRow] {
   
-    override val fields: StateprovinceFields[Row] = new StateprovinceFields[Row] {
-      override val stateprovinceid = new IdField[StateprovinceId, Row](prefix, "stateprovinceid", None, Some("int4"))(x => extract(x).stateprovinceid, (row, value) => merge(row, extract(row).copy(stateprovinceid = value)))
-      override val stateprovincecode = new Field[/* bpchar, max 3 chars */ String, Row](prefix, "stateprovincecode", None, Some("bpchar"))(x => extract(x).stateprovincecode, (row, value) => merge(row, extract(row).copy(stateprovincecode = value)))
-      override val countryregioncode = new Field[CountryregionId, Row](prefix, "countryregioncode", None, None)(x => extract(x).countryregioncode, (row, value) => merge(row, extract(row).copy(countryregioncode = value)))
-      override val isonlystateprovinceflag = new Field[Flag, Row](prefix, "isonlystateprovinceflag", None, Some("bool"))(x => extract(x).isonlystateprovinceflag, (row, value) => merge(row, extract(row).copy(isonlystateprovinceflag = value)))
-      override val name = new Field[Name, Row](prefix, "name", None, Some("varchar"))(x => extract(x).name, (row, value) => merge(row, extract(row).copy(name = value)))
-      override val territoryid = new Field[SalesterritoryId, Row](prefix, "territoryid", None, Some("int4"))(x => extract(x).territoryid, (row, value) => merge(row, extract(row).copy(territoryid = value)))
-      override val rowguid = new Field[TypoUUID, Row](prefix, "rowguid", None, Some("uuid"))(x => extract(x).rowguid, (row, value) => merge(row, extract(row).copy(rowguid = value)))
-      override val modifieddate = new Field[TypoLocalDateTime, Row](prefix, "modifieddate", Some("text"), Some("timestamp"))(x => extract(x).modifieddate, (row, value) => merge(row, extract(row).copy(modifieddate = value)))
+    override lazy val fields: StateprovinceFields = new StateprovinceFields {
+      override def stateprovinceid = IdField[StateprovinceId, StateprovinceRow](_path, "stateprovinceid", None, Some("int4"), x => x.stateprovinceid, (row, value) => row.copy(stateprovinceid = value))
+      override def stateprovincecode = Field[/* bpchar, max 3 chars */ String, StateprovinceRow](_path, "stateprovincecode", None, Some("bpchar"), x => x.stateprovincecode, (row, value) => row.copy(stateprovincecode = value))
+      override def countryregioncode = Field[CountryregionId, StateprovinceRow](_path, "countryregioncode", None, None, x => x.countryregioncode, (row, value) => row.copy(countryregioncode = value))
+      override def isonlystateprovinceflag = Field[Flag, StateprovinceRow](_path, "isonlystateprovinceflag", None, Some("bool"), x => x.isonlystateprovinceflag, (row, value) => row.copy(isonlystateprovinceflag = value))
+      override def name = Field[Name, StateprovinceRow](_path, "name", None, Some("varchar"), x => x.name, (row, value) => row.copy(name = value))
+      override def territoryid = Field[SalesterritoryId, StateprovinceRow](_path, "territoryid", None, Some("int4"), x => x.territoryid, (row, value) => row.copy(territoryid = value))
+      override def rowguid = Field[TypoUUID, StateprovinceRow](_path, "rowguid", None, Some("uuid"), x => x.rowguid, (row, value) => row.copy(rowguid = value))
+      override def modifieddate = Field[TypoLocalDateTime, StateprovinceRow](_path, "modifieddate", Some("text"), Some("timestamp"), x => x.modifieddate, (row, value) => row.copy(modifieddate = value))
     }
   
-    override val columns: List[FieldLikeNoHkt[?, Row]] =
-      List[FieldLikeNoHkt[?, Row]](fields.stateprovinceid, fields.stateprovincecode, fields.countryregioncode, fields.isonlystateprovinceflag, fields.name, fields.territoryid, fields.rowguid, fields.modifieddate)
+    override lazy val columns: List[FieldLikeNoHkt[?, StateprovinceRow]] =
+      List[FieldLikeNoHkt[?, StateprovinceRow]](fields.stateprovinceid, fields.stateprovincecode, fields.countryregioncode, fields.isonlystateprovinceflag, fields.name, fields.territoryid, fields.rowguid, fields.modifieddate)
   
-    override def copy[NewRow](prefix: Option[String], extract: NewRow => StateprovinceRow, merge: (NewRow, StateprovinceRow) => NewRow): Impl[NewRow] =
-      new Impl(prefix, extract, merge)
+    override def copy(path: List[Path]): Impl =
+      new Impl(path)
   }
   
 }

--- a/typo-tester-anorm/generated-and-checked-in/adventureworks/person/stateprovince/StateprovinceRepoMock.scala
+++ b/typo-tester-anorm/generated-and-checked-in/adventureworks/person/stateprovince/StateprovinceRepoMock.scala
@@ -22,7 +22,7 @@ import typo.dsl.UpdateParams
 class StateprovinceRepoMock(toRow: Function1[StateprovinceRowUnsaved, StateprovinceRow],
                             map: scala.collection.mutable.Map[StateprovinceId, StateprovinceRow] = scala.collection.mutable.Map.empty) extends StateprovinceRepo {
   override def delete: DeleteBuilder[StateprovinceFields, StateprovinceRow] = {
-    DeleteBuilderMock(DeleteParams.empty, StateprovinceFields.structure.fields, map)
+    DeleteBuilderMock(DeleteParams.empty, StateprovinceFields.structure, map)
   }
   override def deleteById(stateprovinceid: StateprovinceId)(implicit c: Connection): Boolean = {
     map.remove(stateprovinceid).isDefined
@@ -72,7 +72,7 @@ class StateprovinceRepoMock(toRow: Function1[StateprovinceRowUnsaved, Stateprovi
     stateprovinceids.view.flatMap(id => byId.get(id).map(x => (id, x))).toMap
   }
   override def update: UpdateBuilder[StateprovinceFields, StateprovinceRow] = {
-    UpdateBuilderMock(UpdateParams.empty, StateprovinceFields.structure.fields, map)
+    UpdateBuilderMock(UpdateParams.empty, StateprovinceFields.structure, map)
   }
   override def update(row: StateprovinceRow)(implicit c: Connection): Boolean = {
     map.get(row.stateprovinceid) match {

--- a/typo-tester-anorm/generated-and-checked-in/adventureworks/person/vadditionalcontactinfo/VadditionalcontactinfoViewFields.scala
+++ b/typo-tester-anorm/generated-and-checked-in/adventureworks/person/vadditionalcontactinfo/VadditionalcontactinfoViewFields.scala
@@ -13,63 +13,64 @@ import adventureworks.customtypes.TypoXml
 import adventureworks.person.businessentity.BusinessentityId
 import adventureworks.public.Name
 import adventureworks.userdefined.FirstName
+import typo.dsl.Path
 import typo.dsl.SqlExpr.Field
 import typo.dsl.SqlExpr.FieldLikeNoHkt
 import typo.dsl.SqlExpr.OptField
 import typo.dsl.Structure.Relation
 
-trait VadditionalcontactinfoViewFields[Row] {
-  val businessentityid: Field[BusinessentityId, Row]
-  val firstname: Field[/* user-picked */ FirstName, Row]
-  val middlename: OptField[Name, Row]
-  val lastname: Field[Name, Row]
-  val telephonenumber: OptField[TypoXml, Row]
-  val telephonespecialinstructions: OptField[String, Row]
-  val street: OptField[TypoXml, Row]
-  val city: OptField[TypoXml, Row]
-  val stateprovince: OptField[TypoXml, Row]
-  val postalcode: OptField[TypoXml, Row]
-  val countryregion: OptField[TypoXml, Row]
-  val homeaddressspecialinstructions: OptField[TypoXml, Row]
-  val emailaddress: OptField[TypoXml, Row]
-  val emailspecialinstructions: OptField[String, Row]
-  val emailtelephonenumber: OptField[TypoXml, Row]
-  val rowguid: Field[TypoUUID, Row]
-  val modifieddate: Field[TypoLocalDateTime, Row]
+trait VadditionalcontactinfoViewFields {
+  def businessentityid: Field[BusinessentityId, VadditionalcontactinfoViewRow]
+  def firstname: Field[/* user-picked */ FirstName, VadditionalcontactinfoViewRow]
+  def middlename: OptField[Name, VadditionalcontactinfoViewRow]
+  def lastname: Field[Name, VadditionalcontactinfoViewRow]
+  def telephonenumber: OptField[TypoXml, VadditionalcontactinfoViewRow]
+  def telephonespecialinstructions: OptField[String, VadditionalcontactinfoViewRow]
+  def street: OptField[TypoXml, VadditionalcontactinfoViewRow]
+  def city: OptField[TypoXml, VadditionalcontactinfoViewRow]
+  def stateprovince: OptField[TypoXml, VadditionalcontactinfoViewRow]
+  def postalcode: OptField[TypoXml, VadditionalcontactinfoViewRow]
+  def countryregion: OptField[TypoXml, VadditionalcontactinfoViewRow]
+  def homeaddressspecialinstructions: OptField[TypoXml, VadditionalcontactinfoViewRow]
+  def emailaddress: OptField[TypoXml, VadditionalcontactinfoViewRow]
+  def emailspecialinstructions: OptField[String, VadditionalcontactinfoViewRow]
+  def emailtelephonenumber: OptField[TypoXml, VadditionalcontactinfoViewRow]
+  def rowguid: Field[TypoUUID, VadditionalcontactinfoViewRow]
+  def modifieddate: Field[TypoLocalDateTime, VadditionalcontactinfoViewRow]
 }
 
 object VadditionalcontactinfoViewFields {
-  val structure: Relation[VadditionalcontactinfoViewFields, VadditionalcontactinfoViewRow, VadditionalcontactinfoViewRow] = 
-    new Impl(None, identity, (_, x) => x)
+  lazy val structure: Relation[VadditionalcontactinfoViewFields, VadditionalcontactinfoViewRow] =
+    new Impl(Nil)
     
-  private final class Impl[Row](val prefix: Option[String], val extract: Row => VadditionalcontactinfoViewRow, val merge: (Row, VadditionalcontactinfoViewRow) => Row)
-    extends Relation[VadditionalcontactinfoViewFields, VadditionalcontactinfoViewRow, Row] { 
+  private final class Impl(val _path: List[Path])
+    extends Relation[VadditionalcontactinfoViewFields, VadditionalcontactinfoViewRow] {
   
-    override val fields: VadditionalcontactinfoViewFields[Row] = new VadditionalcontactinfoViewFields[Row] {
-      override val businessentityid = new Field[BusinessentityId, Row](prefix, "businessentityid", None, None)(x => extract(x).businessentityid, (row, value) => merge(row, extract(row).copy(businessentityid = value)))
-      override val firstname = new Field[/* user-picked */ FirstName, Row](prefix, "firstname", None, None)(x => extract(x).firstname, (row, value) => merge(row, extract(row).copy(firstname = value)))
-      override val middlename = new OptField[Name, Row](prefix, "middlename", None, None)(x => extract(x).middlename, (row, value) => merge(row, extract(row).copy(middlename = value)))
-      override val lastname = new Field[Name, Row](prefix, "lastname", None, None)(x => extract(x).lastname, (row, value) => merge(row, extract(row).copy(lastname = value)))
-      override val telephonenumber = new OptField[TypoXml, Row](prefix, "telephonenumber", None, None)(x => extract(x).telephonenumber, (row, value) => merge(row, extract(row).copy(telephonenumber = value)))
-      override val telephonespecialinstructions = new OptField[String, Row](prefix, "telephonespecialinstructions", None, None)(x => extract(x).telephonespecialinstructions, (row, value) => merge(row, extract(row).copy(telephonespecialinstructions = value)))
-      override val street = new OptField[TypoXml, Row](prefix, "street", None, None)(x => extract(x).street, (row, value) => merge(row, extract(row).copy(street = value)))
-      override val city = new OptField[TypoXml, Row](prefix, "city", None, None)(x => extract(x).city, (row, value) => merge(row, extract(row).copy(city = value)))
-      override val stateprovince = new OptField[TypoXml, Row](prefix, "stateprovince", None, None)(x => extract(x).stateprovince, (row, value) => merge(row, extract(row).copy(stateprovince = value)))
-      override val postalcode = new OptField[TypoXml, Row](prefix, "postalcode", None, None)(x => extract(x).postalcode, (row, value) => merge(row, extract(row).copy(postalcode = value)))
-      override val countryregion = new OptField[TypoXml, Row](prefix, "countryregion", None, None)(x => extract(x).countryregion, (row, value) => merge(row, extract(row).copy(countryregion = value)))
-      override val homeaddressspecialinstructions = new OptField[TypoXml, Row](prefix, "homeaddressspecialinstructions", None, None)(x => extract(x).homeaddressspecialinstructions, (row, value) => merge(row, extract(row).copy(homeaddressspecialinstructions = value)))
-      override val emailaddress = new OptField[TypoXml, Row](prefix, "emailaddress", None, None)(x => extract(x).emailaddress, (row, value) => merge(row, extract(row).copy(emailaddress = value)))
-      override val emailspecialinstructions = new OptField[String, Row](prefix, "emailspecialinstructions", None, None)(x => extract(x).emailspecialinstructions, (row, value) => merge(row, extract(row).copy(emailspecialinstructions = value)))
-      override val emailtelephonenumber = new OptField[TypoXml, Row](prefix, "emailtelephonenumber", None, None)(x => extract(x).emailtelephonenumber, (row, value) => merge(row, extract(row).copy(emailtelephonenumber = value)))
-      override val rowguid = new Field[TypoUUID, Row](prefix, "rowguid", None, None)(x => extract(x).rowguid, (row, value) => merge(row, extract(row).copy(rowguid = value)))
-      override val modifieddate = new Field[TypoLocalDateTime, Row](prefix, "modifieddate", Some("text"), None)(x => extract(x).modifieddate, (row, value) => merge(row, extract(row).copy(modifieddate = value)))
+    override lazy val fields: VadditionalcontactinfoViewFields = new VadditionalcontactinfoViewFields {
+      override def businessentityid = Field[BusinessentityId, VadditionalcontactinfoViewRow](_path, "businessentityid", None, None, x => x.businessentityid, (row, value) => row.copy(businessentityid = value))
+      override def firstname = Field[/* user-picked */ FirstName, VadditionalcontactinfoViewRow](_path, "firstname", None, None, x => x.firstname, (row, value) => row.copy(firstname = value))
+      override def middlename = OptField[Name, VadditionalcontactinfoViewRow](_path, "middlename", None, None, x => x.middlename, (row, value) => row.copy(middlename = value))
+      override def lastname = Field[Name, VadditionalcontactinfoViewRow](_path, "lastname", None, None, x => x.lastname, (row, value) => row.copy(lastname = value))
+      override def telephonenumber = OptField[TypoXml, VadditionalcontactinfoViewRow](_path, "telephonenumber", None, None, x => x.telephonenumber, (row, value) => row.copy(telephonenumber = value))
+      override def telephonespecialinstructions = OptField[String, VadditionalcontactinfoViewRow](_path, "telephonespecialinstructions", None, None, x => x.telephonespecialinstructions, (row, value) => row.copy(telephonespecialinstructions = value))
+      override def street = OptField[TypoXml, VadditionalcontactinfoViewRow](_path, "street", None, None, x => x.street, (row, value) => row.copy(street = value))
+      override def city = OptField[TypoXml, VadditionalcontactinfoViewRow](_path, "city", None, None, x => x.city, (row, value) => row.copy(city = value))
+      override def stateprovince = OptField[TypoXml, VadditionalcontactinfoViewRow](_path, "stateprovince", None, None, x => x.stateprovince, (row, value) => row.copy(stateprovince = value))
+      override def postalcode = OptField[TypoXml, VadditionalcontactinfoViewRow](_path, "postalcode", None, None, x => x.postalcode, (row, value) => row.copy(postalcode = value))
+      override def countryregion = OptField[TypoXml, VadditionalcontactinfoViewRow](_path, "countryregion", None, None, x => x.countryregion, (row, value) => row.copy(countryregion = value))
+      override def homeaddressspecialinstructions = OptField[TypoXml, VadditionalcontactinfoViewRow](_path, "homeaddressspecialinstructions", None, None, x => x.homeaddressspecialinstructions, (row, value) => row.copy(homeaddressspecialinstructions = value))
+      override def emailaddress = OptField[TypoXml, VadditionalcontactinfoViewRow](_path, "emailaddress", None, None, x => x.emailaddress, (row, value) => row.copy(emailaddress = value))
+      override def emailspecialinstructions = OptField[String, VadditionalcontactinfoViewRow](_path, "emailspecialinstructions", None, None, x => x.emailspecialinstructions, (row, value) => row.copy(emailspecialinstructions = value))
+      override def emailtelephonenumber = OptField[TypoXml, VadditionalcontactinfoViewRow](_path, "emailtelephonenumber", None, None, x => x.emailtelephonenumber, (row, value) => row.copy(emailtelephonenumber = value))
+      override def rowguid = Field[TypoUUID, VadditionalcontactinfoViewRow](_path, "rowguid", None, None, x => x.rowguid, (row, value) => row.copy(rowguid = value))
+      override def modifieddate = Field[TypoLocalDateTime, VadditionalcontactinfoViewRow](_path, "modifieddate", Some("text"), None, x => x.modifieddate, (row, value) => row.copy(modifieddate = value))
     }
   
-    override val columns: List[FieldLikeNoHkt[?, Row]] =
-      List[FieldLikeNoHkt[?, Row]](fields.businessentityid, fields.firstname, fields.middlename, fields.lastname, fields.telephonenumber, fields.telephonespecialinstructions, fields.street, fields.city, fields.stateprovince, fields.postalcode, fields.countryregion, fields.homeaddressspecialinstructions, fields.emailaddress, fields.emailspecialinstructions, fields.emailtelephonenumber, fields.rowguid, fields.modifieddate)
+    override lazy val columns: List[FieldLikeNoHkt[?, VadditionalcontactinfoViewRow]] =
+      List[FieldLikeNoHkt[?, VadditionalcontactinfoViewRow]](fields.businessentityid, fields.firstname, fields.middlename, fields.lastname, fields.telephonenumber, fields.telephonespecialinstructions, fields.street, fields.city, fields.stateprovince, fields.postalcode, fields.countryregion, fields.homeaddressspecialinstructions, fields.emailaddress, fields.emailspecialinstructions, fields.emailtelephonenumber, fields.rowguid, fields.modifieddate)
   
-    override def copy[NewRow](prefix: Option[String], extract: NewRow => VadditionalcontactinfoViewRow, merge: (NewRow, VadditionalcontactinfoViewRow) => NewRow): Impl[NewRow] =
-      new Impl(prefix, extract, merge)
+    override def copy(path: List[Path]): Impl =
+      new Impl(path)
   }
   
 }

--- a/typo-tester-anorm/generated-and-checked-in/adventureworks/person/vstateprovincecountryregion/VstateprovincecountryregionMVFields.scala
+++ b/typo-tester-anorm/generated-and-checked-in/adventureworks/person/vstateprovincecountryregion/VstateprovincecountryregionMVFields.scala
@@ -12,42 +12,43 @@ import adventureworks.person.stateprovince.StateprovinceId
 import adventureworks.public.Flag
 import adventureworks.public.Name
 import adventureworks.sales.salesterritory.SalesterritoryId
+import typo.dsl.Path
 import typo.dsl.SqlExpr.Field
 import typo.dsl.SqlExpr.FieldLikeNoHkt
 import typo.dsl.Structure.Relation
 
-trait VstateprovincecountryregionMVFields[Row] {
-  val stateprovinceid: Field[StateprovinceId, Row]
-  val stateprovincecode: Field[/* bpchar, max 3 chars */ String, Row]
-  val isonlystateprovinceflag: Field[Flag, Row]
-  val stateprovincename: Field[Name, Row]
-  val territoryid: Field[SalesterritoryId, Row]
-  val countryregioncode: Field[CountryregionId, Row]
-  val countryregionname: Field[Name, Row]
+trait VstateprovincecountryregionMVFields {
+  def stateprovinceid: Field[StateprovinceId, VstateprovincecountryregionMVRow]
+  def stateprovincecode: Field[/* bpchar, max 3 chars */ String, VstateprovincecountryregionMVRow]
+  def isonlystateprovinceflag: Field[Flag, VstateprovincecountryregionMVRow]
+  def stateprovincename: Field[Name, VstateprovincecountryregionMVRow]
+  def territoryid: Field[SalesterritoryId, VstateprovincecountryregionMVRow]
+  def countryregioncode: Field[CountryregionId, VstateprovincecountryregionMVRow]
+  def countryregionname: Field[Name, VstateprovincecountryregionMVRow]
 }
 
 object VstateprovincecountryregionMVFields {
-  val structure: Relation[VstateprovincecountryregionMVFields, VstateprovincecountryregionMVRow, VstateprovincecountryregionMVRow] = 
-    new Impl(None, identity, (_, x) => x)
+  lazy val structure: Relation[VstateprovincecountryregionMVFields, VstateprovincecountryregionMVRow] =
+    new Impl(Nil)
     
-  private final class Impl[Row](val prefix: Option[String], val extract: Row => VstateprovincecountryregionMVRow, val merge: (Row, VstateprovincecountryregionMVRow) => Row)
-    extends Relation[VstateprovincecountryregionMVFields, VstateprovincecountryregionMVRow, Row] { 
+  private final class Impl(val _path: List[Path])
+    extends Relation[VstateprovincecountryregionMVFields, VstateprovincecountryregionMVRow] {
   
-    override val fields: VstateprovincecountryregionMVFields[Row] = new VstateprovincecountryregionMVFields[Row] {
-      override val stateprovinceid = new Field[StateprovinceId, Row](prefix, "stateprovinceid", None, None)(x => extract(x).stateprovinceid, (row, value) => merge(row, extract(row).copy(stateprovinceid = value)))
-      override val stateprovincecode = new Field[/* bpchar, max 3 chars */ String, Row](prefix, "stateprovincecode", None, None)(x => extract(x).stateprovincecode, (row, value) => merge(row, extract(row).copy(stateprovincecode = value)))
-      override val isonlystateprovinceflag = new Field[Flag, Row](prefix, "isonlystateprovinceflag", None, None)(x => extract(x).isonlystateprovinceflag, (row, value) => merge(row, extract(row).copy(isonlystateprovinceflag = value)))
-      override val stateprovincename = new Field[Name, Row](prefix, "stateprovincename", None, None)(x => extract(x).stateprovincename, (row, value) => merge(row, extract(row).copy(stateprovincename = value)))
-      override val territoryid = new Field[SalesterritoryId, Row](prefix, "territoryid", None, None)(x => extract(x).territoryid, (row, value) => merge(row, extract(row).copy(territoryid = value)))
-      override val countryregioncode = new Field[CountryregionId, Row](prefix, "countryregioncode", None, None)(x => extract(x).countryregioncode, (row, value) => merge(row, extract(row).copy(countryregioncode = value)))
-      override val countryregionname = new Field[Name, Row](prefix, "countryregionname", None, None)(x => extract(x).countryregionname, (row, value) => merge(row, extract(row).copy(countryregionname = value)))
+    override lazy val fields: VstateprovincecountryregionMVFields = new VstateprovincecountryregionMVFields {
+      override def stateprovinceid = Field[StateprovinceId, VstateprovincecountryregionMVRow](_path, "stateprovinceid", None, None, x => x.stateprovinceid, (row, value) => row.copy(stateprovinceid = value))
+      override def stateprovincecode = Field[/* bpchar, max 3 chars */ String, VstateprovincecountryregionMVRow](_path, "stateprovincecode", None, None, x => x.stateprovincecode, (row, value) => row.copy(stateprovincecode = value))
+      override def isonlystateprovinceflag = Field[Flag, VstateprovincecountryregionMVRow](_path, "isonlystateprovinceflag", None, None, x => x.isonlystateprovinceflag, (row, value) => row.copy(isonlystateprovinceflag = value))
+      override def stateprovincename = Field[Name, VstateprovincecountryregionMVRow](_path, "stateprovincename", None, None, x => x.stateprovincename, (row, value) => row.copy(stateprovincename = value))
+      override def territoryid = Field[SalesterritoryId, VstateprovincecountryregionMVRow](_path, "territoryid", None, None, x => x.territoryid, (row, value) => row.copy(territoryid = value))
+      override def countryregioncode = Field[CountryregionId, VstateprovincecountryregionMVRow](_path, "countryregioncode", None, None, x => x.countryregioncode, (row, value) => row.copy(countryregioncode = value))
+      override def countryregionname = Field[Name, VstateprovincecountryregionMVRow](_path, "countryregionname", None, None, x => x.countryregionname, (row, value) => row.copy(countryregionname = value))
     }
   
-    override val columns: List[FieldLikeNoHkt[?, Row]] =
-      List[FieldLikeNoHkt[?, Row]](fields.stateprovinceid, fields.stateprovincecode, fields.isonlystateprovinceflag, fields.stateprovincename, fields.territoryid, fields.countryregioncode, fields.countryregionname)
+    override lazy val columns: List[FieldLikeNoHkt[?, VstateprovincecountryregionMVRow]] =
+      List[FieldLikeNoHkt[?, VstateprovincecountryregionMVRow]](fields.stateprovinceid, fields.stateprovincecode, fields.isonlystateprovinceflag, fields.stateprovincename, fields.territoryid, fields.countryregioncode, fields.countryregionname)
   
-    override def copy[NewRow](prefix: Option[String], extract: NewRow => VstateprovincecountryregionMVRow, merge: (NewRow, VstateprovincecountryregionMVRow) => NewRow): Impl[NewRow] =
-      new Impl(prefix, extract, merge)
+    override def copy(path: List[Path]): Impl =
+      new Impl(path)
   }
   
 }

--- a/typo-tester-anorm/generated-and-checked-in/adventureworks/pr/bom/BomViewFields.scala
+++ b/typo-tester-anorm/generated-and-checked-in/adventureworks/pr/bom/BomViewFields.scala
@@ -11,49 +11,50 @@ import adventureworks.customtypes.TypoLocalDateTime
 import adventureworks.customtypes.TypoShort
 import adventureworks.production.product.ProductId
 import adventureworks.production.unitmeasure.UnitmeasureId
+import typo.dsl.Path
 import typo.dsl.SqlExpr.Field
 import typo.dsl.SqlExpr.FieldLikeNoHkt
 import typo.dsl.SqlExpr.OptField
 import typo.dsl.Structure.Relation
 
-trait BomViewFields[Row] {
-  val id: Field[Int, Row]
-  val billofmaterialsid: Field[Int, Row]
-  val productassemblyid: OptField[ProductId, Row]
-  val componentid: Field[ProductId, Row]
-  val startdate: Field[TypoLocalDateTime, Row]
-  val enddate: OptField[TypoLocalDateTime, Row]
-  val unitmeasurecode: Field[UnitmeasureId, Row]
-  val bomlevel: Field[TypoShort, Row]
-  val perassemblyqty: Field[BigDecimal, Row]
-  val modifieddate: Field[TypoLocalDateTime, Row]
+trait BomViewFields {
+  def id: Field[Int, BomViewRow]
+  def billofmaterialsid: Field[Int, BomViewRow]
+  def productassemblyid: OptField[ProductId, BomViewRow]
+  def componentid: Field[ProductId, BomViewRow]
+  def startdate: Field[TypoLocalDateTime, BomViewRow]
+  def enddate: OptField[TypoLocalDateTime, BomViewRow]
+  def unitmeasurecode: Field[UnitmeasureId, BomViewRow]
+  def bomlevel: Field[TypoShort, BomViewRow]
+  def perassemblyqty: Field[BigDecimal, BomViewRow]
+  def modifieddate: Field[TypoLocalDateTime, BomViewRow]
 }
 
 object BomViewFields {
-  val structure: Relation[BomViewFields, BomViewRow, BomViewRow] = 
-    new Impl(None, identity, (_, x) => x)
+  lazy val structure: Relation[BomViewFields, BomViewRow] =
+    new Impl(Nil)
     
-  private final class Impl[Row](val prefix: Option[String], val extract: Row => BomViewRow, val merge: (Row, BomViewRow) => Row)
-    extends Relation[BomViewFields, BomViewRow, Row] { 
+  private final class Impl(val _path: List[Path])
+    extends Relation[BomViewFields, BomViewRow] {
   
-    override val fields: BomViewFields[Row] = new BomViewFields[Row] {
-      override val id = new Field[Int, Row](prefix, "id", None, None)(x => extract(x).id, (row, value) => merge(row, extract(row).copy(id = value)))
-      override val billofmaterialsid = new Field[Int, Row](prefix, "billofmaterialsid", None, None)(x => extract(x).billofmaterialsid, (row, value) => merge(row, extract(row).copy(billofmaterialsid = value)))
-      override val productassemblyid = new OptField[ProductId, Row](prefix, "productassemblyid", None, None)(x => extract(x).productassemblyid, (row, value) => merge(row, extract(row).copy(productassemblyid = value)))
-      override val componentid = new Field[ProductId, Row](prefix, "componentid", None, None)(x => extract(x).componentid, (row, value) => merge(row, extract(row).copy(componentid = value)))
-      override val startdate = new Field[TypoLocalDateTime, Row](prefix, "startdate", Some("text"), None)(x => extract(x).startdate, (row, value) => merge(row, extract(row).copy(startdate = value)))
-      override val enddate = new OptField[TypoLocalDateTime, Row](prefix, "enddate", Some("text"), None)(x => extract(x).enddate, (row, value) => merge(row, extract(row).copy(enddate = value)))
-      override val unitmeasurecode = new Field[UnitmeasureId, Row](prefix, "unitmeasurecode", None, None)(x => extract(x).unitmeasurecode, (row, value) => merge(row, extract(row).copy(unitmeasurecode = value)))
-      override val bomlevel = new Field[TypoShort, Row](prefix, "bomlevel", None, None)(x => extract(x).bomlevel, (row, value) => merge(row, extract(row).copy(bomlevel = value)))
-      override val perassemblyqty = new Field[BigDecimal, Row](prefix, "perassemblyqty", None, None)(x => extract(x).perassemblyqty, (row, value) => merge(row, extract(row).copy(perassemblyqty = value)))
-      override val modifieddate = new Field[TypoLocalDateTime, Row](prefix, "modifieddate", Some("text"), None)(x => extract(x).modifieddate, (row, value) => merge(row, extract(row).copy(modifieddate = value)))
+    override lazy val fields: BomViewFields = new BomViewFields {
+      override def id = Field[Int, BomViewRow](_path, "id", None, None, x => x.id, (row, value) => row.copy(id = value))
+      override def billofmaterialsid = Field[Int, BomViewRow](_path, "billofmaterialsid", None, None, x => x.billofmaterialsid, (row, value) => row.copy(billofmaterialsid = value))
+      override def productassemblyid = OptField[ProductId, BomViewRow](_path, "productassemblyid", None, None, x => x.productassemblyid, (row, value) => row.copy(productassemblyid = value))
+      override def componentid = Field[ProductId, BomViewRow](_path, "componentid", None, None, x => x.componentid, (row, value) => row.copy(componentid = value))
+      override def startdate = Field[TypoLocalDateTime, BomViewRow](_path, "startdate", Some("text"), None, x => x.startdate, (row, value) => row.copy(startdate = value))
+      override def enddate = OptField[TypoLocalDateTime, BomViewRow](_path, "enddate", Some("text"), None, x => x.enddate, (row, value) => row.copy(enddate = value))
+      override def unitmeasurecode = Field[UnitmeasureId, BomViewRow](_path, "unitmeasurecode", None, None, x => x.unitmeasurecode, (row, value) => row.copy(unitmeasurecode = value))
+      override def bomlevel = Field[TypoShort, BomViewRow](_path, "bomlevel", None, None, x => x.bomlevel, (row, value) => row.copy(bomlevel = value))
+      override def perassemblyqty = Field[BigDecimal, BomViewRow](_path, "perassemblyqty", None, None, x => x.perassemblyqty, (row, value) => row.copy(perassemblyqty = value))
+      override def modifieddate = Field[TypoLocalDateTime, BomViewRow](_path, "modifieddate", Some("text"), None, x => x.modifieddate, (row, value) => row.copy(modifieddate = value))
     }
   
-    override val columns: List[FieldLikeNoHkt[?, Row]] =
-      List[FieldLikeNoHkt[?, Row]](fields.id, fields.billofmaterialsid, fields.productassemblyid, fields.componentid, fields.startdate, fields.enddate, fields.unitmeasurecode, fields.bomlevel, fields.perassemblyqty, fields.modifieddate)
+    override lazy val columns: List[FieldLikeNoHkt[?, BomViewRow]] =
+      List[FieldLikeNoHkt[?, BomViewRow]](fields.id, fields.billofmaterialsid, fields.productassemblyid, fields.componentid, fields.startdate, fields.enddate, fields.unitmeasurecode, fields.bomlevel, fields.perassemblyqty, fields.modifieddate)
   
-    override def copy[NewRow](prefix: Option[String], extract: NewRow => BomViewRow, merge: (NewRow, BomViewRow) => NewRow): Impl[NewRow] =
-      new Impl(prefix, extract, merge)
+    override def copy(path: List[Path]): Impl =
+      new Impl(path)
   }
   
 }

--- a/typo-tester-anorm/generated-and-checked-in/adventureworks/pr/d/DViewFields.scala
+++ b/typo-tester-anorm/generated-and-checked-in/adventureworks/pr/d/DViewFields.scala
@@ -14,55 +14,56 @@ import adventureworks.customtypes.TypoUUID
 import adventureworks.person.businessentity.BusinessentityId
 import adventureworks.production.document.DocumentId
 import adventureworks.public.Flag
+import typo.dsl.Path
 import typo.dsl.SqlExpr.Field
 import typo.dsl.SqlExpr.FieldLikeNoHkt
 import typo.dsl.SqlExpr.OptField
 import typo.dsl.Structure.Relation
 
-trait DViewFields[Row] {
-  val title: Field[/* max 50 chars */ String, Row]
-  val owner: Field[BusinessentityId, Row]
-  val folderflag: Field[Flag, Row]
-  val filename: Field[/* max 400 chars */ String, Row]
-  val fileextension: OptField[/* max 8 chars */ String, Row]
-  val revision: Field[/* bpchar, max 5 chars */ String, Row]
-  val changenumber: Field[Int, Row]
-  val status: Field[TypoShort, Row]
-  val documentsummary: OptField[String, Row]
-  val document: OptField[TypoBytea, Row]
-  val rowguid: Field[TypoUUID, Row]
-  val modifieddate: Field[TypoLocalDateTime, Row]
-  val documentnode: Field[DocumentId, Row]
+trait DViewFields {
+  def title: Field[/* max 50 chars */ String, DViewRow]
+  def owner: Field[BusinessentityId, DViewRow]
+  def folderflag: Field[Flag, DViewRow]
+  def filename: Field[/* max 400 chars */ String, DViewRow]
+  def fileextension: OptField[/* max 8 chars */ String, DViewRow]
+  def revision: Field[/* bpchar, max 5 chars */ String, DViewRow]
+  def changenumber: Field[Int, DViewRow]
+  def status: Field[TypoShort, DViewRow]
+  def documentsummary: OptField[String, DViewRow]
+  def document: OptField[TypoBytea, DViewRow]
+  def rowguid: Field[TypoUUID, DViewRow]
+  def modifieddate: Field[TypoLocalDateTime, DViewRow]
+  def documentnode: Field[DocumentId, DViewRow]
 }
 
 object DViewFields {
-  val structure: Relation[DViewFields, DViewRow, DViewRow] = 
-    new Impl(None, identity, (_, x) => x)
+  lazy val structure: Relation[DViewFields, DViewRow] =
+    new Impl(Nil)
     
-  private final class Impl[Row](val prefix: Option[String], val extract: Row => DViewRow, val merge: (Row, DViewRow) => Row)
-    extends Relation[DViewFields, DViewRow, Row] { 
+  private final class Impl(val _path: List[Path])
+    extends Relation[DViewFields, DViewRow] {
   
-    override val fields: DViewFields[Row] = new DViewFields[Row] {
-      override val title = new Field[/* max 50 chars */ String, Row](prefix, "title", None, None)(x => extract(x).title, (row, value) => merge(row, extract(row).copy(title = value)))
-      override val owner = new Field[BusinessentityId, Row](prefix, "owner", None, None)(x => extract(x).owner, (row, value) => merge(row, extract(row).copy(owner = value)))
-      override val folderflag = new Field[Flag, Row](prefix, "folderflag", None, None)(x => extract(x).folderflag, (row, value) => merge(row, extract(row).copy(folderflag = value)))
-      override val filename = new Field[/* max 400 chars */ String, Row](prefix, "filename", None, None)(x => extract(x).filename, (row, value) => merge(row, extract(row).copy(filename = value)))
-      override val fileextension = new OptField[/* max 8 chars */ String, Row](prefix, "fileextension", None, None)(x => extract(x).fileextension, (row, value) => merge(row, extract(row).copy(fileextension = value)))
-      override val revision = new Field[/* bpchar, max 5 chars */ String, Row](prefix, "revision", None, None)(x => extract(x).revision, (row, value) => merge(row, extract(row).copy(revision = value)))
-      override val changenumber = new Field[Int, Row](prefix, "changenumber", None, None)(x => extract(x).changenumber, (row, value) => merge(row, extract(row).copy(changenumber = value)))
-      override val status = new Field[TypoShort, Row](prefix, "status", None, None)(x => extract(x).status, (row, value) => merge(row, extract(row).copy(status = value)))
-      override val documentsummary = new OptField[String, Row](prefix, "documentsummary", None, None)(x => extract(x).documentsummary, (row, value) => merge(row, extract(row).copy(documentsummary = value)))
-      override val document = new OptField[TypoBytea, Row](prefix, "document", None, None)(x => extract(x).document, (row, value) => merge(row, extract(row).copy(document = value)))
-      override val rowguid = new Field[TypoUUID, Row](prefix, "rowguid", None, None)(x => extract(x).rowguid, (row, value) => merge(row, extract(row).copy(rowguid = value)))
-      override val modifieddate = new Field[TypoLocalDateTime, Row](prefix, "modifieddate", Some("text"), None)(x => extract(x).modifieddate, (row, value) => merge(row, extract(row).copy(modifieddate = value)))
-      override val documentnode = new Field[DocumentId, Row](prefix, "documentnode", None, None)(x => extract(x).documentnode, (row, value) => merge(row, extract(row).copy(documentnode = value)))
+    override lazy val fields: DViewFields = new DViewFields {
+      override def title = Field[/* max 50 chars */ String, DViewRow](_path, "title", None, None, x => x.title, (row, value) => row.copy(title = value))
+      override def owner = Field[BusinessentityId, DViewRow](_path, "owner", None, None, x => x.owner, (row, value) => row.copy(owner = value))
+      override def folderflag = Field[Flag, DViewRow](_path, "folderflag", None, None, x => x.folderflag, (row, value) => row.copy(folderflag = value))
+      override def filename = Field[/* max 400 chars */ String, DViewRow](_path, "filename", None, None, x => x.filename, (row, value) => row.copy(filename = value))
+      override def fileextension = OptField[/* max 8 chars */ String, DViewRow](_path, "fileextension", None, None, x => x.fileextension, (row, value) => row.copy(fileextension = value))
+      override def revision = Field[/* bpchar, max 5 chars */ String, DViewRow](_path, "revision", None, None, x => x.revision, (row, value) => row.copy(revision = value))
+      override def changenumber = Field[Int, DViewRow](_path, "changenumber", None, None, x => x.changenumber, (row, value) => row.copy(changenumber = value))
+      override def status = Field[TypoShort, DViewRow](_path, "status", None, None, x => x.status, (row, value) => row.copy(status = value))
+      override def documentsummary = OptField[String, DViewRow](_path, "documentsummary", None, None, x => x.documentsummary, (row, value) => row.copy(documentsummary = value))
+      override def document = OptField[TypoBytea, DViewRow](_path, "document", None, None, x => x.document, (row, value) => row.copy(document = value))
+      override def rowguid = Field[TypoUUID, DViewRow](_path, "rowguid", None, None, x => x.rowguid, (row, value) => row.copy(rowguid = value))
+      override def modifieddate = Field[TypoLocalDateTime, DViewRow](_path, "modifieddate", Some("text"), None, x => x.modifieddate, (row, value) => row.copy(modifieddate = value))
+      override def documentnode = Field[DocumentId, DViewRow](_path, "documentnode", None, None, x => x.documentnode, (row, value) => row.copy(documentnode = value))
     }
   
-    override val columns: List[FieldLikeNoHkt[?, Row]] =
-      List[FieldLikeNoHkt[?, Row]](fields.title, fields.owner, fields.folderflag, fields.filename, fields.fileextension, fields.revision, fields.changenumber, fields.status, fields.documentsummary, fields.document, fields.rowguid, fields.modifieddate, fields.documentnode)
+    override lazy val columns: List[FieldLikeNoHkt[?, DViewRow]] =
+      List[FieldLikeNoHkt[?, DViewRow]](fields.title, fields.owner, fields.folderflag, fields.filename, fields.fileextension, fields.revision, fields.changenumber, fields.status, fields.documentsummary, fields.document, fields.rowguid, fields.modifieddate, fields.documentnode)
   
-    override def copy[NewRow](prefix: Option[String], extract: NewRow => DViewRow, merge: (NewRow, DViewRow) => NewRow): Impl[NewRow] =
-      new Impl(prefix, extract, merge)
+    override def copy(path: List[Path]): Impl =
+      new Impl(path)
   }
   
 }

--- a/typo-tester-anorm/generated-and-checked-in/adventureworks/pr/l/LViewFields.scala
+++ b/typo-tester-anorm/generated-and-checked-in/adventureworks/pr/l/LViewFields.scala
@@ -10,40 +10,41 @@ package l
 import adventureworks.customtypes.TypoLocalDateTime
 import adventureworks.production.location.LocationId
 import adventureworks.public.Name
+import typo.dsl.Path
 import typo.dsl.SqlExpr.Field
 import typo.dsl.SqlExpr.FieldLikeNoHkt
 import typo.dsl.Structure.Relation
 
-trait LViewFields[Row] {
-  val id: Field[LocationId, Row]
-  val locationid: Field[LocationId, Row]
-  val name: Field[Name, Row]
-  val costrate: Field[BigDecimal, Row]
-  val availability: Field[BigDecimal, Row]
-  val modifieddate: Field[TypoLocalDateTime, Row]
+trait LViewFields {
+  def id: Field[LocationId, LViewRow]
+  def locationid: Field[LocationId, LViewRow]
+  def name: Field[Name, LViewRow]
+  def costrate: Field[BigDecimal, LViewRow]
+  def availability: Field[BigDecimal, LViewRow]
+  def modifieddate: Field[TypoLocalDateTime, LViewRow]
 }
 
 object LViewFields {
-  val structure: Relation[LViewFields, LViewRow, LViewRow] = 
-    new Impl(None, identity, (_, x) => x)
+  lazy val structure: Relation[LViewFields, LViewRow] =
+    new Impl(Nil)
     
-  private final class Impl[Row](val prefix: Option[String], val extract: Row => LViewRow, val merge: (Row, LViewRow) => Row)
-    extends Relation[LViewFields, LViewRow, Row] { 
+  private final class Impl(val _path: List[Path])
+    extends Relation[LViewFields, LViewRow] {
   
-    override val fields: LViewFields[Row] = new LViewFields[Row] {
-      override val id = new Field[LocationId, Row](prefix, "id", None, None)(x => extract(x).id, (row, value) => merge(row, extract(row).copy(id = value)))
-      override val locationid = new Field[LocationId, Row](prefix, "locationid", None, None)(x => extract(x).locationid, (row, value) => merge(row, extract(row).copy(locationid = value)))
-      override val name = new Field[Name, Row](prefix, "name", None, None)(x => extract(x).name, (row, value) => merge(row, extract(row).copy(name = value)))
-      override val costrate = new Field[BigDecimal, Row](prefix, "costrate", None, None)(x => extract(x).costrate, (row, value) => merge(row, extract(row).copy(costrate = value)))
-      override val availability = new Field[BigDecimal, Row](prefix, "availability", None, None)(x => extract(x).availability, (row, value) => merge(row, extract(row).copy(availability = value)))
-      override val modifieddate = new Field[TypoLocalDateTime, Row](prefix, "modifieddate", Some("text"), None)(x => extract(x).modifieddate, (row, value) => merge(row, extract(row).copy(modifieddate = value)))
+    override lazy val fields: LViewFields = new LViewFields {
+      override def id = Field[LocationId, LViewRow](_path, "id", None, None, x => x.id, (row, value) => row.copy(id = value))
+      override def locationid = Field[LocationId, LViewRow](_path, "locationid", None, None, x => x.locationid, (row, value) => row.copy(locationid = value))
+      override def name = Field[Name, LViewRow](_path, "name", None, None, x => x.name, (row, value) => row.copy(name = value))
+      override def costrate = Field[BigDecimal, LViewRow](_path, "costrate", None, None, x => x.costrate, (row, value) => row.copy(costrate = value))
+      override def availability = Field[BigDecimal, LViewRow](_path, "availability", None, None, x => x.availability, (row, value) => row.copy(availability = value))
+      override def modifieddate = Field[TypoLocalDateTime, LViewRow](_path, "modifieddate", Some("text"), None, x => x.modifieddate, (row, value) => row.copy(modifieddate = value))
     }
   
-    override val columns: List[FieldLikeNoHkt[?, Row]] =
-      List[FieldLikeNoHkt[?, Row]](fields.id, fields.locationid, fields.name, fields.costrate, fields.availability, fields.modifieddate)
+    override lazy val columns: List[FieldLikeNoHkt[?, LViewRow]] =
+      List[FieldLikeNoHkt[?, LViewRow]](fields.id, fields.locationid, fields.name, fields.costrate, fields.availability, fields.modifieddate)
   
-    override def copy[NewRow](prefix: Option[String], extract: NewRow => LViewRow, merge: (NewRow, LViewRow) => NewRow): Impl[NewRow] =
-      new Impl(prefix, extract, merge)
+    override def copy(path: List[Path]): Impl =
+      new Impl(path)
   }
   
 }

--- a/typo-tester-anorm/generated-and-checked-in/adventureworks/pr/p/PViewFields.scala
+++ b/typo-tester-anorm/generated-and-checked-in/adventureworks/pr/p/PViewFields.scala
@@ -16,81 +16,82 @@ import adventureworks.production.productsubcategory.ProductsubcategoryId
 import adventureworks.production.unitmeasure.UnitmeasureId
 import adventureworks.public.Flag
 import adventureworks.public.Name
+import typo.dsl.Path
 import typo.dsl.SqlExpr.Field
 import typo.dsl.SqlExpr.FieldLikeNoHkt
 import typo.dsl.SqlExpr.OptField
 import typo.dsl.Structure.Relation
 
-trait PViewFields[Row] {
-  val id: Field[ProductId, Row]
-  val productid: Field[ProductId, Row]
-  val name: Field[Name, Row]
-  val productnumber: Field[/* max 25 chars */ String, Row]
-  val makeflag: Field[Flag, Row]
-  val finishedgoodsflag: Field[Flag, Row]
-  val color: OptField[/* max 15 chars */ String, Row]
-  val safetystocklevel: Field[TypoShort, Row]
-  val reorderpoint: Field[TypoShort, Row]
-  val standardcost: Field[BigDecimal, Row]
-  val listprice: Field[BigDecimal, Row]
-  val size: OptField[/* max 5 chars */ String, Row]
-  val sizeunitmeasurecode: OptField[UnitmeasureId, Row]
-  val weightunitmeasurecode: OptField[UnitmeasureId, Row]
-  val weight: OptField[BigDecimal, Row]
-  val daystomanufacture: Field[Int, Row]
-  val productline: OptField[/* bpchar, max 2 chars */ String, Row]
-  val `class`: OptField[/* bpchar, max 2 chars */ String, Row]
-  val style: OptField[/* bpchar, max 2 chars */ String, Row]
-  val productsubcategoryid: OptField[ProductsubcategoryId, Row]
-  val productmodelid: OptField[ProductmodelId, Row]
-  val sellstartdate: Field[TypoLocalDateTime, Row]
-  val sellenddate: OptField[TypoLocalDateTime, Row]
-  val discontinueddate: OptField[TypoLocalDateTime, Row]
-  val rowguid: Field[TypoUUID, Row]
-  val modifieddate: Field[TypoLocalDateTime, Row]
+trait PViewFields {
+  def id: Field[ProductId, PViewRow]
+  def productid: Field[ProductId, PViewRow]
+  def name: Field[Name, PViewRow]
+  def productnumber: Field[/* max 25 chars */ String, PViewRow]
+  def makeflag: Field[Flag, PViewRow]
+  def finishedgoodsflag: Field[Flag, PViewRow]
+  def color: OptField[/* max 15 chars */ String, PViewRow]
+  def safetystocklevel: Field[TypoShort, PViewRow]
+  def reorderpoint: Field[TypoShort, PViewRow]
+  def standardcost: Field[BigDecimal, PViewRow]
+  def listprice: Field[BigDecimal, PViewRow]
+  def size: OptField[/* max 5 chars */ String, PViewRow]
+  def sizeunitmeasurecode: OptField[UnitmeasureId, PViewRow]
+  def weightunitmeasurecode: OptField[UnitmeasureId, PViewRow]
+  def weight: OptField[BigDecimal, PViewRow]
+  def daystomanufacture: Field[Int, PViewRow]
+  def productline: OptField[/* bpchar, max 2 chars */ String, PViewRow]
+  def `class`: OptField[/* bpchar, max 2 chars */ String, PViewRow]
+  def style: OptField[/* bpchar, max 2 chars */ String, PViewRow]
+  def productsubcategoryid: OptField[ProductsubcategoryId, PViewRow]
+  def productmodelid: OptField[ProductmodelId, PViewRow]
+  def sellstartdate: Field[TypoLocalDateTime, PViewRow]
+  def sellenddate: OptField[TypoLocalDateTime, PViewRow]
+  def discontinueddate: OptField[TypoLocalDateTime, PViewRow]
+  def rowguid: Field[TypoUUID, PViewRow]
+  def modifieddate: Field[TypoLocalDateTime, PViewRow]
 }
 
 object PViewFields {
-  val structure: Relation[PViewFields, PViewRow, PViewRow] = 
-    new Impl(None, identity, (_, x) => x)
+  lazy val structure: Relation[PViewFields, PViewRow] =
+    new Impl(Nil)
     
-  private final class Impl[Row](val prefix: Option[String], val extract: Row => PViewRow, val merge: (Row, PViewRow) => Row)
-    extends Relation[PViewFields, PViewRow, Row] { 
+  private final class Impl(val _path: List[Path])
+    extends Relation[PViewFields, PViewRow] {
   
-    override val fields: PViewFields[Row] = new PViewFields[Row] {
-      override val id = new Field[ProductId, Row](prefix, "id", None, None)(x => extract(x).id, (row, value) => merge(row, extract(row).copy(id = value)))
-      override val productid = new Field[ProductId, Row](prefix, "productid", None, None)(x => extract(x).productid, (row, value) => merge(row, extract(row).copy(productid = value)))
-      override val name = new Field[Name, Row](prefix, "name", None, None)(x => extract(x).name, (row, value) => merge(row, extract(row).copy(name = value)))
-      override val productnumber = new Field[/* max 25 chars */ String, Row](prefix, "productnumber", None, None)(x => extract(x).productnumber, (row, value) => merge(row, extract(row).copy(productnumber = value)))
-      override val makeflag = new Field[Flag, Row](prefix, "makeflag", None, None)(x => extract(x).makeflag, (row, value) => merge(row, extract(row).copy(makeflag = value)))
-      override val finishedgoodsflag = new Field[Flag, Row](prefix, "finishedgoodsflag", None, None)(x => extract(x).finishedgoodsflag, (row, value) => merge(row, extract(row).copy(finishedgoodsflag = value)))
-      override val color = new OptField[/* max 15 chars */ String, Row](prefix, "color", None, None)(x => extract(x).color, (row, value) => merge(row, extract(row).copy(color = value)))
-      override val safetystocklevel = new Field[TypoShort, Row](prefix, "safetystocklevel", None, None)(x => extract(x).safetystocklevel, (row, value) => merge(row, extract(row).copy(safetystocklevel = value)))
-      override val reorderpoint = new Field[TypoShort, Row](prefix, "reorderpoint", None, None)(x => extract(x).reorderpoint, (row, value) => merge(row, extract(row).copy(reorderpoint = value)))
-      override val standardcost = new Field[BigDecimal, Row](prefix, "standardcost", None, None)(x => extract(x).standardcost, (row, value) => merge(row, extract(row).copy(standardcost = value)))
-      override val listprice = new Field[BigDecimal, Row](prefix, "listprice", None, None)(x => extract(x).listprice, (row, value) => merge(row, extract(row).copy(listprice = value)))
-      override val size = new OptField[/* max 5 chars */ String, Row](prefix, "size", None, None)(x => extract(x).size, (row, value) => merge(row, extract(row).copy(size = value)))
-      override val sizeunitmeasurecode = new OptField[UnitmeasureId, Row](prefix, "sizeunitmeasurecode", None, None)(x => extract(x).sizeunitmeasurecode, (row, value) => merge(row, extract(row).copy(sizeunitmeasurecode = value)))
-      override val weightunitmeasurecode = new OptField[UnitmeasureId, Row](prefix, "weightunitmeasurecode", None, None)(x => extract(x).weightunitmeasurecode, (row, value) => merge(row, extract(row).copy(weightunitmeasurecode = value)))
-      override val weight = new OptField[BigDecimal, Row](prefix, "weight", None, None)(x => extract(x).weight, (row, value) => merge(row, extract(row).copy(weight = value)))
-      override val daystomanufacture = new Field[Int, Row](prefix, "daystomanufacture", None, None)(x => extract(x).daystomanufacture, (row, value) => merge(row, extract(row).copy(daystomanufacture = value)))
-      override val productline = new OptField[/* bpchar, max 2 chars */ String, Row](prefix, "productline", None, None)(x => extract(x).productline, (row, value) => merge(row, extract(row).copy(productline = value)))
-      override val `class` = new OptField[/* bpchar, max 2 chars */ String, Row](prefix, "class", None, None)(x => extract(x).`class`, (row, value) => merge(row, extract(row).copy(`class` = value)))
-      override val style = new OptField[/* bpchar, max 2 chars */ String, Row](prefix, "style", None, None)(x => extract(x).style, (row, value) => merge(row, extract(row).copy(style = value)))
-      override val productsubcategoryid = new OptField[ProductsubcategoryId, Row](prefix, "productsubcategoryid", None, None)(x => extract(x).productsubcategoryid, (row, value) => merge(row, extract(row).copy(productsubcategoryid = value)))
-      override val productmodelid = new OptField[ProductmodelId, Row](prefix, "productmodelid", None, None)(x => extract(x).productmodelid, (row, value) => merge(row, extract(row).copy(productmodelid = value)))
-      override val sellstartdate = new Field[TypoLocalDateTime, Row](prefix, "sellstartdate", Some("text"), None)(x => extract(x).sellstartdate, (row, value) => merge(row, extract(row).copy(sellstartdate = value)))
-      override val sellenddate = new OptField[TypoLocalDateTime, Row](prefix, "sellenddate", Some("text"), None)(x => extract(x).sellenddate, (row, value) => merge(row, extract(row).copy(sellenddate = value)))
-      override val discontinueddate = new OptField[TypoLocalDateTime, Row](prefix, "discontinueddate", Some("text"), None)(x => extract(x).discontinueddate, (row, value) => merge(row, extract(row).copy(discontinueddate = value)))
-      override val rowguid = new Field[TypoUUID, Row](prefix, "rowguid", None, None)(x => extract(x).rowguid, (row, value) => merge(row, extract(row).copy(rowguid = value)))
-      override val modifieddate = new Field[TypoLocalDateTime, Row](prefix, "modifieddate", Some("text"), None)(x => extract(x).modifieddate, (row, value) => merge(row, extract(row).copy(modifieddate = value)))
+    override lazy val fields: PViewFields = new PViewFields {
+      override def id = Field[ProductId, PViewRow](_path, "id", None, None, x => x.id, (row, value) => row.copy(id = value))
+      override def productid = Field[ProductId, PViewRow](_path, "productid", None, None, x => x.productid, (row, value) => row.copy(productid = value))
+      override def name = Field[Name, PViewRow](_path, "name", None, None, x => x.name, (row, value) => row.copy(name = value))
+      override def productnumber = Field[/* max 25 chars */ String, PViewRow](_path, "productnumber", None, None, x => x.productnumber, (row, value) => row.copy(productnumber = value))
+      override def makeflag = Field[Flag, PViewRow](_path, "makeflag", None, None, x => x.makeflag, (row, value) => row.copy(makeflag = value))
+      override def finishedgoodsflag = Field[Flag, PViewRow](_path, "finishedgoodsflag", None, None, x => x.finishedgoodsflag, (row, value) => row.copy(finishedgoodsflag = value))
+      override def color = OptField[/* max 15 chars */ String, PViewRow](_path, "color", None, None, x => x.color, (row, value) => row.copy(color = value))
+      override def safetystocklevel = Field[TypoShort, PViewRow](_path, "safetystocklevel", None, None, x => x.safetystocklevel, (row, value) => row.copy(safetystocklevel = value))
+      override def reorderpoint = Field[TypoShort, PViewRow](_path, "reorderpoint", None, None, x => x.reorderpoint, (row, value) => row.copy(reorderpoint = value))
+      override def standardcost = Field[BigDecimal, PViewRow](_path, "standardcost", None, None, x => x.standardcost, (row, value) => row.copy(standardcost = value))
+      override def listprice = Field[BigDecimal, PViewRow](_path, "listprice", None, None, x => x.listprice, (row, value) => row.copy(listprice = value))
+      override def size = OptField[/* max 5 chars */ String, PViewRow](_path, "size", None, None, x => x.size, (row, value) => row.copy(size = value))
+      override def sizeunitmeasurecode = OptField[UnitmeasureId, PViewRow](_path, "sizeunitmeasurecode", None, None, x => x.sizeunitmeasurecode, (row, value) => row.copy(sizeunitmeasurecode = value))
+      override def weightunitmeasurecode = OptField[UnitmeasureId, PViewRow](_path, "weightunitmeasurecode", None, None, x => x.weightunitmeasurecode, (row, value) => row.copy(weightunitmeasurecode = value))
+      override def weight = OptField[BigDecimal, PViewRow](_path, "weight", None, None, x => x.weight, (row, value) => row.copy(weight = value))
+      override def daystomanufacture = Field[Int, PViewRow](_path, "daystomanufacture", None, None, x => x.daystomanufacture, (row, value) => row.copy(daystomanufacture = value))
+      override def productline = OptField[/* bpchar, max 2 chars */ String, PViewRow](_path, "productline", None, None, x => x.productline, (row, value) => row.copy(productline = value))
+      override def `class` = OptField[/* bpchar, max 2 chars */ String, PViewRow](_path, "class", None, None, x => x.`class`, (row, value) => row.copy(`class` = value))
+      override def style = OptField[/* bpchar, max 2 chars */ String, PViewRow](_path, "style", None, None, x => x.style, (row, value) => row.copy(style = value))
+      override def productsubcategoryid = OptField[ProductsubcategoryId, PViewRow](_path, "productsubcategoryid", None, None, x => x.productsubcategoryid, (row, value) => row.copy(productsubcategoryid = value))
+      override def productmodelid = OptField[ProductmodelId, PViewRow](_path, "productmodelid", None, None, x => x.productmodelid, (row, value) => row.copy(productmodelid = value))
+      override def sellstartdate = Field[TypoLocalDateTime, PViewRow](_path, "sellstartdate", Some("text"), None, x => x.sellstartdate, (row, value) => row.copy(sellstartdate = value))
+      override def sellenddate = OptField[TypoLocalDateTime, PViewRow](_path, "sellenddate", Some("text"), None, x => x.sellenddate, (row, value) => row.copy(sellenddate = value))
+      override def discontinueddate = OptField[TypoLocalDateTime, PViewRow](_path, "discontinueddate", Some("text"), None, x => x.discontinueddate, (row, value) => row.copy(discontinueddate = value))
+      override def rowguid = Field[TypoUUID, PViewRow](_path, "rowguid", None, None, x => x.rowguid, (row, value) => row.copy(rowguid = value))
+      override def modifieddate = Field[TypoLocalDateTime, PViewRow](_path, "modifieddate", Some("text"), None, x => x.modifieddate, (row, value) => row.copy(modifieddate = value))
     }
   
-    override val columns: List[FieldLikeNoHkt[?, Row]] =
-      List[FieldLikeNoHkt[?, Row]](fields.id, fields.productid, fields.name, fields.productnumber, fields.makeflag, fields.finishedgoodsflag, fields.color, fields.safetystocklevel, fields.reorderpoint, fields.standardcost, fields.listprice, fields.size, fields.sizeunitmeasurecode, fields.weightunitmeasurecode, fields.weight, fields.daystomanufacture, fields.productline, fields.`class`, fields.style, fields.productsubcategoryid, fields.productmodelid, fields.sellstartdate, fields.sellenddate, fields.discontinueddate, fields.rowguid, fields.modifieddate)
+    override lazy val columns: List[FieldLikeNoHkt[?, PViewRow]] =
+      List[FieldLikeNoHkt[?, PViewRow]](fields.id, fields.productid, fields.name, fields.productnumber, fields.makeflag, fields.finishedgoodsflag, fields.color, fields.safetystocklevel, fields.reorderpoint, fields.standardcost, fields.listprice, fields.size, fields.sizeunitmeasurecode, fields.weightunitmeasurecode, fields.weight, fields.daystomanufacture, fields.productline, fields.`class`, fields.style, fields.productsubcategoryid, fields.productmodelid, fields.sellstartdate, fields.sellenddate, fields.discontinueddate, fields.rowguid, fields.modifieddate)
   
-    override def copy[NewRow](prefix: Option[String], extract: NewRow => PViewRow, merge: (NewRow, PViewRow) => NewRow): Impl[NewRow] =
-      new Impl(prefix, extract, merge)
+    override def copy(path: List[Path]): Impl =
+      new Impl(path)
   }
   
 }

--- a/typo-tester-anorm/generated-and-checked-in/adventureworks/pr/pc/PcViewFields.scala
+++ b/typo-tester-anorm/generated-and-checked-in/adventureworks/pr/pc/PcViewFields.scala
@@ -11,38 +11,39 @@ import adventureworks.customtypes.TypoLocalDateTime
 import adventureworks.customtypes.TypoUUID
 import adventureworks.production.productcategory.ProductcategoryId
 import adventureworks.public.Name
+import typo.dsl.Path
 import typo.dsl.SqlExpr.Field
 import typo.dsl.SqlExpr.FieldLikeNoHkt
 import typo.dsl.Structure.Relation
 
-trait PcViewFields[Row] {
-  val id: Field[ProductcategoryId, Row]
-  val productcategoryid: Field[ProductcategoryId, Row]
-  val name: Field[Name, Row]
-  val rowguid: Field[TypoUUID, Row]
-  val modifieddate: Field[TypoLocalDateTime, Row]
+trait PcViewFields {
+  def id: Field[ProductcategoryId, PcViewRow]
+  def productcategoryid: Field[ProductcategoryId, PcViewRow]
+  def name: Field[Name, PcViewRow]
+  def rowguid: Field[TypoUUID, PcViewRow]
+  def modifieddate: Field[TypoLocalDateTime, PcViewRow]
 }
 
 object PcViewFields {
-  val structure: Relation[PcViewFields, PcViewRow, PcViewRow] = 
-    new Impl(None, identity, (_, x) => x)
+  lazy val structure: Relation[PcViewFields, PcViewRow] =
+    new Impl(Nil)
     
-  private final class Impl[Row](val prefix: Option[String], val extract: Row => PcViewRow, val merge: (Row, PcViewRow) => Row)
-    extends Relation[PcViewFields, PcViewRow, Row] { 
+  private final class Impl(val _path: List[Path])
+    extends Relation[PcViewFields, PcViewRow] {
   
-    override val fields: PcViewFields[Row] = new PcViewFields[Row] {
-      override val id = new Field[ProductcategoryId, Row](prefix, "id", None, None)(x => extract(x).id, (row, value) => merge(row, extract(row).copy(id = value)))
-      override val productcategoryid = new Field[ProductcategoryId, Row](prefix, "productcategoryid", None, None)(x => extract(x).productcategoryid, (row, value) => merge(row, extract(row).copy(productcategoryid = value)))
-      override val name = new Field[Name, Row](prefix, "name", None, None)(x => extract(x).name, (row, value) => merge(row, extract(row).copy(name = value)))
-      override val rowguid = new Field[TypoUUID, Row](prefix, "rowguid", None, None)(x => extract(x).rowguid, (row, value) => merge(row, extract(row).copy(rowguid = value)))
-      override val modifieddate = new Field[TypoLocalDateTime, Row](prefix, "modifieddate", Some("text"), None)(x => extract(x).modifieddate, (row, value) => merge(row, extract(row).copy(modifieddate = value)))
+    override lazy val fields: PcViewFields = new PcViewFields {
+      override def id = Field[ProductcategoryId, PcViewRow](_path, "id", None, None, x => x.id, (row, value) => row.copy(id = value))
+      override def productcategoryid = Field[ProductcategoryId, PcViewRow](_path, "productcategoryid", None, None, x => x.productcategoryid, (row, value) => row.copy(productcategoryid = value))
+      override def name = Field[Name, PcViewRow](_path, "name", None, None, x => x.name, (row, value) => row.copy(name = value))
+      override def rowguid = Field[TypoUUID, PcViewRow](_path, "rowguid", None, None, x => x.rowguid, (row, value) => row.copy(rowguid = value))
+      override def modifieddate = Field[TypoLocalDateTime, PcViewRow](_path, "modifieddate", Some("text"), None, x => x.modifieddate, (row, value) => row.copy(modifieddate = value))
     }
   
-    override val columns: List[FieldLikeNoHkt[?, Row]] =
-      List[FieldLikeNoHkt[?, Row]](fields.id, fields.productcategoryid, fields.name, fields.rowguid, fields.modifieddate)
+    override lazy val columns: List[FieldLikeNoHkt[?, PcViewRow]] =
+      List[FieldLikeNoHkt[?, PcViewRow]](fields.id, fields.productcategoryid, fields.name, fields.rowguid, fields.modifieddate)
   
-    override def copy[NewRow](prefix: Option[String], extract: NewRow => PcViewRow, merge: (NewRow, PcViewRow) => NewRow): Impl[NewRow] =
-      new Impl(prefix, extract, merge)
+    override def copy(path: List[Path]): Impl =
+      new Impl(path)
   }
   
 }

--- a/typo-tester-anorm/generated-and-checked-in/adventureworks/pr/pch/PchViewFields.scala
+++ b/typo-tester-anorm/generated-and-checked-in/adventureworks/pr/pch/PchViewFields.scala
@@ -9,41 +9,42 @@ package pch
 
 import adventureworks.customtypes.TypoLocalDateTime
 import adventureworks.production.product.ProductId
+import typo.dsl.Path
 import typo.dsl.SqlExpr.Field
 import typo.dsl.SqlExpr.FieldLikeNoHkt
 import typo.dsl.SqlExpr.OptField
 import typo.dsl.Structure.Relation
 
-trait PchViewFields[Row] {
-  val id: Field[ProductId, Row]
-  val productid: Field[ProductId, Row]
-  val startdate: Field[TypoLocalDateTime, Row]
-  val enddate: OptField[TypoLocalDateTime, Row]
-  val standardcost: Field[BigDecimal, Row]
-  val modifieddate: Field[TypoLocalDateTime, Row]
+trait PchViewFields {
+  def id: Field[ProductId, PchViewRow]
+  def productid: Field[ProductId, PchViewRow]
+  def startdate: Field[TypoLocalDateTime, PchViewRow]
+  def enddate: OptField[TypoLocalDateTime, PchViewRow]
+  def standardcost: Field[BigDecimal, PchViewRow]
+  def modifieddate: Field[TypoLocalDateTime, PchViewRow]
 }
 
 object PchViewFields {
-  val structure: Relation[PchViewFields, PchViewRow, PchViewRow] = 
-    new Impl(None, identity, (_, x) => x)
+  lazy val structure: Relation[PchViewFields, PchViewRow] =
+    new Impl(Nil)
     
-  private final class Impl[Row](val prefix: Option[String], val extract: Row => PchViewRow, val merge: (Row, PchViewRow) => Row)
-    extends Relation[PchViewFields, PchViewRow, Row] { 
+  private final class Impl(val _path: List[Path])
+    extends Relation[PchViewFields, PchViewRow] {
   
-    override val fields: PchViewFields[Row] = new PchViewFields[Row] {
-      override val id = new Field[ProductId, Row](prefix, "id", None, None)(x => extract(x).id, (row, value) => merge(row, extract(row).copy(id = value)))
-      override val productid = new Field[ProductId, Row](prefix, "productid", None, None)(x => extract(x).productid, (row, value) => merge(row, extract(row).copy(productid = value)))
-      override val startdate = new Field[TypoLocalDateTime, Row](prefix, "startdate", Some("text"), None)(x => extract(x).startdate, (row, value) => merge(row, extract(row).copy(startdate = value)))
-      override val enddate = new OptField[TypoLocalDateTime, Row](prefix, "enddate", Some("text"), None)(x => extract(x).enddate, (row, value) => merge(row, extract(row).copy(enddate = value)))
-      override val standardcost = new Field[BigDecimal, Row](prefix, "standardcost", None, None)(x => extract(x).standardcost, (row, value) => merge(row, extract(row).copy(standardcost = value)))
-      override val modifieddate = new Field[TypoLocalDateTime, Row](prefix, "modifieddate", Some("text"), None)(x => extract(x).modifieddate, (row, value) => merge(row, extract(row).copy(modifieddate = value)))
+    override lazy val fields: PchViewFields = new PchViewFields {
+      override def id = Field[ProductId, PchViewRow](_path, "id", None, None, x => x.id, (row, value) => row.copy(id = value))
+      override def productid = Field[ProductId, PchViewRow](_path, "productid", None, None, x => x.productid, (row, value) => row.copy(productid = value))
+      override def startdate = Field[TypoLocalDateTime, PchViewRow](_path, "startdate", Some("text"), None, x => x.startdate, (row, value) => row.copy(startdate = value))
+      override def enddate = OptField[TypoLocalDateTime, PchViewRow](_path, "enddate", Some("text"), None, x => x.enddate, (row, value) => row.copy(enddate = value))
+      override def standardcost = Field[BigDecimal, PchViewRow](_path, "standardcost", None, None, x => x.standardcost, (row, value) => row.copy(standardcost = value))
+      override def modifieddate = Field[TypoLocalDateTime, PchViewRow](_path, "modifieddate", Some("text"), None, x => x.modifieddate, (row, value) => row.copy(modifieddate = value))
     }
   
-    override val columns: List[FieldLikeNoHkt[?, Row]] =
-      List[FieldLikeNoHkt[?, Row]](fields.id, fields.productid, fields.startdate, fields.enddate, fields.standardcost, fields.modifieddate)
+    override lazy val columns: List[FieldLikeNoHkt[?, PchViewRow]] =
+      List[FieldLikeNoHkt[?, PchViewRow]](fields.id, fields.productid, fields.startdate, fields.enddate, fields.standardcost, fields.modifieddate)
   
-    override def copy[NewRow](prefix: Option[String], extract: NewRow => PchViewRow, merge: (NewRow, PchViewRow) => NewRow): Impl[NewRow] =
-      new Impl(prefix, extract, merge)
+    override def copy(path: List[Path]): Impl =
+      new Impl(path)
   }
   
 }

--- a/typo-tester-anorm/generated-and-checked-in/adventureworks/pr/pd/PdViewFields.scala
+++ b/typo-tester-anorm/generated-and-checked-in/adventureworks/pr/pd/PdViewFields.scala
@@ -10,38 +10,39 @@ package pd
 import adventureworks.customtypes.TypoLocalDateTime
 import adventureworks.customtypes.TypoUUID
 import adventureworks.production.productdescription.ProductdescriptionId
+import typo.dsl.Path
 import typo.dsl.SqlExpr.Field
 import typo.dsl.SqlExpr.FieldLikeNoHkt
 import typo.dsl.Structure.Relation
 
-trait PdViewFields[Row] {
-  val id: Field[ProductdescriptionId, Row]
-  val productdescriptionid: Field[ProductdescriptionId, Row]
-  val description: Field[/* max 400 chars */ String, Row]
-  val rowguid: Field[TypoUUID, Row]
-  val modifieddate: Field[TypoLocalDateTime, Row]
+trait PdViewFields {
+  def id: Field[ProductdescriptionId, PdViewRow]
+  def productdescriptionid: Field[ProductdescriptionId, PdViewRow]
+  def description: Field[/* max 400 chars */ String, PdViewRow]
+  def rowguid: Field[TypoUUID, PdViewRow]
+  def modifieddate: Field[TypoLocalDateTime, PdViewRow]
 }
 
 object PdViewFields {
-  val structure: Relation[PdViewFields, PdViewRow, PdViewRow] = 
-    new Impl(None, identity, (_, x) => x)
+  lazy val structure: Relation[PdViewFields, PdViewRow] =
+    new Impl(Nil)
     
-  private final class Impl[Row](val prefix: Option[String], val extract: Row => PdViewRow, val merge: (Row, PdViewRow) => Row)
-    extends Relation[PdViewFields, PdViewRow, Row] { 
+  private final class Impl(val _path: List[Path])
+    extends Relation[PdViewFields, PdViewRow] {
   
-    override val fields: PdViewFields[Row] = new PdViewFields[Row] {
-      override val id = new Field[ProductdescriptionId, Row](prefix, "id", None, None)(x => extract(x).id, (row, value) => merge(row, extract(row).copy(id = value)))
-      override val productdescriptionid = new Field[ProductdescriptionId, Row](prefix, "productdescriptionid", None, None)(x => extract(x).productdescriptionid, (row, value) => merge(row, extract(row).copy(productdescriptionid = value)))
-      override val description = new Field[/* max 400 chars */ String, Row](prefix, "description", None, None)(x => extract(x).description, (row, value) => merge(row, extract(row).copy(description = value)))
-      override val rowguid = new Field[TypoUUID, Row](prefix, "rowguid", None, None)(x => extract(x).rowguid, (row, value) => merge(row, extract(row).copy(rowguid = value)))
-      override val modifieddate = new Field[TypoLocalDateTime, Row](prefix, "modifieddate", Some("text"), None)(x => extract(x).modifieddate, (row, value) => merge(row, extract(row).copy(modifieddate = value)))
+    override lazy val fields: PdViewFields = new PdViewFields {
+      override def id = Field[ProductdescriptionId, PdViewRow](_path, "id", None, None, x => x.id, (row, value) => row.copy(id = value))
+      override def productdescriptionid = Field[ProductdescriptionId, PdViewRow](_path, "productdescriptionid", None, None, x => x.productdescriptionid, (row, value) => row.copy(productdescriptionid = value))
+      override def description = Field[/* max 400 chars */ String, PdViewRow](_path, "description", None, None, x => x.description, (row, value) => row.copy(description = value))
+      override def rowguid = Field[TypoUUID, PdViewRow](_path, "rowguid", None, None, x => x.rowguid, (row, value) => row.copy(rowguid = value))
+      override def modifieddate = Field[TypoLocalDateTime, PdViewRow](_path, "modifieddate", Some("text"), None, x => x.modifieddate, (row, value) => row.copy(modifieddate = value))
     }
   
-    override val columns: List[FieldLikeNoHkt[?, Row]] =
-      List[FieldLikeNoHkt[?, Row]](fields.id, fields.productdescriptionid, fields.description, fields.rowguid, fields.modifieddate)
+    override lazy val columns: List[FieldLikeNoHkt[?, PdViewRow]] =
+      List[FieldLikeNoHkt[?, PdViewRow]](fields.id, fields.productdescriptionid, fields.description, fields.rowguid, fields.modifieddate)
   
-    override def copy[NewRow](prefix: Option[String], extract: NewRow => PdViewRow, merge: (NewRow, PdViewRow) => NewRow): Impl[NewRow] =
-      new Impl(prefix, extract, merge)
+    override def copy(path: List[Path]): Impl =
+      new Impl(path)
   }
   
 }

--- a/typo-tester-anorm/generated-and-checked-in/adventureworks/pr/pi/PiViewFields.scala
+++ b/typo-tester-anorm/generated-and-checked-in/adventureworks/pr/pi/PiViewFields.scala
@@ -12,44 +12,45 @@ import adventureworks.customtypes.TypoShort
 import adventureworks.customtypes.TypoUUID
 import adventureworks.production.location.LocationId
 import adventureworks.production.product.ProductId
+import typo.dsl.Path
 import typo.dsl.SqlExpr.Field
 import typo.dsl.SqlExpr.FieldLikeNoHkt
 import typo.dsl.Structure.Relation
 
-trait PiViewFields[Row] {
-  val id: Field[ProductId, Row]
-  val productid: Field[ProductId, Row]
-  val locationid: Field[LocationId, Row]
-  val shelf: Field[/* max 10 chars */ String, Row]
-  val bin: Field[TypoShort, Row]
-  val quantity: Field[TypoShort, Row]
-  val rowguid: Field[TypoUUID, Row]
-  val modifieddate: Field[TypoLocalDateTime, Row]
+trait PiViewFields {
+  def id: Field[ProductId, PiViewRow]
+  def productid: Field[ProductId, PiViewRow]
+  def locationid: Field[LocationId, PiViewRow]
+  def shelf: Field[/* max 10 chars */ String, PiViewRow]
+  def bin: Field[TypoShort, PiViewRow]
+  def quantity: Field[TypoShort, PiViewRow]
+  def rowguid: Field[TypoUUID, PiViewRow]
+  def modifieddate: Field[TypoLocalDateTime, PiViewRow]
 }
 
 object PiViewFields {
-  val structure: Relation[PiViewFields, PiViewRow, PiViewRow] = 
-    new Impl(None, identity, (_, x) => x)
+  lazy val structure: Relation[PiViewFields, PiViewRow] =
+    new Impl(Nil)
     
-  private final class Impl[Row](val prefix: Option[String], val extract: Row => PiViewRow, val merge: (Row, PiViewRow) => Row)
-    extends Relation[PiViewFields, PiViewRow, Row] { 
+  private final class Impl(val _path: List[Path])
+    extends Relation[PiViewFields, PiViewRow] {
   
-    override val fields: PiViewFields[Row] = new PiViewFields[Row] {
-      override val id = new Field[ProductId, Row](prefix, "id", None, None)(x => extract(x).id, (row, value) => merge(row, extract(row).copy(id = value)))
-      override val productid = new Field[ProductId, Row](prefix, "productid", None, None)(x => extract(x).productid, (row, value) => merge(row, extract(row).copy(productid = value)))
-      override val locationid = new Field[LocationId, Row](prefix, "locationid", None, None)(x => extract(x).locationid, (row, value) => merge(row, extract(row).copy(locationid = value)))
-      override val shelf = new Field[/* max 10 chars */ String, Row](prefix, "shelf", None, None)(x => extract(x).shelf, (row, value) => merge(row, extract(row).copy(shelf = value)))
-      override val bin = new Field[TypoShort, Row](prefix, "bin", None, None)(x => extract(x).bin, (row, value) => merge(row, extract(row).copy(bin = value)))
-      override val quantity = new Field[TypoShort, Row](prefix, "quantity", None, None)(x => extract(x).quantity, (row, value) => merge(row, extract(row).copy(quantity = value)))
-      override val rowguid = new Field[TypoUUID, Row](prefix, "rowguid", None, None)(x => extract(x).rowguid, (row, value) => merge(row, extract(row).copy(rowguid = value)))
-      override val modifieddate = new Field[TypoLocalDateTime, Row](prefix, "modifieddate", Some("text"), None)(x => extract(x).modifieddate, (row, value) => merge(row, extract(row).copy(modifieddate = value)))
+    override lazy val fields: PiViewFields = new PiViewFields {
+      override def id = Field[ProductId, PiViewRow](_path, "id", None, None, x => x.id, (row, value) => row.copy(id = value))
+      override def productid = Field[ProductId, PiViewRow](_path, "productid", None, None, x => x.productid, (row, value) => row.copy(productid = value))
+      override def locationid = Field[LocationId, PiViewRow](_path, "locationid", None, None, x => x.locationid, (row, value) => row.copy(locationid = value))
+      override def shelf = Field[/* max 10 chars */ String, PiViewRow](_path, "shelf", None, None, x => x.shelf, (row, value) => row.copy(shelf = value))
+      override def bin = Field[TypoShort, PiViewRow](_path, "bin", None, None, x => x.bin, (row, value) => row.copy(bin = value))
+      override def quantity = Field[TypoShort, PiViewRow](_path, "quantity", None, None, x => x.quantity, (row, value) => row.copy(quantity = value))
+      override def rowguid = Field[TypoUUID, PiViewRow](_path, "rowguid", None, None, x => x.rowguid, (row, value) => row.copy(rowguid = value))
+      override def modifieddate = Field[TypoLocalDateTime, PiViewRow](_path, "modifieddate", Some("text"), None, x => x.modifieddate, (row, value) => row.copy(modifieddate = value))
     }
   
-    override val columns: List[FieldLikeNoHkt[?, Row]] =
-      List[FieldLikeNoHkt[?, Row]](fields.id, fields.productid, fields.locationid, fields.shelf, fields.bin, fields.quantity, fields.rowguid, fields.modifieddate)
+    override lazy val columns: List[FieldLikeNoHkt[?, PiViewRow]] =
+      List[FieldLikeNoHkt[?, PiViewRow]](fields.id, fields.productid, fields.locationid, fields.shelf, fields.bin, fields.quantity, fields.rowguid, fields.modifieddate)
   
-    override def copy[NewRow](prefix: Option[String], extract: NewRow => PiViewRow, merge: (NewRow, PiViewRow) => NewRow): Impl[NewRow] =
-      new Impl(prefix, extract, merge)
+    override def copy(path: List[Path]): Impl =
+      new Impl(path)
   }
   
 }

--- a/typo-tester-anorm/generated-and-checked-in/adventureworks/pr/plph/PlphViewFields.scala
+++ b/typo-tester-anorm/generated-and-checked-in/adventureworks/pr/plph/PlphViewFields.scala
@@ -9,41 +9,42 @@ package plph
 
 import adventureworks.customtypes.TypoLocalDateTime
 import adventureworks.production.product.ProductId
+import typo.dsl.Path
 import typo.dsl.SqlExpr.Field
 import typo.dsl.SqlExpr.FieldLikeNoHkt
 import typo.dsl.SqlExpr.OptField
 import typo.dsl.Structure.Relation
 
-trait PlphViewFields[Row] {
-  val id: Field[ProductId, Row]
-  val productid: Field[ProductId, Row]
-  val startdate: Field[TypoLocalDateTime, Row]
-  val enddate: OptField[TypoLocalDateTime, Row]
-  val listprice: Field[BigDecimal, Row]
-  val modifieddate: Field[TypoLocalDateTime, Row]
+trait PlphViewFields {
+  def id: Field[ProductId, PlphViewRow]
+  def productid: Field[ProductId, PlphViewRow]
+  def startdate: Field[TypoLocalDateTime, PlphViewRow]
+  def enddate: OptField[TypoLocalDateTime, PlphViewRow]
+  def listprice: Field[BigDecimal, PlphViewRow]
+  def modifieddate: Field[TypoLocalDateTime, PlphViewRow]
 }
 
 object PlphViewFields {
-  val structure: Relation[PlphViewFields, PlphViewRow, PlphViewRow] = 
-    new Impl(None, identity, (_, x) => x)
+  lazy val structure: Relation[PlphViewFields, PlphViewRow] =
+    new Impl(Nil)
     
-  private final class Impl[Row](val prefix: Option[String], val extract: Row => PlphViewRow, val merge: (Row, PlphViewRow) => Row)
-    extends Relation[PlphViewFields, PlphViewRow, Row] { 
+  private final class Impl(val _path: List[Path])
+    extends Relation[PlphViewFields, PlphViewRow] {
   
-    override val fields: PlphViewFields[Row] = new PlphViewFields[Row] {
-      override val id = new Field[ProductId, Row](prefix, "id", None, None)(x => extract(x).id, (row, value) => merge(row, extract(row).copy(id = value)))
-      override val productid = new Field[ProductId, Row](prefix, "productid", None, None)(x => extract(x).productid, (row, value) => merge(row, extract(row).copy(productid = value)))
-      override val startdate = new Field[TypoLocalDateTime, Row](prefix, "startdate", Some("text"), None)(x => extract(x).startdate, (row, value) => merge(row, extract(row).copy(startdate = value)))
-      override val enddate = new OptField[TypoLocalDateTime, Row](prefix, "enddate", Some("text"), None)(x => extract(x).enddate, (row, value) => merge(row, extract(row).copy(enddate = value)))
-      override val listprice = new Field[BigDecimal, Row](prefix, "listprice", None, None)(x => extract(x).listprice, (row, value) => merge(row, extract(row).copy(listprice = value)))
-      override val modifieddate = new Field[TypoLocalDateTime, Row](prefix, "modifieddate", Some("text"), None)(x => extract(x).modifieddate, (row, value) => merge(row, extract(row).copy(modifieddate = value)))
+    override lazy val fields: PlphViewFields = new PlphViewFields {
+      override def id = Field[ProductId, PlphViewRow](_path, "id", None, None, x => x.id, (row, value) => row.copy(id = value))
+      override def productid = Field[ProductId, PlphViewRow](_path, "productid", None, None, x => x.productid, (row, value) => row.copy(productid = value))
+      override def startdate = Field[TypoLocalDateTime, PlphViewRow](_path, "startdate", Some("text"), None, x => x.startdate, (row, value) => row.copy(startdate = value))
+      override def enddate = OptField[TypoLocalDateTime, PlphViewRow](_path, "enddate", Some("text"), None, x => x.enddate, (row, value) => row.copy(enddate = value))
+      override def listprice = Field[BigDecimal, PlphViewRow](_path, "listprice", None, None, x => x.listprice, (row, value) => row.copy(listprice = value))
+      override def modifieddate = Field[TypoLocalDateTime, PlphViewRow](_path, "modifieddate", Some("text"), None, x => x.modifieddate, (row, value) => row.copy(modifieddate = value))
     }
   
-    override val columns: List[FieldLikeNoHkt[?, Row]] =
-      List[FieldLikeNoHkt[?, Row]](fields.id, fields.productid, fields.startdate, fields.enddate, fields.listprice, fields.modifieddate)
+    override lazy val columns: List[FieldLikeNoHkt[?, PlphViewRow]] =
+      List[FieldLikeNoHkt[?, PlphViewRow]](fields.id, fields.productid, fields.startdate, fields.enddate, fields.listprice, fields.modifieddate)
   
-    override def copy[NewRow](prefix: Option[String], extract: NewRow => PlphViewRow, merge: (NewRow, PlphViewRow) => NewRow): Impl[NewRow] =
-      new Impl(prefix, extract, merge)
+    override def copy(path: List[Path]): Impl =
+      new Impl(path)
   }
   
 }

--- a/typo-tester-anorm/generated-and-checked-in/adventureworks/pr/pm/PmViewFields.scala
+++ b/typo-tester-anorm/generated-and-checked-in/adventureworks/pr/pm/PmViewFields.scala
@@ -12,43 +12,44 @@ import adventureworks.customtypes.TypoUUID
 import adventureworks.customtypes.TypoXml
 import adventureworks.production.productmodel.ProductmodelId
 import adventureworks.public.Name
+import typo.dsl.Path
 import typo.dsl.SqlExpr.Field
 import typo.dsl.SqlExpr.FieldLikeNoHkt
 import typo.dsl.SqlExpr.OptField
 import typo.dsl.Structure.Relation
 
-trait PmViewFields[Row] {
-  val id: Field[ProductmodelId, Row]
-  val productmodelid: Field[ProductmodelId, Row]
-  val name: Field[Name, Row]
-  val catalogdescription: OptField[TypoXml, Row]
-  val instructions: OptField[TypoXml, Row]
-  val rowguid: Field[TypoUUID, Row]
-  val modifieddate: Field[TypoLocalDateTime, Row]
+trait PmViewFields {
+  def id: Field[ProductmodelId, PmViewRow]
+  def productmodelid: Field[ProductmodelId, PmViewRow]
+  def name: Field[Name, PmViewRow]
+  def catalogdescription: OptField[TypoXml, PmViewRow]
+  def instructions: OptField[TypoXml, PmViewRow]
+  def rowguid: Field[TypoUUID, PmViewRow]
+  def modifieddate: Field[TypoLocalDateTime, PmViewRow]
 }
 
 object PmViewFields {
-  val structure: Relation[PmViewFields, PmViewRow, PmViewRow] = 
-    new Impl(None, identity, (_, x) => x)
+  lazy val structure: Relation[PmViewFields, PmViewRow] =
+    new Impl(Nil)
     
-  private final class Impl[Row](val prefix: Option[String], val extract: Row => PmViewRow, val merge: (Row, PmViewRow) => Row)
-    extends Relation[PmViewFields, PmViewRow, Row] { 
+  private final class Impl(val _path: List[Path])
+    extends Relation[PmViewFields, PmViewRow] {
   
-    override val fields: PmViewFields[Row] = new PmViewFields[Row] {
-      override val id = new Field[ProductmodelId, Row](prefix, "id", None, None)(x => extract(x).id, (row, value) => merge(row, extract(row).copy(id = value)))
-      override val productmodelid = new Field[ProductmodelId, Row](prefix, "productmodelid", None, None)(x => extract(x).productmodelid, (row, value) => merge(row, extract(row).copy(productmodelid = value)))
-      override val name = new Field[Name, Row](prefix, "name", None, None)(x => extract(x).name, (row, value) => merge(row, extract(row).copy(name = value)))
-      override val catalogdescription = new OptField[TypoXml, Row](prefix, "catalogdescription", None, None)(x => extract(x).catalogdescription, (row, value) => merge(row, extract(row).copy(catalogdescription = value)))
-      override val instructions = new OptField[TypoXml, Row](prefix, "instructions", None, None)(x => extract(x).instructions, (row, value) => merge(row, extract(row).copy(instructions = value)))
-      override val rowguid = new Field[TypoUUID, Row](prefix, "rowguid", None, None)(x => extract(x).rowguid, (row, value) => merge(row, extract(row).copy(rowguid = value)))
-      override val modifieddate = new Field[TypoLocalDateTime, Row](prefix, "modifieddate", Some("text"), None)(x => extract(x).modifieddate, (row, value) => merge(row, extract(row).copy(modifieddate = value)))
+    override lazy val fields: PmViewFields = new PmViewFields {
+      override def id = Field[ProductmodelId, PmViewRow](_path, "id", None, None, x => x.id, (row, value) => row.copy(id = value))
+      override def productmodelid = Field[ProductmodelId, PmViewRow](_path, "productmodelid", None, None, x => x.productmodelid, (row, value) => row.copy(productmodelid = value))
+      override def name = Field[Name, PmViewRow](_path, "name", None, None, x => x.name, (row, value) => row.copy(name = value))
+      override def catalogdescription = OptField[TypoXml, PmViewRow](_path, "catalogdescription", None, None, x => x.catalogdescription, (row, value) => row.copy(catalogdescription = value))
+      override def instructions = OptField[TypoXml, PmViewRow](_path, "instructions", None, None, x => x.instructions, (row, value) => row.copy(instructions = value))
+      override def rowguid = Field[TypoUUID, PmViewRow](_path, "rowguid", None, None, x => x.rowguid, (row, value) => row.copy(rowguid = value))
+      override def modifieddate = Field[TypoLocalDateTime, PmViewRow](_path, "modifieddate", Some("text"), None, x => x.modifieddate, (row, value) => row.copy(modifieddate = value))
     }
   
-    override val columns: List[FieldLikeNoHkt[?, Row]] =
-      List[FieldLikeNoHkt[?, Row]](fields.id, fields.productmodelid, fields.name, fields.catalogdescription, fields.instructions, fields.rowguid, fields.modifieddate)
+    override lazy val columns: List[FieldLikeNoHkt[?, PmViewRow]] =
+      List[FieldLikeNoHkt[?, PmViewRow]](fields.id, fields.productmodelid, fields.name, fields.catalogdescription, fields.instructions, fields.rowguid, fields.modifieddate)
   
-    override def copy[NewRow](prefix: Option[String], extract: NewRow => PmViewRow, merge: (NewRow, PmViewRow) => NewRow): Impl[NewRow] =
-      new Impl(prefix, extract, merge)
+    override def copy(path: List[Path]): Impl =
+      new Impl(path)
   }
   
 }

--- a/typo-tester-anorm/generated-and-checked-in/adventureworks/pr/pmpdc/PmpdcViewFields.scala
+++ b/typo-tester-anorm/generated-and-checked-in/adventureworks/pr/pmpdc/PmpdcViewFields.scala
@@ -11,36 +11,37 @@ import adventureworks.customtypes.TypoLocalDateTime
 import adventureworks.production.culture.CultureId
 import adventureworks.production.productdescription.ProductdescriptionId
 import adventureworks.production.productmodel.ProductmodelId
+import typo.dsl.Path
 import typo.dsl.SqlExpr.Field
 import typo.dsl.SqlExpr.FieldLikeNoHkt
 import typo.dsl.Structure.Relation
 
-trait PmpdcViewFields[Row] {
-  val productmodelid: Field[ProductmodelId, Row]
-  val productdescriptionid: Field[ProductdescriptionId, Row]
-  val cultureid: Field[CultureId, Row]
-  val modifieddate: Field[TypoLocalDateTime, Row]
+trait PmpdcViewFields {
+  def productmodelid: Field[ProductmodelId, PmpdcViewRow]
+  def productdescriptionid: Field[ProductdescriptionId, PmpdcViewRow]
+  def cultureid: Field[CultureId, PmpdcViewRow]
+  def modifieddate: Field[TypoLocalDateTime, PmpdcViewRow]
 }
 
 object PmpdcViewFields {
-  val structure: Relation[PmpdcViewFields, PmpdcViewRow, PmpdcViewRow] = 
-    new Impl(None, identity, (_, x) => x)
+  lazy val structure: Relation[PmpdcViewFields, PmpdcViewRow] =
+    new Impl(Nil)
     
-  private final class Impl[Row](val prefix: Option[String], val extract: Row => PmpdcViewRow, val merge: (Row, PmpdcViewRow) => Row)
-    extends Relation[PmpdcViewFields, PmpdcViewRow, Row] { 
+  private final class Impl(val _path: List[Path])
+    extends Relation[PmpdcViewFields, PmpdcViewRow] {
   
-    override val fields: PmpdcViewFields[Row] = new PmpdcViewFields[Row] {
-      override val productmodelid = new Field[ProductmodelId, Row](prefix, "productmodelid", None, None)(x => extract(x).productmodelid, (row, value) => merge(row, extract(row).copy(productmodelid = value)))
-      override val productdescriptionid = new Field[ProductdescriptionId, Row](prefix, "productdescriptionid", None, None)(x => extract(x).productdescriptionid, (row, value) => merge(row, extract(row).copy(productdescriptionid = value)))
-      override val cultureid = new Field[CultureId, Row](prefix, "cultureid", None, None)(x => extract(x).cultureid, (row, value) => merge(row, extract(row).copy(cultureid = value)))
-      override val modifieddate = new Field[TypoLocalDateTime, Row](prefix, "modifieddate", Some("text"), None)(x => extract(x).modifieddate, (row, value) => merge(row, extract(row).copy(modifieddate = value)))
+    override lazy val fields: PmpdcViewFields = new PmpdcViewFields {
+      override def productmodelid = Field[ProductmodelId, PmpdcViewRow](_path, "productmodelid", None, None, x => x.productmodelid, (row, value) => row.copy(productmodelid = value))
+      override def productdescriptionid = Field[ProductdescriptionId, PmpdcViewRow](_path, "productdescriptionid", None, None, x => x.productdescriptionid, (row, value) => row.copy(productdescriptionid = value))
+      override def cultureid = Field[CultureId, PmpdcViewRow](_path, "cultureid", None, None, x => x.cultureid, (row, value) => row.copy(cultureid = value))
+      override def modifieddate = Field[TypoLocalDateTime, PmpdcViewRow](_path, "modifieddate", Some("text"), None, x => x.modifieddate, (row, value) => row.copy(modifieddate = value))
     }
   
-    override val columns: List[FieldLikeNoHkt[?, Row]] =
-      List[FieldLikeNoHkt[?, Row]](fields.productmodelid, fields.productdescriptionid, fields.cultureid, fields.modifieddate)
+    override lazy val columns: List[FieldLikeNoHkt[?, PmpdcViewRow]] =
+      List[FieldLikeNoHkt[?, PmpdcViewRow]](fields.productmodelid, fields.productdescriptionid, fields.cultureid, fields.modifieddate)
   
-    override def copy[NewRow](prefix: Option[String], extract: NewRow => PmpdcViewRow, merge: (NewRow, PmpdcViewRow) => NewRow): Impl[NewRow] =
-      new Impl(prefix, extract, merge)
+    override def copy(path: List[Path]): Impl =
+      new Impl(path)
   }
   
 }

--- a/typo-tester-anorm/generated-and-checked-in/adventureworks/pr/pp/PpViewFields.scala
+++ b/typo-tester-anorm/generated-and-checked-in/adventureworks/pr/pp/PpViewFields.scala
@@ -10,43 +10,44 @@ package pp
 import adventureworks.customtypes.TypoBytea
 import adventureworks.customtypes.TypoLocalDateTime
 import adventureworks.production.productphoto.ProductphotoId
+import typo.dsl.Path
 import typo.dsl.SqlExpr.Field
 import typo.dsl.SqlExpr.FieldLikeNoHkt
 import typo.dsl.SqlExpr.OptField
 import typo.dsl.Structure.Relation
 
-trait PpViewFields[Row] {
-  val id: Field[ProductphotoId, Row]
-  val productphotoid: Field[ProductphotoId, Row]
-  val thumbnailphoto: OptField[TypoBytea, Row]
-  val thumbnailphotofilename: OptField[/* max 50 chars */ String, Row]
-  val largephoto: OptField[TypoBytea, Row]
-  val largephotofilename: OptField[/* max 50 chars */ String, Row]
-  val modifieddate: Field[TypoLocalDateTime, Row]
+trait PpViewFields {
+  def id: Field[ProductphotoId, PpViewRow]
+  def productphotoid: Field[ProductphotoId, PpViewRow]
+  def thumbnailphoto: OptField[TypoBytea, PpViewRow]
+  def thumbnailphotofilename: OptField[/* max 50 chars */ String, PpViewRow]
+  def largephoto: OptField[TypoBytea, PpViewRow]
+  def largephotofilename: OptField[/* max 50 chars */ String, PpViewRow]
+  def modifieddate: Field[TypoLocalDateTime, PpViewRow]
 }
 
 object PpViewFields {
-  val structure: Relation[PpViewFields, PpViewRow, PpViewRow] = 
-    new Impl(None, identity, (_, x) => x)
+  lazy val structure: Relation[PpViewFields, PpViewRow] =
+    new Impl(Nil)
     
-  private final class Impl[Row](val prefix: Option[String], val extract: Row => PpViewRow, val merge: (Row, PpViewRow) => Row)
-    extends Relation[PpViewFields, PpViewRow, Row] { 
+  private final class Impl(val _path: List[Path])
+    extends Relation[PpViewFields, PpViewRow] {
   
-    override val fields: PpViewFields[Row] = new PpViewFields[Row] {
-      override val id = new Field[ProductphotoId, Row](prefix, "id", None, None)(x => extract(x).id, (row, value) => merge(row, extract(row).copy(id = value)))
-      override val productphotoid = new Field[ProductphotoId, Row](prefix, "productphotoid", None, None)(x => extract(x).productphotoid, (row, value) => merge(row, extract(row).copy(productphotoid = value)))
-      override val thumbnailphoto = new OptField[TypoBytea, Row](prefix, "thumbnailphoto", None, None)(x => extract(x).thumbnailphoto, (row, value) => merge(row, extract(row).copy(thumbnailphoto = value)))
-      override val thumbnailphotofilename = new OptField[/* max 50 chars */ String, Row](prefix, "thumbnailphotofilename", None, None)(x => extract(x).thumbnailphotofilename, (row, value) => merge(row, extract(row).copy(thumbnailphotofilename = value)))
-      override val largephoto = new OptField[TypoBytea, Row](prefix, "largephoto", None, None)(x => extract(x).largephoto, (row, value) => merge(row, extract(row).copy(largephoto = value)))
-      override val largephotofilename = new OptField[/* max 50 chars */ String, Row](prefix, "largephotofilename", None, None)(x => extract(x).largephotofilename, (row, value) => merge(row, extract(row).copy(largephotofilename = value)))
-      override val modifieddate = new Field[TypoLocalDateTime, Row](prefix, "modifieddate", Some("text"), None)(x => extract(x).modifieddate, (row, value) => merge(row, extract(row).copy(modifieddate = value)))
+    override lazy val fields: PpViewFields = new PpViewFields {
+      override def id = Field[ProductphotoId, PpViewRow](_path, "id", None, None, x => x.id, (row, value) => row.copy(id = value))
+      override def productphotoid = Field[ProductphotoId, PpViewRow](_path, "productphotoid", None, None, x => x.productphotoid, (row, value) => row.copy(productphotoid = value))
+      override def thumbnailphoto = OptField[TypoBytea, PpViewRow](_path, "thumbnailphoto", None, None, x => x.thumbnailphoto, (row, value) => row.copy(thumbnailphoto = value))
+      override def thumbnailphotofilename = OptField[/* max 50 chars */ String, PpViewRow](_path, "thumbnailphotofilename", None, None, x => x.thumbnailphotofilename, (row, value) => row.copy(thumbnailphotofilename = value))
+      override def largephoto = OptField[TypoBytea, PpViewRow](_path, "largephoto", None, None, x => x.largephoto, (row, value) => row.copy(largephoto = value))
+      override def largephotofilename = OptField[/* max 50 chars */ String, PpViewRow](_path, "largephotofilename", None, None, x => x.largephotofilename, (row, value) => row.copy(largephotofilename = value))
+      override def modifieddate = Field[TypoLocalDateTime, PpViewRow](_path, "modifieddate", Some("text"), None, x => x.modifieddate, (row, value) => row.copy(modifieddate = value))
     }
   
-    override val columns: List[FieldLikeNoHkt[?, Row]] =
-      List[FieldLikeNoHkt[?, Row]](fields.id, fields.productphotoid, fields.thumbnailphoto, fields.thumbnailphotofilename, fields.largephoto, fields.largephotofilename, fields.modifieddate)
+    override lazy val columns: List[FieldLikeNoHkt[?, PpViewRow]] =
+      List[FieldLikeNoHkt[?, PpViewRow]](fields.id, fields.productphotoid, fields.thumbnailphoto, fields.thumbnailphotofilename, fields.largephoto, fields.largephotofilename, fields.modifieddate)
   
-    override def copy[NewRow](prefix: Option[String], extract: NewRow => PpViewRow, merge: (NewRow, PpViewRow) => NewRow): Impl[NewRow] =
-      new Impl(prefix, extract, merge)
+    override def copy(path: List[Path]): Impl =
+      new Impl(path)
   }
   
 }

--- a/typo-tester-anorm/generated-and-checked-in/adventureworks/pr/ppp/PppViewFields.scala
+++ b/typo-tester-anorm/generated-and-checked-in/adventureworks/pr/ppp/PppViewFields.scala
@@ -11,36 +11,37 @@ import adventureworks.customtypes.TypoLocalDateTime
 import adventureworks.production.product.ProductId
 import adventureworks.production.productphoto.ProductphotoId
 import adventureworks.public.Flag
+import typo.dsl.Path
 import typo.dsl.SqlExpr.Field
 import typo.dsl.SqlExpr.FieldLikeNoHkt
 import typo.dsl.Structure.Relation
 
-trait PppViewFields[Row] {
-  val productid: Field[ProductId, Row]
-  val productphotoid: Field[ProductphotoId, Row]
-  val primary: Field[Flag, Row]
-  val modifieddate: Field[TypoLocalDateTime, Row]
+trait PppViewFields {
+  def productid: Field[ProductId, PppViewRow]
+  def productphotoid: Field[ProductphotoId, PppViewRow]
+  def primary: Field[Flag, PppViewRow]
+  def modifieddate: Field[TypoLocalDateTime, PppViewRow]
 }
 
 object PppViewFields {
-  val structure: Relation[PppViewFields, PppViewRow, PppViewRow] = 
-    new Impl(None, identity, (_, x) => x)
+  lazy val structure: Relation[PppViewFields, PppViewRow] =
+    new Impl(Nil)
     
-  private final class Impl[Row](val prefix: Option[String], val extract: Row => PppViewRow, val merge: (Row, PppViewRow) => Row)
-    extends Relation[PppViewFields, PppViewRow, Row] { 
+  private final class Impl(val _path: List[Path])
+    extends Relation[PppViewFields, PppViewRow] {
   
-    override val fields: PppViewFields[Row] = new PppViewFields[Row] {
-      override val productid = new Field[ProductId, Row](prefix, "productid", None, None)(x => extract(x).productid, (row, value) => merge(row, extract(row).copy(productid = value)))
-      override val productphotoid = new Field[ProductphotoId, Row](prefix, "productphotoid", None, None)(x => extract(x).productphotoid, (row, value) => merge(row, extract(row).copy(productphotoid = value)))
-      override val primary = new Field[Flag, Row](prefix, "primary", None, None)(x => extract(x).primary, (row, value) => merge(row, extract(row).copy(primary = value)))
-      override val modifieddate = new Field[TypoLocalDateTime, Row](prefix, "modifieddate", Some("text"), None)(x => extract(x).modifieddate, (row, value) => merge(row, extract(row).copy(modifieddate = value)))
+    override lazy val fields: PppViewFields = new PppViewFields {
+      override def productid = Field[ProductId, PppViewRow](_path, "productid", None, None, x => x.productid, (row, value) => row.copy(productid = value))
+      override def productphotoid = Field[ProductphotoId, PppViewRow](_path, "productphotoid", None, None, x => x.productphotoid, (row, value) => row.copy(productphotoid = value))
+      override def primary = Field[Flag, PppViewRow](_path, "primary", None, None, x => x.primary, (row, value) => row.copy(primary = value))
+      override def modifieddate = Field[TypoLocalDateTime, PppViewRow](_path, "modifieddate", Some("text"), None, x => x.modifieddate, (row, value) => row.copy(modifieddate = value))
     }
   
-    override val columns: List[FieldLikeNoHkt[?, Row]] =
-      List[FieldLikeNoHkt[?, Row]](fields.productid, fields.productphotoid, fields.primary, fields.modifieddate)
+    override lazy val columns: List[FieldLikeNoHkt[?, PppViewRow]] =
+      List[FieldLikeNoHkt[?, PppViewRow]](fields.productid, fields.productphotoid, fields.primary, fields.modifieddate)
   
-    override def copy[NewRow](prefix: Option[String], extract: NewRow => PppViewRow, merge: (NewRow, PppViewRow) => NewRow): Impl[NewRow] =
-      new Impl(prefix, extract, merge)
+    override def copy(path: List[Path]): Impl =
+      new Impl(path)
   }
   
 }

--- a/typo-tester-anorm/generated-and-checked-in/adventureworks/pr/pr/PrViewFields.scala
+++ b/typo-tester-anorm/generated-and-checked-in/adventureworks/pr/pr/PrViewFields.scala
@@ -11,47 +11,48 @@ import adventureworks.customtypes.TypoLocalDateTime
 import adventureworks.production.product.ProductId
 import adventureworks.production.productreview.ProductreviewId
 import adventureworks.public.Name
+import typo.dsl.Path
 import typo.dsl.SqlExpr.Field
 import typo.dsl.SqlExpr.FieldLikeNoHkt
 import typo.dsl.SqlExpr.OptField
 import typo.dsl.Structure.Relation
 
-trait PrViewFields[Row] {
-  val id: Field[ProductreviewId, Row]
-  val productreviewid: Field[ProductreviewId, Row]
-  val productid: Field[ProductId, Row]
-  val reviewername: Field[Name, Row]
-  val reviewdate: Field[TypoLocalDateTime, Row]
-  val emailaddress: Field[/* max 50 chars */ String, Row]
-  val rating: Field[Int, Row]
-  val comments: OptField[/* max 3850 chars */ String, Row]
-  val modifieddate: Field[TypoLocalDateTime, Row]
+trait PrViewFields {
+  def id: Field[ProductreviewId, PrViewRow]
+  def productreviewid: Field[ProductreviewId, PrViewRow]
+  def productid: Field[ProductId, PrViewRow]
+  def reviewername: Field[Name, PrViewRow]
+  def reviewdate: Field[TypoLocalDateTime, PrViewRow]
+  def emailaddress: Field[/* max 50 chars */ String, PrViewRow]
+  def rating: Field[Int, PrViewRow]
+  def comments: OptField[/* max 3850 chars */ String, PrViewRow]
+  def modifieddate: Field[TypoLocalDateTime, PrViewRow]
 }
 
 object PrViewFields {
-  val structure: Relation[PrViewFields, PrViewRow, PrViewRow] = 
-    new Impl(None, identity, (_, x) => x)
+  lazy val structure: Relation[PrViewFields, PrViewRow] =
+    new Impl(Nil)
     
-  private final class Impl[Row](val prefix: Option[String], val extract: Row => PrViewRow, val merge: (Row, PrViewRow) => Row)
-    extends Relation[PrViewFields, PrViewRow, Row] { 
+  private final class Impl(val _path: List[Path])
+    extends Relation[PrViewFields, PrViewRow] {
   
-    override val fields: PrViewFields[Row] = new PrViewFields[Row] {
-      override val id = new Field[ProductreviewId, Row](prefix, "id", None, None)(x => extract(x).id, (row, value) => merge(row, extract(row).copy(id = value)))
-      override val productreviewid = new Field[ProductreviewId, Row](prefix, "productreviewid", None, None)(x => extract(x).productreviewid, (row, value) => merge(row, extract(row).copy(productreviewid = value)))
-      override val productid = new Field[ProductId, Row](prefix, "productid", None, None)(x => extract(x).productid, (row, value) => merge(row, extract(row).copy(productid = value)))
-      override val reviewername = new Field[Name, Row](prefix, "reviewername", None, None)(x => extract(x).reviewername, (row, value) => merge(row, extract(row).copy(reviewername = value)))
-      override val reviewdate = new Field[TypoLocalDateTime, Row](prefix, "reviewdate", Some("text"), None)(x => extract(x).reviewdate, (row, value) => merge(row, extract(row).copy(reviewdate = value)))
-      override val emailaddress = new Field[/* max 50 chars */ String, Row](prefix, "emailaddress", None, None)(x => extract(x).emailaddress, (row, value) => merge(row, extract(row).copy(emailaddress = value)))
-      override val rating = new Field[Int, Row](prefix, "rating", None, None)(x => extract(x).rating, (row, value) => merge(row, extract(row).copy(rating = value)))
-      override val comments = new OptField[/* max 3850 chars */ String, Row](prefix, "comments", None, None)(x => extract(x).comments, (row, value) => merge(row, extract(row).copy(comments = value)))
-      override val modifieddate = new Field[TypoLocalDateTime, Row](prefix, "modifieddate", Some("text"), None)(x => extract(x).modifieddate, (row, value) => merge(row, extract(row).copy(modifieddate = value)))
+    override lazy val fields: PrViewFields = new PrViewFields {
+      override def id = Field[ProductreviewId, PrViewRow](_path, "id", None, None, x => x.id, (row, value) => row.copy(id = value))
+      override def productreviewid = Field[ProductreviewId, PrViewRow](_path, "productreviewid", None, None, x => x.productreviewid, (row, value) => row.copy(productreviewid = value))
+      override def productid = Field[ProductId, PrViewRow](_path, "productid", None, None, x => x.productid, (row, value) => row.copy(productid = value))
+      override def reviewername = Field[Name, PrViewRow](_path, "reviewername", None, None, x => x.reviewername, (row, value) => row.copy(reviewername = value))
+      override def reviewdate = Field[TypoLocalDateTime, PrViewRow](_path, "reviewdate", Some("text"), None, x => x.reviewdate, (row, value) => row.copy(reviewdate = value))
+      override def emailaddress = Field[/* max 50 chars */ String, PrViewRow](_path, "emailaddress", None, None, x => x.emailaddress, (row, value) => row.copy(emailaddress = value))
+      override def rating = Field[Int, PrViewRow](_path, "rating", None, None, x => x.rating, (row, value) => row.copy(rating = value))
+      override def comments = OptField[/* max 3850 chars */ String, PrViewRow](_path, "comments", None, None, x => x.comments, (row, value) => row.copy(comments = value))
+      override def modifieddate = Field[TypoLocalDateTime, PrViewRow](_path, "modifieddate", Some("text"), None, x => x.modifieddate, (row, value) => row.copy(modifieddate = value))
     }
   
-    override val columns: List[FieldLikeNoHkt[?, Row]] =
-      List[FieldLikeNoHkt[?, Row]](fields.id, fields.productreviewid, fields.productid, fields.reviewername, fields.reviewdate, fields.emailaddress, fields.rating, fields.comments, fields.modifieddate)
+    override lazy val columns: List[FieldLikeNoHkt[?, PrViewRow]] =
+      List[FieldLikeNoHkt[?, PrViewRow]](fields.id, fields.productreviewid, fields.productid, fields.reviewername, fields.reviewdate, fields.emailaddress, fields.rating, fields.comments, fields.modifieddate)
   
-    override def copy[NewRow](prefix: Option[String], extract: NewRow => PrViewRow, merge: (NewRow, PrViewRow) => NewRow): Impl[NewRow] =
-      new Impl(prefix, extract, merge)
+    override def copy(path: List[Path]): Impl =
+      new Impl(path)
   }
   
 }

--- a/typo-tester-anorm/generated-and-checked-in/adventureworks/pr/psc/PscViewFields.scala
+++ b/typo-tester-anorm/generated-and-checked-in/adventureworks/pr/psc/PscViewFields.scala
@@ -12,40 +12,41 @@ import adventureworks.customtypes.TypoUUID
 import adventureworks.production.productcategory.ProductcategoryId
 import adventureworks.production.productsubcategory.ProductsubcategoryId
 import adventureworks.public.Name
+import typo.dsl.Path
 import typo.dsl.SqlExpr.Field
 import typo.dsl.SqlExpr.FieldLikeNoHkt
 import typo.dsl.Structure.Relation
 
-trait PscViewFields[Row] {
-  val id: Field[ProductsubcategoryId, Row]
-  val productsubcategoryid: Field[ProductsubcategoryId, Row]
-  val productcategoryid: Field[ProductcategoryId, Row]
-  val name: Field[Name, Row]
-  val rowguid: Field[TypoUUID, Row]
-  val modifieddate: Field[TypoLocalDateTime, Row]
+trait PscViewFields {
+  def id: Field[ProductsubcategoryId, PscViewRow]
+  def productsubcategoryid: Field[ProductsubcategoryId, PscViewRow]
+  def productcategoryid: Field[ProductcategoryId, PscViewRow]
+  def name: Field[Name, PscViewRow]
+  def rowguid: Field[TypoUUID, PscViewRow]
+  def modifieddate: Field[TypoLocalDateTime, PscViewRow]
 }
 
 object PscViewFields {
-  val structure: Relation[PscViewFields, PscViewRow, PscViewRow] = 
-    new Impl(None, identity, (_, x) => x)
+  lazy val structure: Relation[PscViewFields, PscViewRow] =
+    new Impl(Nil)
     
-  private final class Impl[Row](val prefix: Option[String], val extract: Row => PscViewRow, val merge: (Row, PscViewRow) => Row)
-    extends Relation[PscViewFields, PscViewRow, Row] { 
+  private final class Impl(val _path: List[Path])
+    extends Relation[PscViewFields, PscViewRow] {
   
-    override val fields: PscViewFields[Row] = new PscViewFields[Row] {
-      override val id = new Field[ProductsubcategoryId, Row](prefix, "id", None, None)(x => extract(x).id, (row, value) => merge(row, extract(row).copy(id = value)))
-      override val productsubcategoryid = new Field[ProductsubcategoryId, Row](prefix, "productsubcategoryid", None, None)(x => extract(x).productsubcategoryid, (row, value) => merge(row, extract(row).copy(productsubcategoryid = value)))
-      override val productcategoryid = new Field[ProductcategoryId, Row](prefix, "productcategoryid", None, None)(x => extract(x).productcategoryid, (row, value) => merge(row, extract(row).copy(productcategoryid = value)))
-      override val name = new Field[Name, Row](prefix, "name", None, None)(x => extract(x).name, (row, value) => merge(row, extract(row).copy(name = value)))
-      override val rowguid = new Field[TypoUUID, Row](prefix, "rowguid", None, None)(x => extract(x).rowguid, (row, value) => merge(row, extract(row).copy(rowguid = value)))
-      override val modifieddate = new Field[TypoLocalDateTime, Row](prefix, "modifieddate", Some("text"), None)(x => extract(x).modifieddate, (row, value) => merge(row, extract(row).copy(modifieddate = value)))
+    override lazy val fields: PscViewFields = new PscViewFields {
+      override def id = Field[ProductsubcategoryId, PscViewRow](_path, "id", None, None, x => x.id, (row, value) => row.copy(id = value))
+      override def productsubcategoryid = Field[ProductsubcategoryId, PscViewRow](_path, "productsubcategoryid", None, None, x => x.productsubcategoryid, (row, value) => row.copy(productsubcategoryid = value))
+      override def productcategoryid = Field[ProductcategoryId, PscViewRow](_path, "productcategoryid", None, None, x => x.productcategoryid, (row, value) => row.copy(productcategoryid = value))
+      override def name = Field[Name, PscViewRow](_path, "name", None, None, x => x.name, (row, value) => row.copy(name = value))
+      override def rowguid = Field[TypoUUID, PscViewRow](_path, "rowguid", None, None, x => x.rowguid, (row, value) => row.copy(rowguid = value))
+      override def modifieddate = Field[TypoLocalDateTime, PscViewRow](_path, "modifieddate", Some("text"), None, x => x.modifieddate, (row, value) => row.copy(modifieddate = value))
     }
   
-    override val columns: List[FieldLikeNoHkt[?, Row]] =
-      List[FieldLikeNoHkt[?, Row]](fields.id, fields.productsubcategoryid, fields.productcategoryid, fields.name, fields.rowguid, fields.modifieddate)
+    override lazy val columns: List[FieldLikeNoHkt[?, PscViewRow]] =
+      List[FieldLikeNoHkt[?, PscViewRow]](fields.id, fields.productsubcategoryid, fields.productcategoryid, fields.name, fields.rowguid, fields.modifieddate)
   
-    override def copy[NewRow](prefix: Option[String], extract: NewRow => PscViewRow, merge: (NewRow, PscViewRow) => NewRow): Impl[NewRow] =
-      new Impl(prefix, extract, merge)
+    override def copy(path: List[Path]): Impl =
+      new Impl(path)
   }
   
 }

--- a/typo-tester-anorm/generated-and-checked-in/adventureworks/pr/sr/SrViewFields.scala
+++ b/typo-tester-anorm/generated-and-checked-in/adventureworks/pr/sr/SrViewFields.scala
@@ -10,36 +10,37 @@ package sr
 import adventureworks.customtypes.TypoLocalDateTime
 import adventureworks.production.scrapreason.ScrapreasonId
 import adventureworks.public.Name
+import typo.dsl.Path
 import typo.dsl.SqlExpr.Field
 import typo.dsl.SqlExpr.FieldLikeNoHkt
 import typo.dsl.Structure.Relation
 
-trait SrViewFields[Row] {
-  val id: Field[ScrapreasonId, Row]
-  val scrapreasonid: Field[ScrapreasonId, Row]
-  val name: Field[Name, Row]
-  val modifieddate: Field[TypoLocalDateTime, Row]
+trait SrViewFields {
+  def id: Field[ScrapreasonId, SrViewRow]
+  def scrapreasonid: Field[ScrapreasonId, SrViewRow]
+  def name: Field[Name, SrViewRow]
+  def modifieddate: Field[TypoLocalDateTime, SrViewRow]
 }
 
 object SrViewFields {
-  val structure: Relation[SrViewFields, SrViewRow, SrViewRow] = 
-    new Impl(None, identity, (_, x) => x)
+  lazy val structure: Relation[SrViewFields, SrViewRow] =
+    new Impl(Nil)
     
-  private final class Impl[Row](val prefix: Option[String], val extract: Row => SrViewRow, val merge: (Row, SrViewRow) => Row)
-    extends Relation[SrViewFields, SrViewRow, Row] { 
+  private final class Impl(val _path: List[Path])
+    extends Relation[SrViewFields, SrViewRow] {
   
-    override val fields: SrViewFields[Row] = new SrViewFields[Row] {
-      override val id = new Field[ScrapreasonId, Row](prefix, "id", None, None)(x => extract(x).id, (row, value) => merge(row, extract(row).copy(id = value)))
-      override val scrapreasonid = new Field[ScrapreasonId, Row](prefix, "scrapreasonid", None, None)(x => extract(x).scrapreasonid, (row, value) => merge(row, extract(row).copy(scrapreasonid = value)))
-      override val name = new Field[Name, Row](prefix, "name", None, None)(x => extract(x).name, (row, value) => merge(row, extract(row).copy(name = value)))
-      override val modifieddate = new Field[TypoLocalDateTime, Row](prefix, "modifieddate", Some("text"), None)(x => extract(x).modifieddate, (row, value) => merge(row, extract(row).copy(modifieddate = value)))
+    override lazy val fields: SrViewFields = new SrViewFields {
+      override def id = Field[ScrapreasonId, SrViewRow](_path, "id", None, None, x => x.id, (row, value) => row.copy(id = value))
+      override def scrapreasonid = Field[ScrapreasonId, SrViewRow](_path, "scrapreasonid", None, None, x => x.scrapreasonid, (row, value) => row.copy(scrapreasonid = value))
+      override def name = Field[Name, SrViewRow](_path, "name", None, None, x => x.name, (row, value) => row.copy(name = value))
+      override def modifieddate = Field[TypoLocalDateTime, SrViewRow](_path, "modifieddate", Some("text"), None, x => x.modifieddate, (row, value) => row.copy(modifieddate = value))
     }
   
-    override val columns: List[FieldLikeNoHkt[?, Row]] =
-      List[FieldLikeNoHkt[?, Row]](fields.id, fields.scrapreasonid, fields.name, fields.modifieddate)
+    override lazy val columns: List[FieldLikeNoHkt[?, SrViewRow]] =
+      List[FieldLikeNoHkt[?, SrViewRow]](fields.id, fields.scrapreasonid, fields.name, fields.modifieddate)
   
-    override def copy[NewRow](prefix: Option[String], extract: NewRow => SrViewRow, merge: (NewRow, SrViewRow) => NewRow): Impl[NewRow] =
-      new Impl(prefix, extract, merge)
+    override def copy(path: List[Path]): Impl =
+      new Impl(path)
   }
   
 }

--- a/typo-tester-anorm/generated-and-checked-in/adventureworks/pr/th/ThViewFields.scala
+++ b/typo-tester-anorm/generated-and-checked-in/adventureworks/pr/th/ThViewFields.scala
@@ -10,48 +10,49 @@ package th
 import adventureworks.customtypes.TypoLocalDateTime
 import adventureworks.production.product.ProductId
 import adventureworks.production.transactionhistory.TransactionhistoryId
+import typo.dsl.Path
 import typo.dsl.SqlExpr.Field
 import typo.dsl.SqlExpr.FieldLikeNoHkt
 import typo.dsl.Structure.Relation
 
-trait ThViewFields[Row] {
-  val id: Field[TransactionhistoryId, Row]
-  val transactionid: Field[TransactionhistoryId, Row]
-  val productid: Field[ProductId, Row]
-  val referenceorderid: Field[Int, Row]
-  val referenceorderlineid: Field[Int, Row]
-  val transactiondate: Field[TypoLocalDateTime, Row]
-  val transactiontype: Field[/* bpchar, max 1 chars */ String, Row]
-  val quantity: Field[Int, Row]
-  val actualcost: Field[BigDecimal, Row]
-  val modifieddate: Field[TypoLocalDateTime, Row]
+trait ThViewFields {
+  def id: Field[TransactionhistoryId, ThViewRow]
+  def transactionid: Field[TransactionhistoryId, ThViewRow]
+  def productid: Field[ProductId, ThViewRow]
+  def referenceorderid: Field[Int, ThViewRow]
+  def referenceorderlineid: Field[Int, ThViewRow]
+  def transactiondate: Field[TypoLocalDateTime, ThViewRow]
+  def transactiontype: Field[/* bpchar, max 1 chars */ String, ThViewRow]
+  def quantity: Field[Int, ThViewRow]
+  def actualcost: Field[BigDecimal, ThViewRow]
+  def modifieddate: Field[TypoLocalDateTime, ThViewRow]
 }
 
 object ThViewFields {
-  val structure: Relation[ThViewFields, ThViewRow, ThViewRow] = 
-    new Impl(None, identity, (_, x) => x)
+  lazy val structure: Relation[ThViewFields, ThViewRow] =
+    new Impl(Nil)
     
-  private final class Impl[Row](val prefix: Option[String], val extract: Row => ThViewRow, val merge: (Row, ThViewRow) => Row)
-    extends Relation[ThViewFields, ThViewRow, Row] { 
+  private final class Impl(val _path: List[Path])
+    extends Relation[ThViewFields, ThViewRow] {
   
-    override val fields: ThViewFields[Row] = new ThViewFields[Row] {
-      override val id = new Field[TransactionhistoryId, Row](prefix, "id", None, None)(x => extract(x).id, (row, value) => merge(row, extract(row).copy(id = value)))
-      override val transactionid = new Field[TransactionhistoryId, Row](prefix, "transactionid", None, None)(x => extract(x).transactionid, (row, value) => merge(row, extract(row).copy(transactionid = value)))
-      override val productid = new Field[ProductId, Row](prefix, "productid", None, None)(x => extract(x).productid, (row, value) => merge(row, extract(row).copy(productid = value)))
-      override val referenceorderid = new Field[Int, Row](prefix, "referenceorderid", None, None)(x => extract(x).referenceorderid, (row, value) => merge(row, extract(row).copy(referenceorderid = value)))
-      override val referenceorderlineid = new Field[Int, Row](prefix, "referenceorderlineid", None, None)(x => extract(x).referenceorderlineid, (row, value) => merge(row, extract(row).copy(referenceorderlineid = value)))
-      override val transactiondate = new Field[TypoLocalDateTime, Row](prefix, "transactiondate", Some("text"), None)(x => extract(x).transactiondate, (row, value) => merge(row, extract(row).copy(transactiondate = value)))
-      override val transactiontype = new Field[/* bpchar, max 1 chars */ String, Row](prefix, "transactiontype", None, None)(x => extract(x).transactiontype, (row, value) => merge(row, extract(row).copy(transactiontype = value)))
-      override val quantity = new Field[Int, Row](prefix, "quantity", None, None)(x => extract(x).quantity, (row, value) => merge(row, extract(row).copy(quantity = value)))
-      override val actualcost = new Field[BigDecimal, Row](prefix, "actualcost", None, None)(x => extract(x).actualcost, (row, value) => merge(row, extract(row).copy(actualcost = value)))
-      override val modifieddate = new Field[TypoLocalDateTime, Row](prefix, "modifieddate", Some("text"), None)(x => extract(x).modifieddate, (row, value) => merge(row, extract(row).copy(modifieddate = value)))
+    override lazy val fields: ThViewFields = new ThViewFields {
+      override def id = Field[TransactionhistoryId, ThViewRow](_path, "id", None, None, x => x.id, (row, value) => row.copy(id = value))
+      override def transactionid = Field[TransactionhistoryId, ThViewRow](_path, "transactionid", None, None, x => x.transactionid, (row, value) => row.copy(transactionid = value))
+      override def productid = Field[ProductId, ThViewRow](_path, "productid", None, None, x => x.productid, (row, value) => row.copy(productid = value))
+      override def referenceorderid = Field[Int, ThViewRow](_path, "referenceorderid", None, None, x => x.referenceorderid, (row, value) => row.copy(referenceorderid = value))
+      override def referenceorderlineid = Field[Int, ThViewRow](_path, "referenceorderlineid", None, None, x => x.referenceorderlineid, (row, value) => row.copy(referenceorderlineid = value))
+      override def transactiondate = Field[TypoLocalDateTime, ThViewRow](_path, "transactiondate", Some("text"), None, x => x.transactiondate, (row, value) => row.copy(transactiondate = value))
+      override def transactiontype = Field[/* bpchar, max 1 chars */ String, ThViewRow](_path, "transactiontype", None, None, x => x.transactiontype, (row, value) => row.copy(transactiontype = value))
+      override def quantity = Field[Int, ThViewRow](_path, "quantity", None, None, x => x.quantity, (row, value) => row.copy(quantity = value))
+      override def actualcost = Field[BigDecimal, ThViewRow](_path, "actualcost", None, None, x => x.actualcost, (row, value) => row.copy(actualcost = value))
+      override def modifieddate = Field[TypoLocalDateTime, ThViewRow](_path, "modifieddate", Some("text"), None, x => x.modifieddate, (row, value) => row.copy(modifieddate = value))
     }
   
-    override val columns: List[FieldLikeNoHkt[?, Row]] =
-      List[FieldLikeNoHkt[?, Row]](fields.id, fields.transactionid, fields.productid, fields.referenceorderid, fields.referenceorderlineid, fields.transactiondate, fields.transactiontype, fields.quantity, fields.actualcost, fields.modifieddate)
+    override lazy val columns: List[FieldLikeNoHkt[?, ThViewRow]] =
+      List[FieldLikeNoHkt[?, ThViewRow]](fields.id, fields.transactionid, fields.productid, fields.referenceorderid, fields.referenceorderlineid, fields.transactiondate, fields.transactiontype, fields.quantity, fields.actualcost, fields.modifieddate)
   
-    override def copy[NewRow](prefix: Option[String], extract: NewRow => ThViewRow, merge: (NewRow, ThViewRow) => NewRow): Impl[NewRow] =
-      new Impl(prefix, extract, merge)
+    override def copy(path: List[Path]): Impl =
+      new Impl(path)
   }
   
 }

--- a/typo-tester-anorm/generated-and-checked-in/adventureworks/pr/tha/ThaViewFields.scala
+++ b/typo-tester-anorm/generated-and-checked-in/adventureworks/pr/tha/ThaViewFields.scala
@@ -9,48 +9,49 @@ package tha
 
 import adventureworks.customtypes.TypoLocalDateTime
 import adventureworks.production.transactionhistoryarchive.TransactionhistoryarchiveId
+import typo.dsl.Path
 import typo.dsl.SqlExpr.Field
 import typo.dsl.SqlExpr.FieldLikeNoHkt
 import typo.dsl.Structure.Relation
 
-trait ThaViewFields[Row] {
-  val id: Field[TransactionhistoryarchiveId, Row]
-  val transactionid: Field[TransactionhistoryarchiveId, Row]
-  val productid: Field[Int, Row]
-  val referenceorderid: Field[Int, Row]
-  val referenceorderlineid: Field[Int, Row]
-  val transactiondate: Field[TypoLocalDateTime, Row]
-  val transactiontype: Field[/* bpchar, max 1 chars */ String, Row]
-  val quantity: Field[Int, Row]
-  val actualcost: Field[BigDecimal, Row]
-  val modifieddate: Field[TypoLocalDateTime, Row]
+trait ThaViewFields {
+  def id: Field[TransactionhistoryarchiveId, ThaViewRow]
+  def transactionid: Field[TransactionhistoryarchiveId, ThaViewRow]
+  def productid: Field[Int, ThaViewRow]
+  def referenceorderid: Field[Int, ThaViewRow]
+  def referenceorderlineid: Field[Int, ThaViewRow]
+  def transactiondate: Field[TypoLocalDateTime, ThaViewRow]
+  def transactiontype: Field[/* bpchar, max 1 chars */ String, ThaViewRow]
+  def quantity: Field[Int, ThaViewRow]
+  def actualcost: Field[BigDecimal, ThaViewRow]
+  def modifieddate: Field[TypoLocalDateTime, ThaViewRow]
 }
 
 object ThaViewFields {
-  val structure: Relation[ThaViewFields, ThaViewRow, ThaViewRow] = 
-    new Impl(None, identity, (_, x) => x)
+  lazy val structure: Relation[ThaViewFields, ThaViewRow] =
+    new Impl(Nil)
     
-  private final class Impl[Row](val prefix: Option[String], val extract: Row => ThaViewRow, val merge: (Row, ThaViewRow) => Row)
-    extends Relation[ThaViewFields, ThaViewRow, Row] { 
+  private final class Impl(val _path: List[Path])
+    extends Relation[ThaViewFields, ThaViewRow] {
   
-    override val fields: ThaViewFields[Row] = new ThaViewFields[Row] {
-      override val id = new Field[TransactionhistoryarchiveId, Row](prefix, "id", None, None)(x => extract(x).id, (row, value) => merge(row, extract(row).copy(id = value)))
-      override val transactionid = new Field[TransactionhistoryarchiveId, Row](prefix, "transactionid", None, None)(x => extract(x).transactionid, (row, value) => merge(row, extract(row).copy(transactionid = value)))
-      override val productid = new Field[Int, Row](prefix, "productid", None, None)(x => extract(x).productid, (row, value) => merge(row, extract(row).copy(productid = value)))
-      override val referenceorderid = new Field[Int, Row](prefix, "referenceorderid", None, None)(x => extract(x).referenceorderid, (row, value) => merge(row, extract(row).copy(referenceorderid = value)))
-      override val referenceorderlineid = new Field[Int, Row](prefix, "referenceorderlineid", None, None)(x => extract(x).referenceorderlineid, (row, value) => merge(row, extract(row).copy(referenceorderlineid = value)))
-      override val transactiondate = new Field[TypoLocalDateTime, Row](prefix, "transactiondate", Some("text"), None)(x => extract(x).transactiondate, (row, value) => merge(row, extract(row).copy(transactiondate = value)))
-      override val transactiontype = new Field[/* bpchar, max 1 chars */ String, Row](prefix, "transactiontype", None, None)(x => extract(x).transactiontype, (row, value) => merge(row, extract(row).copy(transactiontype = value)))
-      override val quantity = new Field[Int, Row](prefix, "quantity", None, None)(x => extract(x).quantity, (row, value) => merge(row, extract(row).copy(quantity = value)))
-      override val actualcost = new Field[BigDecimal, Row](prefix, "actualcost", None, None)(x => extract(x).actualcost, (row, value) => merge(row, extract(row).copy(actualcost = value)))
-      override val modifieddate = new Field[TypoLocalDateTime, Row](prefix, "modifieddate", Some("text"), None)(x => extract(x).modifieddate, (row, value) => merge(row, extract(row).copy(modifieddate = value)))
+    override lazy val fields: ThaViewFields = new ThaViewFields {
+      override def id = Field[TransactionhistoryarchiveId, ThaViewRow](_path, "id", None, None, x => x.id, (row, value) => row.copy(id = value))
+      override def transactionid = Field[TransactionhistoryarchiveId, ThaViewRow](_path, "transactionid", None, None, x => x.transactionid, (row, value) => row.copy(transactionid = value))
+      override def productid = Field[Int, ThaViewRow](_path, "productid", None, None, x => x.productid, (row, value) => row.copy(productid = value))
+      override def referenceorderid = Field[Int, ThaViewRow](_path, "referenceorderid", None, None, x => x.referenceorderid, (row, value) => row.copy(referenceorderid = value))
+      override def referenceorderlineid = Field[Int, ThaViewRow](_path, "referenceorderlineid", None, None, x => x.referenceorderlineid, (row, value) => row.copy(referenceorderlineid = value))
+      override def transactiondate = Field[TypoLocalDateTime, ThaViewRow](_path, "transactiondate", Some("text"), None, x => x.transactiondate, (row, value) => row.copy(transactiondate = value))
+      override def transactiontype = Field[/* bpchar, max 1 chars */ String, ThaViewRow](_path, "transactiontype", None, None, x => x.transactiontype, (row, value) => row.copy(transactiontype = value))
+      override def quantity = Field[Int, ThaViewRow](_path, "quantity", None, None, x => x.quantity, (row, value) => row.copy(quantity = value))
+      override def actualcost = Field[BigDecimal, ThaViewRow](_path, "actualcost", None, None, x => x.actualcost, (row, value) => row.copy(actualcost = value))
+      override def modifieddate = Field[TypoLocalDateTime, ThaViewRow](_path, "modifieddate", Some("text"), None, x => x.modifieddate, (row, value) => row.copy(modifieddate = value))
     }
   
-    override val columns: List[FieldLikeNoHkt[?, Row]] =
-      List[FieldLikeNoHkt[?, Row]](fields.id, fields.transactionid, fields.productid, fields.referenceorderid, fields.referenceorderlineid, fields.transactiondate, fields.transactiontype, fields.quantity, fields.actualcost, fields.modifieddate)
+    override lazy val columns: List[FieldLikeNoHkt[?, ThaViewRow]] =
+      List[FieldLikeNoHkt[?, ThaViewRow]](fields.id, fields.transactionid, fields.productid, fields.referenceorderid, fields.referenceorderlineid, fields.transactiondate, fields.transactiontype, fields.quantity, fields.actualcost, fields.modifieddate)
   
-    override def copy[NewRow](prefix: Option[String], extract: NewRow => ThaViewRow, merge: (NewRow, ThaViewRow) => NewRow): Impl[NewRow] =
-      new Impl(prefix, extract, merge)
+    override def copy(path: List[Path]): Impl =
+      new Impl(path)
   }
   
 }

--- a/typo-tester-anorm/generated-and-checked-in/adventureworks/pr/um/UmViewFields.scala
+++ b/typo-tester-anorm/generated-and-checked-in/adventureworks/pr/um/UmViewFields.scala
@@ -10,36 +10,37 @@ package um
 import adventureworks.customtypes.TypoLocalDateTime
 import adventureworks.production.unitmeasure.UnitmeasureId
 import adventureworks.public.Name
+import typo.dsl.Path
 import typo.dsl.SqlExpr.Field
 import typo.dsl.SqlExpr.FieldLikeNoHkt
 import typo.dsl.Structure.Relation
 
-trait UmViewFields[Row] {
-  val id: Field[UnitmeasureId, Row]
-  val unitmeasurecode: Field[UnitmeasureId, Row]
-  val name: Field[Name, Row]
-  val modifieddate: Field[TypoLocalDateTime, Row]
+trait UmViewFields {
+  def id: Field[UnitmeasureId, UmViewRow]
+  def unitmeasurecode: Field[UnitmeasureId, UmViewRow]
+  def name: Field[Name, UmViewRow]
+  def modifieddate: Field[TypoLocalDateTime, UmViewRow]
 }
 
 object UmViewFields {
-  val structure: Relation[UmViewFields, UmViewRow, UmViewRow] = 
-    new Impl(None, identity, (_, x) => x)
+  lazy val structure: Relation[UmViewFields, UmViewRow] =
+    new Impl(Nil)
     
-  private final class Impl[Row](val prefix: Option[String], val extract: Row => UmViewRow, val merge: (Row, UmViewRow) => Row)
-    extends Relation[UmViewFields, UmViewRow, Row] { 
+  private final class Impl(val _path: List[Path])
+    extends Relation[UmViewFields, UmViewRow] {
   
-    override val fields: UmViewFields[Row] = new UmViewFields[Row] {
-      override val id = new Field[UnitmeasureId, Row](prefix, "id", None, None)(x => extract(x).id, (row, value) => merge(row, extract(row).copy(id = value)))
-      override val unitmeasurecode = new Field[UnitmeasureId, Row](prefix, "unitmeasurecode", None, None)(x => extract(x).unitmeasurecode, (row, value) => merge(row, extract(row).copy(unitmeasurecode = value)))
-      override val name = new Field[Name, Row](prefix, "name", None, None)(x => extract(x).name, (row, value) => merge(row, extract(row).copy(name = value)))
-      override val modifieddate = new Field[TypoLocalDateTime, Row](prefix, "modifieddate", Some("text"), None)(x => extract(x).modifieddate, (row, value) => merge(row, extract(row).copy(modifieddate = value)))
+    override lazy val fields: UmViewFields = new UmViewFields {
+      override def id = Field[UnitmeasureId, UmViewRow](_path, "id", None, None, x => x.id, (row, value) => row.copy(id = value))
+      override def unitmeasurecode = Field[UnitmeasureId, UmViewRow](_path, "unitmeasurecode", None, None, x => x.unitmeasurecode, (row, value) => row.copy(unitmeasurecode = value))
+      override def name = Field[Name, UmViewRow](_path, "name", None, None, x => x.name, (row, value) => row.copy(name = value))
+      override def modifieddate = Field[TypoLocalDateTime, UmViewRow](_path, "modifieddate", Some("text"), None, x => x.modifieddate, (row, value) => row.copy(modifieddate = value))
     }
   
-    override val columns: List[FieldLikeNoHkt[?, Row]] =
-      List[FieldLikeNoHkt[?, Row]](fields.id, fields.unitmeasurecode, fields.name, fields.modifieddate)
+    override lazy val columns: List[FieldLikeNoHkt[?, UmViewRow]] =
+      List[FieldLikeNoHkt[?, UmViewRow]](fields.id, fields.unitmeasurecode, fields.name, fields.modifieddate)
   
-    override def copy[NewRow](prefix: Option[String], extract: NewRow => UmViewRow, merge: (NewRow, UmViewRow) => NewRow): Impl[NewRow] =
-      new Impl(prefix, extract, merge)
+    override def copy(path: List[Path]): Impl =
+      new Impl(path)
   }
   
 }

--- a/typo-tester-anorm/generated-and-checked-in/adventureworks/pr/w/WViewFields.scala
+++ b/typo-tester-anorm/generated-and-checked-in/adventureworks/pr/w/WViewFields.scala
@@ -12,49 +12,50 @@ import adventureworks.customtypes.TypoShort
 import adventureworks.production.product.ProductId
 import adventureworks.production.scrapreason.ScrapreasonId
 import adventureworks.production.workorder.WorkorderId
+import typo.dsl.Path
 import typo.dsl.SqlExpr.Field
 import typo.dsl.SqlExpr.FieldLikeNoHkt
 import typo.dsl.SqlExpr.OptField
 import typo.dsl.Structure.Relation
 
-trait WViewFields[Row] {
-  val id: Field[WorkorderId, Row]
-  val workorderid: Field[WorkorderId, Row]
-  val productid: Field[ProductId, Row]
-  val orderqty: Field[Int, Row]
-  val scrappedqty: Field[TypoShort, Row]
-  val startdate: Field[TypoLocalDateTime, Row]
-  val enddate: OptField[TypoLocalDateTime, Row]
-  val duedate: Field[TypoLocalDateTime, Row]
-  val scrapreasonid: OptField[ScrapreasonId, Row]
-  val modifieddate: Field[TypoLocalDateTime, Row]
+trait WViewFields {
+  def id: Field[WorkorderId, WViewRow]
+  def workorderid: Field[WorkorderId, WViewRow]
+  def productid: Field[ProductId, WViewRow]
+  def orderqty: Field[Int, WViewRow]
+  def scrappedqty: Field[TypoShort, WViewRow]
+  def startdate: Field[TypoLocalDateTime, WViewRow]
+  def enddate: OptField[TypoLocalDateTime, WViewRow]
+  def duedate: Field[TypoLocalDateTime, WViewRow]
+  def scrapreasonid: OptField[ScrapreasonId, WViewRow]
+  def modifieddate: Field[TypoLocalDateTime, WViewRow]
 }
 
 object WViewFields {
-  val structure: Relation[WViewFields, WViewRow, WViewRow] = 
-    new Impl(None, identity, (_, x) => x)
+  lazy val structure: Relation[WViewFields, WViewRow] =
+    new Impl(Nil)
     
-  private final class Impl[Row](val prefix: Option[String], val extract: Row => WViewRow, val merge: (Row, WViewRow) => Row)
-    extends Relation[WViewFields, WViewRow, Row] { 
+  private final class Impl(val _path: List[Path])
+    extends Relation[WViewFields, WViewRow] {
   
-    override val fields: WViewFields[Row] = new WViewFields[Row] {
-      override val id = new Field[WorkorderId, Row](prefix, "id", None, None)(x => extract(x).id, (row, value) => merge(row, extract(row).copy(id = value)))
-      override val workorderid = new Field[WorkorderId, Row](prefix, "workorderid", None, None)(x => extract(x).workorderid, (row, value) => merge(row, extract(row).copy(workorderid = value)))
-      override val productid = new Field[ProductId, Row](prefix, "productid", None, None)(x => extract(x).productid, (row, value) => merge(row, extract(row).copy(productid = value)))
-      override val orderqty = new Field[Int, Row](prefix, "orderqty", None, None)(x => extract(x).orderqty, (row, value) => merge(row, extract(row).copy(orderqty = value)))
-      override val scrappedqty = new Field[TypoShort, Row](prefix, "scrappedqty", None, None)(x => extract(x).scrappedqty, (row, value) => merge(row, extract(row).copy(scrappedqty = value)))
-      override val startdate = new Field[TypoLocalDateTime, Row](prefix, "startdate", Some("text"), None)(x => extract(x).startdate, (row, value) => merge(row, extract(row).copy(startdate = value)))
-      override val enddate = new OptField[TypoLocalDateTime, Row](prefix, "enddate", Some("text"), None)(x => extract(x).enddate, (row, value) => merge(row, extract(row).copy(enddate = value)))
-      override val duedate = new Field[TypoLocalDateTime, Row](prefix, "duedate", Some("text"), None)(x => extract(x).duedate, (row, value) => merge(row, extract(row).copy(duedate = value)))
-      override val scrapreasonid = new OptField[ScrapreasonId, Row](prefix, "scrapreasonid", None, None)(x => extract(x).scrapreasonid, (row, value) => merge(row, extract(row).copy(scrapreasonid = value)))
-      override val modifieddate = new Field[TypoLocalDateTime, Row](prefix, "modifieddate", Some("text"), None)(x => extract(x).modifieddate, (row, value) => merge(row, extract(row).copy(modifieddate = value)))
+    override lazy val fields: WViewFields = new WViewFields {
+      override def id = Field[WorkorderId, WViewRow](_path, "id", None, None, x => x.id, (row, value) => row.copy(id = value))
+      override def workorderid = Field[WorkorderId, WViewRow](_path, "workorderid", None, None, x => x.workorderid, (row, value) => row.copy(workorderid = value))
+      override def productid = Field[ProductId, WViewRow](_path, "productid", None, None, x => x.productid, (row, value) => row.copy(productid = value))
+      override def orderqty = Field[Int, WViewRow](_path, "orderqty", None, None, x => x.orderqty, (row, value) => row.copy(orderqty = value))
+      override def scrappedqty = Field[TypoShort, WViewRow](_path, "scrappedqty", None, None, x => x.scrappedqty, (row, value) => row.copy(scrappedqty = value))
+      override def startdate = Field[TypoLocalDateTime, WViewRow](_path, "startdate", Some("text"), None, x => x.startdate, (row, value) => row.copy(startdate = value))
+      override def enddate = OptField[TypoLocalDateTime, WViewRow](_path, "enddate", Some("text"), None, x => x.enddate, (row, value) => row.copy(enddate = value))
+      override def duedate = Field[TypoLocalDateTime, WViewRow](_path, "duedate", Some("text"), None, x => x.duedate, (row, value) => row.copy(duedate = value))
+      override def scrapreasonid = OptField[ScrapreasonId, WViewRow](_path, "scrapreasonid", None, None, x => x.scrapreasonid, (row, value) => row.copy(scrapreasonid = value))
+      override def modifieddate = Field[TypoLocalDateTime, WViewRow](_path, "modifieddate", Some("text"), None, x => x.modifieddate, (row, value) => row.copy(modifieddate = value))
     }
   
-    override val columns: List[FieldLikeNoHkt[?, Row]] =
-      List[FieldLikeNoHkt[?, Row]](fields.id, fields.workorderid, fields.productid, fields.orderqty, fields.scrappedqty, fields.startdate, fields.enddate, fields.duedate, fields.scrapreasonid, fields.modifieddate)
+    override lazy val columns: List[FieldLikeNoHkt[?, WViewRow]] =
+      List[FieldLikeNoHkt[?, WViewRow]](fields.id, fields.workorderid, fields.productid, fields.orderqty, fields.scrappedqty, fields.startdate, fields.enddate, fields.duedate, fields.scrapreasonid, fields.modifieddate)
   
-    override def copy[NewRow](prefix: Option[String], extract: NewRow => WViewRow, merge: (NewRow, WViewRow) => NewRow): Impl[NewRow] =
-      new Impl(prefix, extract, merge)
+    override def copy(path: List[Path]): Impl =
+      new Impl(path)
   }
   
 }

--- a/typo-tester-anorm/generated-and-checked-in/adventureworks/pr/wr/WrViewFields.scala
+++ b/typo-tester-anorm/generated-and-checked-in/adventureworks/pr/wr/WrViewFields.scala
@@ -11,55 +11,56 @@ import adventureworks.customtypes.TypoLocalDateTime
 import adventureworks.customtypes.TypoShort
 import adventureworks.production.location.LocationId
 import adventureworks.production.workorder.WorkorderId
+import typo.dsl.Path
 import typo.dsl.SqlExpr.Field
 import typo.dsl.SqlExpr.FieldLikeNoHkt
 import typo.dsl.SqlExpr.OptField
 import typo.dsl.Structure.Relation
 
-trait WrViewFields[Row] {
-  val id: Field[WorkorderId, Row]
-  val workorderid: Field[WorkorderId, Row]
-  val productid: Field[Int, Row]
-  val operationsequence: Field[TypoShort, Row]
-  val locationid: Field[LocationId, Row]
-  val scheduledstartdate: Field[TypoLocalDateTime, Row]
-  val scheduledenddate: Field[TypoLocalDateTime, Row]
-  val actualstartdate: OptField[TypoLocalDateTime, Row]
-  val actualenddate: OptField[TypoLocalDateTime, Row]
-  val actualresourcehrs: OptField[BigDecimal, Row]
-  val plannedcost: Field[BigDecimal, Row]
-  val actualcost: OptField[BigDecimal, Row]
-  val modifieddate: Field[TypoLocalDateTime, Row]
+trait WrViewFields {
+  def id: Field[WorkorderId, WrViewRow]
+  def workorderid: Field[WorkorderId, WrViewRow]
+  def productid: Field[Int, WrViewRow]
+  def operationsequence: Field[TypoShort, WrViewRow]
+  def locationid: Field[LocationId, WrViewRow]
+  def scheduledstartdate: Field[TypoLocalDateTime, WrViewRow]
+  def scheduledenddate: Field[TypoLocalDateTime, WrViewRow]
+  def actualstartdate: OptField[TypoLocalDateTime, WrViewRow]
+  def actualenddate: OptField[TypoLocalDateTime, WrViewRow]
+  def actualresourcehrs: OptField[BigDecimal, WrViewRow]
+  def plannedcost: Field[BigDecimal, WrViewRow]
+  def actualcost: OptField[BigDecimal, WrViewRow]
+  def modifieddate: Field[TypoLocalDateTime, WrViewRow]
 }
 
 object WrViewFields {
-  val structure: Relation[WrViewFields, WrViewRow, WrViewRow] = 
-    new Impl(None, identity, (_, x) => x)
+  lazy val structure: Relation[WrViewFields, WrViewRow] =
+    new Impl(Nil)
     
-  private final class Impl[Row](val prefix: Option[String], val extract: Row => WrViewRow, val merge: (Row, WrViewRow) => Row)
-    extends Relation[WrViewFields, WrViewRow, Row] { 
+  private final class Impl(val _path: List[Path])
+    extends Relation[WrViewFields, WrViewRow] {
   
-    override val fields: WrViewFields[Row] = new WrViewFields[Row] {
-      override val id = new Field[WorkorderId, Row](prefix, "id", None, None)(x => extract(x).id, (row, value) => merge(row, extract(row).copy(id = value)))
-      override val workorderid = new Field[WorkorderId, Row](prefix, "workorderid", None, None)(x => extract(x).workorderid, (row, value) => merge(row, extract(row).copy(workorderid = value)))
-      override val productid = new Field[Int, Row](prefix, "productid", None, None)(x => extract(x).productid, (row, value) => merge(row, extract(row).copy(productid = value)))
-      override val operationsequence = new Field[TypoShort, Row](prefix, "operationsequence", None, None)(x => extract(x).operationsequence, (row, value) => merge(row, extract(row).copy(operationsequence = value)))
-      override val locationid = new Field[LocationId, Row](prefix, "locationid", None, None)(x => extract(x).locationid, (row, value) => merge(row, extract(row).copy(locationid = value)))
-      override val scheduledstartdate = new Field[TypoLocalDateTime, Row](prefix, "scheduledstartdate", Some("text"), None)(x => extract(x).scheduledstartdate, (row, value) => merge(row, extract(row).copy(scheduledstartdate = value)))
-      override val scheduledenddate = new Field[TypoLocalDateTime, Row](prefix, "scheduledenddate", Some("text"), None)(x => extract(x).scheduledenddate, (row, value) => merge(row, extract(row).copy(scheduledenddate = value)))
-      override val actualstartdate = new OptField[TypoLocalDateTime, Row](prefix, "actualstartdate", Some("text"), None)(x => extract(x).actualstartdate, (row, value) => merge(row, extract(row).copy(actualstartdate = value)))
-      override val actualenddate = new OptField[TypoLocalDateTime, Row](prefix, "actualenddate", Some("text"), None)(x => extract(x).actualenddate, (row, value) => merge(row, extract(row).copy(actualenddate = value)))
-      override val actualresourcehrs = new OptField[BigDecimal, Row](prefix, "actualresourcehrs", None, None)(x => extract(x).actualresourcehrs, (row, value) => merge(row, extract(row).copy(actualresourcehrs = value)))
-      override val plannedcost = new Field[BigDecimal, Row](prefix, "plannedcost", None, None)(x => extract(x).plannedcost, (row, value) => merge(row, extract(row).copy(plannedcost = value)))
-      override val actualcost = new OptField[BigDecimal, Row](prefix, "actualcost", None, None)(x => extract(x).actualcost, (row, value) => merge(row, extract(row).copy(actualcost = value)))
-      override val modifieddate = new Field[TypoLocalDateTime, Row](prefix, "modifieddate", Some("text"), None)(x => extract(x).modifieddate, (row, value) => merge(row, extract(row).copy(modifieddate = value)))
+    override lazy val fields: WrViewFields = new WrViewFields {
+      override def id = Field[WorkorderId, WrViewRow](_path, "id", None, None, x => x.id, (row, value) => row.copy(id = value))
+      override def workorderid = Field[WorkorderId, WrViewRow](_path, "workorderid", None, None, x => x.workorderid, (row, value) => row.copy(workorderid = value))
+      override def productid = Field[Int, WrViewRow](_path, "productid", None, None, x => x.productid, (row, value) => row.copy(productid = value))
+      override def operationsequence = Field[TypoShort, WrViewRow](_path, "operationsequence", None, None, x => x.operationsequence, (row, value) => row.copy(operationsequence = value))
+      override def locationid = Field[LocationId, WrViewRow](_path, "locationid", None, None, x => x.locationid, (row, value) => row.copy(locationid = value))
+      override def scheduledstartdate = Field[TypoLocalDateTime, WrViewRow](_path, "scheduledstartdate", Some("text"), None, x => x.scheduledstartdate, (row, value) => row.copy(scheduledstartdate = value))
+      override def scheduledenddate = Field[TypoLocalDateTime, WrViewRow](_path, "scheduledenddate", Some("text"), None, x => x.scheduledenddate, (row, value) => row.copy(scheduledenddate = value))
+      override def actualstartdate = OptField[TypoLocalDateTime, WrViewRow](_path, "actualstartdate", Some("text"), None, x => x.actualstartdate, (row, value) => row.copy(actualstartdate = value))
+      override def actualenddate = OptField[TypoLocalDateTime, WrViewRow](_path, "actualenddate", Some("text"), None, x => x.actualenddate, (row, value) => row.copy(actualenddate = value))
+      override def actualresourcehrs = OptField[BigDecimal, WrViewRow](_path, "actualresourcehrs", None, None, x => x.actualresourcehrs, (row, value) => row.copy(actualresourcehrs = value))
+      override def plannedcost = Field[BigDecimal, WrViewRow](_path, "plannedcost", None, None, x => x.plannedcost, (row, value) => row.copy(plannedcost = value))
+      override def actualcost = OptField[BigDecimal, WrViewRow](_path, "actualcost", None, None, x => x.actualcost, (row, value) => row.copy(actualcost = value))
+      override def modifieddate = Field[TypoLocalDateTime, WrViewRow](_path, "modifieddate", Some("text"), None, x => x.modifieddate, (row, value) => row.copy(modifieddate = value))
     }
   
-    override val columns: List[FieldLikeNoHkt[?, Row]] =
-      List[FieldLikeNoHkt[?, Row]](fields.id, fields.workorderid, fields.productid, fields.operationsequence, fields.locationid, fields.scheduledstartdate, fields.scheduledenddate, fields.actualstartdate, fields.actualenddate, fields.actualresourcehrs, fields.plannedcost, fields.actualcost, fields.modifieddate)
+    override lazy val columns: List[FieldLikeNoHkt[?, WrViewRow]] =
+      List[FieldLikeNoHkt[?, WrViewRow]](fields.id, fields.workorderid, fields.productid, fields.operationsequence, fields.locationid, fields.scheduledstartdate, fields.scheduledenddate, fields.actualstartdate, fields.actualenddate, fields.actualresourcehrs, fields.plannedcost, fields.actualcost, fields.modifieddate)
   
-    override def copy[NewRow](prefix: Option[String], extract: NewRow => WrViewRow, merge: (NewRow, WrViewRow) => NewRow): Impl[NewRow] =
-      new Impl(prefix, extract, merge)
+    override def copy(path: List[Path]): Impl =
+      new Impl(path)
   }
   
 }

--- a/typo-tester-anorm/generated-and-checked-in/adventureworks/production/billofmaterials/BillofmaterialsFields.scala
+++ b/typo-tester-anorm/generated-and-checked-in/adventureworks/production/billofmaterials/BillofmaterialsFields.scala
@@ -11,48 +11,49 @@ import adventureworks.customtypes.TypoLocalDateTime
 import adventureworks.customtypes.TypoShort
 import adventureworks.production.product.ProductId
 import adventureworks.production.unitmeasure.UnitmeasureId
+import typo.dsl.Path
 import typo.dsl.SqlExpr.Field
 import typo.dsl.SqlExpr.FieldLikeNoHkt
 import typo.dsl.SqlExpr.IdField
 import typo.dsl.SqlExpr.OptField
 import typo.dsl.Structure.Relation
 
-trait BillofmaterialsFields[Row] {
-  val billofmaterialsid: IdField[Int, Row]
-  val productassemblyid: OptField[ProductId, Row]
-  val componentid: Field[ProductId, Row]
-  val startdate: Field[TypoLocalDateTime, Row]
-  val enddate: OptField[TypoLocalDateTime, Row]
-  val unitmeasurecode: Field[UnitmeasureId, Row]
-  val bomlevel: Field[TypoShort, Row]
-  val perassemblyqty: Field[BigDecimal, Row]
-  val modifieddate: Field[TypoLocalDateTime, Row]
+trait BillofmaterialsFields {
+  def billofmaterialsid: IdField[Int, BillofmaterialsRow]
+  def productassemblyid: OptField[ProductId, BillofmaterialsRow]
+  def componentid: Field[ProductId, BillofmaterialsRow]
+  def startdate: Field[TypoLocalDateTime, BillofmaterialsRow]
+  def enddate: OptField[TypoLocalDateTime, BillofmaterialsRow]
+  def unitmeasurecode: Field[UnitmeasureId, BillofmaterialsRow]
+  def bomlevel: Field[TypoShort, BillofmaterialsRow]
+  def perassemblyqty: Field[BigDecimal, BillofmaterialsRow]
+  def modifieddate: Field[TypoLocalDateTime, BillofmaterialsRow]
 }
 
 object BillofmaterialsFields {
-  val structure: Relation[BillofmaterialsFields, BillofmaterialsRow, BillofmaterialsRow] = 
-    new Impl(None, identity, (_, x) => x)
+  lazy val structure: Relation[BillofmaterialsFields, BillofmaterialsRow] =
+    new Impl(Nil)
     
-  private final class Impl[Row](val prefix: Option[String], val extract: Row => BillofmaterialsRow, val merge: (Row, BillofmaterialsRow) => Row)
-    extends Relation[BillofmaterialsFields, BillofmaterialsRow, Row] { 
+  private final class Impl(val _path: List[Path])
+    extends Relation[BillofmaterialsFields, BillofmaterialsRow] {
   
-    override val fields: BillofmaterialsFields[Row] = new BillofmaterialsFields[Row] {
-      override val billofmaterialsid = new IdField[Int, Row](prefix, "billofmaterialsid", None, Some("int4"))(x => extract(x).billofmaterialsid, (row, value) => merge(row, extract(row).copy(billofmaterialsid = value)))
-      override val productassemblyid = new OptField[ProductId, Row](prefix, "productassemblyid", None, Some("int4"))(x => extract(x).productassemblyid, (row, value) => merge(row, extract(row).copy(productassemblyid = value)))
-      override val componentid = new Field[ProductId, Row](prefix, "componentid", None, Some("int4"))(x => extract(x).componentid, (row, value) => merge(row, extract(row).copy(componentid = value)))
-      override val startdate = new Field[TypoLocalDateTime, Row](prefix, "startdate", Some("text"), Some("timestamp"))(x => extract(x).startdate, (row, value) => merge(row, extract(row).copy(startdate = value)))
-      override val enddate = new OptField[TypoLocalDateTime, Row](prefix, "enddate", Some("text"), Some("timestamp"))(x => extract(x).enddate, (row, value) => merge(row, extract(row).copy(enddate = value)))
-      override val unitmeasurecode = new Field[UnitmeasureId, Row](prefix, "unitmeasurecode", None, Some("bpchar"))(x => extract(x).unitmeasurecode, (row, value) => merge(row, extract(row).copy(unitmeasurecode = value)))
-      override val bomlevel = new Field[TypoShort, Row](prefix, "bomlevel", None, Some("int2"))(x => extract(x).bomlevel, (row, value) => merge(row, extract(row).copy(bomlevel = value)))
-      override val perassemblyqty = new Field[BigDecimal, Row](prefix, "perassemblyqty", None, Some("numeric"))(x => extract(x).perassemblyqty, (row, value) => merge(row, extract(row).copy(perassemblyqty = value)))
-      override val modifieddate = new Field[TypoLocalDateTime, Row](prefix, "modifieddate", Some("text"), Some("timestamp"))(x => extract(x).modifieddate, (row, value) => merge(row, extract(row).copy(modifieddate = value)))
+    override lazy val fields: BillofmaterialsFields = new BillofmaterialsFields {
+      override def billofmaterialsid = IdField[Int, BillofmaterialsRow](_path, "billofmaterialsid", None, Some("int4"), x => x.billofmaterialsid, (row, value) => row.copy(billofmaterialsid = value))
+      override def productassemblyid = OptField[ProductId, BillofmaterialsRow](_path, "productassemblyid", None, Some("int4"), x => x.productassemblyid, (row, value) => row.copy(productassemblyid = value))
+      override def componentid = Field[ProductId, BillofmaterialsRow](_path, "componentid", None, Some("int4"), x => x.componentid, (row, value) => row.copy(componentid = value))
+      override def startdate = Field[TypoLocalDateTime, BillofmaterialsRow](_path, "startdate", Some("text"), Some("timestamp"), x => x.startdate, (row, value) => row.copy(startdate = value))
+      override def enddate = OptField[TypoLocalDateTime, BillofmaterialsRow](_path, "enddate", Some("text"), Some("timestamp"), x => x.enddate, (row, value) => row.copy(enddate = value))
+      override def unitmeasurecode = Field[UnitmeasureId, BillofmaterialsRow](_path, "unitmeasurecode", None, Some("bpchar"), x => x.unitmeasurecode, (row, value) => row.copy(unitmeasurecode = value))
+      override def bomlevel = Field[TypoShort, BillofmaterialsRow](_path, "bomlevel", None, Some("int2"), x => x.bomlevel, (row, value) => row.copy(bomlevel = value))
+      override def perassemblyqty = Field[BigDecimal, BillofmaterialsRow](_path, "perassemblyqty", None, Some("numeric"), x => x.perassemblyqty, (row, value) => row.copy(perassemblyqty = value))
+      override def modifieddate = Field[TypoLocalDateTime, BillofmaterialsRow](_path, "modifieddate", Some("text"), Some("timestamp"), x => x.modifieddate, (row, value) => row.copy(modifieddate = value))
     }
   
-    override val columns: List[FieldLikeNoHkt[?, Row]] =
-      List[FieldLikeNoHkt[?, Row]](fields.billofmaterialsid, fields.productassemblyid, fields.componentid, fields.startdate, fields.enddate, fields.unitmeasurecode, fields.bomlevel, fields.perassemblyqty, fields.modifieddate)
+    override lazy val columns: List[FieldLikeNoHkt[?, BillofmaterialsRow]] =
+      List[FieldLikeNoHkt[?, BillofmaterialsRow]](fields.billofmaterialsid, fields.productassemblyid, fields.componentid, fields.startdate, fields.enddate, fields.unitmeasurecode, fields.bomlevel, fields.perassemblyqty, fields.modifieddate)
   
-    override def copy[NewRow](prefix: Option[String], extract: NewRow => BillofmaterialsRow, merge: (NewRow, BillofmaterialsRow) => NewRow): Impl[NewRow] =
-      new Impl(prefix, extract, merge)
+    override def copy(path: List[Path]): Impl =
+      new Impl(path)
   }
   
 }

--- a/typo-tester-anorm/generated-and-checked-in/adventureworks/production/billofmaterials/BillofmaterialsRepoMock.scala
+++ b/typo-tester-anorm/generated-and-checked-in/adventureworks/production/billofmaterials/BillofmaterialsRepoMock.scala
@@ -22,7 +22,7 @@ import typo.dsl.UpdateParams
 class BillofmaterialsRepoMock(toRow: Function1[BillofmaterialsRowUnsaved, BillofmaterialsRow],
                               map: scala.collection.mutable.Map[Int, BillofmaterialsRow] = scala.collection.mutable.Map.empty) extends BillofmaterialsRepo {
   override def delete: DeleteBuilder[BillofmaterialsFields, BillofmaterialsRow] = {
-    DeleteBuilderMock(DeleteParams.empty, BillofmaterialsFields.structure.fields, map)
+    DeleteBuilderMock(DeleteParams.empty, BillofmaterialsFields.structure, map)
   }
   override def deleteById(billofmaterialsid: Int)(implicit c: Connection): Boolean = {
     map.remove(billofmaterialsid).isDefined
@@ -72,7 +72,7 @@ class BillofmaterialsRepoMock(toRow: Function1[BillofmaterialsRowUnsaved, Billof
     billofmaterialsids.view.flatMap(id => byId.get(id).map(x => (id, x))).toMap
   }
   override def update: UpdateBuilder[BillofmaterialsFields, BillofmaterialsRow] = {
-    UpdateBuilderMock(UpdateParams.empty, BillofmaterialsFields.structure.fields, map)
+    UpdateBuilderMock(UpdateParams.empty, BillofmaterialsFields.structure, map)
   }
   override def update(row: BillofmaterialsRow)(implicit c: Connection): Boolean = {
     map.get(row.billofmaterialsid) match {

--- a/typo-tester-anorm/generated-and-checked-in/adventureworks/production/culture/CultureFields.scala
+++ b/typo-tester-anorm/generated-and-checked-in/adventureworks/production/culture/CultureFields.scala
@@ -9,35 +9,36 @@ package culture
 
 import adventureworks.customtypes.TypoLocalDateTime
 import adventureworks.public.Name
+import typo.dsl.Path
 import typo.dsl.SqlExpr.Field
 import typo.dsl.SqlExpr.FieldLikeNoHkt
 import typo.dsl.SqlExpr.IdField
 import typo.dsl.Structure.Relation
 
-trait CultureFields[Row] {
-  val cultureid: IdField[CultureId, Row]
-  val name: Field[Name, Row]
-  val modifieddate: Field[TypoLocalDateTime, Row]
+trait CultureFields {
+  def cultureid: IdField[CultureId, CultureRow]
+  def name: Field[Name, CultureRow]
+  def modifieddate: Field[TypoLocalDateTime, CultureRow]
 }
 
 object CultureFields {
-  val structure: Relation[CultureFields, CultureRow, CultureRow] = 
-    new Impl(None, identity, (_, x) => x)
+  lazy val structure: Relation[CultureFields, CultureRow] =
+    new Impl(Nil)
     
-  private final class Impl[Row](val prefix: Option[String], val extract: Row => CultureRow, val merge: (Row, CultureRow) => Row)
-    extends Relation[CultureFields, CultureRow, Row] { 
+  private final class Impl(val _path: List[Path])
+    extends Relation[CultureFields, CultureRow] {
   
-    override val fields: CultureFields[Row] = new CultureFields[Row] {
-      override val cultureid = new IdField[CultureId, Row](prefix, "cultureid", None, Some("bpchar"))(x => extract(x).cultureid, (row, value) => merge(row, extract(row).copy(cultureid = value)))
-      override val name = new Field[Name, Row](prefix, "name", None, Some("varchar"))(x => extract(x).name, (row, value) => merge(row, extract(row).copy(name = value)))
-      override val modifieddate = new Field[TypoLocalDateTime, Row](prefix, "modifieddate", Some("text"), Some("timestamp"))(x => extract(x).modifieddate, (row, value) => merge(row, extract(row).copy(modifieddate = value)))
+    override lazy val fields: CultureFields = new CultureFields {
+      override def cultureid = IdField[CultureId, CultureRow](_path, "cultureid", None, Some("bpchar"), x => x.cultureid, (row, value) => row.copy(cultureid = value))
+      override def name = Field[Name, CultureRow](_path, "name", None, Some("varchar"), x => x.name, (row, value) => row.copy(name = value))
+      override def modifieddate = Field[TypoLocalDateTime, CultureRow](_path, "modifieddate", Some("text"), Some("timestamp"), x => x.modifieddate, (row, value) => row.copy(modifieddate = value))
     }
   
-    override val columns: List[FieldLikeNoHkt[?, Row]] =
-      List[FieldLikeNoHkt[?, Row]](fields.cultureid, fields.name, fields.modifieddate)
+    override lazy val columns: List[FieldLikeNoHkt[?, CultureRow]] =
+      List[FieldLikeNoHkt[?, CultureRow]](fields.cultureid, fields.name, fields.modifieddate)
   
-    override def copy[NewRow](prefix: Option[String], extract: NewRow => CultureRow, merge: (NewRow, CultureRow) => NewRow): Impl[NewRow] =
-      new Impl(prefix, extract, merge)
+    override def copy(path: List[Path]): Impl =
+      new Impl(path)
   }
   
 }

--- a/typo-tester-anorm/generated-and-checked-in/adventureworks/production/culture/CultureRepoMock.scala
+++ b/typo-tester-anorm/generated-and-checked-in/adventureworks/production/culture/CultureRepoMock.scala
@@ -22,7 +22,7 @@ import typo.dsl.UpdateParams
 class CultureRepoMock(toRow: Function1[CultureRowUnsaved, CultureRow],
                       map: scala.collection.mutable.Map[CultureId, CultureRow] = scala.collection.mutable.Map.empty) extends CultureRepo {
   override def delete: DeleteBuilder[CultureFields, CultureRow] = {
-    DeleteBuilderMock(DeleteParams.empty, CultureFields.structure.fields, map)
+    DeleteBuilderMock(DeleteParams.empty, CultureFields.structure, map)
   }
   override def deleteById(cultureid: CultureId)(implicit c: Connection): Boolean = {
     map.remove(cultureid).isDefined
@@ -72,7 +72,7 @@ class CultureRepoMock(toRow: Function1[CultureRowUnsaved, CultureRow],
     cultureids.view.flatMap(id => byId.get(id).map(x => (id, x))).toMap
   }
   override def update: UpdateBuilder[CultureFields, CultureRow] = {
-    UpdateBuilderMock(UpdateParams.empty, CultureFields.structure.fields, map)
+    UpdateBuilderMock(UpdateParams.empty, CultureFields.structure, map)
   }
   override def update(row: CultureRow)(implicit c: Connection): Boolean = {
     map.get(row.cultureid) match {

--- a/typo-tester-anorm/generated-and-checked-in/adventureworks/production/document/DocumentFields.scala
+++ b/typo-tester-anorm/generated-and-checked-in/adventureworks/production/document/DocumentFields.scala
@@ -13,56 +13,57 @@ import adventureworks.customtypes.TypoShort
 import adventureworks.customtypes.TypoUUID
 import adventureworks.person.businessentity.BusinessentityId
 import adventureworks.public.Flag
+import typo.dsl.Path
 import typo.dsl.SqlExpr.Field
 import typo.dsl.SqlExpr.FieldLikeNoHkt
 import typo.dsl.SqlExpr.IdField
 import typo.dsl.SqlExpr.OptField
 import typo.dsl.Structure.Relation
 
-trait DocumentFields[Row] {
-  val title: Field[/* max 50 chars */ String, Row]
-  val owner: Field[BusinessentityId, Row]
-  val folderflag: Field[Flag, Row]
-  val filename: Field[/* max 400 chars */ String, Row]
-  val fileextension: OptField[/* max 8 chars */ String, Row]
-  val revision: Field[/* bpchar, max 5 chars */ String, Row]
-  val changenumber: Field[Int, Row]
-  val status: Field[TypoShort, Row]
-  val documentsummary: OptField[String, Row]
-  val document: OptField[TypoBytea, Row]
-  val rowguid: Field[TypoUUID, Row]
-  val modifieddate: Field[TypoLocalDateTime, Row]
-  val documentnode: IdField[DocumentId, Row]
+trait DocumentFields {
+  def title: Field[/* max 50 chars */ String, DocumentRow]
+  def owner: Field[BusinessentityId, DocumentRow]
+  def folderflag: Field[Flag, DocumentRow]
+  def filename: Field[/* max 400 chars */ String, DocumentRow]
+  def fileextension: OptField[/* max 8 chars */ String, DocumentRow]
+  def revision: Field[/* bpchar, max 5 chars */ String, DocumentRow]
+  def changenumber: Field[Int, DocumentRow]
+  def status: Field[TypoShort, DocumentRow]
+  def documentsummary: OptField[String, DocumentRow]
+  def document: OptField[TypoBytea, DocumentRow]
+  def rowguid: Field[TypoUUID, DocumentRow]
+  def modifieddate: Field[TypoLocalDateTime, DocumentRow]
+  def documentnode: IdField[DocumentId, DocumentRow]
 }
 
 object DocumentFields {
-  val structure: Relation[DocumentFields, DocumentRow, DocumentRow] = 
-    new Impl(None, identity, (_, x) => x)
+  lazy val structure: Relation[DocumentFields, DocumentRow] =
+    new Impl(Nil)
     
-  private final class Impl[Row](val prefix: Option[String], val extract: Row => DocumentRow, val merge: (Row, DocumentRow) => Row)
-    extends Relation[DocumentFields, DocumentRow, Row] { 
+  private final class Impl(val _path: List[Path])
+    extends Relation[DocumentFields, DocumentRow] {
   
-    override val fields: DocumentFields[Row] = new DocumentFields[Row] {
-      override val title = new Field[/* max 50 chars */ String, Row](prefix, "title", None, None)(x => extract(x).title, (row, value) => merge(row, extract(row).copy(title = value)))
-      override val owner = new Field[BusinessentityId, Row](prefix, "owner", None, Some("int4"))(x => extract(x).owner, (row, value) => merge(row, extract(row).copy(owner = value)))
-      override val folderflag = new Field[Flag, Row](prefix, "folderflag", None, Some("bool"))(x => extract(x).folderflag, (row, value) => merge(row, extract(row).copy(folderflag = value)))
-      override val filename = new Field[/* max 400 chars */ String, Row](prefix, "filename", None, None)(x => extract(x).filename, (row, value) => merge(row, extract(row).copy(filename = value)))
-      override val fileextension = new OptField[/* max 8 chars */ String, Row](prefix, "fileextension", None, None)(x => extract(x).fileextension, (row, value) => merge(row, extract(row).copy(fileextension = value)))
-      override val revision = new Field[/* bpchar, max 5 chars */ String, Row](prefix, "revision", None, Some("bpchar"))(x => extract(x).revision, (row, value) => merge(row, extract(row).copy(revision = value)))
-      override val changenumber = new Field[Int, Row](prefix, "changenumber", None, Some("int4"))(x => extract(x).changenumber, (row, value) => merge(row, extract(row).copy(changenumber = value)))
-      override val status = new Field[TypoShort, Row](prefix, "status", None, Some("int2"))(x => extract(x).status, (row, value) => merge(row, extract(row).copy(status = value)))
-      override val documentsummary = new OptField[String, Row](prefix, "documentsummary", None, None)(x => extract(x).documentsummary, (row, value) => merge(row, extract(row).copy(documentsummary = value)))
-      override val document = new OptField[TypoBytea, Row](prefix, "document", None, Some("bytea"))(x => extract(x).document, (row, value) => merge(row, extract(row).copy(document = value)))
-      override val rowguid = new Field[TypoUUID, Row](prefix, "rowguid", None, Some("uuid"))(x => extract(x).rowguid, (row, value) => merge(row, extract(row).copy(rowguid = value)))
-      override val modifieddate = new Field[TypoLocalDateTime, Row](prefix, "modifieddate", Some("text"), Some("timestamp"))(x => extract(x).modifieddate, (row, value) => merge(row, extract(row).copy(modifieddate = value)))
-      override val documentnode = new IdField[DocumentId, Row](prefix, "documentnode", None, None)(x => extract(x).documentnode, (row, value) => merge(row, extract(row).copy(documentnode = value)))
+    override lazy val fields: DocumentFields = new DocumentFields {
+      override def title = Field[/* max 50 chars */ String, DocumentRow](_path, "title", None, None, x => x.title, (row, value) => row.copy(title = value))
+      override def owner = Field[BusinessentityId, DocumentRow](_path, "owner", None, Some("int4"), x => x.owner, (row, value) => row.copy(owner = value))
+      override def folderflag = Field[Flag, DocumentRow](_path, "folderflag", None, Some("bool"), x => x.folderflag, (row, value) => row.copy(folderflag = value))
+      override def filename = Field[/* max 400 chars */ String, DocumentRow](_path, "filename", None, None, x => x.filename, (row, value) => row.copy(filename = value))
+      override def fileextension = OptField[/* max 8 chars */ String, DocumentRow](_path, "fileextension", None, None, x => x.fileextension, (row, value) => row.copy(fileextension = value))
+      override def revision = Field[/* bpchar, max 5 chars */ String, DocumentRow](_path, "revision", None, Some("bpchar"), x => x.revision, (row, value) => row.copy(revision = value))
+      override def changenumber = Field[Int, DocumentRow](_path, "changenumber", None, Some("int4"), x => x.changenumber, (row, value) => row.copy(changenumber = value))
+      override def status = Field[TypoShort, DocumentRow](_path, "status", None, Some("int2"), x => x.status, (row, value) => row.copy(status = value))
+      override def documentsummary = OptField[String, DocumentRow](_path, "documentsummary", None, None, x => x.documentsummary, (row, value) => row.copy(documentsummary = value))
+      override def document = OptField[TypoBytea, DocumentRow](_path, "document", None, Some("bytea"), x => x.document, (row, value) => row.copy(document = value))
+      override def rowguid = Field[TypoUUID, DocumentRow](_path, "rowguid", None, Some("uuid"), x => x.rowguid, (row, value) => row.copy(rowguid = value))
+      override def modifieddate = Field[TypoLocalDateTime, DocumentRow](_path, "modifieddate", Some("text"), Some("timestamp"), x => x.modifieddate, (row, value) => row.copy(modifieddate = value))
+      override def documentnode = IdField[DocumentId, DocumentRow](_path, "documentnode", None, None, x => x.documentnode, (row, value) => row.copy(documentnode = value))
     }
   
-    override val columns: List[FieldLikeNoHkt[?, Row]] =
-      List[FieldLikeNoHkt[?, Row]](fields.title, fields.owner, fields.folderflag, fields.filename, fields.fileextension, fields.revision, fields.changenumber, fields.status, fields.documentsummary, fields.document, fields.rowguid, fields.modifieddate, fields.documentnode)
+    override lazy val columns: List[FieldLikeNoHkt[?, DocumentRow]] =
+      List[FieldLikeNoHkt[?, DocumentRow]](fields.title, fields.owner, fields.folderflag, fields.filename, fields.fileextension, fields.revision, fields.changenumber, fields.status, fields.documentsummary, fields.document, fields.rowguid, fields.modifieddate, fields.documentnode)
   
-    override def copy[NewRow](prefix: Option[String], extract: NewRow => DocumentRow, merge: (NewRow, DocumentRow) => NewRow): Impl[NewRow] =
-      new Impl(prefix, extract, merge)
+    override def copy(path: List[Path]): Impl =
+      new Impl(path)
   }
   
 }

--- a/typo-tester-anorm/generated-and-checked-in/adventureworks/production/document/DocumentRepoMock.scala
+++ b/typo-tester-anorm/generated-and-checked-in/adventureworks/production/document/DocumentRepoMock.scala
@@ -23,7 +23,7 @@ import typo.dsl.UpdateParams
 class DocumentRepoMock(toRow: Function1[DocumentRowUnsaved, DocumentRow],
                        map: scala.collection.mutable.Map[DocumentId, DocumentRow] = scala.collection.mutable.Map.empty) extends DocumentRepo {
   override def delete: DeleteBuilder[DocumentFields, DocumentRow] = {
-    DeleteBuilderMock(DeleteParams.empty, DocumentFields.structure.fields, map)
+    DeleteBuilderMock(DeleteParams.empty, DocumentFields.structure, map)
   }
   override def deleteById(documentnode: DocumentId)(implicit c: Connection): Boolean = {
     map.remove(documentnode).isDefined
@@ -76,7 +76,7 @@ class DocumentRepoMock(toRow: Function1[DocumentRowUnsaved, DocumentRow],
     map.values.find(v => rowguid == v.rowguid)
   }
   override def update: UpdateBuilder[DocumentFields, DocumentRow] = {
-    UpdateBuilderMock(UpdateParams.empty, DocumentFields.structure.fields, map)
+    UpdateBuilderMock(UpdateParams.empty, DocumentFields.structure, map)
   }
   override def update(row: DocumentRow)(implicit c: Connection): Boolean = {
     map.get(row.documentnode) match {

--- a/typo-tester-anorm/generated-and-checked-in/adventureworks/production/illustration/IllustrationFields.scala
+++ b/typo-tester-anorm/generated-and-checked-in/adventureworks/production/illustration/IllustrationFields.scala
@@ -9,36 +9,37 @@ package illustration
 
 import adventureworks.customtypes.TypoLocalDateTime
 import adventureworks.customtypes.TypoXml
+import typo.dsl.Path
 import typo.dsl.SqlExpr.Field
 import typo.dsl.SqlExpr.FieldLikeNoHkt
 import typo.dsl.SqlExpr.IdField
 import typo.dsl.SqlExpr.OptField
 import typo.dsl.Structure.Relation
 
-trait IllustrationFields[Row] {
-  val illustrationid: IdField[IllustrationId, Row]
-  val diagram: OptField[TypoXml, Row]
-  val modifieddate: Field[TypoLocalDateTime, Row]
+trait IllustrationFields {
+  def illustrationid: IdField[IllustrationId, IllustrationRow]
+  def diagram: OptField[TypoXml, IllustrationRow]
+  def modifieddate: Field[TypoLocalDateTime, IllustrationRow]
 }
 
 object IllustrationFields {
-  val structure: Relation[IllustrationFields, IllustrationRow, IllustrationRow] = 
-    new Impl(None, identity, (_, x) => x)
+  lazy val structure: Relation[IllustrationFields, IllustrationRow] =
+    new Impl(Nil)
     
-  private final class Impl[Row](val prefix: Option[String], val extract: Row => IllustrationRow, val merge: (Row, IllustrationRow) => Row)
-    extends Relation[IllustrationFields, IllustrationRow, Row] { 
+  private final class Impl(val _path: List[Path])
+    extends Relation[IllustrationFields, IllustrationRow] {
   
-    override val fields: IllustrationFields[Row] = new IllustrationFields[Row] {
-      override val illustrationid = new IdField[IllustrationId, Row](prefix, "illustrationid", None, Some("int4"))(x => extract(x).illustrationid, (row, value) => merge(row, extract(row).copy(illustrationid = value)))
-      override val diagram = new OptField[TypoXml, Row](prefix, "diagram", None, Some("xml"))(x => extract(x).diagram, (row, value) => merge(row, extract(row).copy(diagram = value)))
-      override val modifieddate = new Field[TypoLocalDateTime, Row](prefix, "modifieddate", Some("text"), Some("timestamp"))(x => extract(x).modifieddate, (row, value) => merge(row, extract(row).copy(modifieddate = value)))
+    override lazy val fields: IllustrationFields = new IllustrationFields {
+      override def illustrationid = IdField[IllustrationId, IllustrationRow](_path, "illustrationid", None, Some("int4"), x => x.illustrationid, (row, value) => row.copy(illustrationid = value))
+      override def diagram = OptField[TypoXml, IllustrationRow](_path, "diagram", None, Some("xml"), x => x.diagram, (row, value) => row.copy(diagram = value))
+      override def modifieddate = Field[TypoLocalDateTime, IllustrationRow](_path, "modifieddate", Some("text"), Some("timestamp"), x => x.modifieddate, (row, value) => row.copy(modifieddate = value))
     }
   
-    override val columns: List[FieldLikeNoHkt[?, Row]] =
-      List[FieldLikeNoHkt[?, Row]](fields.illustrationid, fields.diagram, fields.modifieddate)
+    override lazy val columns: List[FieldLikeNoHkt[?, IllustrationRow]] =
+      List[FieldLikeNoHkt[?, IllustrationRow]](fields.illustrationid, fields.diagram, fields.modifieddate)
   
-    override def copy[NewRow](prefix: Option[String], extract: NewRow => IllustrationRow, merge: (NewRow, IllustrationRow) => NewRow): Impl[NewRow] =
-      new Impl(prefix, extract, merge)
+    override def copy(path: List[Path]): Impl =
+      new Impl(path)
   }
   
 }

--- a/typo-tester-anorm/generated-and-checked-in/adventureworks/production/illustration/IllustrationRepoMock.scala
+++ b/typo-tester-anorm/generated-and-checked-in/adventureworks/production/illustration/IllustrationRepoMock.scala
@@ -22,7 +22,7 @@ import typo.dsl.UpdateParams
 class IllustrationRepoMock(toRow: Function1[IllustrationRowUnsaved, IllustrationRow],
                            map: scala.collection.mutable.Map[IllustrationId, IllustrationRow] = scala.collection.mutable.Map.empty) extends IllustrationRepo {
   override def delete: DeleteBuilder[IllustrationFields, IllustrationRow] = {
-    DeleteBuilderMock(DeleteParams.empty, IllustrationFields.structure.fields, map)
+    DeleteBuilderMock(DeleteParams.empty, IllustrationFields.structure, map)
   }
   override def deleteById(illustrationid: IllustrationId)(implicit c: Connection): Boolean = {
     map.remove(illustrationid).isDefined
@@ -72,7 +72,7 @@ class IllustrationRepoMock(toRow: Function1[IllustrationRowUnsaved, Illustration
     illustrationids.view.flatMap(id => byId.get(id).map(x => (id, x))).toMap
   }
   override def update: UpdateBuilder[IllustrationFields, IllustrationRow] = {
-    UpdateBuilderMock(UpdateParams.empty, IllustrationFields.structure.fields, map)
+    UpdateBuilderMock(UpdateParams.empty, IllustrationFields.structure, map)
   }
   override def update(row: IllustrationRow)(implicit c: Connection): Boolean = {
     map.get(row.illustrationid) match {

--- a/typo-tester-anorm/generated-and-checked-in/adventureworks/production/location/LocationFields.scala
+++ b/typo-tester-anorm/generated-and-checked-in/adventureworks/production/location/LocationFields.scala
@@ -9,39 +9,40 @@ package location
 
 import adventureworks.customtypes.TypoLocalDateTime
 import adventureworks.public.Name
+import typo.dsl.Path
 import typo.dsl.SqlExpr.Field
 import typo.dsl.SqlExpr.FieldLikeNoHkt
 import typo.dsl.SqlExpr.IdField
 import typo.dsl.Structure.Relation
 
-trait LocationFields[Row] {
-  val locationid: IdField[LocationId, Row]
-  val name: Field[Name, Row]
-  val costrate: Field[BigDecimal, Row]
-  val availability: Field[BigDecimal, Row]
-  val modifieddate: Field[TypoLocalDateTime, Row]
+trait LocationFields {
+  def locationid: IdField[LocationId, LocationRow]
+  def name: Field[Name, LocationRow]
+  def costrate: Field[BigDecimal, LocationRow]
+  def availability: Field[BigDecimal, LocationRow]
+  def modifieddate: Field[TypoLocalDateTime, LocationRow]
 }
 
 object LocationFields {
-  val structure: Relation[LocationFields, LocationRow, LocationRow] = 
-    new Impl(None, identity, (_, x) => x)
+  lazy val structure: Relation[LocationFields, LocationRow] =
+    new Impl(Nil)
     
-  private final class Impl[Row](val prefix: Option[String], val extract: Row => LocationRow, val merge: (Row, LocationRow) => Row)
-    extends Relation[LocationFields, LocationRow, Row] { 
+  private final class Impl(val _path: List[Path])
+    extends Relation[LocationFields, LocationRow] {
   
-    override val fields: LocationFields[Row] = new LocationFields[Row] {
-      override val locationid = new IdField[LocationId, Row](prefix, "locationid", None, Some("int4"))(x => extract(x).locationid, (row, value) => merge(row, extract(row).copy(locationid = value)))
-      override val name = new Field[Name, Row](prefix, "name", None, Some("varchar"))(x => extract(x).name, (row, value) => merge(row, extract(row).copy(name = value)))
-      override val costrate = new Field[BigDecimal, Row](prefix, "costrate", None, Some("numeric"))(x => extract(x).costrate, (row, value) => merge(row, extract(row).copy(costrate = value)))
-      override val availability = new Field[BigDecimal, Row](prefix, "availability", None, Some("numeric"))(x => extract(x).availability, (row, value) => merge(row, extract(row).copy(availability = value)))
-      override val modifieddate = new Field[TypoLocalDateTime, Row](prefix, "modifieddate", Some("text"), Some("timestamp"))(x => extract(x).modifieddate, (row, value) => merge(row, extract(row).copy(modifieddate = value)))
+    override lazy val fields: LocationFields = new LocationFields {
+      override def locationid = IdField[LocationId, LocationRow](_path, "locationid", None, Some("int4"), x => x.locationid, (row, value) => row.copy(locationid = value))
+      override def name = Field[Name, LocationRow](_path, "name", None, Some("varchar"), x => x.name, (row, value) => row.copy(name = value))
+      override def costrate = Field[BigDecimal, LocationRow](_path, "costrate", None, Some("numeric"), x => x.costrate, (row, value) => row.copy(costrate = value))
+      override def availability = Field[BigDecimal, LocationRow](_path, "availability", None, Some("numeric"), x => x.availability, (row, value) => row.copy(availability = value))
+      override def modifieddate = Field[TypoLocalDateTime, LocationRow](_path, "modifieddate", Some("text"), Some("timestamp"), x => x.modifieddate, (row, value) => row.copy(modifieddate = value))
     }
   
-    override val columns: List[FieldLikeNoHkt[?, Row]] =
-      List[FieldLikeNoHkt[?, Row]](fields.locationid, fields.name, fields.costrate, fields.availability, fields.modifieddate)
+    override lazy val columns: List[FieldLikeNoHkt[?, LocationRow]] =
+      List[FieldLikeNoHkt[?, LocationRow]](fields.locationid, fields.name, fields.costrate, fields.availability, fields.modifieddate)
   
-    override def copy[NewRow](prefix: Option[String], extract: NewRow => LocationRow, merge: (NewRow, LocationRow) => NewRow): Impl[NewRow] =
-      new Impl(prefix, extract, merge)
+    override def copy(path: List[Path]): Impl =
+      new Impl(path)
   }
   
 }

--- a/typo-tester-anorm/generated-and-checked-in/adventureworks/production/location/LocationRepoMock.scala
+++ b/typo-tester-anorm/generated-and-checked-in/adventureworks/production/location/LocationRepoMock.scala
@@ -22,7 +22,7 @@ import typo.dsl.UpdateParams
 class LocationRepoMock(toRow: Function1[LocationRowUnsaved, LocationRow],
                        map: scala.collection.mutable.Map[LocationId, LocationRow] = scala.collection.mutable.Map.empty) extends LocationRepo {
   override def delete: DeleteBuilder[LocationFields, LocationRow] = {
-    DeleteBuilderMock(DeleteParams.empty, LocationFields.structure.fields, map)
+    DeleteBuilderMock(DeleteParams.empty, LocationFields.structure, map)
   }
   override def deleteById(locationid: LocationId)(implicit c: Connection): Boolean = {
     map.remove(locationid).isDefined
@@ -72,7 +72,7 @@ class LocationRepoMock(toRow: Function1[LocationRowUnsaved, LocationRow],
     locationids.view.flatMap(id => byId.get(id).map(x => (id, x))).toMap
   }
   override def update: UpdateBuilder[LocationFields, LocationRow] = {
-    UpdateBuilderMock(UpdateParams.empty, LocationFields.structure.fields, map)
+    UpdateBuilderMock(UpdateParams.empty, LocationFields.structure, map)
   }
   override def update(row: LocationRow)(implicit c: Connection): Boolean = {
     map.get(row.locationid) match {

--- a/typo-tester-anorm/generated-and-checked-in/adventureworks/production/product/ProductFields.scala
+++ b/typo-tester-anorm/generated-and-checked-in/adventureworks/production/product/ProductFields.scala
@@ -15,80 +15,81 @@ import adventureworks.production.productsubcategory.ProductsubcategoryId
 import adventureworks.production.unitmeasure.UnitmeasureId
 import adventureworks.public.Flag
 import adventureworks.public.Name
+import typo.dsl.Path
 import typo.dsl.SqlExpr.Field
 import typo.dsl.SqlExpr.FieldLikeNoHkt
 import typo.dsl.SqlExpr.IdField
 import typo.dsl.SqlExpr.OptField
 import typo.dsl.Structure.Relation
 
-trait ProductFields[Row] {
-  val productid: IdField[ProductId, Row]
-  val name: Field[Name, Row]
-  val productnumber: Field[/* max 25 chars */ String, Row]
-  val makeflag: Field[Flag, Row]
-  val finishedgoodsflag: Field[Flag, Row]
-  val color: OptField[/* max 15 chars */ String, Row]
-  val safetystocklevel: Field[TypoShort, Row]
-  val reorderpoint: Field[TypoShort, Row]
-  val standardcost: Field[BigDecimal, Row]
-  val listprice: Field[BigDecimal, Row]
-  val size: OptField[/* max 5 chars */ String, Row]
-  val sizeunitmeasurecode: OptField[UnitmeasureId, Row]
-  val weightunitmeasurecode: OptField[UnitmeasureId, Row]
-  val weight: OptField[BigDecimal, Row]
-  val daystomanufacture: Field[Int, Row]
-  val productline: OptField[/* bpchar, max 2 chars */ String, Row]
-  val `class`: OptField[/* bpchar, max 2 chars */ String, Row]
-  val style: OptField[/* bpchar, max 2 chars */ String, Row]
-  val productsubcategoryid: OptField[ProductsubcategoryId, Row]
-  val productmodelid: OptField[ProductmodelId, Row]
-  val sellstartdate: Field[TypoLocalDateTime, Row]
-  val sellenddate: OptField[TypoLocalDateTime, Row]
-  val discontinueddate: OptField[TypoLocalDateTime, Row]
-  val rowguid: Field[TypoUUID, Row]
-  val modifieddate: Field[TypoLocalDateTime, Row]
+trait ProductFields {
+  def productid: IdField[ProductId, ProductRow]
+  def name: Field[Name, ProductRow]
+  def productnumber: Field[/* max 25 chars */ String, ProductRow]
+  def makeflag: Field[Flag, ProductRow]
+  def finishedgoodsflag: Field[Flag, ProductRow]
+  def color: OptField[/* max 15 chars */ String, ProductRow]
+  def safetystocklevel: Field[TypoShort, ProductRow]
+  def reorderpoint: Field[TypoShort, ProductRow]
+  def standardcost: Field[BigDecimal, ProductRow]
+  def listprice: Field[BigDecimal, ProductRow]
+  def size: OptField[/* max 5 chars */ String, ProductRow]
+  def sizeunitmeasurecode: OptField[UnitmeasureId, ProductRow]
+  def weightunitmeasurecode: OptField[UnitmeasureId, ProductRow]
+  def weight: OptField[BigDecimal, ProductRow]
+  def daystomanufacture: Field[Int, ProductRow]
+  def productline: OptField[/* bpchar, max 2 chars */ String, ProductRow]
+  def `class`: OptField[/* bpchar, max 2 chars */ String, ProductRow]
+  def style: OptField[/* bpchar, max 2 chars */ String, ProductRow]
+  def productsubcategoryid: OptField[ProductsubcategoryId, ProductRow]
+  def productmodelid: OptField[ProductmodelId, ProductRow]
+  def sellstartdate: Field[TypoLocalDateTime, ProductRow]
+  def sellenddate: OptField[TypoLocalDateTime, ProductRow]
+  def discontinueddate: OptField[TypoLocalDateTime, ProductRow]
+  def rowguid: Field[TypoUUID, ProductRow]
+  def modifieddate: Field[TypoLocalDateTime, ProductRow]
 }
 
 object ProductFields {
-  val structure: Relation[ProductFields, ProductRow, ProductRow] = 
-    new Impl(None, identity, (_, x) => x)
+  lazy val structure: Relation[ProductFields, ProductRow] =
+    new Impl(Nil)
     
-  private final class Impl[Row](val prefix: Option[String], val extract: Row => ProductRow, val merge: (Row, ProductRow) => Row)
-    extends Relation[ProductFields, ProductRow, Row] { 
+  private final class Impl(val _path: List[Path])
+    extends Relation[ProductFields, ProductRow] {
   
-    override val fields: ProductFields[Row] = new ProductFields[Row] {
-      override val productid = new IdField[ProductId, Row](prefix, "productid", None, Some("int4"))(x => extract(x).productid, (row, value) => merge(row, extract(row).copy(productid = value)))
-      override val name = new Field[Name, Row](prefix, "name", None, Some("varchar"))(x => extract(x).name, (row, value) => merge(row, extract(row).copy(name = value)))
-      override val productnumber = new Field[/* max 25 chars */ String, Row](prefix, "productnumber", None, None)(x => extract(x).productnumber, (row, value) => merge(row, extract(row).copy(productnumber = value)))
-      override val makeflag = new Field[Flag, Row](prefix, "makeflag", None, Some("bool"))(x => extract(x).makeflag, (row, value) => merge(row, extract(row).copy(makeflag = value)))
-      override val finishedgoodsflag = new Field[Flag, Row](prefix, "finishedgoodsflag", None, Some("bool"))(x => extract(x).finishedgoodsflag, (row, value) => merge(row, extract(row).copy(finishedgoodsflag = value)))
-      override val color = new OptField[/* max 15 chars */ String, Row](prefix, "color", None, None)(x => extract(x).color, (row, value) => merge(row, extract(row).copy(color = value)))
-      override val safetystocklevel = new Field[TypoShort, Row](prefix, "safetystocklevel", None, Some("int2"))(x => extract(x).safetystocklevel, (row, value) => merge(row, extract(row).copy(safetystocklevel = value)))
-      override val reorderpoint = new Field[TypoShort, Row](prefix, "reorderpoint", None, Some("int2"))(x => extract(x).reorderpoint, (row, value) => merge(row, extract(row).copy(reorderpoint = value)))
-      override val standardcost = new Field[BigDecimal, Row](prefix, "standardcost", None, Some("numeric"))(x => extract(x).standardcost, (row, value) => merge(row, extract(row).copy(standardcost = value)))
-      override val listprice = new Field[BigDecimal, Row](prefix, "listprice", None, Some("numeric"))(x => extract(x).listprice, (row, value) => merge(row, extract(row).copy(listprice = value)))
-      override val size = new OptField[/* max 5 chars */ String, Row](prefix, "size", None, None)(x => extract(x).size, (row, value) => merge(row, extract(row).copy(size = value)))
-      override val sizeunitmeasurecode = new OptField[UnitmeasureId, Row](prefix, "sizeunitmeasurecode", None, Some("bpchar"))(x => extract(x).sizeunitmeasurecode, (row, value) => merge(row, extract(row).copy(sizeunitmeasurecode = value)))
-      override val weightunitmeasurecode = new OptField[UnitmeasureId, Row](prefix, "weightunitmeasurecode", None, Some("bpchar"))(x => extract(x).weightunitmeasurecode, (row, value) => merge(row, extract(row).copy(weightunitmeasurecode = value)))
-      override val weight = new OptField[BigDecimal, Row](prefix, "weight", None, Some("numeric"))(x => extract(x).weight, (row, value) => merge(row, extract(row).copy(weight = value)))
-      override val daystomanufacture = new Field[Int, Row](prefix, "daystomanufacture", None, Some("int4"))(x => extract(x).daystomanufacture, (row, value) => merge(row, extract(row).copy(daystomanufacture = value)))
-      override val productline = new OptField[/* bpchar, max 2 chars */ String, Row](prefix, "productline", None, Some("bpchar"))(x => extract(x).productline, (row, value) => merge(row, extract(row).copy(productline = value)))
-      override val `class` = new OptField[/* bpchar, max 2 chars */ String, Row](prefix, "class", None, Some("bpchar"))(x => extract(x).`class`, (row, value) => merge(row, extract(row).copy(`class` = value)))
-      override val style = new OptField[/* bpchar, max 2 chars */ String, Row](prefix, "style", None, Some("bpchar"))(x => extract(x).style, (row, value) => merge(row, extract(row).copy(style = value)))
-      override val productsubcategoryid = new OptField[ProductsubcategoryId, Row](prefix, "productsubcategoryid", None, Some("int4"))(x => extract(x).productsubcategoryid, (row, value) => merge(row, extract(row).copy(productsubcategoryid = value)))
-      override val productmodelid = new OptField[ProductmodelId, Row](prefix, "productmodelid", None, Some("int4"))(x => extract(x).productmodelid, (row, value) => merge(row, extract(row).copy(productmodelid = value)))
-      override val sellstartdate = new Field[TypoLocalDateTime, Row](prefix, "sellstartdate", Some("text"), Some("timestamp"))(x => extract(x).sellstartdate, (row, value) => merge(row, extract(row).copy(sellstartdate = value)))
-      override val sellenddate = new OptField[TypoLocalDateTime, Row](prefix, "sellenddate", Some("text"), Some("timestamp"))(x => extract(x).sellenddate, (row, value) => merge(row, extract(row).copy(sellenddate = value)))
-      override val discontinueddate = new OptField[TypoLocalDateTime, Row](prefix, "discontinueddate", Some("text"), Some("timestamp"))(x => extract(x).discontinueddate, (row, value) => merge(row, extract(row).copy(discontinueddate = value)))
-      override val rowguid = new Field[TypoUUID, Row](prefix, "rowguid", None, Some("uuid"))(x => extract(x).rowguid, (row, value) => merge(row, extract(row).copy(rowguid = value)))
-      override val modifieddate = new Field[TypoLocalDateTime, Row](prefix, "modifieddate", Some("text"), Some("timestamp"))(x => extract(x).modifieddate, (row, value) => merge(row, extract(row).copy(modifieddate = value)))
+    override lazy val fields: ProductFields = new ProductFields {
+      override def productid = IdField[ProductId, ProductRow](_path, "productid", None, Some("int4"), x => x.productid, (row, value) => row.copy(productid = value))
+      override def name = Field[Name, ProductRow](_path, "name", None, Some("varchar"), x => x.name, (row, value) => row.copy(name = value))
+      override def productnumber = Field[/* max 25 chars */ String, ProductRow](_path, "productnumber", None, None, x => x.productnumber, (row, value) => row.copy(productnumber = value))
+      override def makeflag = Field[Flag, ProductRow](_path, "makeflag", None, Some("bool"), x => x.makeflag, (row, value) => row.copy(makeflag = value))
+      override def finishedgoodsflag = Field[Flag, ProductRow](_path, "finishedgoodsflag", None, Some("bool"), x => x.finishedgoodsflag, (row, value) => row.copy(finishedgoodsflag = value))
+      override def color = OptField[/* max 15 chars */ String, ProductRow](_path, "color", None, None, x => x.color, (row, value) => row.copy(color = value))
+      override def safetystocklevel = Field[TypoShort, ProductRow](_path, "safetystocklevel", None, Some("int2"), x => x.safetystocklevel, (row, value) => row.copy(safetystocklevel = value))
+      override def reorderpoint = Field[TypoShort, ProductRow](_path, "reorderpoint", None, Some("int2"), x => x.reorderpoint, (row, value) => row.copy(reorderpoint = value))
+      override def standardcost = Field[BigDecimal, ProductRow](_path, "standardcost", None, Some("numeric"), x => x.standardcost, (row, value) => row.copy(standardcost = value))
+      override def listprice = Field[BigDecimal, ProductRow](_path, "listprice", None, Some("numeric"), x => x.listprice, (row, value) => row.copy(listprice = value))
+      override def size = OptField[/* max 5 chars */ String, ProductRow](_path, "size", None, None, x => x.size, (row, value) => row.copy(size = value))
+      override def sizeunitmeasurecode = OptField[UnitmeasureId, ProductRow](_path, "sizeunitmeasurecode", None, Some("bpchar"), x => x.sizeunitmeasurecode, (row, value) => row.copy(sizeunitmeasurecode = value))
+      override def weightunitmeasurecode = OptField[UnitmeasureId, ProductRow](_path, "weightunitmeasurecode", None, Some("bpchar"), x => x.weightunitmeasurecode, (row, value) => row.copy(weightunitmeasurecode = value))
+      override def weight = OptField[BigDecimal, ProductRow](_path, "weight", None, Some("numeric"), x => x.weight, (row, value) => row.copy(weight = value))
+      override def daystomanufacture = Field[Int, ProductRow](_path, "daystomanufacture", None, Some("int4"), x => x.daystomanufacture, (row, value) => row.copy(daystomanufacture = value))
+      override def productline = OptField[/* bpchar, max 2 chars */ String, ProductRow](_path, "productline", None, Some("bpchar"), x => x.productline, (row, value) => row.copy(productline = value))
+      override def `class` = OptField[/* bpchar, max 2 chars */ String, ProductRow](_path, "class", None, Some("bpchar"), x => x.`class`, (row, value) => row.copy(`class` = value))
+      override def style = OptField[/* bpchar, max 2 chars */ String, ProductRow](_path, "style", None, Some("bpchar"), x => x.style, (row, value) => row.copy(style = value))
+      override def productsubcategoryid = OptField[ProductsubcategoryId, ProductRow](_path, "productsubcategoryid", None, Some("int4"), x => x.productsubcategoryid, (row, value) => row.copy(productsubcategoryid = value))
+      override def productmodelid = OptField[ProductmodelId, ProductRow](_path, "productmodelid", None, Some("int4"), x => x.productmodelid, (row, value) => row.copy(productmodelid = value))
+      override def sellstartdate = Field[TypoLocalDateTime, ProductRow](_path, "sellstartdate", Some("text"), Some("timestamp"), x => x.sellstartdate, (row, value) => row.copy(sellstartdate = value))
+      override def sellenddate = OptField[TypoLocalDateTime, ProductRow](_path, "sellenddate", Some("text"), Some("timestamp"), x => x.sellenddate, (row, value) => row.copy(sellenddate = value))
+      override def discontinueddate = OptField[TypoLocalDateTime, ProductRow](_path, "discontinueddate", Some("text"), Some("timestamp"), x => x.discontinueddate, (row, value) => row.copy(discontinueddate = value))
+      override def rowguid = Field[TypoUUID, ProductRow](_path, "rowguid", None, Some("uuid"), x => x.rowguid, (row, value) => row.copy(rowguid = value))
+      override def modifieddate = Field[TypoLocalDateTime, ProductRow](_path, "modifieddate", Some("text"), Some("timestamp"), x => x.modifieddate, (row, value) => row.copy(modifieddate = value))
     }
   
-    override val columns: List[FieldLikeNoHkt[?, Row]] =
-      List[FieldLikeNoHkt[?, Row]](fields.productid, fields.name, fields.productnumber, fields.makeflag, fields.finishedgoodsflag, fields.color, fields.safetystocklevel, fields.reorderpoint, fields.standardcost, fields.listprice, fields.size, fields.sizeunitmeasurecode, fields.weightunitmeasurecode, fields.weight, fields.daystomanufacture, fields.productline, fields.`class`, fields.style, fields.productsubcategoryid, fields.productmodelid, fields.sellstartdate, fields.sellenddate, fields.discontinueddate, fields.rowguid, fields.modifieddate)
+    override lazy val columns: List[FieldLikeNoHkt[?, ProductRow]] =
+      List[FieldLikeNoHkt[?, ProductRow]](fields.productid, fields.name, fields.productnumber, fields.makeflag, fields.finishedgoodsflag, fields.color, fields.safetystocklevel, fields.reorderpoint, fields.standardcost, fields.listprice, fields.size, fields.sizeunitmeasurecode, fields.weightunitmeasurecode, fields.weight, fields.daystomanufacture, fields.productline, fields.`class`, fields.style, fields.productsubcategoryid, fields.productmodelid, fields.sellstartdate, fields.sellenddate, fields.discontinueddate, fields.rowguid, fields.modifieddate)
   
-    override def copy[NewRow](prefix: Option[String], extract: NewRow => ProductRow, merge: (NewRow, ProductRow) => NewRow): Impl[NewRow] =
-      new Impl(prefix, extract, merge)
+    override def copy(path: List[Path]): Impl =
+      new Impl(path)
   }
   
 }

--- a/typo-tester-anorm/generated-and-checked-in/adventureworks/production/product/ProductRepoMock.scala
+++ b/typo-tester-anorm/generated-and-checked-in/adventureworks/production/product/ProductRepoMock.scala
@@ -22,7 +22,7 @@ import typo.dsl.UpdateParams
 class ProductRepoMock(toRow: Function1[ProductRowUnsaved, ProductRow],
                       map: scala.collection.mutable.Map[ProductId, ProductRow] = scala.collection.mutable.Map.empty) extends ProductRepo {
   override def delete: DeleteBuilder[ProductFields, ProductRow] = {
-    DeleteBuilderMock(DeleteParams.empty, ProductFields.structure.fields, map)
+    DeleteBuilderMock(DeleteParams.empty, ProductFields.structure, map)
   }
   override def deleteById(productid: ProductId)(implicit c: Connection): Boolean = {
     map.remove(productid).isDefined
@@ -72,7 +72,7 @@ class ProductRepoMock(toRow: Function1[ProductRowUnsaved, ProductRow],
     productids.view.flatMap(id => byId.get(id).map(x => (id, x))).toMap
   }
   override def update: UpdateBuilder[ProductFields, ProductRow] = {
-    UpdateBuilderMock(UpdateParams.empty, ProductFields.structure.fields, map)
+    UpdateBuilderMock(UpdateParams.empty, ProductFields.structure, map)
   }
   override def update(row: ProductRow)(implicit c: Connection): Boolean = {
     map.get(row.productid) match {

--- a/typo-tester-anorm/generated-and-checked-in/adventureworks/production/productcategory/ProductcategoryFields.scala
+++ b/typo-tester-anorm/generated-and-checked-in/adventureworks/production/productcategory/ProductcategoryFields.scala
@@ -10,37 +10,38 @@ package productcategory
 import adventureworks.customtypes.TypoLocalDateTime
 import adventureworks.customtypes.TypoUUID
 import adventureworks.public.Name
+import typo.dsl.Path
 import typo.dsl.SqlExpr.Field
 import typo.dsl.SqlExpr.FieldLikeNoHkt
 import typo.dsl.SqlExpr.IdField
 import typo.dsl.Structure.Relation
 
-trait ProductcategoryFields[Row] {
-  val productcategoryid: IdField[ProductcategoryId, Row]
-  val name: Field[Name, Row]
-  val rowguid: Field[TypoUUID, Row]
-  val modifieddate: Field[TypoLocalDateTime, Row]
+trait ProductcategoryFields {
+  def productcategoryid: IdField[ProductcategoryId, ProductcategoryRow]
+  def name: Field[Name, ProductcategoryRow]
+  def rowguid: Field[TypoUUID, ProductcategoryRow]
+  def modifieddate: Field[TypoLocalDateTime, ProductcategoryRow]
 }
 
 object ProductcategoryFields {
-  val structure: Relation[ProductcategoryFields, ProductcategoryRow, ProductcategoryRow] = 
-    new Impl(None, identity, (_, x) => x)
+  lazy val structure: Relation[ProductcategoryFields, ProductcategoryRow] =
+    new Impl(Nil)
     
-  private final class Impl[Row](val prefix: Option[String], val extract: Row => ProductcategoryRow, val merge: (Row, ProductcategoryRow) => Row)
-    extends Relation[ProductcategoryFields, ProductcategoryRow, Row] { 
+  private final class Impl(val _path: List[Path])
+    extends Relation[ProductcategoryFields, ProductcategoryRow] {
   
-    override val fields: ProductcategoryFields[Row] = new ProductcategoryFields[Row] {
-      override val productcategoryid = new IdField[ProductcategoryId, Row](prefix, "productcategoryid", None, Some("int4"))(x => extract(x).productcategoryid, (row, value) => merge(row, extract(row).copy(productcategoryid = value)))
-      override val name = new Field[Name, Row](prefix, "name", None, Some("varchar"))(x => extract(x).name, (row, value) => merge(row, extract(row).copy(name = value)))
-      override val rowguid = new Field[TypoUUID, Row](prefix, "rowguid", None, Some("uuid"))(x => extract(x).rowguid, (row, value) => merge(row, extract(row).copy(rowguid = value)))
-      override val modifieddate = new Field[TypoLocalDateTime, Row](prefix, "modifieddate", Some("text"), Some("timestamp"))(x => extract(x).modifieddate, (row, value) => merge(row, extract(row).copy(modifieddate = value)))
+    override lazy val fields: ProductcategoryFields = new ProductcategoryFields {
+      override def productcategoryid = IdField[ProductcategoryId, ProductcategoryRow](_path, "productcategoryid", None, Some("int4"), x => x.productcategoryid, (row, value) => row.copy(productcategoryid = value))
+      override def name = Field[Name, ProductcategoryRow](_path, "name", None, Some("varchar"), x => x.name, (row, value) => row.copy(name = value))
+      override def rowguid = Field[TypoUUID, ProductcategoryRow](_path, "rowguid", None, Some("uuid"), x => x.rowguid, (row, value) => row.copy(rowguid = value))
+      override def modifieddate = Field[TypoLocalDateTime, ProductcategoryRow](_path, "modifieddate", Some("text"), Some("timestamp"), x => x.modifieddate, (row, value) => row.copy(modifieddate = value))
     }
   
-    override val columns: List[FieldLikeNoHkt[?, Row]] =
-      List[FieldLikeNoHkt[?, Row]](fields.productcategoryid, fields.name, fields.rowguid, fields.modifieddate)
+    override lazy val columns: List[FieldLikeNoHkt[?, ProductcategoryRow]] =
+      List[FieldLikeNoHkt[?, ProductcategoryRow]](fields.productcategoryid, fields.name, fields.rowguid, fields.modifieddate)
   
-    override def copy[NewRow](prefix: Option[String], extract: NewRow => ProductcategoryRow, merge: (NewRow, ProductcategoryRow) => NewRow): Impl[NewRow] =
-      new Impl(prefix, extract, merge)
+    override def copy(path: List[Path]): Impl =
+      new Impl(path)
   }
   
 }

--- a/typo-tester-anorm/generated-and-checked-in/adventureworks/production/productcategory/ProductcategoryRepoMock.scala
+++ b/typo-tester-anorm/generated-and-checked-in/adventureworks/production/productcategory/ProductcategoryRepoMock.scala
@@ -22,7 +22,7 @@ import typo.dsl.UpdateParams
 class ProductcategoryRepoMock(toRow: Function1[ProductcategoryRowUnsaved, ProductcategoryRow],
                               map: scala.collection.mutable.Map[ProductcategoryId, ProductcategoryRow] = scala.collection.mutable.Map.empty) extends ProductcategoryRepo {
   override def delete: DeleteBuilder[ProductcategoryFields, ProductcategoryRow] = {
-    DeleteBuilderMock(DeleteParams.empty, ProductcategoryFields.structure.fields, map)
+    DeleteBuilderMock(DeleteParams.empty, ProductcategoryFields.structure, map)
   }
   override def deleteById(productcategoryid: ProductcategoryId)(implicit c: Connection): Boolean = {
     map.remove(productcategoryid).isDefined
@@ -72,7 +72,7 @@ class ProductcategoryRepoMock(toRow: Function1[ProductcategoryRowUnsaved, Produc
     productcategoryids.view.flatMap(id => byId.get(id).map(x => (id, x))).toMap
   }
   override def update: UpdateBuilder[ProductcategoryFields, ProductcategoryRow] = {
-    UpdateBuilderMock(UpdateParams.empty, ProductcategoryFields.structure.fields, map)
+    UpdateBuilderMock(UpdateParams.empty, ProductcategoryFields.structure, map)
   }
   override def update(row: ProductcategoryRow)(implicit c: Connection): Boolean = {
     map.get(row.productcategoryid) match {

--- a/typo-tester-anorm/generated-and-checked-in/adventureworks/production/productcosthistory/ProductcosthistoryFields.scala
+++ b/typo-tester-anorm/generated-and-checked-in/adventureworks/production/productcosthistory/ProductcosthistoryFields.scala
@@ -9,40 +9,41 @@ package productcosthistory
 
 import adventureworks.customtypes.TypoLocalDateTime
 import adventureworks.production.product.ProductId
+import typo.dsl.Path
 import typo.dsl.SqlExpr.Field
 import typo.dsl.SqlExpr.FieldLikeNoHkt
 import typo.dsl.SqlExpr.IdField
 import typo.dsl.SqlExpr.OptField
 import typo.dsl.Structure.Relation
 
-trait ProductcosthistoryFields[Row] {
-  val productid: IdField[ProductId, Row]
-  val startdate: IdField[TypoLocalDateTime, Row]
-  val enddate: OptField[TypoLocalDateTime, Row]
-  val standardcost: Field[BigDecimal, Row]
-  val modifieddate: Field[TypoLocalDateTime, Row]
+trait ProductcosthistoryFields {
+  def productid: IdField[ProductId, ProductcosthistoryRow]
+  def startdate: IdField[TypoLocalDateTime, ProductcosthistoryRow]
+  def enddate: OptField[TypoLocalDateTime, ProductcosthistoryRow]
+  def standardcost: Field[BigDecimal, ProductcosthistoryRow]
+  def modifieddate: Field[TypoLocalDateTime, ProductcosthistoryRow]
 }
 
 object ProductcosthistoryFields {
-  val structure: Relation[ProductcosthistoryFields, ProductcosthistoryRow, ProductcosthistoryRow] = 
-    new Impl(None, identity, (_, x) => x)
+  lazy val structure: Relation[ProductcosthistoryFields, ProductcosthistoryRow] =
+    new Impl(Nil)
     
-  private final class Impl[Row](val prefix: Option[String], val extract: Row => ProductcosthistoryRow, val merge: (Row, ProductcosthistoryRow) => Row)
-    extends Relation[ProductcosthistoryFields, ProductcosthistoryRow, Row] { 
+  private final class Impl(val _path: List[Path])
+    extends Relation[ProductcosthistoryFields, ProductcosthistoryRow] {
   
-    override val fields: ProductcosthistoryFields[Row] = new ProductcosthistoryFields[Row] {
-      override val productid = new IdField[ProductId, Row](prefix, "productid", None, Some("int4"))(x => extract(x).productid, (row, value) => merge(row, extract(row).copy(productid = value)))
-      override val startdate = new IdField[TypoLocalDateTime, Row](prefix, "startdate", Some("text"), Some("timestamp"))(x => extract(x).startdate, (row, value) => merge(row, extract(row).copy(startdate = value)))
-      override val enddate = new OptField[TypoLocalDateTime, Row](prefix, "enddate", Some("text"), Some("timestamp"))(x => extract(x).enddate, (row, value) => merge(row, extract(row).copy(enddate = value)))
-      override val standardcost = new Field[BigDecimal, Row](prefix, "standardcost", None, Some("numeric"))(x => extract(x).standardcost, (row, value) => merge(row, extract(row).copy(standardcost = value)))
-      override val modifieddate = new Field[TypoLocalDateTime, Row](prefix, "modifieddate", Some("text"), Some("timestamp"))(x => extract(x).modifieddate, (row, value) => merge(row, extract(row).copy(modifieddate = value)))
+    override lazy val fields: ProductcosthistoryFields = new ProductcosthistoryFields {
+      override def productid = IdField[ProductId, ProductcosthistoryRow](_path, "productid", None, Some("int4"), x => x.productid, (row, value) => row.copy(productid = value))
+      override def startdate = IdField[TypoLocalDateTime, ProductcosthistoryRow](_path, "startdate", Some("text"), Some("timestamp"), x => x.startdate, (row, value) => row.copy(startdate = value))
+      override def enddate = OptField[TypoLocalDateTime, ProductcosthistoryRow](_path, "enddate", Some("text"), Some("timestamp"), x => x.enddate, (row, value) => row.copy(enddate = value))
+      override def standardcost = Field[BigDecimal, ProductcosthistoryRow](_path, "standardcost", None, Some("numeric"), x => x.standardcost, (row, value) => row.copy(standardcost = value))
+      override def modifieddate = Field[TypoLocalDateTime, ProductcosthistoryRow](_path, "modifieddate", Some("text"), Some("timestamp"), x => x.modifieddate, (row, value) => row.copy(modifieddate = value))
     }
   
-    override val columns: List[FieldLikeNoHkt[?, Row]] =
-      List[FieldLikeNoHkt[?, Row]](fields.productid, fields.startdate, fields.enddate, fields.standardcost, fields.modifieddate)
+    override lazy val columns: List[FieldLikeNoHkt[?, ProductcosthistoryRow]] =
+      List[FieldLikeNoHkt[?, ProductcosthistoryRow]](fields.productid, fields.startdate, fields.enddate, fields.standardcost, fields.modifieddate)
   
-    override def copy[NewRow](prefix: Option[String], extract: NewRow => ProductcosthistoryRow, merge: (NewRow, ProductcosthistoryRow) => NewRow): Impl[NewRow] =
-      new Impl(prefix, extract, merge)
+    override def copy(path: List[Path]): Impl =
+      new Impl(path)
   }
   
 }

--- a/typo-tester-anorm/generated-and-checked-in/adventureworks/production/productcosthistory/ProductcosthistoryRepoMock.scala
+++ b/typo-tester-anorm/generated-and-checked-in/adventureworks/production/productcosthistory/ProductcosthistoryRepoMock.scala
@@ -22,7 +22,7 @@ import typo.dsl.UpdateParams
 class ProductcosthistoryRepoMock(toRow: Function1[ProductcosthistoryRowUnsaved, ProductcosthistoryRow],
                                  map: scala.collection.mutable.Map[ProductcosthistoryId, ProductcosthistoryRow] = scala.collection.mutable.Map.empty) extends ProductcosthistoryRepo {
   override def delete: DeleteBuilder[ProductcosthistoryFields, ProductcosthistoryRow] = {
-    DeleteBuilderMock(DeleteParams.empty, ProductcosthistoryFields.structure.fields, map)
+    DeleteBuilderMock(DeleteParams.empty, ProductcosthistoryFields.structure, map)
   }
   override def deleteById(compositeId: ProductcosthistoryId)(implicit c: Connection): Boolean = {
     map.remove(compositeId).isDefined
@@ -72,7 +72,7 @@ class ProductcosthistoryRepoMock(toRow: Function1[ProductcosthistoryRowUnsaved, 
     compositeIds.view.flatMap(id => byId.get(id).map(x => (id, x))).toMap
   }
   override def update: UpdateBuilder[ProductcosthistoryFields, ProductcosthistoryRow] = {
-    UpdateBuilderMock(UpdateParams.empty, ProductcosthistoryFields.structure.fields, map)
+    UpdateBuilderMock(UpdateParams.empty, ProductcosthistoryFields.structure, map)
   }
   override def update(row: ProductcosthistoryRow)(implicit c: Connection): Boolean = {
     map.get(row.compositeId) match {

--- a/typo-tester-anorm/generated-and-checked-in/adventureworks/production/productdescription/ProductdescriptionFields.scala
+++ b/typo-tester-anorm/generated-and-checked-in/adventureworks/production/productdescription/ProductdescriptionFields.scala
@@ -9,37 +9,38 @@ package productdescription
 
 import adventureworks.customtypes.TypoLocalDateTime
 import adventureworks.customtypes.TypoUUID
+import typo.dsl.Path
 import typo.dsl.SqlExpr.Field
 import typo.dsl.SqlExpr.FieldLikeNoHkt
 import typo.dsl.SqlExpr.IdField
 import typo.dsl.Structure.Relation
 
-trait ProductdescriptionFields[Row] {
-  val productdescriptionid: IdField[ProductdescriptionId, Row]
-  val description: Field[/* max 400 chars */ String, Row]
-  val rowguid: Field[TypoUUID, Row]
-  val modifieddate: Field[TypoLocalDateTime, Row]
+trait ProductdescriptionFields {
+  def productdescriptionid: IdField[ProductdescriptionId, ProductdescriptionRow]
+  def description: Field[/* max 400 chars */ String, ProductdescriptionRow]
+  def rowguid: Field[TypoUUID, ProductdescriptionRow]
+  def modifieddate: Field[TypoLocalDateTime, ProductdescriptionRow]
 }
 
 object ProductdescriptionFields {
-  val structure: Relation[ProductdescriptionFields, ProductdescriptionRow, ProductdescriptionRow] = 
-    new Impl(None, identity, (_, x) => x)
+  lazy val structure: Relation[ProductdescriptionFields, ProductdescriptionRow] =
+    new Impl(Nil)
     
-  private final class Impl[Row](val prefix: Option[String], val extract: Row => ProductdescriptionRow, val merge: (Row, ProductdescriptionRow) => Row)
-    extends Relation[ProductdescriptionFields, ProductdescriptionRow, Row] { 
+  private final class Impl(val _path: List[Path])
+    extends Relation[ProductdescriptionFields, ProductdescriptionRow] {
   
-    override val fields: ProductdescriptionFields[Row] = new ProductdescriptionFields[Row] {
-      override val productdescriptionid = new IdField[ProductdescriptionId, Row](prefix, "productdescriptionid", None, Some("int4"))(x => extract(x).productdescriptionid, (row, value) => merge(row, extract(row).copy(productdescriptionid = value)))
-      override val description = new Field[/* max 400 chars */ String, Row](prefix, "description", None, None)(x => extract(x).description, (row, value) => merge(row, extract(row).copy(description = value)))
-      override val rowguid = new Field[TypoUUID, Row](prefix, "rowguid", None, Some("uuid"))(x => extract(x).rowguid, (row, value) => merge(row, extract(row).copy(rowguid = value)))
-      override val modifieddate = new Field[TypoLocalDateTime, Row](prefix, "modifieddate", Some("text"), Some("timestamp"))(x => extract(x).modifieddate, (row, value) => merge(row, extract(row).copy(modifieddate = value)))
+    override lazy val fields: ProductdescriptionFields = new ProductdescriptionFields {
+      override def productdescriptionid = IdField[ProductdescriptionId, ProductdescriptionRow](_path, "productdescriptionid", None, Some("int4"), x => x.productdescriptionid, (row, value) => row.copy(productdescriptionid = value))
+      override def description = Field[/* max 400 chars */ String, ProductdescriptionRow](_path, "description", None, None, x => x.description, (row, value) => row.copy(description = value))
+      override def rowguid = Field[TypoUUID, ProductdescriptionRow](_path, "rowguid", None, Some("uuid"), x => x.rowguid, (row, value) => row.copy(rowguid = value))
+      override def modifieddate = Field[TypoLocalDateTime, ProductdescriptionRow](_path, "modifieddate", Some("text"), Some("timestamp"), x => x.modifieddate, (row, value) => row.copy(modifieddate = value))
     }
   
-    override val columns: List[FieldLikeNoHkt[?, Row]] =
-      List[FieldLikeNoHkt[?, Row]](fields.productdescriptionid, fields.description, fields.rowguid, fields.modifieddate)
+    override lazy val columns: List[FieldLikeNoHkt[?, ProductdescriptionRow]] =
+      List[FieldLikeNoHkt[?, ProductdescriptionRow]](fields.productdescriptionid, fields.description, fields.rowguid, fields.modifieddate)
   
-    override def copy[NewRow](prefix: Option[String], extract: NewRow => ProductdescriptionRow, merge: (NewRow, ProductdescriptionRow) => NewRow): Impl[NewRow] =
-      new Impl(prefix, extract, merge)
+    override def copy(path: List[Path]): Impl =
+      new Impl(path)
   }
   
 }

--- a/typo-tester-anorm/generated-and-checked-in/adventureworks/production/productdescription/ProductdescriptionRepoMock.scala
+++ b/typo-tester-anorm/generated-and-checked-in/adventureworks/production/productdescription/ProductdescriptionRepoMock.scala
@@ -22,7 +22,7 @@ import typo.dsl.UpdateParams
 class ProductdescriptionRepoMock(toRow: Function1[ProductdescriptionRowUnsaved, ProductdescriptionRow],
                                  map: scala.collection.mutable.Map[ProductdescriptionId, ProductdescriptionRow] = scala.collection.mutable.Map.empty) extends ProductdescriptionRepo {
   override def delete: DeleteBuilder[ProductdescriptionFields, ProductdescriptionRow] = {
-    DeleteBuilderMock(DeleteParams.empty, ProductdescriptionFields.structure.fields, map)
+    DeleteBuilderMock(DeleteParams.empty, ProductdescriptionFields.structure, map)
   }
   override def deleteById(productdescriptionid: ProductdescriptionId)(implicit c: Connection): Boolean = {
     map.remove(productdescriptionid).isDefined
@@ -72,7 +72,7 @@ class ProductdescriptionRepoMock(toRow: Function1[ProductdescriptionRowUnsaved, 
     productdescriptionids.view.flatMap(id => byId.get(id).map(x => (id, x))).toMap
   }
   override def update: UpdateBuilder[ProductdescriptionFields, ProductdescriptionRow] = {
-    UpdateBuilderMock(UpdateParams.empty, ProductdescriptionFields.structure.fields, map)
+    UpdateBuilderMock(UpdateParams.empty, ProductdescriptionFields.structure, map)
   }
   override def update(row: ProductdescriptionRow)(implicit c: Connection): Boolean = {
     map.get(row.productdescriptionid) match {

--- a/typo-tester-anorm/generated-and-checked-in/adventureworks/production/productdocument/ProductdocumentFields.scala
+++ b/typo-tester-anorm/generated-and-checked-in/adventureworks/production/productdocument/ProductdocumentFields.scala
@@ -10,35 +10,36 @@ package productdocument
 import adventureworks.customtypes.TypoLocalDateTime
 import adventureworks.production.document.DocumentId
 import adventureworks.production.product.ProductId
+import typo.dsl.Path
 import typo.dsl.SqlExpr.Field
 import typo.dsl.SqlExpr.FieldLikeNoHkt
 import typo.dsl.SqlExpr.IdField
 import typo.dsl.Structure.Relation
 
-trait ProductdocumentFields[Row] {
-  val productid: IdField[ProductId, Row]
-  val modifieddate: Field[TypoLocalDateTime, Row]
-  val documentnode: IdField[DocumentId, Row]
+trait ProductdocumentFields {
+  def productid: IdField[ProductId, ProductdocumentRow]
+  def modifieddate: Field[TypoLocalDateTime, ProductdocumentRow]
+  def documentnode: IdField[DocumentId, ProductdocumentRow]
 }
 
 object ProductdocumentFields {
-  val structure: Relation[ProductdocumentFields, ProductdocumentRow, ProductdocumentRow] = 
-    new Impl(None, identity, (_, x) => x)
+  lazy val structure: Relation[ProductdocumentFields, ProductdocumentRow] =
+    new Impl(Nil)
     
-  private final class Impl[Row](val prefix: Option[String], val extract: Row => ProductdocumentRow, val merge: (Row, ProductdocumentRow) => Row)
-    extends Relation[ProductdocumentFields, ProductdocumentRow, Row] { 
+  private final class Impl(val _path: List[Path])
+    extends Relation[ProductdocumentFields, ProductdocumentRow] {
   
-    override val fields: ProductdocumentFields[Row] = new ProductdocumentFields[Row] {
-      override val productid = new IdField[ProductId, Row](prefix, "productid", None, Some("int4"))(x => extract(x).productid, (row, value) => merge(row, extract(row).copy(productid = value)))
-      override val modifieddate = new Field[TypoLocalDateTime, Row](prefix, "modifieddate", Some("text"), Some("timestamp"))(x => extract(x).modifieddate, (row, value) => merge(row, extract(row).copy(modifieddate = value)))
-      override val documentnode = new IdField[DocumentId, Row](prefix, "documentnode", None, None)(x => extract(x).documentnode, (row, value) => merge(row, extract(row).copy(documentnode = value)))
+    override lazy val fields: ProductdocumentFields = new ProductdocumentFields {
+      override def productid = IdField[ProductId, ProductdocumentRow](_path, "productid", None, Some("int4"), x => x.productid, (row, value) => row.copy(productid = value))
+      override def modifieddate = Field[TypoLocalDateTime, ProductdocumentRow](_path, "modifieddate", Some("text"), Some("timestamp"), x => x.modifieddate, (row, value) => row.copy(modifieddate = value))
+      override def documentnode = IdField[DocumentId, ProductdocumentRow](_path, "documentnode", None, None, x => x.documentnode, (row, value) => row.copy(documentnode = value))
     }
   
-    override val columns: List[FieldLikeNoHkt[?, Row]] =
-      List[FieldLikeNoHkt[?, Row]](fields.productid, fields.modifieddate, fields.documentnode)
+    override lazy val columns: List[FieldLikeNoHkt[?, ProductdocumentRow]] =
+      List[FieldLikeNoHkt[?, ProductdocumentRow]](fields.productid, fields.modifieddate, fields.documentnode)
   
-    override def copy[NewRow](prefix: Option[String], extract: NewRow => ProductdocumentRow, merge: (NewRow, ProductdocumentRow) => NewRow): Impl[NewRow] =
-      new Impl(prefix, extract, merge)
+    override def copy(path: List[Path]): Impl =
+      new Impl(path)
   }
   
 }

--- a/typo-tester-anorm/generated-and-checked-in/adventureworks/production/productdocument/ProductdocumentRepoMock.scala
+++ b/typo-tester-anorm/generated-and-checked-in/adventureworks/production/productdocument/ProductdocumentRepoMock.scala
@@ -22,7 +22,7 @@ import typo.dsl.UpdateParams
 class ProductdocumentRepoMock(toRow: Function1[ProductdocumentRowUnsaved, ProductdocumentRow],
                               map: scala.collection.mutable.Map[ProductdocumentId, ProductdocumentRow] = scala.collection.mutable.Map.empty) extends ProductdocumentRepo {
   override def delete: DeleteBuilder[ProductdocumentFields, ProductdocumentRow] = {
-    DeleteBuilderMock(DeleteParams.empty, ProductdocumentFields.structure.fields, map)
+    DeleteBuilderMock(DeleteParams.empty, ProductdocumentFields.structure, map)
   }
   override def deleteById(compositeId: ProductdocumentId)(implicit c: Connection): Boolean = {
     map.remove(compositeId).isDefined
@@ -72,7 +72,7 @@ class ProductdocumentRepoMock(toRow: Function1[ProductdocumentRowUnsaved, Produc
     compositeIds.view.flatMap(id => byId.get(id).map(x => (id, x))).toMap
   }
   override def update: UpdateBuilder[ProductdocumentFields, ProductdocumentRow] = {
-    UpdateBuilderMock(UpdateParams.empty, ProductdocumentFields.structure.fields, map)
+    UpdateBuilderMock(UpdateParams.empty, ProductdocumentFields.structure, map)
   }
   override def update(row: ProductdocumentRow)(implicit c: Connection): Boolean = {
     map.get(row.compositeId) match {

--- a/typo-tester-anorm/generated-and-checked-in/adventureworks/production/productinventory/ProductinventoryFields.scala
+++ b/typo-tester-anorm/generated-and-checked-in/adventureworks/production/productinventory/ProductinventoryFields.scala
@@ -12,43 +12,44 @@ import adventureworks.customtypes.TypoShort
 import adventureworks.customtypes.TypoUUID
 import adventureworks.production.location.LocationId
 import adventureworks.production.product.ProductId
+import typo.dsl.Path
 import typo.dsl.SqlExpr.Field
 import typo.dsl.SqlExpr.FieldLikeNoHkt
 import typo.dsl.SqlExpr.IdField
 import typo.dsl.Structure.Relation
 
-trait ProductinventoryFields[Row] {
-  val productid: IdField[ProductId, Row]
-  val locationid: IdField[LocationId, Row]
-  val shelf: Field[/* max 10 chars */ String, Row]
-  val bin: Field[TypoShort, Row]
-  val quantity: Field[TypoShort, Row]
-  val rowguid: Field[TypoUUID, Row]
-  val modifieddate: Field[TypoLocalDateTime, Row]
+trait ProductinventoryFields {
+  def productid: IdField[ProductId, ProductinventoryRow]
+  def locationid: IdField[LocationId, ProductinventoryRow]
+  def shelf: Field[/* max 10 chars */ String, ProductinventoryRow]
+  def bin: Field[TypoShort, ProductinventoryRow]
+  def quantity: Field[TypoShort, ProductinventoryRow]
+  def rowguid: Field[TypoUUID, ProductinventoryRow]
+  def modifieddate: Field[TypoLocalDateTime, ProductinventoryRow]
 }
 
 object ProductinventoryFields {
-  val structure: Relation[ProductinventoryFields, ProductinventoryRow, ProductinventoryRow] = 
-    new Impl(None, identity, (_, x) => x)
+  lazy val structure: Relation[ProductinventoryFields, ProductinventoryRow] =
+    new Impl(Nil)
     
-  private final class Impl[Row](val prefix: Option[String], val extract: Row => ProductinventoryRow, val merge: (Row, ProductinventoryRow) => Row)
-    extends Relation[ProductinventoryFields, ProductinventoryRow, Row] { 
+  private final class Impl(val _path: List[Path])
+    extends Relation[ProductinventoryFields, ProductinventoryRow] {
   
-    override val fields: ProductinventoryFields[Row] = new ProductinventoryFields[Row] {
-      override val productid = new IdField[ProductId, Row](prefix, "productid", None, Some("int4"))(x => extract(x).productid, (row, value) => merge(row, extract(row).copy(productid = value)))
-      override val locationid = new IdField[LocationId, Row](prefix, "locationid", None, Some("int2"))(x => extract(x).locationid, (row, value) => merge(row, extract(row).copy(locationid = value)))
-      override val shelf = new Field[/* max 10 chars */ String, Row](prefix, "shelf", None, None)(x => extract(x).shelf, (row, value) => merge(row, extract(row).copy(shelf = value)))
-      override val bin = new Field[TypoShort, Row](prefix, "bin", None, Some("int2"))(x => extract(x).bin, (row, value) => merge(row, extract(row).copy(bin = value)))
-      override val quantity = new Field[TypoShort, Row](prefix, "quantity", None, Some("int2"))(x => extract(x).quantity, (row, value) => merge(row, extract(row).copy(quantity = value)))
-      override val rowguid = new Field[TypoUUID, Row](prefix, "rowguid", None, Some("uuid"))(x => extract(x).rowguid, (row, value) => merge(row, extract(row).copy(rowguid = value)))
-      override val modifieddate = new Field[TypoLocalDateTime, Row](prefix, "modifieddate", Some("text"), Some("timestamp"))(x => extract(x).modifieddate, (row, value) => merge(row, extract(row).copy(modifieddate = value)))
+    override lazy val fields: ProductinventoryFields = new ProductinventoryFields {
+      override def productid = IdField[ProductId, ProductinventoryRow](_path, "productid", None, Some("int4"), x => x.productid, (row, value) => row.copy(productid = value))
+      override def locationid = IdField[LocationId, ProductinventoryRow](_path, "locationid", None, Some("int2"), x => x.locationid, (row, value) => row.copy(locationid = value))
+      override def shelf = Field[/* max 10 chars */ String, ProductinventoryRow](_path, "shelf", None, None, x => x.shelf, (row, value) => row.copy(shelf = value))
+      override def bin = Field[TypoShort, ProductinventoryRow](_path, "bin", None, Some("int2"), x => x.bin, (row, value) => row.copy(bin = value))
+      override def quantity = Field[TypoShort, ProductinventoryRow](_path, "quantity", None, Some("int2"), x => x.quantity, (row, value) => row.copy(quantity = value))
+      override def rowguid = Field[TypoUUID, ProductinventoryRow](_path, "rowguid", None, Some("uuid"), x => x.rowguid, (row, value) => row.copy(rowguid = value))
+      override def modifieddate = Field[TypoLocalDateTime, ProductinventoryRow](_path, "modifieddate", Some("text"), Some("timestamp"), x => x.modifieddate, (row, value) => row.copy(modifieddate = value))
     }
   
-    override val columns: List[FieldLikeNoHkt[?, Row]] =
-      List[FieldLikeNoHkt[?, Row]](fields.productid, fields.locationid, fields.shelf, fields.bin, fields.quantity, fields.rowguid, fields.modifieddate)
+    override lazy val columns: List[FieldLikeNoHkt[?, ProductinventoryRow]] =
+      List[FieldLikeNoHkt[?, ProductinventoryRow]](fields.productid, fields.locationid, fields.shelf, fields.bin, fields.quantity, fields.rowguid, fields.modifieddate)
   
-    override def copy[NewRow](prefix: Option[String], extract: NewRow => ProductinventoryRow, merge: (NewRow, ProductinventoryRow) => NewRow): Impl[NewRow] =
-      new Impl(prefix, extract, merge)
+    override def copy(path: List[Path]): Impl =
+      new Impl(path)
   }
   
 }

--- a/typo-tester-anorm/generated-and-checked-in/adventureworks/production/productinventory/ProductinventoryRepoMock.scala
+++ b/typo-tester-anorm/generated-and-checked-in/adventureworks/production/productinventory/ProductinventoryRepoMock.scala
@@ -22,7 +22,7 @@ import typo.dsl.UpdateParams
 class ProductinventoryRepoMock(toRow: Function1[ProductinventoryRowUnsaved, ProductinventoryRow],
                                map: scala.collection.mutable.Map[ProductinventoryId, ProductinventoryRow] = scala.collection.mutable.Map.empty) extends ProductinventoryRepo {
   override def delete: DeleteBuilder[ProductinventoryFields, ProductinventoryRow] = {
-    DeleteBuilderMock(DeleteParams.empty, ProductinventoryFields.structure.fields, map)
+    DeleteBuilderMock(DeleteParams.empty, ProductinventoryFields.structure, map)
   }
   override def deleteById(compositeId: ProductinventoryId)(implicit c: Connection): Boolean = {
     map.remove(compositeId).isDefined
@@ -72,7 +72,7 @@ class ProductinventoryRepoMock(toRow: Function1[ProductinventoryRowUnsaved, Prod
     compositeIds.view.flatMap(id => byId.get(id).map(x => (id, x))).toMap
   }
   override def update: UpdateBuilder[ProductinventoryFields, ProductinventoryRow] = {
-    UpdateBuilderMock(UpdateParams.empty, ProductinventoryFields.structure.fields, map)
+    UpdateBuilderMock(UpdateParams.empty, ProductinventoryFields.structure, map)
   }
   override def update(row: ProductinventoryRow)(implicit c: Connection): Boolean = {
     map.get(row.compositeId) match {

--- a/typo-tester-anorm/generated-and-checked-in/adventureworks/production/productlistpricehistory/ProductlistpricehistoryFields.scala
+++ b/typo-tester-anorm/generated-and-checked-in/adventureworks/production/productlistpricehistory/ProductlistpricehistoryFields.scala
@@ -9,40 +9,41 @@ package productlistpricehistory
 
 import adventureworks.customtypes.TypoLocalDateTime
 import adventureworks.production.product.ProductId
+import typo.dsl.Path
 import typo.dsl.SqlExpr.Field
 import typo.dsl.SqlExpr.FieldLikeNoHkt
 import typo.dsl.SqlExpr.IdField
 import typo.dsl.SqlExpr.OptField
 import typo.dsl.Structure.Relation
 
-trait ProductlistpricehistoryFields[Row] {
-  val productid: IdField[ProductId, Row]
-  val startdate: IdField[TypoLocalDateTime, Row]
-  val enddate: OptField[TypoLocalDateTime, Row]
-  val listprice: Field[BigDecimal, Row]
-  val modifieddate: Field[TypoLocalDateTime, Row]
+trait ProductlistpricehistoryFields {
+  def productid: IdField[ProductId, ProductlistpricehistoryRow]
+  def startdate: IdField[TypoLocalDateTime, ProductlistpricehistoryRow]
+  def enddate: OptField[TypoLocalDateTime, ProductlistpricehistoryRow]
+  def listprice: Field[BigDecimal, ProductlistpricehistoryRow]
+  def modifieddate: Field[TypoLocalDateTime, ProductlistpricehistoryRow]
 }
 
 object ProductlistpricehistoryFields {
-  val structure: Relation[ProductlistpricehistoryFields, ProductlistpricehistoryRow, ProductlistpricehistoryRow] = 
-    new Impl(None, identity, (_, x) => x)
+  lazy val structure: Relation[ProductlistpricehistoryFields, ProductlistpricehistoryRow] =
+    new Impl(Nil)
     
-  private final class Impl[Row](val prefix: Option[String], val extract: Row => ProductlistpricehistoryRow, val merge: (Row, ProductlistpricehistoryRow) => Row)
-    extends Relation[ProductlistpricehistoryFields, ProductlistpricehistoryRow, Row] { 
+  private final class Impl(val _path: List[Path])
+    extends Relation[ProductlistpricehistoryFields, ProductlistpricehistoryRow] {
   
-    override val fields: ProductlistpricehistoryFields[Row] = new ProductlistpricehistoryFields[Row] {
-      override val productid = new IdField[ProductId, Row](prefix, "productid", None, Some("int4"))(x => extract(x).productid, (row, value) => merge(row, extract(row).copy(productid = value)))
-      override val startdate = new IdField[TypoLocalDateTime, Row](prefix, "startdate", Some("text"), Some("timestamp"))(x => extract(x).startdate, (row, value) => merge(row, extract(row).copy(startdate = value)))
-      override val enddate = new OptField[TypoLocalDateTime, Row](prefix, "enddate", Some("text"), Some("timestamp"))(x => extract(x).enddate, (row, value) => merge(row, extract(row).copy(enddate = value)))
-      override val listprice = new Field[BigDecimal, Row](prefix, "listprice", None, Some("numeric"))(x => extract(x).listprice, (row, value) => merge(row, extract(row).copy(listprice = value)))
-      override val modifieddate = new Field[TypoLocalDateTime, Row](prefix, "modifieddate", Some("text"), Some("timestamp"))(x => extract(x).modifieddate, (row, value) => merge(row, extract(row).copy(modifieddate = value)))
+    override lazy val fields: ProductlistpricehistoryFields = new ProductlistpricehistoryFields {
+      override def productid = IdField[ProductId, ProductlistpricehistoryRow](_path, "productid", None, Some("int4"), x => x.productid, (row, value) => row.copy(productid = value))
+      override def startdate = IdField[TypoLocalDateTime, ProductlistpricehistoryRow](_path, "startdate", Some("text"), Some("timestamp"), x => x.startdate, (row, value) => row.copy(startdate = value))
+      override def enddate = OptField[TypoLocalDateTime, ProductlistpricehistoryRow](_path, "enddate", Some("text"), Some("timestamp"), x => x.enddate, (row, value) => row.copy(enddate = value))
+      override def listprice = Field[BigDecimal, ProductlistpricehistoryRow](_path, "listprice", None, Some("numeric"), x => x.listprice, (row, value) => row.copy(listprice = value))
+      override def modifieddate = Field[TypoLocalDateTime, ProductlistpricehistoryRow](_path, "modifieddate", Some("text"), Some("timestamp"), x => x.modifieddate, (row, value) => row.copy(modifieddate = value))
     }
   
-    override val columns: List[FieldLikeNoHkt[?, Row]] =
-      List[FieldLikeNoHkt[?, Row]](fields.productid, fields.startdate, fields.enddate, fields.listprice, fields.modifieddate)
+    override lazy val columns: List[FieldLikeNoHkt[?, ProductlistpricehistoryRow]] =
+      List[FieldLikeNoHkt[?, ProductlistpricehistoryRow]](fields.productid, fields.startdate, fields.enddate, fields.listprice, fields.modifieddate)
   
-    override def copy[NewRow](prefix: Option[String], extract: NewRow => ProductlistpricehistoryRow, merge: (NewRow, ProductlistpricehistoryRow) => NewRow): Impl[NewRow] =
-      new Impl(prefix, extract, merge)
+    override def copy(path: List[Path]): Impl =
+      new Impl(path)
   }
   
 }

--- a/typo-tester-anorm/generated-and-checked-in/adventureworks/production/productlistpricehistory/ProductlistpricehistoryRepoMock.scala
+++ b/typo-tester-anorm/generated-and-checked-in/adventureworks/production/productlistpricehistory/ProductlistpricehistoryRepoMock.scala
@@ -22,7 +22,7 @@ import typo.dsl.UpdateParams
 class ProductlistpricehistoryRepoMock(toRow: Function1[ProductlistpricehistoryRowUnsaved, ProductlistpricehistoryRow],
                                       map: scala.collection.mutable.Map[ProductlistpricehistoryId, ProductlistpricehistoryRow] = scala.collection.mutable.Map.empty) extends ProductlistpricehistoryRepo {
   override def delete: DeleteBuilder[ProductlistpricehistoryFields, ProductlistpricehistoryRow] = {
-    DeleteBuilderMock(DeleteParams.empty, ProductlistpricehistoryFields.structure.fields, map)
+    DeleteBuilderMock(DeleteParams.empty, ProductlistpricehistoryFields.structure, map)
   }
   override def deleteById(compositeId: ProductlistpricehistoryId)(implicit c: Connection): Boolean = {
     map.remove(compositeId).isDefined
@@ -72,7 +72,7 @@ class ProductlistpricehistoryRepoMock(toRow: Function1[ProductlistpricehistoryRo
     compositeIds.view.flatMap(id => byId.get(id).map(x => (id, x))).toMap
   }
   override def update: UpdateBuilder[ProductlistpricehistoryFields, ProductlistpricehistoryRow] = {
-    UpdateBuilderMock(UpdateParams.empty, ProductlistpricehistoryFields.structure.fields, map)
+    UpdateBuilderMock(UpdateParams.empty, ProductlistpricehistoryFields.structure, map)
   }
   override def update(row: ProductlistpricehistoryRow)(implicit c: Connection): Boolean = {
     map.get(row.compositeId) match {

--- a/typo-tester-anorm/generated-and-checked-in/adventureworks/production/productmodel/ProductmodelFields.scala
+++ b/typo-tester-anorm/generated-and-checked-in/adventureworks/production/productmodel/ProductmodelFields.scala
@@ -11,42 +11,43 @@ import adventureworks.customtypes.TypoLocalDateTime
 import adventureworks.customtypes.TypoUUID
 import adventureworks.customtypes.TypoXml
 import adventureworks.public.Name
+import typo.dsl.Path
 import typo.dsl.SqlExpr.Field
 import typo.dsl.SqlExpr.FieldLikeNoHkt
 import typo.dsl.SqlExpr.IdField
 import typo.dsl.SqlExpr.OptField
 import typo.dsl.Structure.Relation
 
-trait ProductmodelFields[Row] {
-  val productmodelid: IdField[ProductmodelId, Row]
-  val name: Field[Name, Row]
-  val catalogdescription: OptField[TypoXml, Row]
-  val instructions: OptField[TypoXml, Row]
-  val rowguid: Field[TypoUUID, Row]
-  val modifieddate: Field[TypoLocalDateTime, Row]
+trait ProductmodelFields {
+  def productmodelid: IdField[ProductmodelId, ProductmodelRow]
+  def name: Field[Name, ProductmodelRow]
+  def catalogdescription: OptField[TypoXml, ProductmodelRow]
+  def instructions: OptField[TypoXml, ProductmodelRow]
+  def rowguid: Field[TypoUUID, ProductmodelRow]
+  def modifieddate: Field[TypoLocalDateTime, ProductmodelRow]
 }
 
 object ProductmodelFields {
-  val structure: Relation[ProductmodelFields, ProductmodelRow, ProductmodelRow] = 
-    new Impl(None, identity, (_, x) => x)
+  lazy val structure: Relation[ProductmodelFields, ProductmodelRow] =
+    new Impl(Nil)
     
-  private final class Impl[Row](val prefix: Option[String], val extract: Row => ProductmodelRow, val merge: (Row, ProductmodelRow) => Row)
-    extends Relation[ProductmodelFields, ProductmodelRow, Row] { 
+  private final class Impl(val _path: List[Path])
+    extends Relation[ProductmodelFields, ProductmodelRow] {
   
-    override val fields: ProductmodelFields[Row] = new ProductmodelFields[Row] {
-      override val productmodelid = new IdField[ProductmodelId, Row](prefix, "productmodelid", None, Some("int4"))(x => extract(x).productmodelid, (row, value) => merge(row, extract(row).copy(productmodelid = value)))
-      override val name = new Field[Name, Row](prefix, "name", None, Some("varchar"))(x => extract(x).name, (row, value) => merge(row, extract(row).copy(name = value)))
-      override val catalogdescription = new OptField[TypoXml, Row](prefix, "catalogdescription", None, Some("xml"))(x => extract(x).catalogdescription, (row, value) => merge(row, extract(row).copy(catalogdescription = value)))
-      override val instructions = new OptField[TypoXml, Row](prefix, "instructions", None, Some("xml"))(x => extract(x).instructions, (row, value) => merge(row, extract(row).copy(instructions = value)))
-      override val rowguid = new Field[TypoUUID, Row](prefix, "rowguid", None, Some("uuid"))(x => extract(x).rowguid, (row, value) => merge(row, extract(row).copy(rowguid = value)))
-      override val modifieddate = new Field[TypoLocalDateTime, Row](prefix, "modifieddate", Some("text"), Some("timestamp"))(x => extract(x).modifieddate, (row, value) => merge(row, extract(row).copy(modifieddate = value)))
+    override lazy val fields: ProductmodelFields = new ProductmodelFields {
+      override def productmodelid = IdField[ProductmodelId, ProductmodelRow](_path, "productmodelid", None, Some("int4"), x => x.productmodelid, (row, value) => row.copy(productmodelid = value))
+      override def name = Field[Name, ProductmodelRow](_path, "name", None, Some("varchar"), x => x.name, (row, value) => row.copy(name = value))
+      override def catalogdescription = OptField[TypoXml, ProductmodelRow](_path, "catalogdescription", None, Some("xml"), x => x.catalogdescription, (row, value) => row.copy(catalogdescription = value))
+      override def instructions = OptField[TypoXml, ProductmodelRow](_path, "instructions", None, Some("xml"), x => x.instructions, (row, value) => row.copy(instructions = value))
+      override def rowguid = Field[TypoUUID, ProductmodelRow](_path, "rowguid", None, Some("uuid"), x => x.rowguid, (row, value) => row.copy(rowguid = value))
+      override def modifieddate = Field[TypoLocalDateTime, ProductmodelRow](_path, "modifieddate", Some("text"), Some("timestamp"), x => x.modifieddate, (row, value) => row.copy(modifieddate = value))
     }
   
-    override val columns: List[FieldLikeNoHkt[?, Row]] =
-      List[FieldLikeNoHkt[?, Row]](fields.productmodelid, fields.name, fields.catalogdescription, fields.instructions, fields.rowguid, fields.modifieddate)
+    override lazy val columns: List[FieldLikeNoHkt[?, ProductmodelRow]] =
+      List[FieldLikeNoHkt[?, ProductmodelRow]](fields.productmodelid, fields.name, fields.catalogdescription, fields.instructions, fields.rowguid, fields.modifieddate)
   
-    override def copy[NewRow](prefix: Option[String], extract: NewRow => ProductmodelRow, merge: (NewRow, ProductmodelRow) => NewRow): Impl[NewRow] =
-      new Impl(prefix, extract, merge)
+    override def copy(path: List[Path]): Impl =
+      new Impl(path)
   }
   
 }

--- a/typo-tester-anorm/generated-and-checked-in/adventureworks/production/productmodel/ProductmodelRepoMock.scala
+++ b/typo-tester-anorm/generated-and-checked-in/adventureworks/production/productmodel/ProductmodelRepoMock.scala
@@ -22,7 +22,7 @@ import typo.dsl.UpdateParams
 class ProductmodelRepoMock(toRow: Function1[ProductmodelRowUnsaved, ProductmodelRow],
                            map: scala.collection.mutable.Map[ProductmodelId, ProductmodelRow] = scala.collection.mutable.Map.empty) extends ProductmodelRepo {
   override def delete: DeleteBuilder[ProductmodelFields, ProductmodelRow] = {
-    DeleteBuilderMock(DeleteParams.empty, ProductmodelFields.structure.fields, map)
+    DeleteBuilderMock(DeleteParams.empty, ProductmodelFields.structure, map)
   }
   override def deleteById(productmodelid: ProductmodelId)(implicit c: Connection): Boolean = {
     map.remove(productmodelid).isDefined
@@ -72,7 +72,7 @@ class ProductmodelRepoMock(toRow: Function1[ProductmodelRowUnsaved, Productmodel
     productmodelids.view.flatMap(id => byId.get(id).map(x => (id, x))).toMap
   }
   override def update: UpdateBuilder[ProductmodelFields, ProductmodelRow] = {
-    UpdateBuilderMock(UpdateParams.empty, ProductmodelFields.structure.fields, map)
+    UpdateBuilderMock(UpdateParams.empty, ProductmodelFields.structure, map)
   }
   override def update(row: ProductmodelRow)(implicit c: Connection): Boolean = {
     map.get(row.productmodelid) match {

--- a/typo-tester-anorm/generated-and-checked-in/adventureworks/production/productmodelillustration/ProductmodelillustrationFields.scala
+++ b/typo-tester-anorm/generated-and-checked-in/adventureworks/production/productmodelillustration/ProductmodelillustrationFields.scala
@@ -10,35 +10,36 @@ package productmodelillustration
 import adventureworks.customtypes.TypoLocalDateTime
 import adventureworks.production.illustration.IllustrationId
 import adventureworks.production.productmodel.ProductmodelId
+import typo.dsl.Path
 import typo.dsl.SqlExpr.Field
 import typo.dsl.SqlExpr.FieldLikeNoHkt
 import typo.dsl.SqlExpr.IdField
 import typo.dsl.Structure.Relation
 
-trait ProductmodelillustrationFields[Row] {
-  val productmodelid: IdField[ProductmodelId, Row]
-  val illustrationid: IdField[IllustrationId, Row]
-  val modifieddate: Field[TypoLocalDateTime, Row]
+trait ProductmodelillustrationFields {
+  def productmodelid: IdField[ProductmodelId, ProductmodelillustrationRow]
+  def illustrationid: IdField[IllustrationId, ProductmodelillustrationRow]
+  def modifieddate: Field[TypoLocalDateTime, ProductmodelillustrationRow]
 }
 
 object ProductmodelillustrationFields {
-  val structure: Relation[ProductmodelillustrationFields, ProductmodelillustrationRow, ProductmodelillustrationRow] = 
-    new Impl(None, identity, (_, x) => x)
+  lazy val structure: Relation[ProductmodelillustrationFields, ProductmodelillustrationRow] =
+    new Impl(Nil)
     
-  private final class Impl[Row](val prefix: Option[String], val extract: Row => ProductmodelillustrationRow, val merge: (Row, ProductmodelillustrationRow) => Row)
-    extends Relation[ProductmodelillustrationFields, ProductmodelillustrationRow, Row] { 
+  private final class Impl(val _path: List[Path])
+    extends Relation[ProductmodelillustrationFields, ProductmodelillustrationRow] {
   
-    override val fields: ProductmodelillustrationFields[Row] = new ProductmodelillustrationFields[Row] {
-      override val productmodelid = new IdField[ProductmodelId, Row](prefix, "productmodelid", None, Some("int4"))(x => extract(x).productmodelid, (row, value) => merge(row, extract(row).copy(productmodelid = value)))
-      override val illustrationid = new IdField[IllustrationId, Row](prefix, "illustrationid", None, Some("int4"))(x => extract(x).illustrationid, (row, value) => merge(row, extract(row).copy(illustrationid = value)))
-      override val modifieddate = new Field[TypoLocalDateTime, Row](prefix, "modifieddate", Some("text"), Some("timestamp"))(x => extract(x).modifieddate, (row, value) => merge(row, extract(row).copy(modifieddate = value)))
+    override lazy val fields: ProductmodelillustrationFields = new ProductmodelillustrationFields {
+      override def productmodelid = IdField[ProductmodelId, ProductmodelillustrationRow](_path, "productmodelid", None, Some("int4"), x => x.productmodelid, (row, value) => row.copy(productmodelid = value))
+      override def illustrationid = IdField[IllustrationId, ProductmodelillustrationRow](_path, "illustrationid", None, Some("int4"), x => x.illustrationid, (row, value) => row.copy(illustrationid = value))
+      override def modifieddate = Field[TypoLocalDateTime, ProductmodelillustrationRow](_path, "modifieddate", Some("text"), Some("timestamp"), x => x.modifieddate, (row, value) => row.copy(modifieddate = value))
     }
   
-    override val columns: List[FieldLikeNoHkt[?, Row]] =
-      List[FieldLikeNoHkt[?, Row]](fields.productmodelid, fields.illustrationid, fields.modifieddate)
+    override lazy val columns: List[FieldLikeNoHkt[?, ProductmodelillustrationRow]] =
+      List[FieldLikeNoHkt[?, ProductmodelillustrationRow]](fields.productmodelid, fields.illustrationid, fields.modifieddate)
   
-    override def copy[NewRow](prefix: Option[String], extract: NewRow => ProductmodelillustrationRow, merge: (NewRow, ProductmodelillustrationRow) => NewRow): Impl[NewRow] =
-      new Impl(prefix, extract, merge)
+    override def copy(path: List[Path]): Impl =
+      new Impl(path)
   }
   
 }

--- a/typo-tester-anorm/generated-and-checked-in/adventureworks/production/productmodelillustration/ProductmodelillustrationRepoMock.scala
+++ b/typo-tester-anorm/generated-and-checked-in/adventureworks/production/productmodelillustration/ProductmodelillustrationRepoMock.scala
@@ -22,7 +22,7 @@ import typo.dsl.UpdateParams
 class ProductmodelillustrationRepoMock(toRow: Function1[ProductmodelillustrationRowUnsaved, ProductmodelillustrationRow],
                                        map: scala.collection.mutable.Map[ProductmodelillustrationId, ProductmodelillustrationRow] = scala.collection.mutable.Map.empty) extends ProductmodelillustrationRepo {
   override def delete: DeleteBuilder[ProductmodelillustrationFields, ProductmodelillustrationRow] = {
-    DeleteBuilderMock(DeleteParams.empty, ProductmodelillustrationFields.structure.fields, map)
+    DeleteBuilderMock(DeleteParams.empty, ProductmodelillustrationFields.structure, map)
   }
   override def deleteById(compositeId: ProductmodelillustrationId)(implicit c: Connection): Boolean = {
     map.remove(compositeId).isDefined
@@ -72,7 +72,7 @@ class ProductmodelillustrationRepoMock(toRow: Function1[Productmodelillustration
     compositeIds.view.flatMap(id => byId.get(id).map(x => (id, x))).toMap
   }
   override def update: UpdateBuilder[ProductmodelillustrationFields, ProductmodelillustrationRow] = {
-    UpdateBuilderMock(UpdateParams.empty, ProductmodelillustrationFields.structure.fields, map)
+    UpdateBuilderMock(UpdateParams.empty, ProductmodelillustrationFields.structure, map)
   }
   override def update(row: ProductmodelillustrationRow)(implicit c: Connection): Boolean = {
     map.get(row.compositeId) match {

--- a/typo-tester-anorm/generated-and-checked-in/adventureworks/production/productmodelproductdescriptionculture/ProductmodelproductdescriptioncultureFields.scala
+++ b/typo-tester-anorm/generated-and-checked-in/adventureworks/production/productmodelproductdescriptionculture/ProductmodelproductdescriptioncultureFields.scala
@@ -11,37 +11,38 @@ import adventureworks.customtypes.TypoLocalDateTime
 import adventureworks.production.culture.CultureId
 import adventureworks.production.productdescription.ProductdescriptionId
 import adventureworks.production.productmodel.ProductmodelId
+import typo.dsl.Path
 import typo.dsl.SqlExpr.Field
 import typo.dsl.SqlExpr.FieldLikeNoHkt
 import typo.dsl.SqlExpr.IdField
 import typo.dsl.Structure.Relation
 
-trait ProductmodelproductdescriptioncultureFields[Row] {
-  val productmodelid: IdField[ProductmodelId, Row]
-  val productdescriptionid: IdField[ProductdescriptionId, Row]
-  val cultureid: IdField[CultureId, Row]
-  val modifieddate: Field[TypoLocalDateTime, Row]
+trait ProductmodelproductdescriptioncultureFields {
+  def productmodelid: IdField[ProductmodelId, ProductmodelproductdescriptioncultureRow]
+  def productdescriptionid: IdField[ProductdescriptionId, ProductmodelproductdescriptioncultureRow]
+  def cultureid: IdField[CultureId, ProductmodelproductdescriptioncultureRow]
+  def modifieddate: Field[TypoLocalDateTime, ProductmodelproductdescriptioncultureRow]
 }
 
 object ProductmodelproductdescriptioncultureFields {
-  val structure: Relation[ProductmodelproductdescriptioncultureFields, ProductmodelproductdescriptioncultureRow, ProductmodelproductdescriptioncultureRow] = 
-    new Impl(None, identity, (_, x) => x)
+  lazy val structure: Relation[ProductmodelproductdescriptioncultureFields, ProductmodelproductdescriptioncultureRow] =
+    new Impl(Nil)
     
-  private final class Impl[Row](val prefix: Option[String], val extract: Row => ProductmodelproductdescriptioncultureRow, val merge: (Row, ProductmodelproductdescriptioncultureRow) => Row)
-    extends Relation[ProductmodelproductdescriptioncultureFields, ProductmodelproductdescriptioncultureRow, Row] { 
+  private final class Impl(val _path: List[Path])
+    extends Relation[ProductmodelproductdescriptioncultureFields, ProductmodelproductdescriptioncultureRow] {
   
-    override val fields: ProductmodelproductdescriptioncultureFields[Row] = new ProductmodelproductdescriptioncultureFields[Row] {
-      override val productmodelid = new IdField[ProductmodelId, Row](prefix, "productmodelid", None, Some("int4"))(x => extract(x).productmodelid, (row, value) => merge(row, extract(row).copy(productmodelid = value)))
-      override val productdescriptionid = new IdField[ProductdescriptionId, Row](prefix, "productdescriptionid", None, Some("int4"))(x => extract(x).productdescriptionid, (row, value) => merge(row, extract(row).copy(productdescriptionid = value)))
-      override val cultureid = new IdField[CultureId, Row](prefix, "cultureid", None, Some("bpchar"))(x => extract(x).cultureid, (row, value) => merge(row, extract(row).copy(cultureid = value)))
-      override val modifieddate = new Field[TypoLocalDateTime, Row](prefix, "modifieddate", Some("text"), Some("timestamp"))(x => extract(x).modifieddate, (row, value) => merge(row, extract(row).copy(modifieddate = value)))
+    override lazy val fields: ProductmodelproductdescriptioncultureFields = new ProductmodelproductdescriptioncultureFields {
+      override def productmodelid = IdField[ProductmodelId, ProductmodelproductdescriptioncultureRow](_path, "productmodelid", None, Some("int4"), x => x.productmodelid, (row, value) => row.copy(productmodelid = value))
+      override def productdescriptionid = IdField[ProductdescriptionId, ProductmodelproductdescriptioncultureRow](_path, "productdescriptionid", None, Some("int4"), x => x.productdescriptionid, (row, value) => row.copy(productdescriptionid = value))
+      override def cultureid = IdField[CultureId, ProductmodelproductdescriptioncultureRow](_path, "cultureid", None, Some("bpchar"), x => x.cultureid, (row, value) => row.copy(cultureid = value))
+      override def modifieddate = Field[TypoLocalDateTime, ProductmodelproductdescriptioncultureRow](_path, "modifieddate", Some("text"), Some("timestamp"), x => x.modifieddate, (row, value) => row.copy(modifieddate = value))
     }
   
-    override val columns: List[FieldLikeNoHkt[?, Row]] =
-      List[FieldLikeNoHkt[?, Row]](fields.productmodelid, fields.productdescriptionid, fields.cultureid, fields.modifieddate)
+    override lazy val columns: List[FieldLikeNoHkt[?, ProductmodelproductdescriptioncultureRow]] =
+      List[FieldLikeNoHkt[?, ProductmodelproductdescriptioncultureRow]](fields.productmodelid, fields.productdescriptionid, fields.cultureid, fields.modifieddate)
   
-    override def copy[NewRow](prefix: Option[String], extract: NewRow => ProductmodelproductdescriptioncultureRow, merge: (NewRow, ProductmodelproductdescriptioncultureRow) => NewRow): Impl[NewRow] =
-      new Impl(prefix, extract, merge)
+    override def copy(path: List[Path]): Impl =
+      new Impl(path)
   }
   
 }

--- a/typo-tester-anorm/generated-and-checked-in/adventureworks/production/productmodelproductdescriptionculture/ProductmodelproductdescriptioncultureRepoMock.scala
+++ b/typo-tester-anorm/generated-and-checked-in/adventureworks/production/productmodelproductdescriptionculture/ProductmodelproductdescriptioncultureRepoMock.scala
@@ -22,7 +22,7 @@ import typo.dsl.UpdateParams
 class ProductmodelproductdescriptioncultureRepoMock(toRow: Function1[ProductmodelproductdescriptioncultureRowUnsaved, ProductmodelproductdescriptioncultureRow],
                                                     map: scala.collection.mutable.Map[ProductmodelproductdescriptioncultureId, ProductmodelproductdescriptioncultureRow] = scala.collection.mutable.Map.empty) extends ProductmodelproductdescriptioncultureRepo {
   override def delete: DeleteBuilder[ProductmodelproductdescriptioncultureFields, ProductmodelproductdescriptioncultureRow] = {
-    DeleteBuilderMock(DeleteParams.empty, ProductmodelproductdescriptioncultureFields.structure.fields, map)
+    DeleteBuilderMock(DeleteParams.empty, ProductmodelproductdescriptioncultureFields.structure, map)
   }
   override def deleteById(compositeId: ProductmodelproductdescriptioncultureId)(implicit c: Connection): Boolean = {
     map.remove(compositeId).isDefined
@@ -72,7 +72,7 @@ class ProductmodelproductdescriptioncultureRepoMock(toRow: Function1[Productmode
     compositeIds.view.flatMap(id => byId.get(id).map(x => (id, x))).toMap
   }
   override def update: UpdateBuilder[ProductmodelproductdescriptioncultureFields, ProductmodelproductdescriptioncultureRow] = {
-    UpdateBuilderMock(UpdateParams.empty, ProductmodelproductdescriptioncultureFields.structure.fields, map)
+    UpdateBuilderMock(UpdateParams.empty, ProductmodelproductdescriptioncultureFields.structure, map)
   }
   override def update(row: ProductmodelproductdescriptioncultureRow)(implicit c: Connection): Boolean = {
     map.get(row.compositeId) match {

--- a/typo-tester-anorm/generated-and-checked-in/adventureworks/production/productphoto/ProductphotoFields.scala
+++ b/typo-tester-anorm/generated-and-checked-in/adventureworks/production/productphoto/ProductphotoFields.scala
@@ -9,42 +9,43 @@ package productphoto
 
 import adventureworks.customtypes.TypoBytea
 import adventureworks.customtypes.TypoLocalDateTime
+import typo.dsl.Path
 import typo.dsl.SqlExpr.Field
 import typo.dsl.SqlExpr.FieldLikeNoHkt
 import typo.dsl.SqlExpr.IdField
 import typo.dsl.SqlExpr.OptField
 import typo.dsl.Structure.Relation
 
-trait ProductphotoFields[Row] {
-  val productphotoid: IdField[ProductphotoId, Row]
-  val thumbnailphoto: OptField[TypoBytea, Row]
-  val thumbnailphotofilename: OptField[/* max 50 chars */ String, Row]
-  val largephoto: OptField[TypoBytea, Row]
-  val largephotofilename: OptField[/* max 50 chars */ String, Row]
-  val modifieddate: Field[TypoLocalDateTime, Row]
+trait ProductphotoFields {
+  def productphotoid: IdField[ProductphotoId, ProductphotoRow]
+  def thumbnailphoto: OptField[TypoBytea, ProductphotoRow]
+  def thumbnailphotofilename: OptField[/* max 50 chars */ String, ProductphotoRow]
+  def largephoto: OptField[TypoBytea, ProductphotoRow]
+  def largephotofilename: OptField[/* max 50 chars */ String, ProductphotoRow]
+  def modifieddate: Field[TypoLocalDateTime, ProductphotoRow]
 }
 
 object ProductphotoFields {
-  val structure: Relation[ProductphotoFields, ProductphotoRow, ProductphotoRow] = 
-    new Impl(None, identity, (_, x) => x)
+  lazy val structure: Relation[ProductphotoFields, ProductphotoRow] =
+    new Impl(Nil)
     
-  private final class Impl[Row](val prefix: Option[String], val extract: Row => ProductphotoRow, val merge: (Row, ProductphotoRow) => Row)
-    extends Relation[ProductphotoFields, ProductphotoRow, Row] { 
+  private final class Impl(val _path: List[Path])
+    extends Relation[ProductphotoFields, ProductphotoRow] {
   
-    override val fields: ProductphotoFields[Row] = new ProductphotoFields[Row] {
-      override val productphotoid = new IdField[ProductphotoId, Row](prefix, "productphotoid", None, Some("int4"))(x => extract(x).productphotoid, (row, value) => merge(row, extract(row).copy(productphotoid = value)))
-      override val thumbnailphoto = new OptField[TypoBytea, Row](prefix, "thumbnailphoto", None, Some("bytea"))(x => extract(x).thumbnailphoto, (row, value) => merge(row, extract(row).copy(thumbnailphoto = value)))
-      override val thumbnailphotofilename = new OptField[/* max 50 chars */ String, Row](prefix, "thumbnailphotofilename", None, None)(x => extract(x).thumbnailphotofilename, (row, value) => merge(row, extract(row).copy(thumbnailphotofilename = value)))
-      override val largephoto = new OptField[TypoBytea, Row](prefix, "largephoto", None, Some("bytea"))(x => extract(x).largephoto, (row, value) => merge(row, extract(row).copy(largephoto = value)))
-      override val largephotofilename = new OptField[/* max 50 chars */ String, Row](prefix, "largephotofilename", None, None)(x => extract(x).largephotofilename, (row, value) => merge(row, extract(row).copy(largephotofilename = value)))
-      override val modifieddate = new Field[TypoLocalDateTime, Row](prefix, "modifieddate", Some("text"), Some("timestamp"))(x => extract(x).modifieddate, (row, value) => merge(row, extract(row).copy(modifieddate = value)))
+    override lazy val fields: ProductphotoFields = new ProductphotoFields {
+      override def productphotoid = IdField[ProductphotoId, ProductphotoRow](_path, "productphotoid", None, Some("int4"), x => x.productphotoid, (row, value) => row.copy(productphotoid = value))
+      override def thumbnailphoto = OptField[TypoBytea, ProductphotoRow](_path, "thumbnailphoto", None, Some("bytea"), x => x.thumbnailphoto, (row, value) => row.copy(thumbnailphoto = value))
+      override def thumbnailphotofilename = OptField[/* max 50 chars */ String, ProductphotoRow](_path, "thumbnailphotofilename", None, None, x => x.thumbnailphotofilename, (row, value) => row.copy(thumbnailphotofilename = value))
+      override def largephoto = OptField[TypoBytea, ProductphotoRow](_path, "largephoto", None, Some("bytea"), x => x.largephoto, (row, value) => row.copy(largephoto = value))
+      override def largephotofilename = OptField[/* max 50 chars */ String, ProductphotoRow](_path, "largephotofilename", None, None, x => x.largephotofilename, (row, value) => row.copy(largephotofilename = value))
+      override def modifieddate = Field[TypoLocalDateTime, ProductphotoRow](_path, "modifieddate", Some("text"), Some("timestamp"), x => x.modifieddate, (row, value) => row.copy(modifieddate = value))
     }
   
-    override val columns: List[FieldLikeNoHkt[?, Row]] =
-      List[FieldLikeNoHkt[?, Row]](fields.productphotoid, fields.thumbnailphoto, fields.thumbnailphotofilename, fields.largephoto, fields.largephotofilename, fields.modifieddate)
+    override lazy val columns: List[FieldLikeNoHkt[?, ProductphotoRow]] =
+      List[FieldLikeNoHkt[?, ProductphotoRow]](fields.productphotoid, fields.thumbnailphoto, fields.thumbnailphotofilename, fields.largephoto, fields.largephotofilename, fields.modifieddate)
   
-    override def copy[NewRow](prefix: Option[String], extract: NewRow => ProductphotoRow, merge: (NewRow, ProductphotoRow) => NewRow): Impl[NewRow] =
-      new Impl(prefix, extract, merge)
+    override def copy(path: List[Path]): Impl =
+      new Impl(path)
   }
   
 }

--- a/typo-tester-anorm/generated-and-checked-in/adventureworks/production/productphoto/ProductphotoRepoMock.scala
+++ b/typo-tester-anorm/generated-and-checked-in/adventureworks/production/productphoto/ProductphotoRepoMock.scala
@@ -22,7 +22,7 @@ import typo.dsl.UpdateParams
 class ProductphotoRepoMock(toRow: Function1[ProductphotoRowUnsaved, ProductphotoRow],
                            map: scala.collection.mutable.Map[ProductphotoId, ProductphotoRow] = scala.collection.mutable.Map.empty) extends ProductphotoRepo {
   override def delete: DeleteBuilder[ProductphotoFields, ProductphotoRow] = {
-    DeleteBuilderMock(DeleteParams.empty, ProductphotoFields.structure.fields, map)
+    DeleteBuilderMock(DeleteParams.empty, ProductphotoFields.structure, map)
   }
   override def deleteById(productphotoid: ProductphotoId)(implicit c: Connection): Boolean = {
     map.remove(productphotoid).isDefined
@@ -72,7 +72,7 @@ class ProductphotoRepoMock(toRow: Function1[ProductphotoRowUnsaved, Productphoto
     productphotoids.view.flatMap(id => byId.get(id).map(x => (id, x))).toMap
   }
   override def update: UpdateBuilder[ProductphotoFields, ProductphotoRow] = {
-    UpdateBuilderMock(UpdateParams.empty, ProductphotoFields.structure.fields, map)
+    UpdateBuilderMock(UpdateParams.empty, ProductphotoFields.structure, map)
   }
   override def update(row: ProductphotoRow)(implicit c: Connection): Boolean = {
     map.get(row.productphotoid) match {

--- a/typo-tester-anorm/generated-and-checked-in/adventureworks/production/productproductphoto/ProductproductphotoFields.scala
+++ b/typo-tester-anorm/generated-and-checked-in/adventureworks/production/productproductphoto/ProductproductphotoFields.scala
@@ -11,37 +11,38 @@ import adventureworks.customtypes.TypoLocalDateTime
 import adventureworks.production.product.ProductId
 import adventureworks.production.productphoto.ProductphotoId
 import adventureworks.public.Flag
+import typo.dsl.Path
 import typo.dsl.SqlExpr.Field
 import typo.dsl.SqlExpr.FieldLikeNoHkt
 import typo.dsl.SqlExpr.IdField
 import typo.dsl.Structure.Relation
 
-trait ProductproductphotoFields[Row] {
-  val productid: IdField[ProductId, Row]
-  val productphotoid: IdField[ProductphotoId, Row]
-  val primary: Field[Flag, Row]
-  val modifieddate: Field[TypoLocalDateTime, Row]
+trait ProductproductphotoFields {
+  def productid: IdField[ProductId, ProductproductphotoRow]
+  def productphotoid: IdField[ProductphotoId, ProductproductphotoRow]
+  def primary: Field[Flag, ProductproductphotoRow]
+  def modifieddate: Field[TypoLocalDateTime, ProductproductphotoRow]
 }
 
 object ProductproductphotoFields {
-  val structure: Relation[ProductproductphotoFields, ProductproductphotoRow, ProductproductphotoRow] = 
-    new Impl(None, identity, (_, x) => x)
+  lazy val structure: Relation[ProductproductphotoFields, ProductproductphotoRow] =
+    new Impl(Nil)
     
-  private final class Impl[Row](val prefix: Option[String], val extract: Row => ProductproductphotoRow, val merge: (Row, ProductproductphotoRow) => Row)
-    extends Relation[ProductproductphotoFields, ProductproductphotoRow, Row] { 
+  private final class Impl(val _path: List[Path])
+    extends Relation[ProductproductphotoFields, ProductproductphotoRow] {
   
-    override val fields: ProductproductphotoFields[Row] = new ProductproductphotoFields[Row] {
-      override val productid = new IdField[ProductId, Row](prefix, "productid", None, Some("int4"))(x => extract(x).productid, (row, value) => merge(row, extract(row).copy(productid = value)))
-      override val productphotoid = new IdField[ProductphotoId, Row](prefix, "productphotoid", None, Some("int4"))(x => extract(x).productphotoid, (row, value) => merge(row, extract(row).copy(productphotoid = value)))
-      override val primary = new Field[Flag, Row](prefix, "primary", None, Some("bool"))(x => extract(x).primary, (row, value) => merge(row, extract(row).copy(primary = value)))
-      override val modifieddate = new Field[TypoLocalDateTime, Row](prefix, "modifieddate", Some("text"), Some("timestamp"))(x => extract(x).modifieddate, (row, value) => merge(row, extract(row).copy(modifieddate = value)))
+    override lazy val fields: ProductproductphotoFields = new ProductproductphotoFields {
+      override def productid = IdField[ProductId, ProductproductphotoRow](_path, "productid", None, Some("int4"), x => x.productid, (row, value) => row.copy(productid = value))
+      override def productphotoid = IdField[ProductphotoId, ProductproductphotoRow](_path, "productphotoid", None, Some("int4"), x => x.productphotoid, (row, value) => row.copy(productphotoid = value))
+      override def primary = Field[Flag, ProductproductphotoRow](_path, "primary", None, Some("bool"), x => x.primary, (row, value) => row.copy(primary = value))
+      override def modifieddate = Field[TypoLocalDateTime, ProductproductphotoRow](_path, "modifieddate", Some("text"), Some("timestamp"), x => x.modifieddate, (row, value) => row.copy(modifieddate = value))
     }
   
-    override val columns: List[FieldLikeNoHkt[?, Row]] =
-      List[FieldLikeNoHkt[?, Row]](fields.productid, fields.productphotoid, fields.primary, fields.modifieddate)
+    override lazy val columns: List[FieldLikeNoHkt[?, ProductproductphotoRow]] =
+      List[FieldLikeNoHkt[?, ProductproductphotoRow]](fields.productid, fields.productphotoid, fields.primary, fields.modifieddate)
   
-    override def copy[NewRow](prefix: Option[String], extract: NewRow => ProductproductphotoRow, merge: (NewRow, ProductproductphotoRow) => NewRow): Impl[NewRow] =
-      new Impl(prefix, extract, merge)
+    override def copy(path: List[Path]): Impl =
+      new Impl(path)
   }
   
 }

--- a/typo-tester-anorm/generated-and-checked-in/adventureworks/production/productproductphoto/ProductproductphotoRepoMock.scala
+++ b/typo-tester-anorm/generated-and-checked-in/adventureworks/production/productproductphoto/ProductproductphotoRepoMock.scala
@@ -22,7 +22,7 @@ import typo.dsl.UpdateParams
 class ProductproductphotoRepoMock(toRow: Function1[ProductproductphotoRowUnsaved, ProductproductphotoRow],
                                   map: scala.collection.mutable.Map[ProductproductphotoId, ProductproductphotoRow] = scala.collection.mutable.Map.empty) extends ProductproductphotoRepo {
   override def delete: DeleteBuilder[ProductproductphotoFields, ProductproductphotoRow] = {
-    DeleteBuilderMock(DeleteParams.empty, ProductproductphotoFields.structure.fields, map)
+    DeleteBuilderMock(DeleteParams.empty, ProductproductphotoFields.structure, map)
   }
   override def deleteById(compositeId: ProductproductphotoId)(implicit c: Connection): Boolean = {
     map.remove(compositeId).isDefined
@@ -72,7 +72,7 @@ class ProductproductphotoRepoMock(toRow: Function1[ProductproductphotoRowUnsaved
     compositeIds.view.flatMap(id => byId.get(id).map(x => (id, x))).toMap
   }
   override def update: UpdateBuilder[ProductproductphotoFields, ProductproductphotoRow] = {
-    UpdateBuilderMock(UpdateParams.empty, ProductproductphotoFields.structure.fields, map)
+    UpdateBuilderMock(UpdateParams.empty, ProductproductphotoFields.structure, map)
   }
   override def update(row: ProductproductphotoRow)(implicit c: Connection): Boolean = {
     map.get(row.compositeId) match {

--- a/typo-tester-anorm/generated-and-checked-in/adventureworks/production/productreview/ProductreviewFields.scala
+++ b/typo-tester-anorm/generated-and-checked-in/adventureworks/production/productreview/ProductreviewFields.scala
@@ -10,46 +10,47 @@ package productreview
 import adventureworks.customtypes.TypoLocalDateTime
 import adventureworks.production.product.ProductId
 import adventureworks.public.Name
+import typo.dsl.Path
 import typo.dsl.SqlExpr.Field
 import typo.dsl.SqlExpr.FieldLikeNoHkt
 import typo.dsl.SqlExpr.IdField
 import typo.dsl.SqlExpr.OptField
 import typo.dsl.Structure.Relation
 
-trait ProductreviewFields[Row] {
-  val productreviewid: IdField[ProductreviewId, Row]
-  val productid: Field[ProductId, Row]
-  val reviewername: Field[Name, Row]
-  val reviewdate: Field[TypoLocalDateTime, Row]
-  val emailaddress: Field[/* max 50 chars */ String, Row]
-  val rating: Field[Int, Row]
-  val comments: OptField[/* max 3850 chars */ String, Row]
-  val modifieddate: Field[TypoLocalDateTime, Row]
+trait ProductreviewFields {
+  def productreviewid: IdField[ProductreviewId, ProductreviewRow]
+  def productid: Field[ProductId, ProductreviewRow]
+  def reviewername: Field[Name, ProductreviewRow]
+  def reviewdate: Field[TypoLocalDateTime, ProductreviewRow]
+  def emailaddress: Field[/* max 50 chars */ String, ProductreviewRow]
+  def rating: Field[Int, ProductreviewRow]
+  def comments: OptField[/* max 3850 chars */ String, ProductreviewRow]
+  def modifieddate: Field[TypoLocalDateTime, ProductreviewRow]
 }
 
 object ProductreviewFields {
-  val structure: Relation[ProductreviewFields, ProductreviewRow, ProductreviewRow] = 
-    new Impl(None, identity, (_, x) => x)
+  lazy val structure: Relation[ProductreviewFields, ProductreviewRow] =
+    new Impl(Nil)
     
-  private final class Impl[Row](val prefix: Option[String], val extract: Row => ProductreviewRow, val merge: (Row, ProductreviewRow) => Row)
-    extends Relation[ProductreviewFields, ProductreviewRow, Row] { 
+  private final class Impl(val _path: List[Path])
+    extends Relation[ProductreviewFields, ProductreviewRow] {
   
-    override val fields: ProductreviewFields[Row] = new ProductreviewFields[Row] {
-      override val productreviewid = new IdField[ProductreviewId, Row](prefix, "productreviewid", None, Some("int4"))(x => extract(x).productreviewid, (row, value) => merge(row, extract(row).copy(productreviewid = value)))
-      override val productid = new Field[ProductId, Row](prefix, "productid", None, Some("int4"))(x => extract(x).productid, (row, value) => merge(row, extract(row).copy(productid = value)))
-      override val reviewername = new Field[Name, Row](prefix, "reviewername", None, Some("varchar"))(x => extract(x).reviewername, (row, value) => merge(row, extract(row).copy(reviewername = value)))
-      override val reviewdate = new Field[TypoLocalDateTime, Row](prefix, "reviewdate", Some("text"), Some("timestamp"))(x => extract(x).reviewdate, (row, value) => merge(row, extract(row).copy(reviewdate = value)))
-      override val emailaddress = new Field[/* max 50 chars */ String, Row](prefix, "emailaddress", None, None)(x => extract(x).emailaddress, (row, value) => merge(row, extract(row).copy(emailaddress = value)))
-      override val rating = new Field[Int, Row](prefix, "rating", None, Some("int4"))(x => extract(x).rating, (row, value) => merge(row, extract(row).copy(rating = value)))
-      override val comments = new OptField[/* max 3850 chars */ String, Row](prefix, "comments", None, None)(x => extract(x).comments, (row, value) => merge(row, extract(row).copy(comments = value)))
-      override val modifieddate = new Field[TypoLocalDateTime, Row](prefix, "modifieddate", Some("text"), Some("timestamp"))(x => extract(x).modifieddate, (row, value) => merge(row, extract(row).copy(modifieddate = value)))
+    override lazy val fields: ProductreviewFields = new ProductreviewFields {
+      override def productreviewid = IdField[ProductreviewId, ProductreviewRow](_path, "productreviewid", None, Some("int4"), x => x.productreviewid, (row, value) => row.copy(productreviewid = value))
+      override def productid = Field[ProductId, ProductreviewRow](_path, "productid", None, Some("int4"), x => x.productid, (row, value) => row.copy(productid = value))
+      override def reviewername = Field[Name, ProductreviewRow](_path, "reviewername", None, Some("varchar"), x => x.reviewername, (row, value) => row.copy(reviewername = value))
+      override def reviewdate = Field[TypoLocalDateTime, ProductreviewRow](_path, "reviewdate", Some("text"), Some("timestamp"), x => x.reviewdate, (row, value) => row.copy(reviewdate = value))
+      override def emailaddress = Field[/* max 50 chars */ String, ProductreviewRow](_path, "emailaddress", None, None, x => x.emailaddress, (row, value) => row.copy(emailaddress = value))
+      override def rating = Field[Int, ProductreviewRow](_path, "rating", None, Some("int4"), x => x.rating, (row, value) => row.copy(rating = value))
+      override def comments = OptField[/* max 3850 chars */ String, ProductreviewRow](_path, "comments", None, None, x => x.comments, (row, value) => row.copy(comments = value))
+      override def modifieddate = Field[TypoLocalDateTime, ProductreviewRow](_path, "modifieddate", Some("text"), Some("timestamp"), x => x.modifieddate, (row, value) => row.copy(modifieddate = value))
     }
   
-    override val columns: List[FieldLikeNoHkt[?, Row]] =
-      List[FieldLikeNoHkt[?, Row]](fields.productreviewid, fields.productid, fields.reviewername, fields.reviewdate, fields.emailaddress, fields.rating, fields.comments, fields.modifieddate)
+    override lazy val columns: List[FieldLikeNoHkt[?, ProductreviewRow]] =
+      List[FieldLikeNoHkt[?, ProductreviewRow]](fields.productreviewid, fields.productid, fields.reviewername, fields.reviewdate, fields.emailaddress, fields.rating, fields.comments, fields.modifieddate)
   
-    override def copy[NewRow](prefix: Option[String], extract: NewRow => ProductreviewRow, merge: (NewRow, ProductreviewRow) => NewRow): Impl[NewRow] =
-      new Impl(prefix, extract, merge)
+    override def copy(path: List[Path]): Impl =
+      new Impl(path)
   }
   
 }

--- a/typo-tester-anorm/generated-and-checked-in/adventureworks/production/productreview/ProductreviewRepoMock.scala
+++ b/typo-tester-anorm/generated-and-checked-in/adventureworks/production/productreview/ProductreviewRepoMock.scala
@@ -22,7 +22,7 @@ import typo.dsl.UpdateParams
 class ProductreviewRepoMock(toRow: Function1[ProductreviewRowUnsaved, ProductreviewRow],
                             map: scala.collection.mutable.Map[ProductreviewId, ProductreviewRow] = scala.collection.mutable.Map.empty) extends ProductreviewRepo {
   override def delete: DeleteBuilder[ProductreviewFields, ProductreviewRow] = {
-    DeleteBuilderMock(DeleteParams.empty, ProductreviewFields.structure.fields, map)
+    DeleteBuilderMock(DeleteParams.empty, ProductreviewFields.structure, map)
   }
   override def deleteById(productreviewid: ProductreviewId)(implicit c: Connection): Boolean = {
     map.remove(productreviewid).isDefined
@@ -72,7 +72,7 @@ class ProductreviewRepoMock(toRow: Function1[ProductreviewRowUnsaved, Productrev
     productreviewids.view.flatMap(id => byId.get(id).map(x => (id, x))).toMap
   }
   override def update: UpdateBuilder[ProductreviewFields, ProductreviewRow] = {
-    UpdateBuilderMock(UpdateParams.empty, ProductreviewFields.structure.fields, map)
+    UpdateBuilderMock(UpdateParams.empty, ProductreviewFields.structure, map)
   }
   override def update(row: ProductreviewRow)(implicit c: Connection): Boolean = {
     map.get(row.productreviewid) match {

--- a/typo-tester-anorm/generated-and-checked-in/adventureworks/production/productsubcategory/ProductsubcategoryFields.scala
+++ b/typo-tester-anorm/generated-and-checked-in/adventureworks/production/productsubcategory/ProductsubcategoryFields.scala
@@ -11,39 +11,40 @@ import adventureworks.customtypes.TypoLocalDateTime
 import adventureworks.customtypes.TypoUUID
 import adventureworks.production.productcategory.ProductcategoryId
 import adventureworks.public.Name
+import typo.dsl.Path
 import typo.dsl.SqlExpr.Field
 import typo.dsl.SqlExpr.FieldLikeNoHkt
 import typo.dsl.SqlExpr.IdField
 import typo.dsl.Structure.Relation
 
-trait ProductsubcategoryFields[Row] {
-  val productsubcategoryid: IdField[ProductsubcategoryId, Row]
-  val productcategoryid: Field[ProductcategoryId, Row]
-  val name: Field[Name, Row]
-  val rowguid: Field[TypoUUID, Row]
-  val modifieddate: Field[TypoLocalDateTime, Row]
+trait ProductsubcategoryFields {
+  def productsubcategoryid: IdField[ProductsubcategoryId, ProductsubcategoryRow]
+  def productcategoryid: Field[ProductcategoryId, ProductsubcategoryRow]
+  def name: Field[Name, ProductsubcategoryRow]
+  def rowguid: Field[TypoUUID, ProductsubcategoryRow]
+  def modifieddate: Field[TypoLocalDateTime, ProductsubcategoryRow]
 }
 
 object ProductsubcategoryFields {
-  val structure: Relation[ProductsubcategoryFields, ProductsubcategoryRow, ProductsubcategoryRow] = 
-    new Impl(None, identity, (_, x) => x)
+  lazy val structure: Relation[ProductsubcategoryFields, ProductsubcategoryRow] =
+    new Impl(Nil)
     
-  private final class Impl[Row](val prefix: Option[String], val extract: Row => ProductsubcategoryRow, val merge: (Row, ProductsubcategoryRow) => Row)
-    extends Relation[ProductsubcategoryFields, ProductsubcategoryRow, Row] { 
+  private final class Impl(val _path: List[Path])
+    extends Relation[ProductsubcategoryFields, ProductsubcategoryRow] {
   
-    override val fields: ProductsubcategoryFields[Row] = new ProductsubcategoryFields[Row] {
-      override val productsubcategoryid = new IdField[ProductsubcategoryId, Row](prefix, "productsubcategoryid", None, Some("int4"))(x => extract(x).productsubcategoryid, (row, value) => merge(row, extract(row).copy(productsubcategoryid = value)))
-      override val productcategoryid = new Field[ProductcategoryId, Row](prefix, "productcategoryid", None, Some("int4"))(x => extract(x).productcategoryid, (row, value) => merge(row, extract(row).copy(productcategoryid = value)))
-      override val name = new Field[Name, Row](prefix, "name", None, Some("varchar"))(x => extract(x).name, (row, value) => merge(row, extract(row).copy(name = value)))
-      override val rowguid = new Field[TypoUUID, Row](prefix, "rowguid", None, Some("uuid"))(x => extract(x).rowguid, (row, value) => merge(row, extract(row).copy(rowguid = value)))
-      override val modifieddate = new Field[TypoLocalDateTime, Row](prefix, "modifieddate", Some("text"), Some("timestamp"))(x => extract(x).modifieddate, (row, value) => merge(row, extract(row).copy(modifieddate = value)))
+    override lazy val fields: ProductsubcategoryFields = new ProductsubcategoryFields {
+      override def productsubcategoryid = IdField[ProductsubcategoryId, ProductsubcategoryRow](_path, "productsubcategoryid", None, Some("int4"), x => x.productsubcategoryid, (row, value) => row.copy(productsubcategoryid = value))
+      override def productcategoryid = Field[ProductcategoryId, ProductsubcategoryRow](_path, "productcategoryid", None, Some("int4"), x => x.productcategoryid, (row, value) => row.copy(productcategoryid = value))
+      override def name = Field[Name, ProductsubcategoryRow](_path, "name", None, Some("varchar"), x => x.name, (row, value) => row.copy(name = value))
+      override def rowguid = Field[TypoUUID, ProductsubcategoryRow](_path, "rowguid", None, Some("uuid"), x => x.rowguid, (row, value) => row.copy(rowguid = value))
+      override def modifieddate = Field[TypoLocalDateTime, ProductsubcategoryRow](_path, "modifieddate", Some("text"), Some("timestamp"), x => x.modifieddate, (row, value) => row.copy(modifieddate = value))
     }
   
-    override val columns: List[FieldLikeNoHkt[?, Row]] =
-      List[FieldLikeNoHkt[?, Row]](fields.productsubcategoryid, fields.productcategoryid, fields.name, fields.rowguid, fields.modifieddate)
+    override lazy val columns: List[FieldLikeNoHkt[?, ProductsubcategoryRow]] =
+      List[FieldLikeNoHkt[?, ProductsubcategoryRow]](fields.productsubcategoryid, fields.productcategoryid, fields.name, fields.rowguid, fields.modifieddate)
   
-    override def copy[NewRow](prefix: Option[String], extract: NewRow => ProductsubcategoryRow, merge: (NewRow, ProductsubcategoryRow) => NewRow): Impl[NewRow] =
-      new Impl(prefix, extract, merge)
+    override def copy(path: List[Path]): Impl =
+      new Impl(path)
   }
   
 }

--- a/typo-tester-anorm/generated-and-checked-in/adventureworks/production/productsubcategory/ProductsubcategoryRepoMock.scala
+++ b/typo-tester-anorm/generated-and-checked-in/adventureworks/production/productsubcategory/ProductsubcategoryRepoMock.scala
@@ -22,7 +22,7 @@ import typo.dsl.UpdateParams
 class ProductsubcategoryRepoMock(toRow: Function1[ProductsubcategoryRowUnsaved, ProductsubcategoryRow],
                                  map: scala.collection.mutable.Map[ProductsubcategoryId, ProductsubcategoryRow] = scala.collection.mutable.Map.empty) extends ProductsubcategoryRepo {
   override def delete: DeleteBuilder[ProductsubcategoryFields, ProductsubcategoryRow] = {
-    DeleteBuilderMock(DeleteParams.empty, ProductsubcategoryFields.structure.fields, map)
+    DeleteBuilderMock(DeleteParams.empty, ProductsubcategoryFields.structure, map)
   }
   override def deleteById(productsubcategoryid: ProductsubcategoryId)(implicit c: Connection): Boolean = {
     map.remove(productsubcategoryid).isDefined
@@ -72,7 +72,7 @@ class ProductsubcategoryRepoMock(toRow: Function1[ProductsubcategoryRowUnsaved, 
     productsubcategoryids.view.flatMap(id => byId.get(id).map(x => (id, x))).toMap
   }
   override def update: UpdateBuilder[ProductsubcategoryFields, ProductsubcategoryRow] = {
-    UpdateBuilderMock(UpdateParams.empty, ProductsubcategoryFields.structure.fields, map)
+    UpdateBuilderMock(UpdateParams.empty, ProductsubcategoryFields.structure, map)
   }
   override def update(row: ProductsubcategoryRow)(implicit c: Connection): Boolean = {
     map.get(row.productsubcategoryid) match {

--- a/typo-tester-anorm/generated-and-checked-in/adventureworks/production/scrapreason/ScrapreasonFields.scala
+++ b/typo-tester-anorm/generated-and-checked-in/adventureworks/production/scrapreason/ScrapreasonFields.scala
@@ -9,35 +9,36 @@ package scrapreason
 
 import adventureworks.customtypes.TypoLocalDateTime
 import adventureworks.public.Name
+import typo.dsl.Path
 import typo.dsl.SqlExpr.Field
 import typo.dsl.SqlExpr.FieldLikeNoHkt
 import typo.dsl.SqlExpr.IdField
 import typo.dsl.Structure.Relation
 
-trait ScrapreasonFields[Row] {
-  val scrapreasonid: IdField[ScrapreasonId, Row]
-  val name: Field[Name, Row]
-  val modifieddate: Field[TypoLocalDateTime, Row]
+trait ScrapreasonFields {
+  def scrapreasonid: IdField[ScrapreasonId, ScrapreasonRow]
+  def name: Field[Name, ScrapreasonRow]
+  def modifieddate: Field[TypoLocalDateTime, ScrapreasonRow]
 }
 
 object ScrapreasonFields {
-  val structure: Relation[ScrapreasonFields, ScrapreasonRow, ScrapreasonRow] = 
-    new Impl(None, identity, (_, x) => x)
+  lazy val structure: Relation[ScrapreasonFields, ScrapreasonRow] =
+    new Impl(Nil)
     
-  private final class Impl[Row](val prefix: Option[String], val extract: Row => ScrapreasonRow, val merge: (Row, ScrapreasonRow) => Row)
-    extends Relation[ScrapreasonFields, ScrapreasonRow, Row] { 
+  private final class Impl(val _path: List[Path])
+    extends Relation[ScrapreasonFields, ScrapreasonRow] {
   
-    override val fields: ScrapreasonFields[Row] = new ScrapreasonFields[Row] {
-      override val scrapreasonid = new IdField[ScrapreasonId, Row](prefix, "scrapreasonid", None, Some("int4"))(x => extract(x).scrapreasonid, (row, value) => merge(row, extract(row).copy(scrapreasonid = value)))
-      override val name = new Field[Name, Row](prefix, "name", None, Some("varchar"))(x => extract(x).name, (row, value) => merge(row, extract(row).copy(name = value)))
-      override val modifieddate = new Field[TypoLocalDateTime, Row](prefix, "modifieddate", Some("text"), Some("timestamp"))(x => extract(x).modifieddate, (row, value) => merge(row, extract(row).copy(modifieddate = value)))
+    override lazy val fields: ScrapreasonFields = new ScrapreasonFields {
+      override def scrapreasonid = IdField[ScrapreasonId, ScrapreasonRow](_path, "scrapreasonid", None, Some("int4"), x => x.scrapreasonid, (row, value) => row.copy(scrapreasonid = value))
+      override def name = Field[Name, ScrapreasonRow](_path, "name", None, Some("varchar"), x => x.name, (row, value) => row.copy(name = value))
+      override def modifieddate = Field[TypoLocalDateTime, ScrapreasonRow](_path, "modifieddate", Some("text"), Some("timestamp"), x => x.modifieddate, (row, value) => row.copy(modifieddate = value))
     }
   
-    override val columns: List[FieldLikeNoHkt[?, Row]] =
-      List[FieldLikeNoHkt[?, Row]](fields.scrapreasonid, fields.name, fields.modifieddate)
+    override lazy val columns: List[FieldLikeNoHkt[?, ScrapreasonRow]] =
+      List[FieldLikeNoHkt[?, ScrapreasonRow]](fields.scrapreasonid, fields.name, fields.modifieddate)
   
-    override def copy[NewRow](prefix: Option[String], extract: NewRow => ScrapreasonRow, merge: (NewRow, ScrapreasonRow) => NewRow): Impl[NewRow] =
-      new Impl(prefix, extract, merge)
+    override def copy(path: List[Path]): Impl =
+      new Impl(path)
   }
   
 }

--- a/typo-tester-anorm/generated-and-checked-in/adventureworks/production/scrapreason/ScrapreasonRepoMock.scala
+++ b/typo-tester-anorm/generated-and-checked-in/adventureworks/production/scrapreason/ScrapreasonRepoMock.scala
@@ -22,7 +22,7 @@ import typo.dsl.UpdateParams
 class ScrapreasonRepoMock(toRow: Function1[ScrapreasonRowUnsaved, ScrapreasonRow],
                           map: scala.collection.mutable.Map[ScrapreasonId, ScrapreasonRow] = scala.collection.mutable.Map.empty) extends ScrapreasonRepo {
   override def delete: DeleteBuilder[ScrapreasonFields, ScrapreasonRow] = {
-    DeleteBuilderMock(DeleteParams.empty, ScrapreasonFields.structure.fields, map)
+    DeleteBuilderMock(DeleteParams.empty, ScrapreasonFields.structure, map)
   }
   override def deleteById(scrapreasonid: ScrapreasonId)(implicit c: Connection): Boolean = {
     map.remove(scrapreasonid).isDefined
@@ -72,7 +72,7 @@ class ScrapreasonRepoMock(toRow: Function1[ScrapreasonRowUnsaved, ScrapreasonRow
     scrapreasonids.view.flatMap(id => byId.get(id).map(x => (id, x))).toMap
   }
   override def update: UpdateBuilder[ScrapreasonFields, ScrapreasonRow] = {
-    UpdateBuilderMock(UpdateParams.empty, ScrapreasonFields.structure.fields, map)
+    UpdateBuilderMock(UpdateParams.empty, ScrapreasonFields.structure, map)
   }
   override def update(row: ScrapreasonRow)(implicit c: Connection): Boolean = {
     map.get(row.scrapreasonid) match {

--- a/typo-tester-anorm/generated-and-checked-in/adventureworks/production/transactionhistory/TransactionhistoryFields.scala
+++ b/typo-tester-anorm/generated-and-checked-in/adventureworks/production/transactionhistory/TransactionhistoryFields.scala
@@ -9,47 +9,48 @@ package transactionhistory
 
 import adventureworks.customtypes.TypoLocalDateTime
 import adventureworks.production.product.ProductId
+import typo.dsl.Path
 import typo.dsl.SqlExpr.Field
 import typo.dsl.SqlExpr.FieldLikeNoHkt
 import typo.dsl.SqlExpr.IdField
 import typo.dsl.Structure.Relation
 
-trait TransactionhistoryFields[Row] {
-  val transactionid: IdField[TransactionhistoryId, Row]
-  val productid: Field[ProductId, Row]
-  val referenceorderid: Field[Int, Row]
-  val referenceorderlineid: Field[Int, Row]
-  val transactiondate: Field[TypoLocalDateTime, Row]
-  val transactiontype: Field[/* bpchar, max 1 chars */ String, Row]
-  val quantity: Field[Int, Row]
-  val actualcost: Field[BigDecimal, Row]
-  val modifieddate: Field[TypoLocalDateTime, Row]
+trait TransactionhistoryFields {
+  def transactionid: IdField[TransactionhistoryId, TransactionhistoryRow]
+  def productid: Field[ProductId, TransactionhistoryRow]
+  def referenceorderid: Field[Int, TransactionhistoryRow]
+  def referenceorderlineid: Field[Int, TransactionhistoryRow]
+  def transactiondate: Field[TypoLocalDateTime, TransactionhistoryRow]
+  def transactiontype: Field[/* bpchar, max 1 chars */ String, TransactionhistoryRow]
+  def quantity: Field[Int, TransactionhistoryRow]
+  def actualcost: Field[BigDecimal, TransactionhistoryRow]
+  def modifieddate: Field[TypoLocalDateTime, TransactionhistoryRow]
 }
 
 object TransactionhistoryFields {
-  val structure: Relation[TransactionhistoryFields, TransactionhistoryRow, TransactionhistoryRow] = 
-    new Impl(None, identity, (_, x) => x)
+  lazy val structure: Relation[TransactionhistoryFields, TransactionhistoryRow] =
+    new Impl(Nil)
     
-  private final class Impl[Row](val prefix: Option[String], val extract: Row => TransactionhistoryRow, val merge: (Row, TransactionhistoryRow) => Row)
-    extends Relation[TransactionhistoryFields, TransactionhistoryRow, Row] { 
+  private final class Impl(val _path: List[Path])
+    extends Relation[TransactionhistoryFields, TransactionhistoryRow] {
   
-    override val fields: TransactionhistoryFields[Row] = new TransactionhistoryFields[Row] {
-      override val transactionid = new IdField[TransactionhistoryId, Row](prefix, "transactionid", None, Some("int4"))(x => extract(x).transactionid, (row, value) => merge(row, extract(row).copy(transactionid = value)))
-      override val productid = new Field[ProductId, Row](prefix, "productid", None, Some("int4"))(x => extract(x).productid, (row, value) => merge(row, extract(row).copy(productid = value)))
-      override val referenceorderid = new Field[Int, Row](prefix, "referenceorderid", None, Some("int4"))(x => extract(x).referenceorderid, (row, value) => merge(row, extract(row).copy(referenceorderid = value)))
-      override val referenceorderlineid = new Field[Int, Row](prefix, "referenceorderlineid", None, Some("int4"))(x => extract(x).referenceorderlineid, (row, value) => merge(row, extract(row).copy(referenceorderlineid = value)))
-      override val transactiondate = new Field[TypoLocalDateTime, Row](prefix, "transactiondate", Some("text"), Some("timestamp"))(x => extract(x).transactiondate, (row, value) => merge(row, extract(row).copy(transactiondate = value)))
-      override val transactiontype = new Field[/* bpchar, max 1 chars */ String, Row](prefix, "transactiontype", None, Some("bpchar"))(x => extract(x).transactiontype, (row, value) => merge(row, extract(row).copy(transactiontype = value)))
-      override val quantity = new Field[Int, Row](prefix, "quantity", None, Some("int4"))(x => extract(x).quantity, (row, value) => merge(row, extract(row).copy(quantity = value)))
-      override val actualcost = new Field[BigDecimal, Row](prefix, "actualcost", None, Some("numeric"))(x => extract(x).actualcost, (row, value) => merge(row, extract(row).copy(actualcost = value)))
-      override val modifieddate = new Field[TypoLocalDateTime, Row](prefix, "modifieddate", Some("text"), Some("timestamp"))(x => extract(x).modifieddate, (row, value) => merge(row, extract(row).copy(modifieddate = value)))
+    override lazy val fields: TransactionhistoryFields = new TransactionhistoryFields {
+      override def transactionid = IdField[TransactionhistoryId, TransactionhistoryRow](_path, "transactionid", None, Some("int4"), x => x.transactionid, (row, value) => row.copy(transactionid = value))
+      override def productid = Field[ProductId, TransactionhistoryRow](_path, "productid", None, Some("int4"), x => x.productid, (row, value) => row.copy(productid = value))
+      override def referenceorderid = Field[Int, TransactionhistoryRow](_path, "referenceorderid", None, Some("int4"), x => x.referenceorderid, (row, value) => row.copy(referenceorderid = value))
+      override def referenceorderlineid = Field[Int, TransactionhistoryRow](_path, "referenceorderlineid", None, Some("int4"), x => x.referenceorderlineid, (row, value) => row.copy(referenceorderlineid = value))
+      override def transactiondate = Field[TypoLocalDateTime, TransactionhistoryRow](_path, "transactiondate", Some("text"), Some("timestamp"), x => x.transactiondate, (row, value) => row.copy(transactiondate = value))
+      override def transactiontype = Field[/* bpchar, max 1 chars */ String, TransactionhistoryRow](_path, "transactiontype", None, Some("bpchar"), x => x.transactiontype, (row, value) => row.copy(transactiontype = value))
+      override def quantity = Field[Int, TransactionhistoryRow](_path, "quantity", None, Some("int4"), x => x.quantity, (row, value) => row.copy(quantity = value))
+      override def actualcost = Field[BigDecimal, TransactionhistoryRow](_path, "actualcost", None, Some("numeric"), x => x.actualcost, (row, value) => row.copy(actualcost = value))
+      override def modifieddate = Field[TypoLocalDateTime, TransactionhistoryRow](_path, "modifieddate", Some("text"), Some("timestamp"), x => x.modifieddate, (row, value) => row.copy(modifieddate = value))
     }
   
-    override val columns: List[FieldLikeNoHkt[?, Row]] =
-      List[FieldLikeNoHkt[?, Row]](fields.transactionid, fields.productid, fields.referenceorderid, fields.referenceorderlineid, fields.transactiondate, fields.transactiontype, fields.quantity, fields.actualcost, fields.modifieddate)
+    override lazy val columns: List[FieldLikeNoHkt[?, TransactionhistoryRow]] =
+      List[FieldLikeNoHkt[?, TransactionhistoryRow]](fields.transactionid, fields.productid, fields.referenceorderid, fields.referenceorderlineid, fields.transactiondate, fields.transactiontype, fields.quantity, fields.actualcost, fields.modifieddate)
   
-    override def copy[NewRow](prefix: Option[String], extract: NewRow => TransactionhistoryRow, merge: (NewRow, TransactionhistoryRow) => NewRow): Impl[NewRow] =
-      new Impl(prefix, extract, merge)
+    override def copy(path: List[Path]): Impl =
+      new Impl(path)
   }
   
 }

--- a/typo-tester-anorm/generated-and-checked-in/adventureworks/production/transactionhistory/TransactionhistoryRepoMock.scala
+++ b/typo-tester-anorm/generated-and-checked-in/adventureworks/production/transactionhistory/TransactionhistoryRepoMock.scala
@@ -22,7 +22,7 @@ import typo.dsl.UpdateParams
 class TransactionhistoryRepoMock(toRow: Function1[TransactionhistoryRowUnsaved, TransactionhistoryRow],
                                  map: scala.collection.mutable.Map[TransactionhistoryId, TransactionhistoryRow] = scala.collection.mutable.Map.empty) extends TransactionhistoryRepo {
   override def delete: DeleteBuilder[TransactionhistoryFields, TransactionhistoryRow] = {
-    DeleteBuilderMock(DeleteParams.empty, TransactionhistoryFields.structure.fields, map)
+    DeleteBuilderMock(DeleteParams.empty, TransactionhistoryFields.structure, map)
   }
   override def deleteById(transactionid: TransactionhistoryId)(implicit c: Connection): Boolean = {
     map.remove(transactionid).isDefined
@@ -72,7 +72,7 @@ class TransactionhistoryRepoMock(toRow: Function1[TransactionhistoryRowUnsaved, 
     transactionids.view.flatMap(id => byId.get(id).map(x => (id, x))).toMap
   }
   override def update: UpdateBuilder[TransactionhistoryFields, TransactionhistoryRow] = {
-    UpdateBuilderMock(UpdateParams.empty, TransactionhistoryFields.structure.fields, map)
+    UpdateBuilderMock(UpdateParams.empty, TransactionhistoryFields.structure, map)
   }
   override def update(row: TransactionhistoryRow)(implicit c: Connection): Boolean = {
     map.get(row.transactionid) match {

--- a/typo-tester-anorm/generated-and-checked-in/adventureworks/production/transactionhistoryarchive/TransactionhistoryarchiveFields.scala
+++ b/typo-tester-anorm/generated-and-checked-in/adventureworks/production/transactionhistoryarchive/TransactionhistoryarchiveFields.scala
@@ -8,47 +8,48 @@ package production
 package transactionhistoryarchive
 
 import adventureworks.customtypes.TypoLocalDateTime
+import typo.dsl.Path
 import typo.dsl.SqlExpr.Field
 import typo.dsl.SqlExpr.FieldLikeNoHkt
 import typo.dsl.SqlExpr.IdField
 import typo.dsl.Structure.Relation
 
-trait TransactionhistoryarchiveFields[Row] {
-  val transactionid: IdField[TransactionhistoryarchiveId, Row]
-  val productid: Field[Int, Row]
-  val referenceorderid: Field[Int, Row]
-  val referenceorderlineid: Field[Int, Row]
-  val transactiondate: Field[TypoLocalDateTime, Row]
-  val transactiontype: Field[/* bpchar, max 1 chars */ String, Row]
-  val quantity: Field[Int, Row]
-  val actualcost: Field[BigDecimal, Row]
-  val modifieddate: Field[TypoLocalDateTime, Row]
+trait TransactionhistoryarchiveFields {
+  def transactionid: IdField[TransactionhistoryarchiveId, TransactionhistoryarchiveRow]
+  def productid: Field[Int, TransactionhistoryarchiveRow]
+  def referenceorderid: Field[Int, TransactionhistoryarchiveRow]
+  def referenceorderlineid: Field[Int, TransactionhistoryarchiveRow]
+  def transactiondate: Field[TypoLocalDateTime, TransactionhistoryarchiveRow]
+  def transactiontype: Field[/* bpchar, max 1 chars */ String, TransactionhistoryarchiveRow]
+  def quantity: Field[Int, TransactionhistoryarchiveRow]
+  def actualcost: Field[BigDecimal, TransactionhistoryarchiveRow]
+  def modifieddate: Field[TypoLocalDateTime, TransactionhistoryarchiveRow]
 }
 
 object TransactionhistoryarchiveFields {
-  val structure: Relation[TransactionhistoryarchiveFields, TransactionhistoryarchiveRow, TransactionhistoryarchiveRow] = 
-    new Impl(None, identity, (_, x) => x)
+  lazy val structure: Relation[TransactionhistoryarchiveFields, TransactionhistoryarchiveRow] =
+    new Impl(Nil)
     
-  private final class Impl[Row](val prefix: Option[String], val extract: Row => TransactionhistoryarchiveRow, val merge: (Row, TransactionhistoryarchiveRow) => Row)
-    extends Relation[TransactionhistoryarchiveFields, TransactionhistoryarchiveRow, Row] { 
+  private final class Impl(val _path: List[Path])
+    extends Relation[TransactionhistoryarchiveFields, TransactionhistoryarchiveRow] {
   
-    override val fields: TransactionhistoryarchiveFields[Row] = new TransactionhistoryarchiveFields[Row] {
-      override val transactionid = new IdField[TransactionhistoryarchiveId, Row](prefix, "transactionid", None, Some("int4"))(x => extract(x).transactionid, (row, value) => merge(row, extract(row).copy(transactionid = value)))
-      override val productid = new Field[Int, Row](prefix, "productid", None, Some("int4"))(x => extract(x).productid, (row, value) => merge(row, extract(row).copy(productid = value)))
-      override val referenceorderid = new Field[Int, Row](prefix, "referenceorderid", None, Some("int4"))(x => extract(x).referenceorderid, (row, value) => merge(row, extract(row).copy(referenceorderid = value)))
-      override val referenceorderlineid = new Field[Int, Row](prefix, "referenceorderlineid", None, Some("int4"))(x => extract(x).referenceorderlineid, (row, value) => merge(row, extract(row).copy(referenceorderlineid = value)))
-      override val transactiondate = new Field[TypoLocalDateTime, Row](prefix, "transactiondate", Some("text"), Some("timestamp"))(x => extract(x).transactiondate, (row, value) => merge(row, extract(row).copy(transactiondate = value)))
-      override val transactiontype = new Field[/* bpchar, max 1 chars */ String, Row](prefix, "transactiontype", None, Some("bpchar"))(x => extract(x).transactiontype, (row, value) => merge(row, extract(row).copy(transactiontype = value)))
-      override val quantity = new Field[Int, Row](prefix, "quantity", None, Some("int4"))(x => extract(x).quantity, (row, value) => merge(row, extract(row).copy(quantity = value)))
-      override val actualcost = new Field[BigDecimal, Row](prefix, "actualcost", None, Some("numeric"))(x => extract(x).actualcost, (row, value) => merge(row, extract(row).copy(actualcost = value)))
-      override val modifieddate = new Field[TypoLocalDateTime, Row](prefix, "modifieddate", Some("text"), Some("timestamp"))(x => extract(x).modifieddate, (row, value) => merge(row, extract(row).copy(modifieddate = value)))
+    override lazy val fields: TransactionhistoryarchiveFields = new TransactionhistoryarchiveFields {
+      override def transactionid = IdField[TransactionhistoryarchiveId, TransactionhistoryarchiveRow](_path, "transactionid", None, Some("int4"), x => x.transactionid, (row, value) => row.copy(transactionid = value))
+      override def productid = Field[Int, TransactionhistoryarchiveRow](_path, "productid", None, Some("int4"), x => x.productid, (row, value) => row.copy(productid = value))
+      override def referenceorderid = Field[Int, TransactionhistoryarchiveRow](_path, "referenceorderid", None, Some("int4"), x => x.referenceorderid, (row, value) => row.copy(referenceorderid = value))
+      override def referenceorderlineid = Field[Int, TransactionhistoryarchiveRow](_path, "referenceorderlineid", None, Some("int4"), x => x.referenceorderlineid, (row, value) => row.copy(referenceorderlineid = value))
+      override def transactiondate = Field[TypoLocalDateTime, TransactionhistoryarchiveRow](_path, "transactiondate", Some("text"), Some("timestamp"), x => x.transactiondate, (row, value) => row.copy(transactiondate = value))
+      override def transactiontype = Field[/* bpchar, max 1 chars */ String, TransactionhistoryarchiveRow](_path, "transactiontype", None, Some("bpchar"), x => x.transactiontype, (row, value) => row.copy(transactiontype = value))
+      override def quantity = Field[Int, TransactionhistoryarchiveRow](_path, "quantity", None, Some("int4"), x => x.quantity, (row, value) => row.copy(quantity = value))
+      override def actualcost = Field[BigDecimal, TransactionhistoryarchiveRow](_path, "actualcost", None, Some("numeric"), x => x.actualcost, (row, value) => row.copy(actualcost = value))
+      override def modifieddate = Field[TypoLocalDateTime, TransactionhistoryarchiveRow](_path, "modifieddate", Some("text"), Some("timestamp"), x => x.modifieddate, (row, value) => row.copy(modifieddate = value))
     }
   
-    override val columns: List[FieldLikeNoHkt[?, Row]] =
-      List[FieldLikeNoHkt[?, Row]](fields.transactionid, fields.productid, fields.referenceorderid, fields.referenceorderlineid, fields.transactiondate, fields.transactiontype, fields.quantity, fields.actualcost, fields.modifieddate)
+    override lazy val columns: List[FieldLikeNoHkt[?, TransactionhistoryarchiveRow]] =
+      List[FieldLikeNoHkt[?, TransactionhistoryarchiveRow]](fields.transactionid, fields.productid, fields.referenceorderid, fields.referenceorderlineid, fields.transactiondate, fields.transactiontype, fields.quantity, fields.actualcost, fields.modifieddate)
   
-    override def copy[NewRow](prefix: Option[String], extract: NewRow => TransactionhistoryarchiveRow, merge: (NewRow, TransactionhistoryarchiveRow) => NewRow): Impl[NewRow] =
-      new Impl(prefix, extract, merge)
+    override def copy(path: List[Path]): Impl =
+      new Impl(path)
   }
   
 }

--- a/typo-tester-anorm/generated-and-checked-in/adventureworks/production/transactionhistoryarchive/TransactionhistoryarchiveRepoMock.scala
+++ b/typo-tester-anorm/generated-and-checked-in/adventureworks/production/transactionhistoryarchive/TransactionhistoryarchiveRepoMock.scala
@@ -22,7 +22,7 @@ import typo.dsl.UpdateParams
 class TransactionhistoryarchiveRepoMock(toRow: Function1[TransactionhistoryarchiveRowUnsaved, TransactionhistoryarchiveRow],
                                         map: scala.collection.mutable.Map[TransactionhistoryarchiveId, TransactionhistoryarchiveRow] = scala.collection.mutable.Map.empty) extends TransactionhistoryarchiveRepo {
   override def delete: DeleteBuilder[TransactionhistoryarchiveFields, TransactionhistoryarchiveRow] = {
-    DeleteBuilderMock(DeleteParams.empty, TransactionhistoryarchiveFields.structure.fields, map)
+    DeleteBuilderMock(DeleteParams.empty, TransactionhistoryarchiveFields.structure, map)
   }
   override def deleteById(transactionid: TransactionhistoryarchiveId)(implicit c: Connection): Boolean = {
     map.remove(transactionid).isDefined
@@ -72,7 +72,7 @@ class TransactionhistoryarchiveRepoMock(toRow: Function1[Transactionhistoryarchi
     transactionids.view.flatMap(id => byId.get(id).map(x => (id, x))).toMap
   }
   override def update: UpdateBuilder[TransactionhistoryarchiveFields, TransactionhistoryarchiveRow] = {
-    UpdateBuilderMock(UpdateParams.empty, TransactionhistoryarchiveFields.structure.fields, map)
+    UpdateBuilderMock(UpdateParams.empty, TransactionhistoryarchiveFields.structure, map)
   }
   override def update(row: TransactionhistoryarchiveRow)(implicit c: Connection): Boolean = {
     map.get(row.transactionid) match {

--- a/typo-tester-anorm/generated-and-checked-in/adventureworks/production/unitmeasure/UnitmeasureFields.scala
+++ b/typo-tester-anorm/generated-and-checked-in/adventureworks/production/unitmeasure/UnitmeasureFields.scala
@@ -9,35 +9,36 @@ package unitmeasure
 
 import adventureworks.customtypes.TypoLocalDateTime
 import adventureworks.public.Name
+import typo.dsl.Path
 import typo.dsl.SqlExpr.Field
 import typo.dsl.SqlExpr.FieldLikeNoHkt
 import typo.dsl.SqlExpr.IdField
 import typo.dsl.Structure.Relation
 
-trait UnitmeasureFields[Row] {
-  val unitmeasurecode: IdField[UnitmeasureId, Row]
-  val name: Field[Name, Row]
-  val modifieddate: Field[TypoLocalDateTime, Row]
+trait UnitmeasureFields {
+  def unitmeasurecode: IdField[UnitmeasureId, UnitmeasureRow]
+  def name: Field[Name, UnitmeasureRow]
+  def modifieddate: Field[TypoLocalDateTime, UnitmeasureRow]
 }
 
 object UnitmeasureFields {
-  val structure: Relation[UnitmeasureFields, UnitmeasureRow, UnitmeasureRow] = 
-    new Impl(None, identity, (_, x) => x)
+  lazy val structure: Relation[UnitmeasureFields, UnitmeasureRow] =
+    new Impl(Nil)
     
-  private final class Impl[Row](val prefix: Option[String], val extract: Row => UnitmeasureRow, val merge: (Row, UnitmeasureRow) => Row)
-    extends Relation[UnitmeasureFields, UnitmeasureRow, Row] { 
+  private final class Impl(val _path: List[Path])
+    extends Relation[UnitmeasureFields, UnitmeasureRow] {
   
-    override val fields: UnitmeasureFields[Row] = new UnitmeasureFields[Row] {
-      override val unitmeasurecode = new IdField[UnitmeasureId, Row](prefix, "unitmeasurecode", None, Some("bpchar"))(x => extract(x).unitmeasurecode, (row, value) => merge(row, extract(row).copy(unitmeasurecode = value)))
-      override val name = new Field[Name, Row](prefix, "name", None, Some("varchar"))(x => extract(x).name, (row, value) => merge(row, extract(row).copy(name = value)))
-      override val modifieddate = new Field[TypoLocalDateTime, Row](prefix, "modifieddate", Some("text"), Some("timestamp"))(x => extract(x).modifieddate, (row, value) => merge(row, extract(row).copy(modifieddate = value)))
+    override lazy val fields: UnitmeasureFields = new UnitmeasureFields {
+      override def unitmeasurecode = IdField[UnitmeasureId, UnitmeasureRow](_path, "unitmeasurecode", None, Some("bpchar"), x => x.unitmeasurecode, (row, value) => row.copy(unitmeasurecode = value))
+      override def name = Field[Name, UnitmeasureRow](_path, "name", None, Some("varchar"), x => x.name, (row, value) => row.copy(name = value))
+      override def modifieddate = Field[TypoLocalDateTime, UnitmeasureRow](_path, "modifieddate", Some("text"), Some("timestamp"), x => x.modifieddate, (row, value) => row.copy(modifieddate = value))
     }
   
-    override val columns: List[FieldLikeNoHkt[?, Row]] =
-      List[FieldLikeNoHkt[?, Row]](fields.unitmeasurecode, fields.name, fields.modifieddate)
+    override lazy val columns: List[FieldLikeNoHkt[?, UnitmeasureRow]] =
+      List[FieldLikeNoHkt[?, UnitmeasureRow]](fields.unitmeasurecode, fields.name, fields.modifieddate)
   
-    override def copy[NewRow](prefix: Option[String], extract: NewRow => UnitmeasureRow, merge: (NewRow, UnitmeasureRow) => NewRow): Impl[NewRow] =
-      new Impl(prefix, extract, merge)
+    override def copy(path: List[Path]): Impl =
+      new Impl(path)
   }
   
 }

--- a/typo-tester-anorm/generated-and-checked-in/adventureworks/production/unitmeasure/UnitmeasureRepoMock.scala
+++ b/typo-tester-anorm/generated-and-checked-in/adventureworks/production/unitmeasure/UnitmeasureRepoMock.scala
@@ -22,7 +22,7 @@ import typo.dsl.UpdateParams
 class UnitmeasureRepoMock(toRow: Function1[UnitmeasureRowUnsaved, UnitmeasureRow],
                           map: scala.collection.mutable.Map[UnitmeasureId, UnitmeasureRow] = scala.collection.mutable.Map.empty) extends UnitmeasureRepo {
   override def delete: DeleteBuilder[UnitmeasureFields, UnitmeasureRow] = {
-    DeleteBuilderMock(DeleteParams.empty, UnitmeasureFields.structure.fields, map)
+    DeleteBuilderMock(DeleteParams.empty, UnitmeasureFields.structure, map)
   }
   override def deleteById(unitmeasurecode: UnitmeasureId)(implicit c: Connection): Boolean = {
     map.remove(unitmeasurecode).isDefined
@@ -72,7 +72,7 @@ class UnitmeasureRepoMock(toRow: Function1[UnitmeasureRowUnsaved, UnitmeasureRow
     unitmeasurecodes.view.flatMap(id => byId.get(id).map(x => (id, x))).toMap
   }
   override def update: UpdateBuilder[UnitmeasureFields, UnitmeasureRow] = {
-    UpdateBuilderMock(UpdateParams.empty, UnitmeasureFields.structure.fields, map)
+    UpdateBuilderMock(UpdateParams.empty, UnitmeasureFields.structure, map)
   }
   override def update(row: UnitmeasureRow)(implicit c: Connection): Boolean = {
     map.get(row.unitmeasurecode) match {

--- a/typo-tester-anorm/generated-and-checked-in/adventureworks/production/vproductanddescription/VproductanddescriptionMVFields.scala
+++ b/typo-tester-anorm/generated-and-checked-in/adventureworks/production/vproductanddescription/VproductanddescriptionMVFields.scala
@@ -10,38 +10,39 @@ package vproductanddescription
 import adventureworks.production.culture.CultureId
 import adventureworks.production.product.ProductId
 import adventureworks.public.Name
+import typo.dsl.Path
 import typo.dsl.SqlExpr.Field
 import typo.dsl.SqlExpr.FieldLikeNoHkt
 import typo.dsl.Structure.Relation
 
-trait VproductanddescriptionMVFields[Row] {
-  val productid: Field[ProductId, Row]
-  val name: Field[Name, Row]
-  val productmodel: Field[Name, Row]
-  val cultureid: Field[CultureId, Row]
-  val description: Field[/* max 400 chars */ String, Row]
+trait VproductanddescriptionMVFields {
+  def productid: Field[ProductId, VproductanddescriptionMVRow]
+  def name: Field[Name, VproductanddescriptionMVRow]
+  def productmodel: Field[Name, VproductanddescriptionMVRow]
+  def cultureid: Field[CultureId, VproductanddescriptionMVRow]
+  def description: Field[/* max 400 chars */ String, VproductanddescriptionMVRow]
 }
 
 object VproductanddescriptionMVFields {
-  val structure: Relation[VproductanddescriptionMVFields, VproductanddescriptionMVRow, VproductanddescriptionMVRow] = 
-    new Impl(None, identity, (_, x) => x)
+  lazy val structure: Relation[VproductanddescriptionMVFields, VproductanddescriptionMVRow] =
+    new Impl(Nil)
     
-  private final class Impl[Row](val prefix: Option[String], val extract: Row => VproductanddescriptionMVRow, val merge: (Row, VproductanddescriptionMVRow) => Row)
-    extends Relation[VproductanddescriptionMVFields, VproductanddescriptionMVRow, Row] { 
+  private final class Impl(val _path: List[Path])
+    extends Relation[VproductanddescriptionMVFields, VproductanddescriptionMVRow] {
   
-    override val fields: VproductanddescriptionMVFields[Row] = new VproductanddescriptionMVFields[Row] {
-      override val productid = new Field[ProductId, Row](prefix, "productid", None, None)(x => extract(x).productid, (row, value) => merge(row, extract(row).copy(productid = value)))
-      override val name = new Field[Name, Row](prefix, "name", None, None)(x => extract(x).name, (row, value) => merge(row, extract(row).copy(name = value)))
-      override val productmodel = new Field[Name, Row](prefix, "productmodel", None, None)(x => extract(x).productmodel, (row, value) => merge(row, extract(row).copy(productmodel = value)))
-      override val cultureid = new Field[CultureId, Row](prefix, "cultureid", None, None)(x => extract(x).cultureid, (row, value) => merge(row, extract(row).copy(cultureid = value)))
-      override val description = new Field[/* max 400 chars */ String, Row](prefix, "description", None, None)(x => extract(x).description, (row, value) => merge(row, extract(row).copy(description = value)))
+    override lazy val fields: VproductanddescriptionMVFields = new VproductanddescriptionMVFields {
+      override def productid = Field[ProductId, VproductanddescriptionMVRow](_path, "productid", None, None, x => x.productid, (row, value) => row.copy(productid = value))
+      override def name = Field[Name, VproductanddescriptionMVRow](_path, "name", None, None, x => x.name, (row, value) => row.copy(name = value))
+      override def productmodel = Field[Name, VproductanddescriptionMVRow](_path, "productmodel", None, None, x => x.productmodel, (row, value) => row.copy(productmodel = value))
+      override def cultureid = Field[CultureId, VproductanddescriptionMVRow](_path, "cultureid", None, None, x => x.cultureid, (row, value) => row.copy(cultureid = value))
+      override def description = Field[/* max 400 chars */ String, VproductanddescriptionMVRow](_path, "description", None, None, x => x.description, (row, value) => row.copy(description = value))
     }
   
-    override val columns: List[FieldLikeNoHkt[?, Row]] =
-      List[FieldLikeNoHkt[?, Row]](fields.productid, fields.name, fields.productmodel, fields.cultureid, fields.description)
+    override lazy val columns: List[FieldLikeNoHkt[?, VproductanddescriptionMVRow]] =
+      List[FieldLikeNoHkt[?, VproductanddescriptionMVRow]](fields.productid, fields.name, fields.productmodel, fields.cultureid, fields.description)
   
-    override def copy[NewRow](prefix: Option[String], extract: NewRow => VproductanddescriptionMVRow, merge: (NewRow, VproductanddescriptionMVRow) => NewRow): Impl[NewRow] =
-      new Impl(prefix, extract, merge)
+    override def copy(path: List[Path]): Impl =
+      new Impl(path)
   }
   
 }

--- a/typo-tester-anorm/generated-and-checked-in/adventureworks/production/vproductmodelcatalogdescription/VproductmodelcatalogdescriptionViewFields.scala
+++ b/typo-tester-anorm/generated-and-checked-in/adventureworks/production/vproductmodelcatalogdescription/VproductmodelcatalogdescriptionViewFields.scala
@@ -11,79 +11,80 @@ import adventureworks.customtypes.TypoLocalDateTime
 import adventureworks.customtypes.TypoUUID
 import adventureworks.production.productmodel.ProductmodelId
 import adventureworks.public.Name
+import typo.dsl.Path
 import typo.dsl.SqlExpr.Field
 import typo.dsl.SqlExpr.FieldLikeNoHkt
 import typo.dsl.SqlExpr.OptField
 import typo.dsl.Structure.Relation
 
-trait VproductmodelcatalogdescriptionViewFields[Row] {
-  val productmodelid: Field[ProductmodelId, Row]
-  val name: Field[Name, Row]
-  val Summary: OptField[String, Row]
-  val manufacturer: OptField[String, Row]
-  val copyright: OptField[/* max 30 chars */ String, Row]
-  val producturl: OptField[/* max 256 chars */ String, Row]
-  val warrantyperiod: OptField[/* max 256 chars */ String, Row]
-  val warrantydescription: OptField[/* max 256 chars */ String, Row]
-  val noofyears: OptField[/* max 256 chars */ String, Row]
-  val maintenancedescription: OptField[/* max 256 chars */ String, Row]
-  val wheel: OptField[/* max 256 chars */ String, Row]
-  val saddle: OptField[/* max 256 chars */ String, Row]
-  val pedal: OptField[/* max 256 chars */ String, Row]
-  val bikeframe: OptField[String, Row]
-  val crankset: OptField[/* max 256 chars */ String, Row]
-  val pictureangle: OptField[/* max 256 chars */ String, Row]
-  val picturesize: OptField[/* max 256 chars */ String, Row]
-  val productphotoid: OptField[/* max 256 chars */ String, Row]
-  val material: OptField[/* max 256 chars */ String, Row]
-  val color: OptField[/* max 256 chars */ String, Row]
-  val productline: OptField[/* max 256 chars */ String, Row]
-  val style: OptField[/* max 256 chars */ String, Row]
-  val riderexperience: OptField[/* max 1024 chars */ String, Row]
-  val rowguid: Field[TypoUUID, Row]
-  val modifieddate: Field[TypoLocalDateTime, Row]
+trait VproductmodelcatalogdescriptionViewFields {
+  def productmodelid: Field[ProductmodelId, VproductmodelcatalogdescriptionViewRow]
+  def name: Field[Name, VproductmodelcatalogdescriptionViewRow]
+  def Summary: OptField[String, VproductmodelcatalogdescriptionViewRow]
+  def manufacturer: OptField[String, VproductmodelcatalogdescriptionViewRow]
+  def copyright: OptField[/* max 30 chars */ String, VproductmodelcatalogdescriptionViewRow]
+  def producturl: OptField[/* max 256 chars */ String, VproductmodelcatalogdescriptionViewRow]
+  def warrantyperiod: OptField[/* max 256 chars */ String, VproductmodelcatalogdescriptionViewRow]
+  def warrantydescription: OptField[/* max 256 chars */ String, VproductmodelcatalogdescriptionViewRow]
+  def noofyears: OptField[/* max 256 chars */ String, VproductmodelcatalogdescriptionViewRow]
+  def maintenancedescription: OptField[/* max 256 chars */ String, VproductmodelcatalogdescriptionViewRow]
+  def wheel: OptField[/* max 256 chars */ String, VproductmodelcatalogdescriptionViewRow]
+  def saddle: OptField[/* max 256 chars */ String, VproductmodelcatalogdescriptionViewRow]
+  def pedal: OptField[/* max 256 chars */ String, VproductmodelcatalogdescriptionViewRow]
+  def bikeframe: OptField[String, VproductmodelcatalogdescriptionViewRow]
+  def crankset: OptField[/* max 256 chars */ String, VproductmodelcatalogdescriptionViewRow]
+  def pictureangle: OptField[/* max 256 chars */ String, VproductmodelcatalogdescriptionViewRow]
+  def picturesize: OptField[/* max 256 chars */ String, VproductmodelcatalogdescriptionViewRow]
+  def productphotoid: OptField[/* max 256 chars */ String, VproductmodelcatalogdescriptionViewRow]
+  def material: OptField[/* max 256 chars */ String, VproductmodelcatalogdescriptionViewRow]
+  def color: OptField[/* max 256 chars */ String, VproductmodelcatalogdescriptionViewRow]
+  def productline: OptField[/* max 256 chars */ String, VproductmodelcatalogdescriptionViewRow]
+  def style: OptField[/* max 256 chars */ String, VproductmodelcatalogdescriptionViewRow]
+  def riderexperience: OptField[/* max 1024 chars */ String, VproductmodelcatalogdescriptionViewRow]
+  def rowguid: Field[TypoUUID, VproductmodelcatalogdescriptionViewRow]
+  def modifieddate: Field[TypoLocalDateTime, VproductmodelcatalogdescriptionViewRow]
 }
 
 object VproductmodelcatalogdescriptionViewFields {
-  val structure: Relation[VproductmodelcatalogdescriptionViewFields, VproductmodelcatalogdescriptionViewRow, VproductmodelcatalogdescriptionViewRow] = 
-    new Impl(None, identity, (_, x) => x)
+  lazy val structure: Relation[VproductmodelcatalogdescriptionViewFields, VproductmodelcatalogdescriptionViewRow] =
+    new Impl(Nil)
     
-  private final class Impl[Row](val prefix: Option[String], val extract: Row => VproductmodelcatalogdescriptionViewRow, val merge: (Row, VproductmodelcatalogdescriptionViewRow) => Row)
-    extends Relation[VproductmodelcatalogdescriptionViewFields, VproductmodelcatalogdescriptionViewRow, Row] { 
+  private final class Impl(val _path: List[Path])
+    extends Relation[VproductmodelcatalogdescriptionViewFields, VproductmodelcatalogdescriptionViewRow] {
   
-    override val fields: VproductmodelcatalogdescriptionViewFields[Row] = new VproductmodelcatalogdescriptionViewFields[Row] {
-      override val productmodelid = new Field[ProductmodelId, Row](prefix, "productmodelid", None, None)(x => extract(x).productmodelid, (row, value) => merge(row, extract(row).copy(productmodelid = value)))
-      override val name = new Field[Name, Row](prefix, "name", None, None)(x => extract(x).name, (row, value) => merge(row, extract(row).copy(name = value)))
-      override val Summary = new OptField[String, Row](prefix, "Summary", None, None)(x => extract(x).Summary, (row, value) => merge(row, extract(row).copy(Summary = value)))
-      override val manufacturer = new OptField[String, Row](prefix, "manufacturer", None, None)(x => extract(x).manufacturer, (row, value) => merge(row, extract(row).copy(manufacturer = value)))
-      override val copyright = new OptField[/* max 30 chars */ String, Row](prefix, "copyright", None, None)(x => extract(x).copyright, (row, value) => merge(row, extract(row).copy(copyright = value)))
-      override val producturl = new OptField[/* max 256 chars */ String, Row](prefix, "producturl", None, None)(x => extract(x).producturl, (row, value) => merge(row, extract(row).copy(producturl = value)))
-      override val warrantyperiod = new OptField[/* max 256 chars */ String, Row](prefix, "warrantyperiod", None, None)(x => extract(x).warrantyperiod, (row, value) => merge(row, extract(row).copy(warrantyperiod = value)))
-      override val warrantydescription = new OptField[/* max 256 chars */ String, Row](prefix, "warrantydescription", None, None)(x => extract(x).warrantydescription, (row, value) => merge(row, extract(row).copy(warrantydescription = value)))
-      override val noofyears = new OptField[/* max 256 chars */ String, Row](prefix, "noofyears", None, None)(x => extract(x).noofyears, (row, value) => merge(row, extract(row).copy(noofyears = value)))
-      override val maintenancedescription = new OptField[/* max 256 chars */ String, Row](prefix, "maintenancedescription", None, None)(x => extract(x).maintenancedescription, (row, value) => merge(row, extract(row).copy(maintenancedescription = value)))
-      override val wheel = new OptField[/* max 256 chars */ String, Row](prefix, "wheel", None, None)(x => extract(x).wheel, (row, value) => merge(row, extract(row).copy(wheel = value)))
-      override val saddle = new OptField[/* max 256 chars */ String, Row](prefix, "saddle", None, None)(x => extract(x).saddle, (row, value) => merge(row, extract(row).copy(saddle = value)))
-      override val pedal = new OptField[/* max 256 chars */ String, Row](prefix, "pedal", None, None)(x => extract(x).pedal, (row, value) => merge(row, extract(row).copy(pedal = value)))
-      override val bikeframe = new OptField[String, Row](prefix, "bikeframe", None, None)(x => extract(x).bikeframe, (row, value) => merge(row, extract(row).copy(bikeframe = value)))
-      override val crankset = new OptField[/* max 256 chars */ String, Row](prefix, "crankset", None, None)(x => extract(x).crankset, (row, value) => merge(row, extract(row).copy(crankset = value)))
-      override val pictureangle = new OptField[/* max 256 chars */ String, Row](prefix, "pictureangle", None, None)(x => extract(x).pictureangle, (row, value) => merge(row, extract(row).copy(pictureangle = value)))
-      override val picturesize = new OptField[/* max 256 chars */ String, Row](prefix, "picturesize", None, None)(x => extract(x).picturesize, (row, value) => merge(row, extract(row).copy(picturesize = value)))
-      override val productphotoid = new OptField[/* max 256 chars */ String, Row](prefix, "productphotoid", None, None)(x => extract(x).productphotoid, (row, value) => merge(row, extract(row).copy(productphotoid = value)))
-      override val material = new OptField[/* max 256 chars */ String, Row](prefix, "material", None, None)(x => extract(x).material, (row, value) => merge(row, extract(row).copy(material = value)))
-      override val color = new OptField[/* max 256 chars */ String, Row](prefix, "color", None, None)(x => extract(x).color, (row, value) => merge(row, extract(row).copy(color = value)))
-      override val productline = new OptField[/* max 256 chars */ String, Row](prefix, "productline", None, None)(x => extract(x).productline, (row, value) => merge(row, extract(row).copy(productline = value)))
-      override val style = new OptField[/* max 256 chars */ String, Row](prefix, "style", None, None)(x => extract(x).style, (row, value) => merge(row, extract(row).copy(style = value)))
-      override val riderexperience = new OptField[/* max 1024 chars */ String, Row](prefix, "riderexperience", None, None)(x => extract(x).riderexperience, (row, value) => merge(row, extract(row).copy(riderexperience = value)))
-      override val rowguid = new Field[TypoUUID, Row](prefix, "rowguid", None, None)(x => extract(x).rowguid, (row, value) => merge(row, extract(row).copy(rowguid = value)))
-      override val modifieddate = new Field[TypoLocalDateTime, Row](prefix, "modifieddate", Some("text"), None)(x => extract(x).modifieddate, (row, value) => merge(row, extract(row).copy(modifieddate = value)))
+    override lazy val fields: VproductmodelcatalogdescriptionViewFields = new VproductmodelcatalogdescriptionViewFields {
+      override def productmodelid = Field[ProductmodelId, VproductmodelcatalogdescriptionViewRow](_path, "productmodelid", None, None, x => x.productmodelid, (row, value) => row.copy(productmodelid = value))
+      override def name = Field[Name, VproductmodelcatalogdescriptionViewRow](_path, "name", None, None, x => x.name, (row, value) => row.copy(name = value))
+      override def Summary = OptField[String, VproductmodelcatalogdescriptionViewRow](_path, "Summary", None, None, x => x.Summary, (row, value) => row.copy(Summary = value))
+      override def manufacturer = OptField[String, VproductmodelcatalogdescriptionViewRow](_path, "manufacturer", None, None, x => x.manufacturer, (row, value) => row.copy(manufacturer = value))
+      override def copyright = OptField[/* max 30 chars */ String, VproductmodelcatalogdescriptionViewRow](_path, "copyright", None, None, x => x.copyright, (row, value) => row.copy(copyright = value))
+      override def producturl = OptField[/* max 256 chars */ String, VproductmodelcatalogdescriptionViewRow](_path, "producturl", None, None, x => x.producturl, (row, value) => row.copy(producturl = value))
+      override def warrantyperiod = OptField[/* max 256 chars */ String, VproductmodelcatalogdescriptionViewRow](_path, "warrantyperiod", None, None, x => x.warrantyperiod, (row, value) => row.copy(warrantyperiod = value))
+      override def warrantydescription = OptField[/* max 256 chars */ String, VproductmodelcatalogdescriptionViewRow](_path, "warrantydescription", None, None, x => x.warrantydescription, (row, value) => row.copy(warrantydescription = value))
+      override def noofyears = OptField[/* max 256 chars */ String, VproductmodelcatalogdescriptionViewRow](_path, "noofyears", None, None, x => x.noofyears, (row, value) => row.copy(noofyears = value))
+      override def maintenancedescription = OptField[/* max 256 chars */ String, VproductmodelcatalogdescriptionViewRow](_path, "maintenancedescription", None, None, x => x.maintenancedescription, (row, value) => row.copy(maintenancedescription = value))
+      override def wheel = OptField[/* max 256 chars */ String, VproductmodelcatalogdescriptionViewRow](_path, "wheel", None, None, x => x.wheel, (row, value) => row.copy(wheel = value))
+      override def saddle = OptField[/* max 256 chars */ String, VproductmodelcatalogdescriptionViewRow](_path, "saddle", None, None, x => x.saddle, (row, value) => row.copy(saddle = value))
+      override def pedal = OptField[/* max 256 chars */ String, VproductmodelcatalogdescriptionViewRow](_path, "pedal", None, None, x => x.pedal, (row, value) => row.copy(pedal = value))
+      override def bikeframe = OptField[String, VproductmodelcatalogdescriptionViewRow](_path, "bikeframe", None, None, x => x.bikeframe, (row, value) => row.copy(bikeframe = value))
+      override def crankset = OptField[/* max 256 chars */ String, VproductmodelcatalogdescriptionViewRow](_path, "crankset", None, None, x => x.crankset, (row, value) => row.copy(crankset = value))
+      override def pictureangle = OptField[/* max 256 chars */ String, VproductmodelcatalogdescriptionViewRow](_path, "pictureangle", None, None, x => x.pictureangle, (row, value) => row.copy(pictureangle = value))
+      override def picturesize = OptField[/* max 256 chars */ String, VproductmodelcatalogdescriptionViewRow](_path, "picturesize", None, None, x => x.picturesize, (row, value) => row.copy(picturesize = value))
+      override def productphotoid = OptField[/* max 256 chars */ String, VproductmodelcatalogdescriptionViewRow](_path, "productphotoid", None, None, x => x.productphotoid, (row, value) => row.copy(productphotoid = value))
+      override def material = OptField[/* max 256 chars */ String, VproductmodelcatalogdescriptionViewRow](_path, "material", None, None, x => x.material, (row, value) => row.copy(material = value))
+      override def color = OptField[/* max 256 chars */ String, VproductmodelcatalogdescriptionViewRow](_path, "color", None, None, x => x.color, (row, value) => row.copy(color = value))
+      override def productline = OptField[/* max 256 chars */ String, VproductmodelcatalogdescriptionViewRow](_path, "productline", None, None, x => x.productline, (row, value) => row.copy(productline = value))
+      override def style = OptField[/* max 256 chars */ String, VproductmodelcatalogdescriptionViewRow](_path, "style", None, None, x => x.style, (row, value) => row.copy(style = value))
+      override def riderexperience = OptField[/* max 1024 chars */ String, VproductmodelcatalogdescriptionViewRow](_path, "riderexperience", None, None, x => x.riderexperience, (row, value) => row.copy(riderexperience = value))
+      override def rowguid = Field[TypoUUID, VproductmodelcatalogdescriptionViewRow](_path, "rowguid", None, None, x => x.rowguid, (row, value) => row.copy(rowguid = value))
+      override def modifieddate = Field[TypoLocalDateTime, VproductmodelcatalogdescriptionViewRow](_path, "modifieddate", Some("text"), None, x => x.modifieddate, (row, value) => row.copy(modifieddate = value))
     }
   
-    override val columns: List[FieldLikeNoHkt[?, Row]] =
-      List[FieldLikeNoHkt[?, Row]](fields.productmodelid, fields.name, fields.Summary, fields.manufacturer, fields.copyright, fields.producturl, fields.warrantyperiod, fields.warrantydescription, fields.noofyears, fields.maintenancedescription, fields.wheel, fields.saddle, fields.pedal, fields.bikeframe, fields.crankset, fields.pictureangle, fields.picturesize, fields.productphotoid, fields.material, fields.color, fields.productline, fields.style, fields.riderexperience, fields.rowguid, fields.modifieddate)
+    override lazy val columns: List[FieldLikeNoHkt[?, VproductmodelcatalogdescriptionViewRow]] =
+      List[FieldLikeNoHkt[?, VproductmodelcatalogdescriptionViewRow]](fields.productmodelid, fields.name, fields.Summary, fields.manufacturer, fields.copyright, fields.producturl, fields.warrantyperiod, fields.warrantydescription, fields.noofyears, fields.maintenancedescription, fields.wheel, fields.saddle, fields.pedal, fields.bikeframe, fields.crankset, fields.pictureangle, fields.picturesize, fields.productphotoid, fields.material, fields.color, fields.productline, fields.style, fields.riderexperience, fields.rowguid, fields.modifieddate)
   
-    override def copy[NewRow](prefix: Option[String], extract: NewRow => VproductmodelcatalogdescriptionViewRow, merge: (NewRow, VproductmodelcatalogdescriptionViewRow) => NewRow): Impl[NewRow] =
-      new Impl(prefix, extract, merge)
+    override def copy(path: List[Path]): Impl =
+      new Impl(path)
   }
   
 }

--- a/typo-tester-anorm/generated-and-checked-in/adventureworks/production/vproductmodelinstructions/VproductmodelinstructionsViewFields.scala
+++ b/typo-tester-anorm/generated-and-checked-in/adventureworks/production/vproductmodelinstructions/VproductmodelinstructionsViewFields.scala
@@ -11,51 +11,52 @@ import adventureworks.customtypes.TypoLocalDateTime
 import adventureworks.customtypes.TypoUUID
 import adventureworks.production.productmodel.ProductmodelId
 import adventureworks.public.Name
+import typo.dsl.Path
 import typo.dsl.SqlExpr.Field
 import typo.dsl.SqlExpr.FieldLikeNoHkt
 import typo.dsl.SqlExpr.OptField
 import typo.dsl.Structure.Relation
 
-trait VproductmodelinstructionsViewFields[Row] {
-  val productmodelid: Field[ProductmodelId, Row]
-  val name: Field[Name, Row]
-  val instructions: OptField[String, Row]
-  val LocationID: OptField[Int, Row]
-  val SetupHours: OptField[BigDecimal, Row]
-  val MachineHours: OptField[BigDecimal, Row]
-  val LaborHours: OptField[BigDecimal, Row]
-  val LotSize: OptField[Int, Row]
-  val Step: OptField[/* max 1024 chars */ String, Row]
-  val rowguid: Field[TypoUUID, Row]
-  val modifieddate: Field[TypoLocalDateTime, Row]
+trait VproductmodelinstructionsViewFields {
+  def productmodelid: Field[ProductmodelId, VproductmodelinstructionsViewRow]
+  def name: Field[Name, VproductmodelinstructionsViewRow]
+  def instructions: OptField[String, VproductmodelinstructionsViewRow]
+  def LocationID: OptField[Int, VproductmodelinstructionsViewRow]
+  def SetupHours: OptField[BigDecimal, VproductmodelinstructionsViewRow]
+  def MachineHours: OptField[BigDecimal, VproductmodelinstructionsViewRow]
+  def LaborHours: OptField[BigDecimal, VproductmodelinstructionsViewRow]
+  def LotSize: OptField[Int, VproductmodelinstructionsViewRow]
+  def Step: OptField[/* max 1024 chars */ String, VproductmodelinstructionsViewRow]
+  def rowguid: Field[TypoUUID, VproductmodelinstructionsViewRow]
+  def modifieddate: Field[TypoLocalDateTime, VproductmodelinstructionsViewRow]
 }
 
 object VproductmodelinstructionsViewFields {
-  val structure: Relation[VproductmodelinstructionsViewFields, VproductmodelinstructionsViewRow, VproductmodelinstructionsViewRow] = 
-    new Impl(None, identity, (_, x) => x)
+  lazy val structure: Relation[VproductmodelinstructionsViewFields, VproductmodelinstructionsViewRow] =
+    new Impl(Nil)
     
-  private final class Impl[Row](val prefix: Option[String], val extract: Row => VproductmodelinstructionsViewRow, val merge: (Row, VproductmodelinstructionsViewRow) => Row)
-    extends Relation[VproductmodelinstructionsViewFields, VproductmodelinstructionsViewRow, Row] { 
+  private final class Impl(val _path: List[Path])
+    extends Relation[VproductmodelinstructionsViewFields, VproductmodelinstructionsViewRow] {
   
-    override val fields: VproductmodelinstructionsViewFields[Row] = new VproductmodelinstructionsViewFields[Row] {
-      override val productmodelid = new Field[ProductmodelId, Row](prefix, "productmodelid", None, None)(x => extract(x).productmodelid, (row, value) => merge(row, extract(row).copy(productmodelid = value)))
-      override val name = new Field[Name, Row](prefix, "name", None, None)(x => extract(x).name, (row, value) => merge(row, extract(row).copy(name = value)))
-      override val instructions = new OptField[String, Row](prefix, "instructions", None, None)(x => extract(x).instructions, (row, value) => merge(row, extract(row).copy(instructions = value)))
-      override val LocationID = new OptField[Int, Row](prefix, "LocationID", None, None)(x => extract(x).LocationID, (row, value) => merge(row, extract(row).copy(LocationID = value)))
-      override val SetupHours = new OptField[BigDecimal, Row](prefix, "SetupHours", None, None)(x => extract(x).SetupHours, (row, value) => merge(row, extract(row).copy(SetupHours = value)))
-      override val MachineHours = new OptField[BigDecimal, Row](prefix, "MachineHours", None, None)(x => extract(x).MachineHours, (row, value) => merge(row, extract(row).copy(MachineHours = value)))
-      override val LaborHours = new OptField[BigDecimal, Row](prefix, "LaborHours", None, None)(x => extract(x).LaborHours, (row, value) => merge(row, extract(row).copy(LaborHours = value)))
-      override val LotSize = new OptField[Int, Row](prefix, "LotSize", None, None)(x => extract(x).LotSize, (row, value) => merge(row, extract(row).copy(LotSize = value)))
-      override val Step = new OptField[/* max 1024 chars */ String, Row](prefix, "Step", None, None)(x => extract(x).Step, (row, value) => merge(row, extract(row).copy(Step = value)))
-      override val rowguid = new Field[TypoUUID, Row](prefix, "rowguid", None, None)(x => extract(x).rowguid, (row, value) => merge(row, extract(row).copy(rowguid = value)))
-      override val modifieddate = new Field[TypoLocalDateTime, Row](prefix, "modifieddate", Some("text"), None)(x => extract(x).modifieddate, (row, value) => merge(row, extract(row).copy(modifieddate = value)))
+    override lazy val fields: VproductmodelinstructionsViewFields = new VproductmodelinstructionsViewFields {
+      override def productmodelid = Field[ProductmodelId, VproductmodelinstructionsViewRow](_path, "productmodelid", None, None, x => x.productmodelid, (row, value) => row.copy(productmodelid = value))
+      override def name = Field[Name, VproductmodelinstructionsViewRow](_path, "name", None, None, x => x.name, (row, value) => row.copy(name = value))
+      override def instructions = OptField[String, VproductmodelinstructionsViewRow](_path, "instructions", None, None, x => x.instructions, (row, value) => row.copy(instructions = value))
+      override def LocationID = OptField[Int, VproductmodelinstructionsViewRow](_path, "LocationID", None, None, x => x.LocationID, (row, value) => row.copy(LocationID = value))
+      override def SetupHours = OptField[BigDecimal, VproductmodelinstructionsViewRow](_path, "SetupHours", None, None, x => x.SetupHours, (row, value) => row.copy(SetupHours = value))
+      override def MachineHours = OptField[BigDecimal, VproductmodelinstructionsViewRow](_path, "MachineHours", None, None, x => x.MachineHours, (row, value) => row.copy(MachineHours = value))
+      override def LaborHours = OptField[BigDecimal, VproductmodelinstructionsViewRow](_path, "LaborHours", None, None, x => x.LaborHours, (row, value) => row.copy(LaborHours = value))
+      override def LotSize = OptField[Int, VproductmodelinstructionsViewRow](_path, "LotSize", None, None, x => x.LotSize, (row, value) => row.copy(LotSize = value))
+      override def Step = OptField[/* max 1024 chars */ String, VproductmodelinstructionsViewRow](_path, "Step", None, None, x => x.Step, (row, value) => row.copy(Step = value))
+      override def rowguid = Field[TypoUUID, VproductmodelinstructionsViewRow](_path, "rowguid", None, None, x => x.rowguid, (row, value) => row.copy(rowguid = value))
+      override def modifieddate = Field[TypoLocalDateTime, VproductmodelinstructionsViewRow](_path, "modifieddate", Some("text"), None, x => x.modifieddate, (row, value) => row.copy(modifieddate = value))
     }
   
-    override val columns: List[FieldLikeNoHkt[?, Row]] =
-      List[FieldLikeNoHkt[?, Row]](fields.productmodelid, fields.name, fields.instructions, fields.LocationID, fields.SetupHours, fields.MachineHours, fields.LaborHours, fields.LotSize, fields.Step, fields.rowguid, fields.modifieddate)
+    override lazy val columns: List[FieldLikeNoHkt[?, VproductmodelinstructionsViewRow]] =
+      List[FieldLikeNoHkt[?, VproductmodelinstructionsViewRow]](fields.productmodelid, fields.name, fields.instructions, fields.LocationID, fields.SetupHours, fields.MachineHours, fields.LaborHours, fields.LotSize, fields.Step, fields.rowguid, fields.modifieddate)
   
-    override def copy[NewRow](prefix: Option[String], extract: NewRow => VproductmodelinstructionsViewRow, merge: (NewRow, VproductmodelinstructionsViewRow) => NewRow): Impl[NewRow] =
-      new Impl(prefix, extract, merge)
+    override def copy(path: List[Path]): Impl =
+      new Impl(path)
   }
   
 }

--- a/typo-tester-anorm/generated-and-checked-in/adventureworks/production/workorder/WorkorderFields.scala
+++ b/typo-tester-anorm/generated-and-checked-in/adventureworks/production/workorder/WorkorderFields.scala
@@ -11,48 +11,49 @@ import adventureworks.customtypes.TypoLocalDateTime
 import adventureworks.customtypes.TypoShort
 import adventureworks.production.product.ProductId
 import adventureworks.production.scrapreason.ScrapreasonId
+import typo.dsl.Path
 import typo.dsl.SqlExpr.Field
 import typo.dsl.SqlExpr.FieldLikeNoHkt
 import typo.dsl.SqlExpr.IdField
 import typo.dsl.SqlExpr.OptField
 import typo.dsl.Structure.Relation
 
-trait WorkorderFields[Row] {
-  val workorderid: IdField[WorkorderId, Row]
-  val productid: Field[ProductId, Row]
-  val orderqty: Field[Int, Row]
-  val scrappedqty: Field[TypoShort, Row]
-  val startdate: Field[TypoLocalDateTime, Row]
-  val enddate: OptField[TypoLocalDateTime, Row]
-  val duedate: Field[TypoLocalDateTime, Row]
-  val scrapreasonid: OptField[ScrapreasonId, Row]
-  val modifieddate: Field[TypoLocalDateTime, Row]
+trait WorkorderFields {
+  def workorderid: IdField[WorkorderId, WorkorderRow]
+  def productid: Field[ProductId, WorkorderRow]
+  def orderqty: Field[Int, WorkorderRow]
+  def scrappedqty: Field[TypoShort, WorkorderRow]
+  def startdate: Field[TypoLocalDateTime, WorkorderRow]
+  def enddate: OptField[TypoLocalDateTime, WorkorderRow]
+  def duedate: Field[TypoLocalDateTime, WorkorderRow]
+  def scrapreasonid: OptField[ScrapreasonId, WorkorderRow]
+  def modifieddate: Field[TypoLocalDateTime, WorkorderRow]
 }
 
 object WorkorderFields {
-  val structure: Relation[WorkorderFields, WorkorderRow, WorkorderRow] = 
-    new Impl(None, identity, (_, x) => x)
+  lazy val structure: Relation[WorkorderFields, WorkorderRow] =
+    new Impl(Nil)
     
-  private final class Impl[Row](val prefix: Option[String], val extract: Row => WorkorderRow, val merge: (Row, WorkorderRow) => Row)
-    extends Relation[WorkorderFields, WorkorderRow, Row] { 
+  private final class Impl(val _path: List[Path])
+    extends Relation[WorkorderFields, WorkorderRow] {
   
-    override val fields: WorkorderFields[Row] = new WorkorderFields[Row] {
-      override val workorderid = new IdField[WorkorderId, Row](prefix, "workorderid", None, Some("int4"))(x => extract(x).workorderid, (row, value) => merge(row, extract(row).copy(workorderid = value)))
-      override val productid = new Field[ProductId, Row](prefix, "productid", None, Some("int4"))(x => extract(x).productid, (row, value) => merge(row, extract(row).copy(productid = value)))
-      override val orderqty = new Field[Int, Row](prefix, "orderqty", None, Some("int4"))(x => extract(x).orderqty, (row, value) => merge(row, extract(row).copy(orderqty = value)))
-      override val scrappedqty = new Field[TypoShort, Row](prefix, "scrappedqty", None, Some("int2"))(x => extract(x).scrappedqty, (row, value) => merge(row, extract(row).copy(scrappedqty = value)))
-      override val startdate = new Field[TypoLocalDateTime, Row](prefix, "startdate", Some("text"), Some("timestamp"))(x => extract(x).startdate, (row, value) => merge(row, extract(row).copy(startdate = value)))
-      override val enddate = new OptField[TypoLocalDateTime, Row](prefix, "enddate", Some("text"), Some("timestamp"))(x => extract(x).enddate, (row, value) => merge(row, extract(row).copy(enddate = value)))
-      override val duedate = new Field[TypoLocalDateTime, Row](prefix, "duedate", Some("text"), Some("timestamp"))(x => extract(x).duedate, (row, value) => merge(row, extract(row).copy(duedate = value)))
-      override val scrapreasonid = new OptField[ScrapreasonId, Row](prefix, "scrapreasonid", None, Some("int2"))(x => extract(x).scrapreasonid, (row, value) => merge(row, extract(row).copy(scrapreasonid = value)))
-      override val modifieddate = new Field[TypoLocalDateTime, Row](prefix, "modifieddate", Some("text"), Some("timestamp"))(x => extract(x).modifieddate, (row, value) => merge(row, extract(row).copy(modifieddate = value)))
+    override lazy val fields: WorkorderFields = new WorkorderFields {
+      override def workorderid = IdField[WorkorderId, WorkorderRow](_path, "workorderid", None, Some("int4"), x => x.workorderid, (row, value) => row.copy(workorderid = value))
+      override def productid = Field[ProductId, WorkorderRow](_path, "productid", None, Some("int4"), x => x.productid, (row, value) => row.copy(productid = value))
+      override def orderqty = Field[Int, WorkorderRow](_path, "orderqty", None, Some("int4"), x => x.orderqty, (row, value) => row.copy(orderqty = value))
+      override def scrappedqty = Field[TypoShort, WorkorderRow](_path, "scrappedqty", None, Some("int2"), x => x.scrappedqty, (row, value) => row.copy(scrappedqty = value))
+      override def startdate = Field[TypoLocalDateTime, WorkorderRow](_path, "startdate", Some("text"), Some("timestamp"), x => x.startdate, (row, value) => row.copy(startdate = value))
+      override def enddate = OptField[TypoLocalDateTime, WorkorderRow](_path, "enddate", Some("text"), Some("timestamp"), x => x.enddate, (row, value) => row.copy(enddate = value))
+      override def duedate = Field[TypoLocalDateTime, WorkorderRow](_path, "duedate", Some("text"), Some("timestamp"), x => x.duedate, (row, value) => row.copy(duedate = value))
+      override def scrapreasonid = OptField[ScrapreasonId, WorkorderRow](_path, "scrapreasonid", None, Some("int2"), x => x.scrapreasonid, (row, value) => row.copy(scrapreasonid = value))
+      override def modifieddate = Field[TypoLocalDateTime, WorkorderRow](_path, "modifieddate", Some("text"), Some("timestamp"), x => x.modifieddate, (row, value) => row.copy(modifieddate = value))
     }
   
-    override val columns: List[FieldLikeNoHkt[?, Row]] =
-      List[FieldLikeNoHkt[?, Row]](fields.workorderid, fields.productid, fields.orderqty, fields.scrappedqty, fields.startdate, fields.enddate, fields.duedate, fields.scrapreasonid, fields.modifieddate)
+    override lazy val columns: List[FieldLikeNoHkt[?, WorkorderRow]] =
+      List[FieldLikeNoHkt[?, WorkorderRow]](fields.workorderid, fields.productid, fields.orderqty, fields.scrappedqty, fields.startdate, fields.enddate, fields.duedate, fields.scrapreasonid, fields.modifieddate)
   
-    override def copy[NewRow](prefix: Option[String], extract: NewRow => WorkorderRow, merge: (NewRow, WorkorderRow) => NewRow): Impl[NewRow] =
-      new Impl(prefix, extract, merge)
+    override def copy(path: List[Path]): Impl =
+      new Impl(path)
   }
   
 }

--- a/typo-tester-anorm/generated-and-checked-in/adventureworks/production/workorder/WorkorderRepoMock.scala
+++ b/typo-tester-anorm/generated-and-checked-in/adventureworks/production/workorder/WorkorderRepoMock.scala
@@ -22,7 +22,7 @@ import typo.dsl.UpdateParams
 class WorkorderRepoMock(toRow: Function1[WorkorderRowUnsaved, WorkorderRow],
                         map: scala.collection.mutable.Map[WorkorderId, WorkorderRow] = scala.collection.mutable.Map.empty) extends WorkorderRepo {
   override def delete: DeleteBuilder[WorkorderFields, WorkorderRow] = {
-    DeleteBuilderMock(DeleteParams.empty, WorkorderFields.structure.fields, map)
+    DeleteBuilderMock(DeleteParams.empty, WorkorderFields.structure, map)
   }
   override def deleteById(workorderid: WorkorderId)(implicit c: Connection): Boolean = {
     map.remove(workorderid).isDefined
@@ -72,7 +72,7 @@ class WorkorderRepoMock(toRow: Function1[WorkorderRowUnsaved, WorkorderRow],
     workorderids.view.flatMap(id => byId.get(id).map(x => (id, x))).toMap
   }
   override def update: UpdateBuilder[WorkorderFields, WorkorderRow] = {
-    UpdateBuilderMock(UpdateParams.empty, WorkorderFields.structure.fields, map)
+    UpdateBuilderMock(UpdateParams.empty, WorkorderFields.structure, map)
   }
   override def update(row: WorkorderRow)(implicit c: Connection): Boolean = {
     map.get(row.workorderid) match {

--- a/typo-tester-anorm/generated-and-checked-in/adventureworks/production/workorderrouting/WorkorderroutingFields.scala
+++ b/typo-tester-anorm/generated-and-checked-in/adventureworks/production/workorderrouting/WorkorderroutingFields.scala
@@ -11,54 +11,55 @@ import adventureworks.customtypes.TypoLocalDateTime
 import adventureworks.customtypes.TypoShort
 import adventureworks.production.location.LocationId
 import adventureworks.production.workorder.WorkorderId
+import typo.dsl.Path
 import typo.dsl.SqlExpr.Field
 import typo.dsl.SqlExpr.FieldLikeNoHkt
 import typo.dsl.SqlExpr.IdField
 import typo.dsl.SqlExpr.OptField
 import typo.dsl.Structure.Relation
 
-trait WorkorderroutingFields[Row] {
-  val workorderid: IdField[WorkorderId, Row]
-  val productid: IdField[Int, Row]
-  val operationsequence: IdField[TypoShort, Row]
-  val locationid: Field[LocationId, Row]
-  val scheduledstartdate: Field[TypoLocalDateTime, Row]
-  val scheduledenddate: Field[TypoLocalDateTime, Row]
-  val actualstartdate: OptField[TypoLocalDateTime, Row]
-  val actualenddate: OptField[TypoLocalDateTime, Row]
-  val actualresourcehrs: OptField[BigDecimal, Row]
-  val plannedcost: Field[BigDecimal, Row]
-  val actualcost: OptField[BigDecimal, Row]
-  val modifieddate: Field[TypoLocalDateTime, Row]
+trait WorkorderroutingFields {
+  def workorderid: IdField[WorkorderId, WorkorderroutingRow]
+  def productid: IdField[Int, WorkorderroutingRow]
+  def operationsequence: IdField[TypoShort, WorkorderroutingRow]
+  def locationid: Field[LocationId, WorkorderroutingRow]
+  def scheduledstartdate: Field[TypoLocalDateTime, WorkorderroutingRow]
+  def scheduledenddate: Field[TypoLocalDateTime, WorkorderroutingRow]
+  def actualstartdate: OptField[TypoLocalDateTime, WorkorderroutingRow]
+  def actualenddate: OptField[TypoLocalDateTime, WorkorderroutingRow]
+  def actualresourcehrs: OptField[BigDecimal, WorkorderroutingRow]
+  def plannedcost: Field[BigDecimal, WorkorderroutingRow]
+  def actualcost: OptField[BigDecimal, WorkorderroutingRow]
+  def modifieddate: Field[TypoLocalDateTime, WorkorderroutingRow]
 }
 
 object WorkorderroutingFields {
-  val structure: Relation[WorkorderroutingFields, WorkorderroutingRow, WorkorderroutingRow] = 
-    new Impl(None, identity, (_, x) => x)
+  lazy val structure: Relation[WorkorderroutingFields, WorkorderroutingRow] =
+    new Impl(Nil)
     
-  private final class Impl[Row](val prefix: Option[String], val extract: Row => WorkorderroutingRow, val merge: (Row, WorkorderroutingRow) => Row)
-    extends Relation[WorkorderroutingFields, WorkorderroutingRow, Row] { 
+  private final class Impl(val _path: List[Path])
+    extends Relation[WorkorderroutingFields, WorkorderroutingRow] {
   
-    override val fields: WorkorderroutingFields[Row] = new WorkorderroutingFields[Row] {
-      override val workorderid = new IdField[WorkorderId, Row](prefix, "workorderid", None, Some("int4"))(x => extract(x).workorderid, (row, value) => merge(row, extract(row).copy(workorderid = value)))
-      override val productid = new IdField[Int, Row](prefix, "productid", None, Some("int4"))(x => extract(x).productid, (row, value) => merge(row, extract(row).copy(productid = value)))
-      override val operationsequence = new IdField[TypoShort, Row](prefix, "operationsequence", None, Some("int2"))(x => extract(x).operationsequence, (row, value) => merge(row, extract(row).copy(operationsequence = value)))
-      override val locationid = new Field[LocationId, Row](prefix, "locationid", None, Some("int2"))(x => extract(x).locationid, (row, value) => merge(row, extract(row).copy(locationid = value)))
-      override val scheduledstartdate = new Field[TypoLocalDateTime, Row](prefix, "scheduledstartdate", Some("text"), Some("timestamp"))(x => extract(x).scheduledstartdate, (row, value) => merge(row, extract(row).copy(scheduledstartdate = value)))
-      override val scheduledenddate = new Field[TypoLocalDateTime, Row](prefix, "scheduledenddate", Some("text"), Some("timestamp"))(x => extract(x).scheduledenddate, (row, value) => merge(row, extract(row).copy(scheduledenddate = value)))
-      override val actualstartdate = new OptField[TypoLocalDateTime, Row](prefix, "actualstartdate", Some("text"), Some("timestamp"))(x => extract(x).actualstartdate, (row, value) => merge(row, extract(row).copy(actualstartdate = value)))
-      override val actualenddate = new OptField[TypoLocalDateTime, Row](prefix, "actualenddate", Some("text"), Some("timestamp"))(x => extract(x).actualenddate, (row, value) => merge(row, extract(row).copy(actualenddate = value)))
-      override val actualresourcehrs = new OptField[BigDecimal, Row](prefix, "actualresourcehrs", None, Some("numeric"))(x => extract(x).actualresourcehrs, (row, value) => merge(row, extract(row).copy(actualresourcehrs = value)))
-      override val plannedcost = new Field[BigDecimal, Row](prefix, "plannedcost", None, Some("numeric"))(x => extract(x).plannedcost, (row, value) => merge(row, extract(row).copy(plannedcost = value)))
-      override val actualcost = new OptField[BigDecimal, Row](prefix, "actualcost", None, Some("numeric"))(x => extract(x).actualcost, (row, value) => merge(row, extract(row).copy(actualcost = value)))
-      override val modifieddate = new Field[TypoLocalDateTime, Row](prefix, "modifieddate", Some("text"), Some("timestamp"))(x => extract(x).modifieddate, (row, value) => merge(row, extract(row).copy(modifieddate = value)))
+    override lazy val fields: WorkorderroutingFields = new WorkorderroutingFields {
+      override def workorderid = IdField[WorkorderId, WorkorderroutingRow](_path, "workorderid", None, Some("int4"), x => x.workorderid, (row, value) => row.copy(workorderid = value))
+      override def productid = IdField[Int, WorkorderroutingRow](_path, "productid", None, Some("int4"), x => x.productid, (row, value) => row.copy(productid = value))
+      override def operationsequence = IdField[TypoShort, WorkorderroutingRow](_path, "operationsequence", None, Some("int2"), x => x.operationsequence, (row, value) => row.copy(operationsequence = value))
+      override def locationid = Field[LocationId, WorkorderroutingRow](_path, "locationid", None, Some("int2"), x => x.locationid, (row, value) => row.copy(locationid = value))
+      override def scheduledstartdate = Field[TypoLocalDateTime, WorkorderroutingRow](_path, "scheduledstartdate", Some("text"), Some("timestamp"), x => x.scheduledstartdate, (row, value) => row.copy(scheduledstartdate = value))
+      override def scheduledenddate = Field[TypoLocalDateTime, WorkorderroutingRow](_path, "scheduledenddate", Some("text"), Some("timestamp"), x => x.scheduledenddate, (row, value) => row.copy(scheduledenddate = value))
+      override def actualstartdate = OptField[TypoLocalDateTime, WorkorderroutingRow](_path, "actualstartdate", Some("text"), Some("timestamp"), x => x.actualstartdate, (row, value) => row.copy(actualstartdate = value))
+      override def actualenddate = OptField[TypoLocalDateTime, WorkorderroutingRow](_path, "actualenddate", Some("text"), Some("timestamp"), x => x.actualenddate, (row, value) => row.copy(actualenddate = value))
+      override def actualresourcehrs = OptField[BigDecimal, WorkorderroutingRow](_path, "actualresourcehrs", None, Some("numeric"), x => x.actualresourcehrs, (row, value) => row.copy(actualresourcehrs = value))
+      override def plannedcost = Field[BigDecimal, WorkorderroutingRow](_path, "plannedcost", None, Some("numeric"), x => x.plannedcost, (row, value) => row.copy(plannedcost = value))
+      override def actualcost = OptField[BigDecimal, WorkorderroutingRow](_path, "actualcost", None, Some("numeric"), x => x.actualcost, (row, value) => row.copy(actualcost = value))
+      override def modifieddate = Field[TypoLocalDateTime, WorkorderroutingRow](_path, "modifieddate", Some("text"), Some("timestamp"), x => x.modifieddate, (row, value) => row.copy(modifieddate = value))
     }
   
-    override val columns: List[FieldLikeNoHkt[?, Row]] =
-      List[FieldLikeNoHkt[?, Row]](fields.workorderid, fields.productid, fields.operationsequence, fields.locationid, fields.scheduledstartdate, fields.scheduledenddate, fields.actualstartdate, fields.actualenddate, fields.actualresourcehrs, fields.plannedcost, fields.actualcost, fields.modifieddate)
+    override lazy val columns: List[FieldLikeNoHkt[?, WorkorderroutingRow]] =
+      List[FieldLikeNoHkt[?, WorkorderroutingRow]](fields.workorderid, fields.productid, fields.operationsequence, fields.locationid, fields.scheduledstartdate, fields.scheduledenddate, fields.actualstartdate, fields.actualenddate, fields.actualresourcehrs, fields.plannedcost, fields.actualcost, fields.modifieddate)
   
-    override def copy[NewRow](prefix: Option[String], extract: NewRow => WorkorderroutingRow, merge: (NewRow, WorkorderroutingRow) => NewRow): Impl[NewRow] =
-      new Impl(prefix, extract, merge)
+    override def copy(path: List[Path]): Impl =
+      new Impl(path)
   }
   
 }

--- a/typo-tester-anorm/generated-and-checked-in/adventureworks/production/workorderrouting/WorkorderroutingRepoMock.scala
+++ b/typo-tester-anorm/generated-and-checked-in/adventureworks/production/workorderrouting/WorkorderroutingRepoMock.scala
@@ -22,7 +22,7 @@ import typo.dsl.UpdateParams
 class WorkorderroutingRepoMock(toRow: Function1[WorkorderroutingRowUnsaved, WorkorderroutingRow],
                                map: scala.collection.mutable.Map[WorkorderroutingId, WorkorderroutingRow] = scala.collection.mutable.Map.empty) extends WorkorderroutingRepo {
   override def delete: DeleteBuilder[WorkorderroutingFields, WorkorderroutingRow] = {
-    DeleteBuilderMock(DeleteParams.empty, WorkorderroutingFields.structure.fields, map)
+    DeleteBuilderMock(DeleteParams.empty, WorkorderroutingFields.structure, map)
   }
   override def deleteById(compositeId: WorkorderroutingId)(implicit c: Connection): Boolean = {
     map.remove(compositeId).isDefined
@@ -72,7 +72,7 @@ class WorkorderroutingRepoMock(toRow: Function1[WorkorderroutingRowUnsaved, Work
     compositeIds.view.flatMap(id => byId.get(id).map(x => (id, x))).toMap
   }
   override def update: UpdateBuilder[WorkorderroutingFields, WorkorderroutingRow] = {
-    UpdateBuilderMock(UpdateParams.empty, WorkorderroutingFields.structure.fields, map)
+    UpdateBuilderMock(UpdateParams.empty, WorkorderroutingFields.structure, map)
   }
   override def update(row: WorkorderroutingRow)(implicit c: Connection): Boolean = {
     map.get(row.compositeId) match {

--- a/typo-tester-anorm/generated-and-checked-in/adventureworks/pu/pod/PodViewFields.scala
+++ b/typo-tester-anorm/generated-and-checked-in/adventureworks/pu/pod/PodViewFields.scala
@@ -11,48 +11,49 @@ import adventureworks.customtypes.TypoLocalDateTime
 import adventureworks.customtypes.TypoShort
 import adventureworks.production.product.ProductId
 import adventureworks.purchasing.purchaseorderheader.PurchaseorderheaderId
+import typo.dsl.Path
 import typo.dsl.SqlExpr.Field
 import typo.dsl.SqlExpr.FieldLikeNoHkt
 import typo.dsl.Structure.Relation
 
-trait PodViewFields[Row] {
-  val id: Field[Int, Row]
-  val purchaseorderid: Field[PurchaseorderheaderId, Row]
-  val purchaseorderdetailid: Field[Int, Row]
-  val duedate: Field[TypoLocalDateTime, Row]
-  val orderqty: Field[TypoShort, Row]
-  val productid: Field[ProductId, Row]
-  val unitprice: Field[BigDecimal, Row]
-  val receivedqty: Field[BigDecimal, Row]
-  val rejectedqty: Field[BigDecimal, Row]
-  val modifieddate: Field[TypoLocalDateTime, Row]
+trait PodViewFields {
+  def id: Field[Int, PodViewRow]
+  def purchaseorderid: Field[PurchaseorderheaderId, PodViewRow]
+  def purchaseorderdetailid: Field[Int, PodViewRow]
+  def duedate: Field[TypoLocalDateTime, PodViewRow]
+  def orderqty: Field[TypoShort, PodViewRow]
+  def productid: Field[ProductId, PodViewRow]
+  def unitprice: Field[BigDecimal, PodViewRow]
+  def receivedqty: Field[BigDecimal, PodViewRow]
+  def rejectedqty: Field[BigDecimal, PodViewRow]
+  def modifieddate: Field[TypoLocalDateTime, PodViewRow]
 }
 
 object PodViewFields {
-  val structure: Relation[PodViewFields, PodViewRow, PodViewRow] = 
-    new Impl(None, identity, (_, x) => x)
+  lazy val structure: Relation[PodViewFields, PodViewRow] =
+    new Impl(Nil)
     
-  private final class Impl[Row](val prefix: Option[String], val extract: Row => PodViewRow, val merge: (Row, PodViewRow) => Row)
-    extends Relation[PodViewFields, PodViewRow, Row] { 
+  private final class Impl(val _path: List[Path])
+    extends Relation[PodViewFields, PodViewRow] {
   
-    override val fields: PodViewFields[Row] = new PodViewFields[Row] {
-      override val id = new Field[Int, Row](prefix, "id", None, None)(x => extract(x).id, (row, value) => merge(row, extract(row).copy(id = value)))
-      override val purchaseorderid = new Field[PurchaseorderheaderId, Row](prefix, "purchaseorderid", None, None)(x => extract(x).purchaseorderid, (row, value) => merge(row, extract(row).copy(purchaseorderid = value)))
-      override val purchaseorderdetailid = new Field[Int, Row](prefix, "purchaseorderdetailid", None, None)(x => extract(x).purchaseorderdetailid, (row, value) => merge(row, extract(row).copy(purchaseorderdetailid = value)))
-      override val duedate = new Field[TypoLocalDateTime, Row](prefix, "duedate", Some("text"), None)(x => extract(x).duedate, (row, value) => merge(row, extract(row).copy(duedate = value)))
-      override val orderqty = new Field[TypoShort, Row](prefix, "orderqty", None, None)(x => extract(x).orderqty, (row, value) => merge(row, extract(row).copy(orderqty = value)))
-      override val productid = new Field[ProductId, Row](prefix, "productid", None, None)(x => extract(x).productid, (row, value) => merge(row, extract(row).copy(productid = value)))
-      override val unitprice = new Field[BigDecimal, Row](prefix, "unitprice", None, None)(x => extract(x).unitprice, (row, value) => merge(row, extract(row).copy(unitprice = value)))
-      override val receivedqty = new Field[BigDecimal, Row](prefix, "receivedqty", None, None)(x => extract(x).receivedqty, (row, value) => merge(row, extract(row).copy(receivedqty = value)))
-      override val rejectedqty = new Field[BigDecimal, Row](prefix, "rejectedqty", None, None)(x => extract(x).rejectedqty, (row, value) => merge(row, extract(row).copy(rejectedqty = value)))
-      override val modifieddate = new Field[TypoLocalDateTime, Row](prefix, "modifieddate", Some("text"), None)(x => extract(x).modifieddate, (row, value) => merge(row, extract(row).copy(modifieddate = value)))
+    override lazy val fields: PodViewFields = new PodViewFields {
+      override def id = Field[Int, PodViewRow](_path, "id", None, None, x => x.id, (row, value) => row.copy(id = value))
+      override def purchaseorderid = Field[PurchaseorderheaderId, PodViewRow](_path, "purchaseorderid", None, None, x => x.purchaseorderid, (row, value) => row.copy(purchaseorderid = value))
+      override def purchaseorderdetailid = Field[Int, PodViewRow](_path, "purchaseorderdetailid", None, None, x => x.purchaseorderdetailid, (row, value) => row.copy(purchaseorderdetailid = value))
+      override def duedate = Field[TypoLocalDateTime, PodViewRow](_path, "duedate", Some("text"), None, x => x.duedate, (row, value) => row.copy(duedate = value))
+      override def orderqty = Field[TypoShort, PodViewRow](_path, "orderqty", None, None, x => x.orderqty, (row, value) => row.copy(orderqty = value))
+      override def productid = Field[ProductId, PodViewRow](_path, "productid", None, None, x => x.productid, (row, value) => row.copy(productid = value))
+      override def unitprice = Field[BigDecimal, PodViewRow](_path, "unitprice", None, None, x => x.unitprice, (row, value) => row.copy(unitprice = value))
+      override def receivedqty = Field[BigDecimal, PodViewRow](_path, "receivedqty", None, None, x => x.receivedqty, (row, value) => row.copy(receivedqty = value))
+      override def rejectedqty = Field[BigDecimal, PodViewRow](_path, "rejectedqty", None, None, x => x.rejectedqty, (row, value) => row.copy(rejectedqty = value))
+      override def modifieddate = Field[TypoLocalDateTime, PodViewRow](_path, "modifieddate", Some("text"), None, x => x.modifieddate, (row, value) => row.copy(modifieddate = value))
     }
   
-    override val columns: List[FieldLikeNoHkt[?, Row]] =
-      List[FieldLikeNoHkt[?, Row]](fields.id, fields.purchaseorderid, fields.purchaseorderdetailid, fields.duedate, fields.orderqty, fields.productid, fields.unitprice, fields.receivedqty, fields.rejectedqty, fields.modifieddate)
+    override lazy val columns: List[FieldLikeNoHkt[?, PodViewRow]] =
+      List[FieldLikeNoHkt[?, PodViewRow]](fields.id, fields.purchaseorderid, fields.purchaseorderdetailid, fields.duedate, fields.orderqty, fields.productid, fields.unitprice, fields.receivedqty, fields.rejectedqty, fields.modifieddate)
   
-    override def copy[NewRow](prefix: Option[String], extract: NewRow => PodViewRow, merge: (NewRow, PodViewRow) => NewRow): Impl[NewRow] =
-      new Impl(prefix, extract, merge)
+    override def copy(path: List[Path]): Impl =
+      new Impl(path)
   }
   
 }

--- a/typo-tester-anorm/generated-and-checked-in/adventureworks/pu/poh/PohViewFields.scala
+++ b/typo-tester-anorm/generated-and-checked-in/adventureworks/pu/poh/PohViewFields.scala
@@ -12,55 +12,56 @@ import adventureworks.customtypes.TypoShort
 import adventureworks.person.businessentity.BusinessentityId
 import adventureworks.purchasing.purchaseorderheader.PurchaseorderheaderId
 import adventureworks.purchasing.shipmethod.ShipmethodId
+import typo.dsl.Path
 import typo.dsl.SqlExpr.Field
 import typo.dsl.SqlExpr.FieldLikeNoHkt
 import typo.dsl.SqlExpr.OptField
 import typo.dsl.Structure.Relation
 
-trait PohViewFields[Row] {
-  val id: Field[PurchaseorderheaderId, Row]
-  val purchaseorderid: Field[PurchaseorderheaderId, Row]
-  val revisionnumber: Field[TypoShort, Row]
-  val status: Field[TypoShort, Row]
-  val employeeid: Field[BusinessentityId, Row]
-  val vendorid: Field[BusinessentityId, Row]
-  val shipmethodid: Field[ShipmethodId, Row]
-  val orderdate: Field[TypoLocalDateTime, Row]
-  val shipdate: OptField[TypoLocalDateTime, Row]
-  val subtotal: Field[BigDecimal, Row]
-  val taxamt: Field[BigDecimal, Row]
-  val freight: Field[BigDecimal, Row]
-  val modifieddate: Field[TypoLocalDateTime, Row]
+trait PohViewFields {
+  def id: Field[PurchaseorderheaderId, PohViewRow]
+  def purchaseorderid: Field[PurchaseorderheaderId, PohViewRow]
+  def revisionnumber: Field[TypoShort, PohViewRow]
+  def status: Field[TypoShort, PohViewRow]
+  def employeeid: Field[BusinessentityId, PohViewRow]
+  def vendorid: Field[BusinessentityId, PohViewRow]
+  def shipmethodid: Field[ShipmethodId, PohViewRow]
+  def orderdate: Field[TypoLocalDateTime, PohViewRow]
+  def shipdate: OptField[TypoLocalDateTime, PohViewRow]
+  def subtotal: Field[BigDecimal, PohViewRow]
+  def taxamt: Field[BigDecimal, PohViewRow]
+  def freight: Field[BigDecimal, PohViewRow]
+  def modifieddate: Field[TypoLocalDateTime, PohViewRow]
 }
 
 object PohViewFields {
-  val structure: Relation[PohViewFields, PohViewRow, PohViewRow] = 
-    new Impl(None, identity, (_, x) => x)
+  lazy val structure: Relation[PohViewFields, PohViewRow] =
+    new Impl(Nil)
     
-  private final class Impl[Row](val prefix: Option[String], val extract: Row => PohViewRow, val merge: (Row, PohViewRow) => Row)
-    extends Relation[PohViewFields, PohViewRow, Row] { 
+  private final class Impl(val _path: List[Path])
+    extends Relation[PohViewFields, PohViewRow] {
   
-    override val fields: PohViewFields[Row] = new PohViewFields[Row] {
-      override val id = new Field[PurchaseorderheaderId, Row](prefix, "id", None, None)(x => extract(x).id, (row, value) => merge(row, extract(row).copy(id = value)))
-      override val purchaseorderid = new Field[PurchaseorderheaderId, Row](prefix, "purchaseorderid", None, None)(x => extract(x).purchaseorderid, (row, value) => merge(row, extract(row).copy(purchaseorderid = value)))
-      override val revisionnumber = new Field[TypoShort, Row](prefix, "revisionnumber", None, None)(x => extract(x).revisionnumber, (row, value) => merge(row, extract(row).copy(revisionnumber = value)))
-      override val status = new Field[TypoShort, Row](prefix, "status", None, None)(x => extract(x).status, (row, value) => merge(row, extract(row).copy(status = value)))
-      override val employeeid = new Field[BusinessentityId, Row](prefix, "employeeid", None, None)(x => extract(x).employeeid, (row, value) => merge(row, extract(row).copy(employeeid = value)))
-      override val vendorid = new Field[BusinessentityId, Row](prefix, "vendorid", None, None)(x => extract(x).vendorid, (row, value) => merge(row, extract(row).copy(vendorid = value)))
-      override val shipmethodid = new Field[ShipmethodId, Row](prefix, "shipmethodid", None, None)(x => extract(x).shipmethodid, (row, value) => merge(row, extract(row).copy(shipmethodid = value)))
-      override val orderdate = new Field[TypoLocalDateTime, Row](prefix, "orderdate", Some("text"), None)(x => extract(x).orderdate, (row, value) => merge(row, extract(row).copy(orderdate = value)))
-      override val shipdate = new OptField[TypoLocalDateTime, Row](prefix, "shipdate", Some("text"), None)(x => extract(x).shipdate, (row, value) => merge(row, extract(row).copy(shipdate = value)))
-      override val subtotal = new Field[BigDecimal, Row](prefix, "subtotal", None, None)(x => extract(x).subtotal, (row, value) => merge(row, extract(row).copy(subtotal = value)))
-      override val taxamt = new Field[BigDecimal, Row](prefix, "taxamt", None, None)(x => extract(x).taxamt, (row, value) => merge(row, extract(row).copy(taxamt = value)))
-      override val freight = new Field[BigDecimal, Row](prefix, "freight", None, None)(x => extract(x).freight, (row, value) => merge(row, extract(row).copy(freight = value)))
-      override val modifieddate = new Field[TypoLocalDateTime, Row](prefix, "modifieddate", Some("text"), None)(x => extract(x).modifieddate, (row, value) => merge(row, extract(row).copy(modifieddate = value)))
+    override lazy val fields: PohViewFields = new PohViewFields {
+      override def id = Field[PurchaseorderheaderId, PohViewRow](_path, "id", None, None, x => x.id, (row, value) => row.copy(id = value))
+      override def purchaseorderid = Field[PurchaseorderheaderId, PohViewRow](_path, "purchaseorderid", None, None, x => x.purchaseorderid, (row, value) => row.copy(purchaseorderid = value))
+      override def revisionnumber = Field[TypoShort, PohViewRow](_path, "revisionnumber", None, None, x => x.revisionnumber, (row, value) => row.copy(revisionnumber = value))
+      override def status = Field[TypoShort, PohViewRow](_path, "status", None, None, x => x.status, (row, value) => row.copy(status = value))
+      override def employeeid = Field[BusinessentityId, PohViewRow](_path, "employeeid", None, None, x => x.employeeid, (row, value) => row.copy(employeeid = value))
+      override def vendorid = Field[BusinessentityId, PohViewRow](_path, "vendorid", None, None, x => x.vendorid, (row, value) => row.copy(vendorid = value))
+      override def shipmethodid = Field[ShipmethodId, PohViewRow](_path, "shipmethodid", None, None, x => x.shipmethodid, (row, value) => row.copy(shipmethodid = value))
+      override def orderdate = Field[TypoLocalDateTime, PohViewRow](_path, "orderdate", Some("text"), None, x => x.orderdate, (row, value) => row.copy(orderdate = value))
+      override def shipdate = OptField[TypoLocalDateTime, PohViewRow](_path, "shipdate", Some("text"), None, x => x.shipdate, (row, value) => row.copy(shipdate = value))
+      override def subtotal = Field[BigDecimal, PohViewRow](_path, "subtotal", None, None, x => x.subtotal, (row, value) => row.copy(subtotal = value))
+      override def taxamt = Field[BigDecimal, PohViewRow](_path, "taxamt", None, None, x => x.taxamt, (row, value) => row.copy(taxamt = value))
+      override def freight = Field[BigDecimal, PohViewRow](_path, "freight", None, None, x => x.freight, (row, value) => row.copy(freight = value))
+      override def modifieddate = Field[TypoLocalDateTime, PohViewRow](_path, "modifieddate", Some("text"), None, x => x.modifieddate, (row, value) => row.copy(modifieddate = value))
     }
   
-    override val columns: List[FieldLikeNoHkt[?, Row]] =
-      List[FieldLikeNoHkt[?, Row]](fields.id, fields.purchaseorderid, fields.revisionnumber, fields.status, fields.employeeid, fields.vendorid, fields.shipmethodid, fields.orderdate, fields.shipdate, fields.subtotal, fields.taxamt, fields.freight, fields.modifieddate)
+    override lazy val columns: List[FieldLikeNoHkt[?, PohViewRow]] =
+      List[FieldLikeNoHkt[?, PohViewRow]](fields.id, fields.purchaseorderid, fields.revisionnumber, fields.status, fields.employeeid, fields.vendorid, fields.shipmethodid, fields.orderdate, fields.shipdate, fields.subtotal, fields.taxamt, fields.freight, fields.modifieddate)
   
-    override def copy[NewRow](prefix: Option[String], extract: NewRow => PohViewRow, merge: (NewRow, PohViewRow) => NewRow): Impl[NewRow] =
-      new Impl(prefix, extract, merge)
+    override def copy(path: List[Path]): Impl =
+      new Impl(path)
   }
   
 }

--- a/typo-tester-anorm/generated-and-checked-in/adventureworks/pu/pv/PvViewFields.scala
+++ b/typo-tester-anorm/generated-and-checked-in/adventureworks/pu/pv/PvViewFields.scala
@@ -11,53 +11,54 @@ import adventureworks.customtypes.TypoLocalDateTime
 import adventureworks.person.businessentity.BusinessentityId
 import adventureworks.production.product.ProductId
 import adventureworks.production.unitmeasure.UnitmeasureId
+import typo.dsl.Path
 import typo.dsl.SqlExpr.Field
 import typo.dsl.SqlExpr.FieldLikeNoHkt
 import typo.dsl.SqlExpr.OptField
 import typo.dsl.Structure.Relation
 
-trait PvViewFields[Row] {
-  val id: Field[ProductId, Row]
-  val productid: Field[ProductId, Row]
-  val businessentityid: Field[BusinessentityId, Row]
-  val averageleadtime: Field[Int, Row]
-  val standardprice: Field[BigDecimal, Row]
-  val lastreceiptcost: OptField[BigDecimal, Row]
-  val lastreceiptdate: OptField[TypoLocalDateTime, Row]
-  val minorderqty: Field[Int, Row]
-  val maxorderqty: Field[Int, Row]
-  val onorderqty: OptField[Int, Row]
-  val unitmeasurecode: Field[UnitmeasureId, Row]
-  val modifieddate: Field[TypoLocalDateTime, Row]
+trait PvViewFields {
+  def id: Field[ProductId, PvViewRow]
+  def productid: Field[ProductId, PvViewRow]
+  def businessentityid: Field[BusinessentityId, PvViewRow]
+  def averageleadtime: Field[Int, PvViewRow]
+  def standardprice: Field[BigDecimal, PvViewRow]
+  def lastreceiptcost: OptField[BigDecimal, PvViewRow]
+  def lastreceiptdate: OptField[TypoLocalDateTime, PvViewRow]
+  def minorderqty: Field[Int, PvViewRow]
+  def maxorderqty: Field[Int, PvViewRow]
+  def onorderqty: OptField[Int, PvViewRow]
+  def unitmeasurecode: Field[UnitmeasureId, PvViewRow]
+  def modifieddate: Field[TypoLocalDateTime, PvViewRow]
 }
 
 object PvViewFields {
-  val structure: Relation[PvViewFields, PvViewRow, PvViewRow] = 
-    new Impl(None, identity, (_, x) => x)
+  lazy val structure: Relation[PvViewFields, PvViewRow] =
+    new Impl(Nil)
     
-  private final class Impl[Row](val prefix: Option[String], val extract: Row => PvViewRow, val merge: (Row, PvViewRow) => Row)
-    extends Relation[PvViewFields, PvViewRow, Row] { 
+  private final class Impl(val _path: List[Path])
+    extends Relation[PvViewFields, PvViewRow] {
   
-    override val fields: PvViewFields[Row] = new PvViewFields[Row] {
-      override val id = new Field[ProductId, Row](prefix, "id", None, None)(x => extract(x).id, (row, value) => merge(row, extract(row).copy(id = value)))
-      override val productid = new Field[ProductId, Row](prefix, "productid", None, None)(x => extract(x).productid, (row, value) => merge(row, extract(row).copy(productid = value)))
-      override val businessentityid = new Field[BusinessentityId, Row](prefix, "businessentityid", None, None)(x => extract(x).businessentityid, (row, value) => merge(row, extract(row).copy(businessentityid = value)))
-      override val averageleadtime = new Field[Int, Row](prefix, "averageleadtime", None, None)(x => extract(x).averageleadtime, (row, value) => merge(row, extract(row).copy(averageleadtime = value)))
-      override val standardprice = new Field[BigDecimal, Row](prefix, "standardprice", None, None)(x => extract(x).standardprice, (row, value) => merge(row, extract(row).copy(standardprice = value)))
-      override val lastreceiptcost = new OptField[BigDecimal, Row](prefix, "lastreceiptcost", None, None)(x => extract(x).lastreceiptcost, (row, value) => merge(row, extract(row).copy(lastreceiptcost = value)))
-      override val lastreceiptdate = new OptField[TypoLocalDateTime, Row](prefix, "lastreceiptdate", Some("text"), None)(x => extract(x).lastreceiptdate, (row, value) => merge(row, extract(row).copy(lastreceiptdate = value)))
-      override val minorderqty = new Field[Int, Row](prefix, "minorderqty", None, None)(x => extract(x).minorderqty, (row, value) => merge(row, extract(row).copy(minorderqty = value)))
-      override val maxorderqty = new Field[Int, Row](prefix, "maxorderqty", None, None)(x => extract(x).maxorderqty, (row, value) => merge(row, extract(row).copy(maxorderqty = value)))
-      override val onorderqty = new OptField[Int, Row](prefix, "onorderqty", None, None)(x => extract(x).onorderqty, (row, value) => merge(row, extract(row).copy(onorderqty = value)))
-      override val unitmeasurecode = new Field[UnitmeasureId, Row](prefix, "unitmeasurecode", None, None)(x => extract(x).unitmeasurecode, (row, value) => merge(row, extract(row).copy(unitmeasurecode = value)))
-      override val modifieddate = new Field[TypoLocalDateTime, Row](prefix, "modifieddate", Some("text"), None)(x => extract(x).modifieddate, (row, value) => merge(row, extract(row).copy(modifieddate = value)))
+    override lazy val fields: PvViewFields = new PvViewFields {
+      override def id = Field[ProductId, PvViewRow](_path, "id", None, None, x => x.id, (row, value) => row.copy(id = value))
+      override def productid = Field[ProductId, PvViewRow](_path, "productid", None, None, x => x.productid, (row, value) => row.copy(productid = value))
+      override def businessentityid = Field[BusinessentityId, PvViewRow](_path, "businessentityid", None, None, x => x.businessentityid, (row, value) => row.copy(businessentityid = value))
+      override def averageleadtime = Field[Int, PvViewRow](_path, "averageleadtime", None, None, x => x.averageleadtime, (row, value) => row.copy(averageleadtime = value))
+      override def standardprice = Field[BigDecimal, PvViewRow](_path, "standardprice", None, None, x => x.standardprice, (row, value) => row.copy(standardprice = value))
+      override def lastreceiptcost = OptField[BigDecimal, PvViewRow](_path, "lastreceiptcost", None, None, x => x.lastreceiptcost, (row, value) => row.copy(lastreceiptcost = value))
+      override def lastreceiptdate = OptField[TypoLocalDateTime, PvViewRow](_path, "lastreceiptdate", Some("text"), None, x => x.lastreceiptdate, (row, value) => row.copy(lastreceiptdate = value))
+      override def minorderqty = Field[Int, PvViewRow](_path, "minorderqty", None, None, x => x.minorderqty, (row, value) => row.copy(minorderqty = value))
+      override def maxorderqty = Field[Int, PvViewRow](_path, "maxorderqty", None, None, x => x.maxorderqty, (row, value) => row.copy(maxorderqty = value))
+      override def onorderqty = OptField[Int, PvViewRow](_path, "onorderqty", None, None, x => x.onorderqty, (row, value) => row.copy(onorderqty = value))
+      override def unitmeasurecode = Field[UnitmeasureId, PvViewRow](_path, "unitmeasurecode", None, None, x => x.unitmeasurecode, (row, value) => row.copy(unitmeasurecode = value))
+      override def modifieddate = Field[TypoLocalDateTime, PvViewRow](_path, "modifieddate", Some("text"), None, x => x.modifieddate, (row, value) => row.copy(modifieddate = value))
     }
   
-    override val columns: List[FieldLikeNoHkt[?, Row]] =
-      List[FieldLikeNoHkt[?, Row]](fields.id, fields.productid, fields.businessentityid, fields.averageleadtime, fields.standardprice, fields.lastreceiptcost, fields.lastreceiptdate, fields.minorderqty, fields.maxorderqty, fields.onorderqty, fields.unitmeasurecode, fields.modifieddate)
+    override lazy val columns: List[FieldLikeNoHkt[?, PvViewRow]] =
+      List[FieldLikeNoHkt[?, PvViewRow]](fields.id, fields.productid, fields.businessentityid, fields.averageleadtime, fields.standardprice, fields.lastreceiptcost, fields.lastreceiptdate, fields.minorderqty, fields.maxorderqty, fields.onorderqty, fields.unitmeasurecode, fields.modifieddate)
   
-    override def copy[NewRow](prefix: Option[String], extract: NewRow => PvViewRow, merge: (NewRow, PvViewRow) => NewRow): Impl[NewRow] =
-      new Impl(prefix, extract, merge)
+    override def copy(path: List[Path]): Impl =
+      new Impl(path)
   }
   
 }

--- a/typo-tester-anorm/generated-and-checked-in/adventureworks/pu/sm/SmViewFields.scala
+++ b/typo-tester-anorm/generated-and-checked-in/adventureworks/pu/sm/SmViewFields.scala
@@ -11,42 +11,43 @@ import adventureworks.customtypes.TypoLocalDateTime
 import adventureworks.customtypes.TypoUUID
 import adventureworks.public.Name
 import adventureworks.purchasing.shipmethod.ShipmethodId
+import typo.dsl.Path
 import typo.dsl.SqlExpr.Field
 import typo.dsl.SqlExpr.FieldLikeNoHkt
 import typo.dsl.Structure.Relation
 
-trait SmViewFields[Row] {
-  val id: Field[ShipmethodId, Row]
-  val shipmethodid: Field[ShipmethodId, Row]
-  val name: Field[Name, Row]
-  val shipbase: Field[BigDecimal, Row]
-  val shiprate: Field[BigDecimal, Row]
-  val rowguid: Field[TypoUUID, Row]
-  val modifieddate: Field[TypoLocalDateTime, Row]
+trait SmViewFields {
+  def id: Field[ShipmethodId, SmViewRow]
+  def shipmethodid: Field[ShipmethodId, SmViewRow]
+  def name: Field[Name, SmViewRow]
+  def shipbase: Field[BigDecimal, SmViewRow]
+  def shiprate: Field[BigDecimal, SmViewRow]
+  def rowguid: Field[TypoUUID, SmViewRow]
+  def modifieddate: Field[TypoLocalDateTime, SmViewRow]
 }
 
 object SmViewFields {
-  val structure: Relation[SmViewFields, SmViewRow, SmViewRow] = 
-    new Impl(None, identity, (_, x) => x)
+  lazy val structure: Relation[SmViewFields, SmViewRow] =
+    new Impl(Nil)
     
-  private final class Impl[Row](val prefix: Option[String], val extract: Row => SmViewRow, val merge: (Row, SmViewRow) => Row)
-    extends Relation[SmViewFields, SmViewRow, Row] { 
+  private final class Impl(val _path: List[Path])
+    extends Relation[SmViewFields, SmViewRow] {
   
-    override val fields: SmViewFields[Row] = new SmViewFields[Row] {
-      override val id = new Field[ShipmethodId, Row](prefix, "id", None, None)(x => extract(x).id, (row, value) => merge(row, extract(row).copy(id = value)))
-      override val shipmethodid = new Field[ShipmethodId, Row](prefix, "shipmethodid", None, None)(x => extract(x).shipmethodid, (row, value) => merge(row, extract(row).copy(shipmethodid = value)))
-      override val name = new Field[Name, Row](prefix, "name", None, None)(x => extract(x).name, (row, value) => merge(row, extract(row).copy(name = value)))
-      override val shipbase = new Field[BigDecimal, Row](prefix, "shipbase", None, None)(x => extract(x).shipbase, (row, value) => merge(row, extract(row).copy(shipbase = value)))
-      override val shiprate = new Field[BigDecimal, Row](prefix, "shiprate", None, None)(x => extract(x).shiprate, (row, value) => merge(row, extract(row).copy(shiprate = value)))
-      override val rowguid = new Field[TypoUUID, Row](prefix, "rowguid", None, None)(x => extract(x).rowguid, (row, value) => merge(row, extract(row).copy(rowguid = value)))
-      override val modifieddate = new Field[TypoLocalDateTime, Row](prefix, "modifieddate", Some("text"), None)(x => extract(x).modifieddate, (row, value) => merge(row, extract(row).copy(modifieddate = value)))
+    override lazy val fields: SmViewFields = new SmViewFields {
+      override def id = Field[ShipmethodId, SmViewRow](_path, "id", None, None, x => x.id, (row, value) => row.copy(id = value))
+      override def shipmethodid = Field[ShipmethodId, SmViewRow](_path, "shipmethodid", None, None, x => x.shipmethodid, (row, value) => row.copy(shipmethodid = value))
+      override def name = Field[Name, SmViewRow](_path, "name", None, None, x => x.name, (row, value) => row.copy(name = value))
+      override def shipbase = Field[BigDecimal, SmViewRow](_path, "shipbase", None, None, x => x.shipbase, (row, value) => row.copy(shipbase = value))
+      override def shiprate = Field[BigDecimal, SmViewRow](_path, "shiprate", None, None, x => x.shiprate, (row, value) => row.copy(shiprate = value))
+      override def rowguid = Field[TypoUUID, SmViewRow](_path, "rowguid", None, None, x => x.rowguid, (row, value) => row.copy(rowguid = value))
+      override def modifieddate = Field[TypoLocalDateTime, SmViewRow](_path, "modifieddate", Some("text"), None, x => x.modifieddate, (row, value) => row.copy(modifieddate = value))
     }
   
-    override val columns: List[FieldLikeNoHkt[?, Row]] =
-      List[FieldLikeNoHkt[?, Row]](fields.id, fields.shipmethodid, fields.name, fields.shipbase, fields.shiprate, fields.rowguid, fields.modifieddate)
+    override lazy val columns: List[FieldLikeNoHkt[?, SmViewRow]] =
+      List[FieldLikeNoHkt[?, SmViewRow]](fields.id, fields.shipmethodid, fields.name, fields.shipbase, fields.shiprate, fields.rowguid, fields.modifieddate)
   
-    override def copy[NewRow](prefix: Option[String], extract: NewRow => SmViewRow, merge: (NewRow, SmViewRow) => NewRow): Impl[NewRow] =
-      new Impl(prefix, extract, merge)
+    override def copy(path: List[Path]): Impl =
+      new Impl(path)
   }
   
 }

--- a/typo-tester-anorm/generated-and-checked-in/adventureworks/pu/v/VViewFields.scala
+++ b/typo-tester-anorm/generated-and-checked-in/adventureworks/pu/v/VViewFields.scala
@@ -13,47 +13,48 @@ import adventureworks.person.businessentity.BusinessentityId
 import adventureworks.public.AccountNumber
 import adventureworks.public.Flag
 import adventureworks.public.Name
+import typo.dsl.Path
 import typo.dsl.SqlExpr.Field
 import typo.dsl.SqlExpr.FieldLikeNoHkt
 import typo.dsl.SqlExpr.OptField
 import typo.dsl.Structure.Relation
 
-trait VViewFields[Row] {
-  val id: Field[BusinessentityId, Row]
-  val businessentityid: Field[BusinessentityId, Row]
-  val accountnumber: Field[AccountNumber, Row]
-  val name: Field[Name, Row]
-  val creditrating: Field[TypoShort, Row]
-  val preferredvendorstatus: Field[Flag, Row]
-  val activeflag: Field[Flag, Row]
-  val purchasingwebserviceurl: OptField[/* max 1024 chars */ String, Row]
-  val modifieddate: Field[TypoLocalDateTime, Row]
+trait VViewFields {
+  def id: Field[BusinessentityId, VViewRow]
+  def businessentityid: Field[BusinessentityId, VViewRow]
+  def accountnumber: Field[AccountNumber, VViewRow]
+  def name: Field[Name, VViewRow]
+  def creditrating: Field[TypoShort, VViewRow]
+  def preferredvendorstatus: Field[Flag, VViewRow]
+  def activeflag: Field[Flag, VViewRow]
+  def purchasingwebserviceurl: OptField[/* max 1024 chars */ String, VViewRow]
+  def modifieddate: Field[TypoLocalDateTime, VViewRow]
 }
 
 object VViewFields {
-  val structure: Relation[VViewFields, VViewRow, VViewRow] = 
-    new Impl(None, identity, (_, x) => x)
+  lazy val structure: Relation[VViewFields, VViewRow] =
+    new Impl(Nil)
     
-  private final class Impl[Row](val prefix: Option[String], val extract: Row => VViewRow, val merge: (Row, VViewRow) => Row)
-    extends Relation[VViewFields, VViewRow, Row] { 
+  private final class Impl(val _path: List[Path])
+    extends Relation[VViewFields, VViewRow] {
   
-    override val fields: VViewFields[Row] = new VViewFields[Row] {
-      override val id = new Field[BusinessentityId, Row](prefix, "id", None, None)(x => extract(x).id, (row, value) => merge(row, extract(row).copy(id = value)))
-      override val businessentityid = new Field[BusinessentityId, Row](prefix, "businessentityid", None, None)(x => extract(x).businessentityid, (row, value) => merge(row, extract(row).copy(businessentityid = value)))
-      override val accountnumber = new Field[AccountNumber, Row](prefix, "accountnumber", None, None)(x => extract(x).accountnumber, (row, value) => merge(row, extract(row).copy(accountnumber = value)))
-      override val name = new Field[Name, Row](prefix, "name", None, None)(x => extract(x).name, (row, value) => merge(row, extract(row).copy(name = value)))
-      override val creditrating = new Field[TypoShort, Row](prefix, "creditrating", None, None)(x => extract(x).creditrating, (row, value) => merge(row, extract(row).copy(creditrating = value)))
-      override val preferredvendorstatus = new Field[Flag, Row](prefix, "preferredvendorstatus", None, None)(x => extract(x).preferredvendorstatus, (row, value) => merge(row, extract(row).copy(preferredvendorstatus = value)))
-      override val activeflag = new Field[Flag, Row](prefix, "activeflag", None, None)(x => extract(x).activeflag, (row, value) => merge(row, extract(row).copy(activeflag = value)))
-      override val purchasingwebserviceurl = new OptField[/* max 1024 chars */ String, Row](prefix, "purchasingwebserviceurl", None, None)(x => extract(x).purchasingwebserviceurl, (row, value) => merge(row, extract(row).copy(purchasingwebserviceurl = value)))
-      override val modifieddate = new Field[TypoLocalDateTime, Row](prefix, "modifieddate", Some("text"), None)(x => extract(x).modifieddate, (row, value) => merge(row, extract(row).copy(modifieddate = value)))
+    override lazy val fields: VViewFields = new VViewFields {
+      override def id = Field[BusinessentityId, VViewRow](_path, "id", None, None, x => x.id, (row, value) => row.copy(id = value))
+      override def businessentityid = Field[BusinessentityId, VViewRow](_path, "businessentityid", None, None, x => x.businessentityid, (row, value) => row.copy(businessentityid = value))
+      override def accountnumber = Field[AccountNumber, VViewRow](_path, "accountnumber", None, None, x => x.accountnumber, (row, value) => row.copy(accountnumber = value))
+      override def name = Field[Name, VViewRow](_path, "name", None, None, x => x.name, (row, value) => row.copy(name = value))
+      override def creditrating = Field[TypoShort, VViewRow](_path, "creditrating", None, None, x => x.creditrating, (row, value) => row.copy(creditrating = value))
+      override def preferredvendorstatus = Field[Flag, VViewRow](_path, "preferredvendorstatus", None, None, x => x.preferredvendorstatus, (row, value) => row.copy(preferredvendorstatus = value))
+      override def activeflag = Field[Flag, VViewRow](_path, "activeflag", None, None, x => x.activeflag, (row, value) => row.copy(activeflag = value))
+      override def purchasingwebserviceurl = OptField[/* max 1024 chars */ String, VViewRow](_path, "purchasingwebserviceurl", None, None, x => x.purchasingwebserviceurl, (row, value) => row.copy(purchasingwebserviceurl = value))
+      override def modifieddate = Field[TypoLocalDateTime, VViewRow](_path, "modifieddate", Some("text"), None, x => x.modifieddate, (row, value) => row.copy(modifieddate = value))
     }
   
-    override val columns: List[FieldLikeNoHkt[?, Row]] =
-      List[FieldLikeNoHkt[?, Row]](fields.id, fields.businessentityid, fields.accountnumber, fields.name, fields.creditrating, fields.preferredvendorstatus, fields.activeflag, fields.purchasingwebserviceurl, fields.modifieddate)
+    override lazy val columns: List[FieldLikeNoHkt[?, VViewRow]] =
+      List[FieldLikeNoHkt[?, VViewRow]](fields.id, fields.businessentityid, fields.accountnumber, fields.name, fields.creditrating, fields.preferredvendorstatus, fields.activeflag, fields.purchasingwebserviceurl, fields.modifieddate)
   
-    override def copy[NewRow](prefix: Option[String], extract: NewRow => VViewRow, merge: (NewRow, VViewRow) => NewRow): Impl[NewRow] =
-      new Impl(prefix, extract, merge)
+    override def copy(path: List[Path]): Impl =
+      new Impl(path)
   }
   
 }

--- a/typo-tester-anorm/generated-and-checked-in/adventureworks/public/flaff/FlaffFields.scala
+++ b/typo-tester-anorm/generated-and-checked-in/adventureworks/public/flaff/FlaffFields.scala
@@ -8,39 +8,40 @@ package public
 package flaff
 
 import adventureworks.public.ShortText
+import typo.dsl.Path
 import typo.dsl.SqlExpr.FieldLikeNoHkt
 import typo.dsl.SqlExpr.IdField
 import typo.dsl.SqlExpr.OptField
 import typo.dsl.Structure.Relation
 
-trait FlaffFields[Row] {
-  val code: IdField[ShortText, Row]
-  val anotherCode: IdField[/* max 20 chars */ String, Row]
-  val someNumber: IdField[Int, Row]
-  val specifier: IdField[ShortText, Row]
-  val parentspecifier: OptField[ShortText, Row]
+trait FlaffFields {
+  def code: IdField[ShortText, FlaffRow]
+  def anotherCode: IdField[/* max 20 chars */ String, FlaffRow]
+  def someNumber: IdField[Int, FlaffRow]
+  def specifier: IdField[ShortText, FlaffRow]
+  def parentspecifier: OptField[ShortText, FlaffRow]
 }
 
 object FlaffFields {
-  val structure: Relation[FlaffFields, FlaffRow, FlaffRow] = 
-    new Impl(None, identity, (_, x) => x)
+  lazy val structure: Relation[FlaffFields, FlaffRow] =
+    new Impl(Nil)
     
-  private final class Impl[Row](val prefix: Option[String], val extract: Row => FlaffRow, val merge: (Row, FlaffRow) => Row)
-    extends Relation[FlaffFields, FlaffRow, Row] { 
+  private final class Impl(val _path: List[Path])
+    extends Relation[FlaffFields, FlaffRow] {
   
-    override val fields: FlaffFields[Row] = new FlaffFields[Row] {
-      override val code = new IdField[ShortText, Row](prefix, "code", None, Some("text"))(x => extract(x).code, (row, value) => merge(row, extract(row).copy(code = value)))
-      override val anotherCode = new IdField[/* max 20 chars */ String, Row](prefix, "another_code", None, None)(x => extract(x).anotherCode, (row, value) => merge(row, extract(row).copy(anotherCode = value)))
-      override val someNumber = new IdField[Int, Row](prefix, "some_number", None, Some("int4"))(x => extract(x).someNumber, (row, value) => merge(row, extract(row).copy(someNumber = value)))
-      override val specifier = new IdField[ShortText, Row](prefix, "specifier", None, Some("text"))(x => extract(x).specifier, (row, value) => merge(row, extract(row).copy(specifier = value)))
-      override val parentspecifier = new OptField[ShortText, Row](prefix, "parentspecifier", None, Some("text"))(x => extract(x).parentspecifier, (row, value) => merge(row, extract(row).copy(parentspecifier = value)))
+    override lazy val fields: FlaffFields = new FlaffFields {
+      override def code = IdField[ShortText, FlaffRow](_path, "code", None, Some("text"), x => x.code, (row, value) => row.copy(code = value))
+      override def anotherCode = IdField[/* max 20 chars */ String, FlaffRow](_path, "another_code", None, None, x => x.anotherCode, (row, value) => row.copy(anotherCode = value))
+      override def someNumber = IdField[Int, FlaffRow](_path, "some_number", None, Some("int4"), x => x.someNumber, (row, value) => row.copy(someNumber = value))
+      override def specifier = IdField[ShortText, FlaffRow](_path, "specifier", None, Some("text"), x => x.specifier, (row, value) => row.copy(specifier = value))
+      override def parentspecifier = OptField[ShortText, FlaffRow](_path, "parentspecifier", None, Some("text"), x => x.parentspecifier, (row, value) => row.copy(parentspecifier = value))
     }
   
-    override val columns: List[FieldLikeNoHkt[?, Row]] =
-      List[FieldLikeNoHkt[?, Row]](fields.code, fields.anotherCode, fields.someNumber, fields.specifier, fields.parentspecifier)
+    override lazy val columns: List[FieldLikeNoHkt[?, FlaffRow]] =
+      List[FieldLikeNoHkt[?, FlaffRow]](fields.code, fields.anotherCode, fields.someNumber, fields.specifier, fields.parentspecifier)
   
-    override def copy[NewRow](prefix: Option[String], extract: NewRow => FlaffRow, merge: (NewRow, FlaffRow) => NewRow): Impl[NewRow] =
-      new Impl(prefix, extract, merge)
+    override def copy(path: List[Path]): Impl =
+      new Impl(path)
   }
   
 }

--- a/typo-tester-anorm/generated-and-checked-in/adventureworks/public/flaff/FlaffRepoMock.scala
+++ b/typo-tester-anorm/generated-and-checked-in/adventureworks/public/flaff/FlaffRepoMock.scala
@@ -21,7 +21,7 @@ import typo.dsl.UpdateParams
 
 class FlaffRepoMock(map: scala.collection.mutable.Map[FlaffId, FlaffRow] = scala.collection.mutable.Map.empty) extends FlaffRepo {
   override def delete: DeleteBuilder[FlaffFields, FlaffRow] = {
-    DeleteBuilderMock(DeleteParams.empty, FlaffFields.structure.fields, map)
+    DeleteBuilderMock(DeleteParams.empty, FlaffFields.structure, map)
   }
   override def deleteById(compositeId: FlaffId)(implicit c: Connection): Boolean = {
     map.remove(compositeId).isDefined
@@ -60,7 +60,7 @@ class FlaffRepoMock(map: scala.collection.mutable.Map[FlaffId, FlaffRow] = scala
     compositeIds.view.flatMap(id => byId.get(id).map(x => (id, x))).toMap
   }
   override def update: UpdateBuilder[FlaffFields, FlaffRow] = {
-    UpdateBuilderMock(UpdateParams.empty, FlaffFields.structure.fields, map)
+    UpdateBuilderMock(UpdateParams.empty, FlaffFields.structure, map)
   }
   override def update(row: FlaffRow)(implicit c: Connection): Boolean = {
     map.get(row.compositeId) match {

--- a/typo-tester-anorm/generated-and-checked-in/adventureworks/public/identity_test/IdentityTestRepoMock.scala
+++ b/typo-tester-anorm/generated-and-checked-in/adventureworks/public/identity_test/IdentityTestRepoMock.scala
@@ -22,7 +22,7 @@ import typo.dsl.UpdateParams
 class IdentityTestRepoMock(toRow: Function1[IdentityTestRowUnsaved, IdentityTestRow],
                            map: scala.collection.mutable.Map[IdentityTestId, IdentityTestRow] = scala.collection.mutable.Map.empty) extends IdentityTestRepo {
   override def delete: DeleteBuilder[IdentityTestFields, IdentityTestRow] = {
-    DeleteBuilderMock(DeleteParams.empty, IdentityTestFields.structure.fields, map)
+    DeleteBuilderMock(DeleteParams.empty, IdentityTestFields.structure, map)
   }
   override def deleteById(name: IdentityTestId)(implicit c: Connection): Boolean = {
     map.remove(name).isDefined
@@ -72,7 +72,7 @@ class IdentityTestRepoMock(toRow: Function1[IdentityTestRowUnsaved, IdentityTest
     names.view.flatMap(id => byId.get(id).map(x => (id, x))).toMap
   }
   override def update: UpdateBuilder[IdentityTestFields, IdentityTestRow] = {
-    UpdateBuilderMock(UpdateParams.empty, IdentityTestFields.structure.fields, map)
+    UpdateBuilderMock(UpdateParams.empty, IdentityTestFields.structure, map)
   }
   override def update(row: IdentityTestRow)(implicit c: Connection): Boolean = {
     map.get(row.name) match {

--- a/typo-tester-anorm/generated-and-checked-in/adventureworks/public/pgtest/PgtestFields.scala
+++ b/typo-tester-anorm/generated-and-checked-in/adventureworks/public/pgtest/PgtestFields.scala
@@ -33,166 +33,167 @@ import adventureworks.customtypes.TypoVector
 import adventureworks.customtypes.TypoXml
 import adventureworks.public.Mydomain
 import adventureworks.public.Myenum
+import typo.dsl.Path
 import typo.dsl.SqlExpr.Field
 import typo.dsl.SqlExpr.FieldLikeNoHkt
 import typo.dsl.Structure.Relation
 
-trait PgtestFields[Row] {
-  val bool: Field[Boolean, Row]
-  val box: Field[TypoBox, Row]
-  val bpchar: Field[/* bpchar, max 3 chars */ String, Row]
-  val bytea: Field[TypoBytea, Row]
-  val char: Field[/* bpchar, max 1 chars */ String, Row]
-  val circle: Field[TypoCircle, Row]
-  val date: Field[TypoLocalDate, Row]
-  val float4: Field[Float, Row]
-  val float8: Field[Double, Row]
-  val hstore: Field[TypoHStore, Row]
-  val inet: Field[TypoInet, Row]
-  val int2: Field[TypoShort, Row]
-  val int2vector: Field[TypoInt2Vector, Row]
-  val int4: Field[Int, Row]
-  val int8: Field[Long, Row]
-  val interval: Field[TypoInterval, Row]
-  val json: Field[TypoJson, Row]
-  val jsonb: Field[TypoJsonb, Row]
-  val line: Field[TypoLine, Row]
-  val lseg: Field[TypoLineSegment, Row]
-  val money: Field[TypoMoney, Row]
-  val mydomain: Field[Mydomain, Row]
-  val myenum: Field[Myenum, Row]
-  val name: Field[String, Row]
-  val numeric: Field[BigDecimal, Row]
-  val path: Field[TypoPath, Row]
-  val point: Field[TypoPoint, Row]
-  val polygon: Field[TypoPolygon, Row]
-  val text: Field[String, Row]
-  val time: Field[TypoLocalTime, Row]
-  val timestamp: Field[TypoLocalDateTime, Row]
-  val timestampz: Field[TypoInstant, Row]
-  val timez: Field[TypoOffsetTime, Row]
-  val uuid: Field[TypoUUID, Row]
-  val varchar: Field[String, Row]
-  val vector: Field[TypoVector, Row]
-  val xml: Field[TypoXml, Row]
-  val boxes: Field[Array[TypoBox], Row]
-  val bpchares: Field[Array[/* bpchar */ String], Row]
-  val chares: Field[Array[/* bpchar */ String], Row]
-  val circlees: Field[Array[TypoCircle], Row]
-  val datees: Field[Array[TypoLocalDate], Row]
-  val float4es: Field[Array[Float], Row]
-  val float8es: Field[Array[Double], Row]
-  val inetes: Field[Array[TypoInet], Row]
-  val int2es: Field[Array[TypoShort], Row]
-  val int2vectores: Field[Array[TypoInt2Vector], Row]
-  val int4es: Field[Array[Int], Row]
-  val int8es: Field[Array[Long], Row]
-  val intervales: Field[Array[TypoInterval], Row]
-  val jsones: Field[Array[TypoJson], Row]
-  val jsonbes: Field[Array[TypoJsonb], Row]
-  val linees: Field[Array[TypoLine], Row]
-  val lseges: Field[Array[TypoLineSegment], Row]
-  val moneyes: Field[Array[TypoMoney], Row]
-  val myenumes: Field[Array[Myenum], Row]
-  val namees: Field[Array[String], Row]
-  val numerices: Field[Array[BigDecimal], Row]
-  val pathes: Field[Array[TypoPath], Row]
-  val pointes: Field[Array[TypoPoint], Row]
-  val polygones: Field[Array[TypoPolygon], Row]
-  val textes: Field[Array[String], Row]
-  val timees: Field[Array[TypoLocalTime], Row]
-  val timestampes: Field[Array[TypoLocalDateTime], Row]
-  val timestampzes: Field[Array[TypoInstant], Row]
-  val timezes: Field[Array[TypoOffsetTime], Row]
-  val uuides: Field[Array[TypoUUID], Row]
-  val varchares: Field[Array[String], Row]
-  val xmles: Field[Array[TypoXml], Row]
+trait PgtestFields {
+  def bool: Field[Boolean, PgtestRow]
+  def box: Field[TypoBox, PgtestRow]
+  def bpchar: Field[/* bpchar, max 3 chars */ String, PgtestRow]
+  def bytea: Field[TypoBytea, PgtestRow]
+  def char: Field[/* bpchar, max 1 chars */ String, PgtestRow]
+  def circle: Field[TypoCircle, PgtestRow]
+  def date: Field[TypoLocalDate, PgtestRow]
+  def float4: Field[Float, PgtestRow]
+  def float8: Field[Double, PgtestRow]
+  def hstore: Field[TypoHStore, PgtestRow]
+  def inet: Field[TypoInet, PgtestRow]
+  def int2: Field[TypoShort, PgtestRow]
+  def int2vector: Field[TypoInt2Vector, PgtestRow]
+  def int4: Field[Int, PgtestRow]
+  def int8: Field[Long, PgtestRow]
+  def interval: Field[TypoInterval, PgtestRow]
+  def json: Field[TypoJson, PgtestRow]
+  def jsonb: Field[TypoJsonb, PgtestRow]
+  def line: Field[TypoLine, PgtestRow]
+  def lseg: Field[TypoLineSegment, PgtestRow]
+  def money: Field[TypoMoney, PgtestRow]
+  def mydomain: Field[Mydomain, PgtestRow]
+  def myenum: Field[Myenum, PgtestRow]
+  def name: Field[String, PgtestRow]
+  def numeric: Field[BigDecimal, PgtestRow]
+  def path: Field[TypoPath, PgtestRow]
+  def point: Field[TypoPoint, PgtestRow]
+  def polygon: Field[TypoPolygon, PgtestRow]
+  def text: Field[String, PgtestRow]
+  def time: Field[TypoLocalTime, PgtestRow]
+  def timestamp: Field[TypoLocalDateTime, PgtestRow]
+  def timestampz: Field[TypoInstant, PgtestRow]
+  def timez: Field[TypoOffsetTime, PgtestRow]
+  def uuid: Field[TypoUUID, PgtestRow]
+  def varchar: Field[String, PgtestRow]
+  def vector: Field[TypoVector, PgtestRow]
+  def xml: Field[TypoXml, PgtestRow]
+  def boxes: Field[Array[TypoBox], PgtestRow]
+  def bpchares: Field[Array[/* bpchar */ String], PgtestRow]
+  def chares: Field[Array[/* bpchar */ String], PgtestRow]
+  def circlees: Field[Array[TypoCircle], PgtestRow]
+  def datees: Field[Array[TypoLocalDate], PgtestRow]
+  def float4es: Field[Array[Float], PgtestRow]
+  def float8es: Field[Array[Double], PgtestRow]
+  def inetes: Field[Array[TypoInet], PgtestRow]
+  def int2es: Field[Array[TypoShort], PgtestRow]
+  def int2vectores: Field[Array[TypoInt2Vector], PgtestRow]
+  def int4es: Field[Array[Int], PgtestRow]
+  def int8es: Field[Array[Long], PgtestRow]
+  def intervales: Field[Array[TypoInterval], PgtestRow]
+  def jsones: Field[Array[TypoJson], PgtestRow]
+  def jsonbes: Field[Array[TypoJsonb], PgtestRow]
+  def linees: Field[Array[TypoLine], PgtestRow]
+  def lseges: Field[Array[TypoLineSegment], PgtestRow]
+  def moneyes: Field[Array[TypoMoney], PgtestRow]
+  def myenumes: Field[Array[Myenum], PgtestRow]
+  def namees: Field[Array[String], PgtestRow]
+  def numerices: Field[Array[BigDecimal], PgtestRow]
+  def pathes: Field[Array[TypoPath], PgtestRow]
+  def pointes: Field[Array[TypoPoint], PgtestRow]
+  def polygones: Field[Array[TypoPolygon], PgtestRow]
+  def textes: Field[Array[String], PgtestRow]
+  def timees: Field[Array[TypoLocalTime], PgtestRow]
+  def timestampes: Field[Array[TypoLocalDateTime], PgtestRow]
+  def timestampzes: Field[Array[TypoInstant], PgtestRow]
+  def timezes: Field[Array[TypoOffsetTime], PgtestRow]
+  def uuides: Field[Array[TypoUUID], PgtestRow]
+  def varchares: Field[Array[String], PgtestRow]
+  def xmles: Field[Array[TypoXml], PgtestRow]
 }
 
 object PgtestFields {
-  val structure: Relation[PgtestFields, PgtestRow, PgtestRow] = 
-    new Impl(None, identity, (_, x) => x)
+  lazy val structure: Relation[PgtestFields, PgtestRow] =
+    new Impl(Nil)
     
-  private final class Impl[Row](val prefix: Option[String], val extract: Row => PgtestRow, val merge: (Row, PgtestRow) => Row)
-    extends Relation[PgtestFields, PgtestRow, Row] { 
+  private final class Impl(val _path: List[Path])
+    extends Relation[PgtestFields, PgtestRow] {
   
-    override val fields: PgtestFields[Row] = new PgtestFields[Row] {
-      override val bool = new Field[Boolean, Row](prefix, "bool", None, None)(x => extract(x).bool, (row, value) => merge(row, extract(row).copy(bool = value)))
-      override val box = new Field[TypoBox, Row](prefix, "box", None, Some("box"))(x => extract(x).box, (row, value) => merge(row, extract(row).copy(box = value)))
-      override val bpchar = new Field[/* bpchar, max 3 chars */ String, Row](prefix, "bpchar", None, Some("bpchar"))(x => extract(x).bpchar, (row, value) => merge(row, extract(row).copy(bpchar = value)))
-      override val bytea = new Field[TypoBytea, Row](prefix, "bytea", None, Some("bytea"))(x => extract(x).bytea, (row, value) => merge(row, extract(row).copy(bytea = value)))
-      override val char = new Field[/* bpchar, max 1 chars */ String, Row](prefix, "char", None, Some("bpchar"))(x => extract(x).char, (row, value) => merge(row, extract(row).copy(char = value)))
-      override val circle = new Field[TypoCircle, Row](prefix, "circle", None, Some("circle"))(x => extract(x).circle, (row, value) => merge(row, extract(row).copy(circle = value)))
-      override val date = new Field[TypoLocalDate, Row](prefix, "date", Some("text"), Some("date"))(x => extract(x).date, (row, value) => merge(row, extract(row).copy(date = value)))
-      override val float4 = new Field[Float, Row](prefix, "float4", None, Some("float4"))(x => extract(x).float4, (row, value) => merge(row, extract(row).copy(float4 = value)))
-      override val float8 = new Field[Double, Row](prefix, "float8", None, Some("float8"))(x => extract(x).float8, (row, value) => merge(row, extract(row).copy(float8 = value)))
-      override val hstore = new Field[TypoHStore, Row](prefix, "hstore", None, Some("hstore"))(x => extract(x).hstore, (row, value) => merge(row, extract(row).copy(hstore = value)))
-      override val inet = new Field[TypoInet, Row](prefix, "inet", None, Some("inet"))(x => extract(x).inet, (row, value) => merge(row, extract(row).copy(inet = value)))
-      override val int2 = new Field[TypoShort, Row](prefix, "int2", None, Some("int2"))(x => extract(x).int2, (row, value) => merge(row, extract(row).copy(int2 = value)))
-      override val int2vector = new Field[TypoInt2Vector, Row](prefix, "int2vector", None, Some("int2vector"))(x => extract(x).int2vector, (row, value) => merge(row, extract(row).copy(int2vector = value)))
-      override val int4 = new Field[Int, Row](prefix, "int4", None, Some("int4"))(x => extract(x).int4, (row, value) => merge(row, extract(row).copy(int4 = value)))
-      override val int8 = new Field[Long, Row](prefix, "int8", None, Some("int8"))(x => extract(x).int8, (row, value) => merge(row, extract(row).copy(int8 = value)))
-      override val interval = new Field[TypoInterval, Row](prefix, "interval", None, Some("interval"))(x => extract(x).interval, (row, value) => merge(row, extract(row).copy(interval = value)))
-      override val json = new Field[TypoJson, Row](prefix, "json", None, Some("json"))(x => extract(x).json, (row, value) => merge(row, extract(row).copy(json = value)))
-      override val jsonb = new Field[TypoJsonb, Row](prefix, "jsonb", None, Some("jsonb"))(x => extract(x).jsonb, (row, value) => merge(row, extract(row).copy(jsonb = value)))
-      override val line = new Field[TypoLine, Row](prefix, "line", None, Some("line"))(x => extract(x).line, (row, value) => merge(row, extract(row).copy(line = value)))
-      override val lseg = new Field[TypoLineSegment, Row](prefix, "lseg", None, Some("lseg"))(x => extract(x).lseg, (row, value) => merge(row, extract(row).copy(lseg = value)))
-      override val money = new Field[TypoMoney, Row](prefix, "money", Some("numeric"), Some("money"))(x => extract(x).money, (row, value) => merge(row, extract(row).copy(money = value)))
-      override val mydomain = new Field[Mydomain, Row](prefix, "mydomain", None, Some("text"))(x => extract(x).mydomain, (row, value) => merge(row, extract(row).copy(mydomain = value)))
-      override val myenum = new Field[Myenum, Row](prefix, "myenum", None, Some("public.myenum"))(x => extract(x).myenum, (row, value) => merge(row, extract(row).copy(myenum = value)))
-      override val name = new Field[String, Row](prefix, "name", None, Some("name"))(x => extract(x).name, (row, value) => merge(row, extract(row).copy(name = value)))
-      override val numeric = new Field[BigDecimal, Row](prefix, "numeric", None, Some("numeric"))(x => extract(x).numeric, (row, value) => merge(row, extract(row).copy(numeric = value)))
-      override val path = new Field[TypoPath, Row](prefix, "path", None, Some("path"))(x => extract(x).path, (row, value) => merge(row, extract(row).copy(path = value)))
-      override val point = new Field[TypoPoint, Row](prefix, "point", None, Some("point"))(x => extract(x).point, (row, value) => merge(row, extract(row).copy(point = value)))
-      override val polygon = new Field[TypoPolygon, Row](prefix, "polygon", None, Some("polygon"))(x => extract(x).polygon, (row, value) => merge(row, extract(row).copy(polygon = value)))
-      override val text = new Field[String, Row](prefix, "text", None, None)(x => extract(x).text, (row, value) => merge(row, extract(row).copy(text = value)))
-      override val time = new Field[TypoLocalTime, Row](prefix, "time", Some("text"), Some("time"))(x => extract(x).time, (row, value) => merge(row, extract(row).copy(time = value)))
-      override val timestamp = new Field[TypoLocalDateTime, Row](prefix, "timestamp", Some("text"), Some("timestamp"))(x => extract(x).timestamp, (row, value) => merge(row, extract(row).copy(timestamp = value)))
-      override val timestampz = new Field[TypoInstant, Row](prefix, "timestampz", Some("text"), Some("timestamptz"))(x => extract(x).timestampz, (row, value) => merge(row, extract(row).copy(timestampz = value)))
-      override val timez = new Field[TypoOffsetTime, Row](prefix, "timez", Some("text"), Some("timetz"))(x => extract(x).timez, (row, value) => merge(row, extract(row).copy(timez = value)))
-      override val uuid = new Field[TypoUUID, Row](prefix, "uuid", None, Some("uuid"))(x => extract(x).uuid, (row, value) => merge(row, extract(row).copy(uuid = value)))
-      override val varchar = new Field[String, Row](prefix, "varchar", None, None)(x => extract(x).varchar, (row, value) => merge(row, extract(row).copy(varchar = value)))
-      override val vector = new Field[TypoVector, Row](prefix, "vector", Some("float4[]"), Some("vector"))(x => extract(x).vector, (row, value) => merge(row, extract(row).copy(vector = value)))
-      override val xml = new Field[TypoXml, Row](prefix, "xml", None, Some("xml"))(x => extract(x).xml, (row, value) => merge(row, extract(row).copy(xml = value)))
-      override val boxes = new Field[Array[TypoBox], Row](prefix, "boxes", None, Some("_box"))(x => extract(x).boxes, (row, value) => merge(row, extract(row).copy(boxes = value)))
-      override val bpchares = new Field[Array[/* bpchar */ String], Row](prefix, "bpchares", None, Some("_bpchar"))(x => extract(x).bpchares, (row, value) => merge(row, extract(row).copy(bpchares = value)))
-      override val chares = new Field[Array[/* bpchar */ String], Row](prefix, "chares", None, Some("_bpchar"))(x => extract(x).chares, (row, value) => merge(row, extract(row).copy(chares = value)))
-      override val circlees = new Field[Array[TypoCircle], Row](prefix, "circlees", None, Some("_circle"))(x => extract(x).circlees, (row, value) => merge(row, extract(row).copy(circlees = value)))
-      override val datees = new Field[Array[TypoLocalDate], Row](prefix, "datees", Some("text[]"), Some("_date"))(x => extract(x).datees, (row, value) => merge(row, extract(row).copy(datees = value)))
-      override val float4es = new Field[Array[Float], Row](prefix, "float4es", None, Some("_float4"))(x => extract(x).float4es, (row, value) => merge(row, extract(row).copy(float4es = value)))
-      override val float8es = new Field[Array[Double], Row](prefix, "float8es", None, Some("_float8"))(x => extract(x).float8es, (row, value) => merge(row, extract(row).copy(float8es = value)))
-      override val inetes = new Field[Array[TypoInet], Row](prefix, "inetes", None, Some("_inet"))(x => extract(x).inetes, (row, value) => merge(row, extract(row).copy(inetes = value)))
-      override val int2es = new Field[Array[TypoShort], Row](prefix, "int2es", None, Some("_int2"))(x => extract(x).int2es, (row, value) => merge(row, extract(row).copy(int2es = value)))
-      override val int2vectores = new Field[Array[TypoInt2Vector], Row](prefix, "int2vectores", None, Some("_int2vector"))(x => extract(x).int2vectores, (row, value) => merge(row, extract(row).copy(int2vectores = value)))
-      override val int4es = new Field[Array[Int], Row](prefix, "int4es", None, Some("_int4"))(x => extract(x).int4es, (row, value) => merge(row, extract(row).copy(int4es = value)))
-      override val int8es = new Field[Array[Long], Row](prefix, "int8es", None, Some("_int8"))(x => extract(x).int8es, (row, value) => merge(row, extract(row).copy(int8es = value)))
-      override val intervales = new Field[Array[TypoInterval], Row](prefix, "intervales", None, Some("_interval"))(x => extract(x).intervales, (row, value) => merge(row, extract(row).copy(intervales = value)))
-      override val jsones = new Field[Array[TypoJson], Row](prefix, "jsones", None, Some("_json"))(x => extract(x).jsones, (row, value) => merge(row, extract(row).copy(jsones = value)))
-      override val jsonbes = new Field[Array[TypoJsonb], Row](prefix, "jsonbes", None, Some("_jsonb"))(x => extract(x).jsonbes, (row, value) => merge(row, extract(row).copy(jsonbes = value)))
-      override val linees = new Field[Array[TypoLine], Row](prefix, "linees", None, Some("_line"))(x => extract(x).linees, (row, value) => merge(row, extract(row).copy(linees = value)))
-      override val lseges = new Field[Array[TypoLineSegment], Row](prefix, "lseges", None, Some("_lseg"))(x => extract(x).lseges, (row, value) => merge(row, extract(row).copy(lseges = value)))
-      override val moneyes = new Field[Array[TypoMoney], Row](prefix, "moneyes", Some("numeric[]"), Some("_money"))(x => extract(x).moneyes, (row, value) => merge(row, extract(row).copy(moneyes = value)))
-      override val myenumes = new Field[Array[Myenum], Row](prefix, "myenumes", None, Some("_myenum"))(x => extract(x).myenumes, (row, value) => merge(row, extract(row).copy(myenumes = value)))
-      override val namees = new Field[Array[String], Row](prefix, "namees", None, Some("_name"))(x => extract(x).namees, (row, value) => merge(row, extract(row).copy(namees = value)))
-      override val numerices = new Field[Array[BigDecimal], Row](prefix, "numerices", None, Some("_numeric"))(x => extract(x).numerices, (row, value) => merge(row, extract(row).copy(numerices = value)))
-      override val pathes = new Field[Array[TypoPath], Row](prefix, "pathes", None, Some("_path"))(x => extract(x).pathes, (row, value) => merge(row, extract(row).copy(pathes = value)))
-      override val pointes = new Field[Array[TypoPoint], Row](prefix, "pointes", None, Some("_point"))(x => extract(x).pointes, (row, value) => merge(row, extract(row).copy(pointes = value)))
-      override val polygones = new Field[Array[TypoPolygon], Row](prefix, "polygones", None, Some("_polygon"))(x => extract(x).polygones, (row, value) => merge(row, extract(row).copy(polygones = value)))
-      override val textes = new Field[Array[String], Row](prefix, "textes", None, Some("_text"))(x => extract(x).textes, (row, value) => merge(row, extract(row).copy(textes = value)))
-      override val timees = new Field[Array[TypoLocalTime], Row](prefix, "timees", Some("text[]"), Some("_time"))(x => extract(x).timees, (row, value) => merge(row, extract(row).copy(timees = value)))
-      override val timestampes = new Field[Array[TypoLocalDateTime], Row](prefix, "timestampes", Some("text[]"), Some("_timestamp"))(x => extract(x).timestampes, (row, value) => merge(row, extract(row).copy(timestampes = value)))
-      override val timestampzes = new Field[Array[TypoInstant], Row](prefix, "timestampzes", Some("text[]"), Some("_timestamptz"))(x => extract(x).timestampzes, (row, value) => merge(row, extract(row).copy(timestampzes = value)))
-      override val timezes = new Field[Array[TypoOffsetTime], Row](prefix, "timezes", Some("text[]"), Some("_timetz"))(x => extract(x).timezes, (row, value) => merge(row, extract(row).copy(timezes = value)))
-      override val uuides = new Field[Array[TypoUUID], Row](prefix, "uuides", None, Some("_uuid"))(x => extract(x).uuides, (row, value) => merge(row, extract(row).copy(uuides = value)))
-      override val varchares = new Field[Array[String], Row](prefix, "varchares", None, Some("_varchar"))(x => extract(x).varchares, (row, value) => merge(row, extract(row).copy(varchares = value)))
-      override val xmles = new Field[Array[TypoXml], Row](prefix, "xmles", None, Some("_xml"))(x => extract(x).xmles, (row, value) => merge(row, extract(row).copy(xmles = value)))
+    override lazy val fields: PgtestFields = new PgtestFields {
+      override def bool = Field[Boolean, PgtestRow](_path, "bool", None, None, x => x.bool, (row, value) => row.copy(bool = value))
+      override def box = Field[TypoBox, PgtestRow](_path, "box", None, Some("box"), x => x.box, (row, value) => row.copy(box = value))
+      override def bpchar = Field[/* bpchar, max 3 chars */ String, PgtestRow](_path, "bpchar", None, Some("bpchar"), x => x.bpchar, (row, value) => row.copy(bpchar = value))
+      override def bytea = Field[TypoBytea, PgtestRow](_path, "bytea", None, Some("bytea"), x => x.bytea, (row, value) => row.copy(bytea = value))
+      override def char = Field[/* bpchar, max 1 chars */ String, PgtestRow](_path, "char", None, Some("bpchar"), x => x.char, (row, value) => row.copy(char = value))
+      override def circle = Field[TypoCircle, PgtestRow](_path, "circle", None, Some("circle"), x => x.circle, (row, value) => row.copy(circle = value))
+      override def date = Field[TypoLocalDate, PgtestRow](_path, "date", Some("text"), Some("date"), x => x.date, (row, value) => row.copy(date = value))
+      override def float4 = Field[Float, PgtestRow](_path, "float4", None, Some("float4"), x => x.float4, (row, value) => row.copy(float4 = value))
+      override def float8 = Field[Double, PgtestRow](_path, "float8", None, Some("float8"), x => x.float8, (row, value) => row.copy(float8 = value))
+      override def hstore = Field[TypoHStore, PgtestRow](_path, "hstore", None, Some("hstore"), x => x.hstore, (row, value) => row.copy(hstore = value))
+      override def inet = Field[TypoInet, PgtestRow](_path, "inet", None, Some("inet"), x => x.inet, (row, value) => row.copy(inet = value))
+      override def int2 = Field[TypoShort, PgtestRow](_path, "int2", None, Some("int2"), x => x.int2, (row, value) => row.copy(int2 = value))
+      override def int2vector = Field[TypoInt2Vector, PgtestRow](_path, "int2vector", None, Some("int2vector"), x => x.int2vector, (row, value) => row.copy(int2vector = value))
+      override def int4 = Field[Int, PgtestRow](_path, "int4", None, Some("int4"), x => x.int4, (row, value) => row.copy(int4 = value))
+      override def int8 = Field[Long, PgtestRow](_path, "int8", None, Some("int8"), x => x.int8, (row, value) => row.copy(int8 = value))
+      override def interval = Field[TypoInterval, PgtestRow](_path, "interval", None, Some("interval"), x => x.interval, (row, value) => row.copy(interval = value))
+      override def json = Field[TypoJson, PgtestRow](_path, "json", None, Some("json"), x => x.json, (row, value) => row.copy(json = value))
+      override def jsonb = Field[TypoJsonb, PgtestRow](_path, "jsonb", None, Some("jsonb"), x => x.jsonb, (row, value) => row.copy(jsonb = value))
+      override def line = Field[TypoLine, PgtestRow](_path, "line", None, Some("line"), x => x.line, (row, value) => row.copy(line = value))
+      override def lseg = Field[TypoLineSegment, PgtestRow](_path, "lseg", None, Some("lseg"), x => x.lseg, (row, value) => row.copy(lseg = value))
+      override def money = Field[TypoMoney, PgtestRow](_path, "money", Some("numeric"), Some("money"), x => x.money, (row, value) => row.copy(money = value))
+      override def mydomain = Field[Mydomain, PgtestRow](_path, "mydomain", None, Some("text"), x => x.mydomain, (row, value) => row.copy(mydomain = value))
+      override def myenum = Field[Myenum, PgtestRow](_path, "myenum", None, Some("public.myenum"), x => x.myenum, (row, value) => row.copy(myenum = value))
+      override def name = Field[String, PgtestRow](_path, "name", None, Some("name"), x => x.name, (row, value) => row.copy(name = value))
+      override def numeric = Field[BigDecimal, PgtestRow](_path, "numeric", None, Some("numeric"), x => x.numeric, (row, value) => row.copy(numeric = value))
+      override def path = Field[TypoPath, PgtestRow](_path, "path", None, Some("path"), x => x.path, (row, value) => row.copy(path = value))
+      override def point = Field[TypoPoint, PgtestRow](_path, "point", None, Some("point"), x => x.point, (row, value) => row.copy(point = value))
+      override def polygon = Field[TypoPolygon, PgtestRow](_path, "polygon", None, Some("polygon"), x => x.polygon, (row, value) => row.copy(polygon = value))
+      override def text = Field[String, PgtestRow](_path, "text", None, None, x => x.text, (row, value) => row.copy(text = value))
+      override def time = Field[TypoLocalTime, PgtestRow](_path, "time", Some("text"), Some("time"), x => x.time, (row, value) => row.copy(time = value))
+      override def timestamp = Field[TypoLocalDateTime, PgtestRow](_path, "timestamp", Some("text"), Some("timestamp"), x => x.timestamp, (row, value) => row.copy(timestamp = value))
+      override def timestampz = Field[TypoInstant, PgtestRow](_path, "timestampz", Some("text"), Some("timestamptz"), x => x.timestampz, (row, value) => row.copy(timestampz = value))
+      override def timez = Field[TypoOffsetTime, PgtestRow](_path, "timez", Some("text"), Some("timetz"), x => x.timez, (row, value) => row.copy(timez = value))
+      override def uuid = Field[TypoUUID, PgtestRow](_path, "uuid", None, Some("uuid"), x => x.uuid, (row, value) => row.copy(uuid = value))
+      override def varchar = Field[String, PgtestRow](_path, "varchar", None, None, x => x.varchar, (row, value) => row.copy(varchar = value))
+      override def vector = Field[TypoVector, PgtestRow](_path, "vector", Some("float4[]"), Some("vector"), x => x.vector, (row, value) => row.copy(vector = value))
+      override def xml = Field[TypoXml, PgtestRow](_path, "xml", None, Some("xml"), x => x.xml, (row, value) => row.copy(xml = value))
+      override def boxes = Field[Array[TypoBox], PgtestRow](_path, "boxes", None, Some("_box"), x => x.boxes, (row, value) => row.copy(boxes = value))
+      override def bpchares = Field[Array[/* bpchar */ String], PgtestRow](_path, "bpchares", None, Some("_bpchar"), x => x.bpchares, (row, value) => row.copy(bpchares = value))
+      override def chares = Field[Array[/* bpchar */ String], PgtestRow](_path, "chares", None, Some("_bpchar"), x => x.chares, (row, value) => row.copy(chares = value))
+      override def circlees = Field[Array[TypoCircle], PgtestRow](_path, "circlees", None, Some("_circle"), x => x.circlees, (row, value) => row.copy(circlees = value))
+      override def datees = Field[Array[TypoLocalDate], PgtestRow](_path, "datees", Some("text[]"), Some("_date"), x => x.datees, (row, value) => row.copy(datees = value))
+      override def float4es = Field[Array[Float], PgtestRow](_path, "float4es", None, Some("_float4"), x => x.float4es, (row, value) => row.copy(float4es = value))
+      override def float8es = Field[Array[Double], PgtestRow](_path, "float8es", None, Some("_float8"), x => x.float8es, (row, value) => row.copy(float8es = value))
+      override def inetes = Field[Array[TypoInet], PgtestRow](_path, "inetes", None, Some("_inet"), x => x.inetes, (row, value) => row.copy(inetes = value))
+      override def int2es = Field[Array[TypoShort], PgtestRow](_path, "int2es", None, Some("_int2"), x => x.int2es, (row, value) => row.copy(int2es = value))
+      override def int2vectores = Field[Array[TypoInt2Vector], PgtestRow](_path, "int2vectores", None, Some("_int2vector"), x => x.int2vectores, (row, value) => row.copy(int2vectores = value))
+      override def int4es = Field[Array[Int], PgtestRow](_path, "int4es", None, Some("_int4"), x => x.int4es, (row, value) => row.copy(int4es = value))
+      override def int8es = Field[Array[Long], PgtestRow](_path, "int8es", None, Some("_int8"), x => x.int8es, (row, value) => row.copy(int8es = value))
+      override def intervales = Field[Array[TypoInterval], PgtestRow](_path, "intervales", None, Some("_interval"), x => x.intervales, (row, value) => row.copy(intervales = value))
+      override def jsones = Field[Array[TypoJson], PgtestRow](_path, "jsones", None, Some("_json"), x => x.jsones, (row, value) => row.copy(jsones = value))
+      override def jsonbes = Field[Array[TypoJsonb], PgtestRow](_path, "jsonbes", None, Some("_jsonb"), x => x.jsonbes, (row, value) => row.copy(jsonbes = value))
+      override def linees = Field[Array[TypoLine], PgtestRow](_path, "linees", None, Some("_line"), x => x.linees, (row, value) => row.copy(linees = value))
+      override def lseges = Field[Array[TypoLineSegment], PgtestRow](_path, "lseges", None, Some("_lseg"), x => x.lseges, (row, value) => row.copy(lseges = value))
+      override def moneyes = Field[Array[TypoMoney], PgtestRow](_path, "moneyes", Some("numeric[]"), Some("_money"), x => x.moneyes, (row, value) => row.copy(moneyes = value))
+      override def myenumes = Field[Array[Myenum], PgtestRow](_path, "myenumes", None, Some("_myenum"), x => x.myenumes, (row, value) => row.copy(myenumes = value))
+      override def namees = Field[Array[String], PgtestRow](_path, "namees", None, Some("_name"), x => x.namees, (row, value) => row.copy(namees = value))
+      override def numerices = Field[Array[BigDecimal], PgtestRow](_path, "numerices", None, Some("_numeric"), x => x.numerices, (row, value) => row.copy(numerices = value))
+      override def pathes = Field[Array[TypoPath], PgtestRow](_path, "pathes", None, Some("_path"), x => x.pathes, (row, value) => row.copy(pathes = value))
+      override def pointes = Field[Array[TypoPoint], PgtestRow](_path, "pointes", None, Some("_point"), x => x.pointes, (row, value) => row.copy(pointes = value))
+      override def polygones = Field[Array[TypoPolygon], PgtestRow](_path, "polygones", None, Some("_polygon"), x => x.polygones, (row, value) => row.copy(polygones = value))
+      override def textes = Field[Array[String], PgtestRow](_path, "textes", None, Some("_text"), x => x.textes, (row, value) => row.copy(textes = value))
+      override def timees = Field[Array[TypoLocalTime], PgtestRow](_path, "timees", Some("text[]"), Some("_time"), x => x.timees, (row, value) => row.copy(timees = value))
+      override def timestampes = Field[Array[TypoLocalDateTime], PgtestRow](_path, "timestampes", Some("text[]"), Some("_timestamp"), x => x.timestampes, (row, value) => row.copy(timestampes = value))
+      override def timestampzes = Field[Array[TypoInstant], PgtestRow](_path, "timestampzes", Some("text[]"), Some("_timestamptz"), x => x.timestampzes, (row, value) => row.copy(timestampzes = value))
+      override def timezes = Field[Array[TypoOffsetTime], PgtestRow](_path, "timezes", Some("text[]"), Some("_timetz"), x => x.timezes, (row, value) => row.copy(timezes = value))
+      override def uuides = Field[Array[TypoUUID], PgtestRow](_path, "uuides", None, Some("_uuid"), x => x.uuides, (row, value) => row.copy(uuides = value))
+      override def varchares = Field[Array[String], PgtestRow](_path, "varchares", None, Some("_varchar"), x => x.varchares, (row, value) => row.copy(varchares = value))
+      override def xmles = Field[Array[TypoXml], PgtestRow](_path, "xmles", None, Some("_xml"), x => x.xmles, (row, value) => row.copy(xmles = value))
     }
   
-    override val columns: List[FieldLikeNoHkt[?, Row]] =
-      List[FieldLikeNoHkt[?, Row]](fields.bool, fields.box, fields.bpchar, fields.bytea, fields.char, fields.circle, fields.date, fields.float4, fields.float8, fields.hstore, fields.inet, fields.int2, fields.int2vector, fields.int4, fields.int8, fields.interval, fields.json, fields.jsonb, fields.line, fields.lseg, fields.money, fields.mydomain, fields.myenum, fields.name, fields.numeric, fields.path, fields.point, fields.polygon, fields.text, fields.time, fields.timestamp, fields.timestampz, fields.timez, fields.uuid, fields.varchar, fields.vector, fields.xml, fields.boxes, fields.bpchares, fields.chares, fields.circlees, fields.datees, fields.float4es, fields.float8es, fields.inetes, fields.int2es, fields.int2vectores, fields.int4es, fields.int8es, fields.intervales, fields.jsones, fields.jsonbes, fields.linees, fields.lseges, fields.moneyes, fields.myenumes, fields.namees, fields.numerices, fields.pathes, fields.pointes, fields.polygones, fields.textes, fields.timees, fields.timestampes, fields.timestampzes, fields.timezes, fields.uuides, fields.varchares, fields.xmles)
+    override lazy val columns: List[FieldLikeNoHkt[?, PgtestRow]] =
+      List[FieldLikeNoHkt[?, PgtestRow]](fields.bool, fields.box, fields.bpchar, fields.bytea, fields.char, fields.circle, fields.date, fields.float4, fields.float8, fields.hstore, fields.inet, fields.int2, fields.int2vector, fields.int4, fields.int8, fields.interval, fields.json, fields.jsonb, fields.line, fields.lseg, fields.money, fields.mydomain, fields.myenum, fields.name, fields.numeric, fields.path, fields.point, fields.polygon, fields.text, fields.time, fields.timestamp, fields.timestampz, fields.timez, fields.uuid, fields.varchar, fields.vector, fields.xml, fields.boxes, fields.bpchares, fields.chares, fields.circlees, fields.datees, fields.float4es, fields.float8es, fields.inetes, fields.int2es, fields.int2vectores, fields.int4es, fields.int8es, fields.intervales, fields.jsones, fields.jsonbes, fields.linees, fields.lseges, fields.moneyes, fields.myenumes, fields.namees, fields.numerices, fields.pathes, fields.pointes, fields.polygones, fields.textes, fields.timees, fields.timestampes, fields.timestampzes, fields.timezes, fields.uuides, fields.varchares, fields.xmles)
   
-    override def copy[NewRow](prefix: Option[String], extract: NewRow => PgtestRow, merge: (NewRow, PgtestRow) => NewRow): Impl[NewRow] =
-      new Impl(prefix, extract, merge)
+    override def copy(path: List[Path]): Impl =
+      new Impl(path)
   }
   
 }

--- a/typo-tester-anorm/generated-and-checked-in/adventureworks/public/pgtestnull/PgtestnullFields.scala
+++ b/typo-tester-anorm/generated-and-checked-in/adventureworks/public/pgtestnull/PgtestnullFields.scala
@@ -33,166 +33,167 @@ import adventureworks.customtypes.TypoVector
 import adventureworks.customtypes.TypoXml
 import adventureworks.public.Mydomain
 import adventureworks.public.Myenum
+import typo.dsl.Path
 import typo.dsl.SqlExpr.FieldLikeNoHkt
 import typo.dsl.SqlExpr.OptField
 import typo.dsl.Structure.Relation
 
-trait PgtestnullFields[Row] {
-  val bool: OptField[Boolean, Row]
-  val box: OptField[TypoBox, Row]
-  val bpchar: OptField[/* bpchar, max 3 chars */ String, Row]
-  val bytea: OptField[TypoBytea, Row]
-  val char: OptField[/* bpchar, max 1 chars */ String, Row]
-  val circle: OptField[TypoCircle, Row]
-  val date: OptField[TypoLocalDate, Row]
-  val float4: OptField[Float, Row]
-  val float8: OptField[Double, Row]
-  val hstore: OptField[TypoHStore, Row]
-  val inet: OptField[TypoInet, Row]
-  val int2: OptField[TypoShort, Row]
-  val int2vector: OptField[TypoInt2Vector, Row]
-  val int4: OptField[Int, Row]
-  val int8: OptField[Long, Row]
-  val interval: OptField[TypoInterval, Row]
-  val json: OptField[TypoJson, Row]
-  val jsonb: OptField[TypoJsonb, Row]
-  val line: OptField[TypoLine, Row]
-  val lseg: OptField[TypoLineSegment, Row]
-  val money: OptField[TypoMoney, Row]
-  val mydomain: OptField[Mydomain, Row]
-  val myenum: OptField[Myenum, Row]
-  val name: OptField[String, Row]
-  val numeric: OptField[BigDecimal, Row]
-  val path: OptField[TypoPath, Row]
-  val point: OptField[TypoPoint, Row]
-  val polygon: OptField[TypoPolygon, Row]
-  val text: OptField[String, Row]
-  val time: OptField[TypoLocalTime, Row]
-  val timestamp: OptField[TypoLocalDateTime, Row]
-  val timestampz: OptField[TypoInstant, Row]
-  val timez: OptField[TypoOffsetTime, Row]
-  val uuid: OptField[TypoUUID, Row]
-  val varchar: OptField[String, Row]
-  val vector: OptField[TypoVector, Row]
-  val xml: OptField[TypoXml, Row]
-  val boxes: OptField[Array[TypoBox], Row]
-  val bpchares: OptField[Array[/* bpchar */ String], Row]
-  val chares: OptField[Array[/* bpchar */ String], Row]
-  val circlees: OptField[Array[TypoCircle], Row]
-  val datees: OptField[Array[TypoLocalDate], Row]
-  val float4es: OptField[Array[Float], Row]
-  val float8es: OptField[Array[Double], Row]
-  val inetes: OptField[Array[TypoInet], Row]
-  val int2es: OptField[Array[TypoShort], Row]
-  val int2vectores: OptField[Array[TypoInt2Vector], Row]
-  val int4es: OptField[Array[Int], Row]
-  val int8es: OptField[Array[Long], Row]
-  val intervales: OptField[Array[TypoInterval], Row]
-  val jsones: OptField[Array[TypoJson], Row]
-  val jsonbes: OptField[Array[TypoJsonb], Row]
-  val linees: OptField[Array[TypoLine], Row]
-  val lseges: OptField[Array[TypoLineSegment], Row]
-  val moneyes: OptField[Array[TypoMoney], Row]
-  val myenumes: OptField[Array[Myenum], Row]
-  val namees: OptField[Array[String], Row]
-  val numerices: OptField[Array[BigDecimal], Row]
-  val pathes: OptField[Array[TypoPath], Row]
-  val pointes: OptField[Array[TypoPoint], Row]
-  val polygones: OptField[Array[TypoPolygon], Row]
-  val textes: OptField[Array[String], Row]
-  val timees: OptField[Array[TypoLocalTime], Row]
-  val timestampes: OptField[Array[TypoLocalDateTime], Row]
-  val timestampzes: OptField[Array[TypoInstant], Row]
-  val timezes: OptField[Array[TypoOffsetTime], Row]
-  val uuides: OptField[Array[TypoUUID], Row]
-  val varchares: OptField[Array[String], Row]
-  val xmles: OptField[Array[TypoXml], Row]
+trait PgtestnullFields {
+  def bool: OptField[Boolean, PgtestnullRow]
+  def box: OptField[TypoBox, PgtestnullRow]
+  def bpchar: OptField[/* bpchar, max 3 chars */ String, PgtestnullRow]
+  def bytea: OptField[TypoBytea, PgtestnullRow]
+  def char: OptField[/* bpchar, max 1 chars */ String, PgtestnullRow]
+  def circle: OptField[TypoCircle, PgtestnullRow]
+  def date: OptField[TypoLocalDate, PgtestnullRow]
+  def float4: OptField[Float, PgtestnullRow]
+  def float8: OptField[Double, PgtestnullRow]
+  def hstore: OptField[TypoHStore, PgtestnullRow]
+  def inet: OptField[TypoInet, PgtestnullRow]
+  def int2: OptField[TypoShort, PgtestnullRow]
+  def int2vector: OptField[TypoInt2Vector, PgtestnullRow]
+  def int4: OptField[Int, PgtestnullRow]
+  def int8: OptField[Long, PgtestnullRow]
+  def interval: OptField[TypoInterval, PgtestnullRow]
+  def json: OptField[TypoJson, PgtestnullRow]
+  def jsonb: OptField[TypoJsonb, PgtestnullRow]
+  def line: OptField[TypoLine, PgtestnullRow]
+  def lseg: OptField[TypoLineSegment, PgtestnullRow]
+  def money: OptField[TypoMoney, PgtestnullRow]
+  def mydomain: OptField[Mydomain, PgtestnullRow]
+  def myenum: OptField[Myenum, PgtestnullRow]
+  def name: OptField[String, PgtestnullRow]
+  def numeric: OptField[BigDecimal, PgtestnullRow]
+  def path: OptField[TypoPath, PgtestnullRow]
+  def point: OptField[TypoPoint, PgtestnullRow]
+  def polygon: OptField[TypoPolygon, PgtestnullRow]
+  def text: OptField[String, PgtestnullRow]
+  def time: OptField[TypoLocalTime, PgtestnullRow]
+  def timestamp: OptField[TypoLocalDateTime, PgtestnullRow]
+  def timestampz: OptField[TypoInstant, PgtestnullRow]
+  def timez: OptField[TypoOffsetTime, PgtestnullRow]
+  def uuid: OptField[TypoUUID, PgtestnullRow]
+  def varchar: OptField[String, PgtestnullRow]
+  def vector: OptField[TypoVector, PgtestnullRow]
+  def xml: OptField[TypoXml, PgtestnullRow]
+  def boxes: OptField[Array[TypoBox], PgtestnullRow]
+  def bpchares: OptField[Array[/* bpchar */ String], PgtestnullRow]
+  def chares: OptField[Array[/* bpchar */ String], PgtestnullRow]
+  def circlees: OptField[Array[TypoCircle], PgtestnullRow]
+  def datees: OptField[Array[TypoLocalDate], PgtestnullRow]
+  def float4es: OptField[Array[Float], PgtestnullRow]
+  def float8es: OptField[Array[Double], PgtestnullRow]
+  def inetes: OptField[Array[TypoInet], PgtestnullRow]
+  def int2es: OptField[Array[TypoShort], PgtestnullRow]
+  def int2vectores: OptField[Array[TypoInt2Vector], PgtestnullRow]
+  def int4es: OptField[Array[Int], PgtestnullRow]
+  def int8es: OptField[Array[Long], PgtestnullRow]
+  def intervales: OptField[Array[TypoInterval], PgtestnullRow]
+  def jsones: OptField[Array[TypoJson], PgtestnullRow]
+  def jsonbes: OptField[Array[TypoJsonb], PgtestnullRow]
+  def linees: OptField[Array[TypoLine], PgtestnullRow]
+  def lseges: OptField[Array[TypoLineSegment], PgtestnullRow]
+  def moneyes: OptField[Array[TypoMoney], PgtestnullRow]
+  def myenumes: OptField[Array[Myenum], PgtestnullRow]
+  def namees: OptField[Array[String], PgtestnullRow]
+  def numerices: OptField[Array[BigDecimal], PgtestnullRow]
+  def pathes: OptField[Array[TypoPath], PgtestnullRow]
+  def pointes: OptField[Array[TypoPoint], PgtestnullRow]
+  def polygones: OptField[Array[TypoPolygon], PgtestnullRow]
+  def textes: OptField[Array[String], PgtestnullRow]
+  def timees: OptField[Array[TypoLocalTime], PgtestnullRow]
+  def timestampes: OptField[Array[TypoLocalDateTime], PgtestnullRow]
+  def timestampzes: OptField[Array[TypoInstant], PgtestnullRow]
+  def timezes: OptField[Array[TypoOffsetTime], PgtestnullRow]
+  def uuides: OptField[Array[TypoUUID], PgtestnullRow]
+  def varchares: OptField[Array[String], PgtestnullRow]
+  def xmles: OptField[Array[TypoXml], PgtestnullRow]
 }
 
 object PgtestnullFields {
-  val structure: Relation[PgtestnullFields, PgtestnullRow, PgtestnullRow] = 
-    new Impl(None, identity, (_, x) => x)
+  lazy val structure: Relation[PgtestnullFields, PgtestnullRow] =
+    new Impl(Nil)
     
-  private final class Impl[Row](val prefix: Option[String], val extract: Row => PgtestnullRow, val merge: (Row, PgtestnullRow) => Row)
-    extends Relation[PgtestnullFields, PgtestnullRow, Row] { 
+  private final class Impl(val _path: List[Path])
+    extends Relation[PgtestnullFields, PgtestnullRow] {
   
-    override val fields: PgtestnullFields[Row] = new PgtestnullFields[Row] {
-      override val bool = new OptField[Boolean, Row](prefix, "bool", None, None)(x => extract(x).bool, (row, value) => merge(row, extract(row).copy(bool = value)))
-      override val box = new OptField[TypoBox, Row](prefix, "box", None, Some("box"))(x => extract(x).box, (row, value) => merge(row, extract(row).copy(box = value)))
-      override val bpchar = new OptField[/* bpchar, max 3 chars */ String, Row](prefix, "bpchar", None, Some("bpchar"))(x => extract(x).bpchar, (row, value) => merge(row, extract(row).copy(bpchar = value)))
-      override val bytea = new OptField[TypoBytea, Row](prefix, "bytea", None, Some("bytea"))(x => extract(x).bytea, (row, value) => merge(row, extract(row).copy(bytea = value)))
-      override val char = new OptField[/* bpchar, max 1 chars */ String, Row](prefix, "char", None, Some("bpchar"))(x => extract(x).char, (row, value) => merge(row, extract(row).copy(char = value)))
-      override val circle = new OptField[TypoCircle, Row](prefix, "circle", None, Some("circle"))(x => extract(x).circle, (row, value) => merge(row, extract(row).copy(circle = value)))
-      override val date = new OptField[TypoLocalDate, Row](prefix, "date", Some("text"), Some("date"))(x => extract(x).date, (row, value) => merge(row, extract(row).copy(date = value)))
-      override val float4 = new OptField[Float, Row](prefix, "float4", None, Some("float4"))(x => extract(x).float4, (row, value) => merge(row, extract(row).copy(float4 = value)))
-      override val float8 = new OptField[Double, Row](prefix, "float8", None, Some("float8"))(x => extract(x).float8, (row, value) => merge(row, extract(row).copy(float8 = value)))
-      override val hstore = new OptField[TypoHStore, Row](prefix, "hstore", None, Some("hstore"))(x => extract(x).hstore, (row, value) => merge(row, extract(row).copy(hstore = value)))
-      override val inet = new OptField[TypoInet, Row](prefix, "inet", None, Some("inet"))(x => extract(x).inet, (row, value) => merge(row, extract(row).copy(inet = value)))
-      override val int2 = new OptField[TypoShort, Row](prefix, "int2", None, Some("int2"))(x => extract(x).int2, (row, value) => merge(row, extract(row).copy(int2 = value)))
-      override val int2vector = new OptField[TypoInt2Vector, Row](prefix, "int2vector", None, Some("int2vector"))(x => extract(x).int2vector, (row, value) => merge(row, extract(row).copy(int2vector = value)))
-      override val int4 = new OptField[Int, Row](prefix, "int4", None, Some("int4"))(x => extract(x).int4, (row, value) => merge(row, extract(row).copy(int4 = value)))
-      override val int8 = new OptField[Long, Row](prefix, "int8", None, Some("int8"))(x => extract(x).int8, (row, value) => merge(row, extract(row).copy(int8 = value)))
-      override val interval = new OptField[TypoInterval, Row](prefix, "interval", None, Some("interval"))(x => extract(x).interval, (row, value) => merge(row, extract(row).copy(interval = value)))
-      override val json = new OptField[TypoJson, Row](prefix, "json", None, Some("json"))(x => extract(x).json, (row, value) => merge(row, extract(row).copy(json = value)))
-      override val jsonb = new OptField[TypoJsonb, Row](prefix, "jsonb", None, Some("jsonb"))(x => extract(x).jsonb, (row, value) => merge(row, extract(row).copy(jsonb = value)))
-      override val line = new OptField[TypoLine, Row](prefix, "line", None, Some("line"))(x => extract(x).line, (row, value) => merge(row, extract(row).copy(line = value)))
-      override val lseg = new OptField[TypoLineSegment, Row](prefix, "lseg", None, Some("lseg"))(x => extract(x).lseg, (row, value) => merge(row, extract(row).copy(lseg = value)))
-      override val money = new OptField[TypoMoney, Row](prefix, "money", Some("numeric"), Some("money"))(x => extract(x).money, (row, value) => merge(row, extract(row).copy(money = value)))
-      override val mydomain = new OptField[Mydomain, Row](prefix, "mydomain", None, Some("text"))(x => extract(x).mydomain, (row, value) => merge(row, extract(row).copy(mydomain = value)))
-      override val myenum = new OptField[Myenum, Row](prefix, "myenum", None, Some("public.myenum"))(x => extract(x).myenum, (row, value) => merge(row, extract(row).copy(myenum = value)))
-      override val name = new OptField[String, Row](prefix, "name", None, Some("name"))(x => extract(x).name, (row, value) => merge(row, extract(row).copy(name = value)))
-      override val numeric = new OptField[BigDecimal, Row](prefix, "numeric", None, Some("numeric"))(x => extract(x).numeric, (row, value) => merge(row, extract(row).copy(numeric = value)))
-      override val path = new OptField[TypoPath, Row](prefix, "path", None, Some("path"))(x => extract(x).path, (row, value) => merge(row, extract(row).copy(path = value)))
-      override val point = new OptField[TypoPoint, Row](prefix, "point", None, Some("point"))(x => extract(x).point, (row, value) => merge(row, extract(row).copy(point = value)))
-      override val polygon = new OptField[TypoPolygon, Row](prefix, "polygon", None, Some("polygon"))(x => extract(x).polygon, (row, value) => merge(row, extract(row).copy(polygon = value)))
-      override val text = new OptField[String, Row](prefix, "text", None, None)(x => extract(x).text, (row, value) => merge(row, extract(row).copy(text = value)))
-      override val time = new OptField[TypoLocalTime, Row](prefix, "time", Some("text"), Some("time"))(x => extract(x).time, (row, value) => merge(row, extract(row).copy(time = value)))
-      override val timestamp = new OptField[TypoLocalDateTime, Row](prefix, "timestamp", Some("text"), Some("timestamp"))(x => extract(x).timestamp, (row, value) => merge(row, extract(row).copy(timestamp = value)))
-      override val timestampz = new OptField[TypoInstant, Row](prefix, "timestampz", Some("text"), Some("timestamptz"))(x => extract(x).timestampz, (row, value) => merge(row, extract(row).copy(timestampz = value)))
-      override val timez = new OptField[TypoOffsetTime, Row](prefix, "timez", Some("text"), Some("timetz"))(x => extract(x).timez, (row, value) => merge(row, extract(row).copy(timez = value)))
-      override val uuid = new OptField[TypoUUID, Row](prefix, "uuid", None, Some("uuid"))(x => extract(x).uuid, (row, value) => merge(row, extract(row).copy(uuid = value)))
-      override val varchar = new OptField[String, Row](prefix, "varchar", None, None)(x => extract(x).varchar, (row, value) => merge(row, extract(row).copy(varchar = value)))
-      override val vector = new OptField[TypoVector, Row](prefix, "vector", Some("float4[]"), Some("vector"))(x => extract(x).vector, (row, value) => merge(row, extract(row).copy(vector = value)))
-      override val xml = new OptField[TypoXml, Row](prefix, "xml", None, Some("xml"))(x => extract(x).xml, (row, value) => merge(row, extract(row).copy(xml = value)))
-      override val boxes = new OptField[Array[TypoBox], Row](prefix, "boxes", None, Some("_box"))(x => extract(x).boxes, (row, value) => merge(row, extract(row).copy(boxes = value)))
-      override val bpchares = new OptField[Array[/* bpchar */ String], Row](prefix, "bpchares", None, Some("_bpchar"))(x => extract(x).bpchares, (row, value) => merge(row, extract(row).copy(bpchares = value)))
-      override val chares = new OptField[Array[/* bpchar */ String], Row](prefix, "chares", None, Some("_bpchar"))(x => extract(x).chares, (row, value) => merge(row, extract(row).copy(chares = value)))
-      override val circlees = new OptField[Array[TypoCircle], Row](prefix, "circlees", None, Some("_circle"))(x => extract(x).circlees, (row, value) => merge(row, extract(row).copy(circlees = value)))
-      override val datees = new OptField[Array[TypoLocalDate], Row](prefix, "datees", Some("text[]"), Some("_date"))(x => extract(x).datees, (row, value) => merge(row, extract(row).copy(datees = value)))
-      override val float4es = new OptField[Array[Float], Row](prefix, "float4es", None, Some("_float4"))(x => extract(x).float4es, (row, value) => merge(row, extract(row).copy(float4es = value)))
-      override val float8es = new OptField[Array[Double], Row](prefix, "float8es", None, Some("_float8"))(x => extract(x).float8es, (row, value) => merge(row, extract(row).copy(float8es = value)))
-      override val inetes = new OptField[Array[TypoInet], Row](prefix, "inetes", None, Some("_inet"))(x => extract(x).inetes, (row, value) => merge(row, extract(row).copy(inetes = value)))
-      override val int2es = new OptField[Array[TypoShort], Row](prefix, "int2es", None, Some("_int2"))(x => extract(x).int2es, (row, value) => merge(row, extract(row).copy(int2es = value)))
-      override val int2vectores = new OptField[Array[TypoInt2Vector], Row](prefix, "int2vectores", None, Some("_int2vector"))(x => extract(x).int2vectores, (row, value) => merge(row, extract(row).copy(int2vectores = value)))
-      override val int4es = new OptField[Array[Int], Row](prefix, "int4es", None, Some("_int4"))(x => extract(x).int4es, (row, value) => merge(row, extract(row).copy(int4es = value)))
-      override val int8es = new OptField[Array[Long], Row](prefix, "int8es", None, Some("_int8"))(x => extract(x).int8es, (row, value) => merge(row, extract(row).copy(int8es = value)))
-      override val intervales = new OptField[Array[TypoInterval], Row](prefix, "intervales", None, Some("_interval"))(x => extract(x).intervales, (row, value) => merge(row, extract(row).copy(intervales = value)))
-      override val jsones = new OptField[Array[TypoJson], Row](prefix, "jsones", None, Some("_json"))(x => extract(x).jsones, (row, value) => merge(row, extract(row).copy(jsones = value)))
-      override val jsonbes = new OptField[Array[TypoJsonb], Row](prefix, "jsonbes", None, Some("_jsonb"))(x => extract(x).jsonbes, (row, value) => merge(row, extract(row).copy(jsonbes = value)))
-      override val linees = new OptField[Array[TypoLine], Row](prefix, "linees", None, Some("_line"))(x => extract(x).linees, (row, value) => merge(row, extract(row).copy(linees = value)))
-      override val lseges = new OptField[Array[TypoLineSegment], Row](prefix, "lseges", None, Some("_lseg"))(x => extract(x).lseges, (row, value) => merge(row, extract(row).copy(lseges = value)))
-      override val moneyes = new OptField[Array[TypoMoney], Row](prefix, "moneyes", Some("numeric[]"), Some("_money"))(x => extract(x).moneyes, (row, value) => merge(row, extract(row).copy(moneyes = value)))
-      override val myenumes = new OptField[Array[Myenum], Row](prefix, "myenumes", None, Some("_myenum"))(x => extract(x).myenumes, (row, value) => merge(row, extract(row).copy(myenumes = value)))
-      override val namees = new OptField[Array[String], Row](prefix, "namees", None, Some("_name"))(x => extract(x).namees, (row, value) => merge(row, extract(row).copy(namees = value)))
-      override val numerices = new OptField[Array[BigDecimal], Row](prefix, "numerices", None, Some("_numeric"))(x => extract(x).numerices, (row, value) => merge(row, extract(row).copy(numerices = value)))
-      override val pathes = new OptField[Array[TypoPath], Row](prefix, "pathes", None, Some("_path"))(x => extract(x).pathes, (row, value) => merge(row, extract(row).copy(pathes = value)))
-      override val pointes = new OptField[Array[TypoPoint], Row](prefix, "pointes", None, Some("_point"))(x => extract(x).pointes, (row, value) => merge(row, extract(row).copy(pointes = value)))
-      override val polygones = new OptField[Array[TypoPolygon], Row](prefix, "polygones", None, Some("_polygon"))(x => extract(x).polygones, (row, value) => merge(row, extract(row).copy(polygones = value)))
-      override val textes = new OptField[Array[String], Row](prefix, "textes", None, Some("_text"))(x => extract(x).textes, (row, value) => merge(row, extract(row).copy(textes = value)))
-      override val timees = new OptField[Array[TypoLocalTime], Row](prefix, "timees", Some("text[]"), Some("_time"))(x => extract(x).timees, (row, value) => merge(row, extract(row).copy(timees = value)))
-      override val timestampes = new OptField[Array[TypoLocalDateTime], Row](prefix, "timestampes", Some("text[]"), Some("_timestamp"))(x => extract(x).timestampes, (row, value) => merge(row, extract(row).copy(timestampes = value)))
-      override val timestampzes = new OptField[Array[TypoInstant], Row](prefix, "timestampzes", Some("text[]"), Some("_timestamptz"))(x => extract(x).timestampzes, (row, value) => merge(row, extract(row).copy(timestampzes = value)))
-      override val timezes = new OptField[Array[TypoOffsetTime], Row](prefix, "timezes", Some("text[]"), Some("_timetz"))(x => extract(x).timezes, (row, value) => merge(row, extract(row).copy(timezes = value)))
-      override val uuides = new OptField[Array[TypoUUID], Row](prefix, "uuides", None, Some("_uuid"))(x => extract(x).uuides, (row, value) => merge(row, extract(row).copy(uuides = value)))
-      override val varchares = new OptField[Array[String], Row](prefix, "varchares", None, Some("_varchar"))(x => extract(x).varchares, (row, value) => merge(row, extract(row).copy(varchares = value)))
-      override val xmles = new OptField[Array[TypoXml], Row](prefix, "xmles", None, Some("_xml"))(x => extract(x).xmles, (row, value) => merge(row, extract(row).copy(xmles = value)))
+    override lazy val fields: PgtestnullFields = new PgtestnullFields {
+      override def bool = OptField[Boolean, PgtestnullRow](_path, "bool", None, None, x => x.bool, (row, value) => row.copy(bool = value))
+      override def box = OptField[TypoBox, PgtestnullRow](_path, "box", None, Some("box"), x => x.box, (row, value) => row.copy(box = value))
+      override def bpchar = OptField[/* bpchar, max 3 chars */ String, PgtestnullRow](_path, "bpchar", None, Some("bpchar"), x => x.bpchar, (row, value) => row.copy(bpchar = value))
+      override def bytea = OptField[TypoBytea, PgtestnullRow](_path, "bytea", None, Some("bytea"), x => x.bytea, (row, value) => row.copy(bytea = value))
+      override def char = OptField[/* bpchar, max 1 chars */ String, PgtestnullRow](_path, "char", None, Some("bpchar"), x => x.char, (row, value) => row.copy(char = value))
+      override def circle = OptField[TypoCircle, PgtestnullRow](_path, "circle", None, Some("circle"), x => x.circle, (row, value) => row.copy(circle = value))
+      override def date = OptField[TypoLocalDate, PgtestnullRow](_path, "date", Some("text"), Some("date"), x => x.date, (row, value) => row.copy(date = value))
+      override def float4 = OptField[Float, PgtestnullRow](_path, "float4", None, Some("float4"), x => x.float4, (row, value) => row.copy(float4 = value))
+      override def float8 = OptField[Double, PgtestnullRow](_path, "float8", None, Some("float8"), x => x.float8, (row, value) => row.copy(float8 = value))
+      override def hstore = OptField[TypoHStore, PgtestnullRow](_path, "hstore", None, Some("hstore"), x => x.hstore, (row, value) => row.copy(hstore = value))
+      override def inet = OptField[TypoInet, PgtestnullRow](_path, "inet", None, Some("inet"), x => x.inet, (row, value) => row.copy(inet = value))
+      override def int2 = OptField[TypoShort, PgtestnullRow](_path, "int2", None, Some("int2"), x => x.int2, (row, value) => row.copy(int2 = value))
+      override def int2vector = OptField[TypoInt2Vector, PgtestnullRow](_path, "int2vector", None, Some("int2vector"), x => x.int2vector, (row, value) => row.copy(int2vector = value))
+      override def int4 = OptField[Int, PgtestnullRow](_path, "int4", None, Some("int4"), x => x.int4, (row, value) => row.copy(int4 = value))
+      override def int8 = OptField[Long, PgtestnullRow](_path, "int8", None, Some("int8"), x => x.int8, (row, value) => row.copy(int8 = value))
+      override def interval = OptField[TypoInterval, PgtestnullRow](_path, "interval", None, Some("interval"), x => x.interval, (row, value) => row.copy(interval = value))
+      override def json = OptField[TypoJson, PgtestnullRow](_path, "json", None, Some("json"), x => x.json, (row, value) => row.copy(json = value))
+      override def jsonb = OptField[TypoJsonb, PgtestnullRow](_path, "jsonb", None, Some("jsonb"), x => x.jsonb, (row, value) => row.copy(jsonb = value))
+      override def line = OptField[TypoLine, PgtestnullRow](_path, "line", None, Some("line"), x => x.line, (row, value) => row.copy(line = value))
+      override def lseg = OptField[TypoLineSegment, PgtestnullRow](_path, "lseg", None, Some("lseg"), x => x.lseg, (row, value) => row.copy(lseg = value))
+      override def money = OptField[TypoMoney, PgtestnullRow](_path, "money", Some("numeric"), Some("money"), x => x.money, (row, value) => row.copy(money = value))
+      override def mydomain = OptField[Mydomain, PgtestnullRow](_path, "mydomain", None, Some("text"), x => x.mydomain, (row, value) => row.copy(mydomain = value))
+      override def myenum = OptField[Myenum, PgtestnullRow](_path, "myenum", None, Some("public.myenum"), x => x.myenum, (row, value) => row.copy(myenum = value))
+      override def name = OptField[String, PgtestnullRow](_path, "name", None, Some("name"), x => x.name, (row, value) => row.copy(name = value))
+      override def numeric = OptField[BigDecimal, PgtestnullRow](_path, "numeric", None, Some("numeric"), x => x.numeric, (row, value) => row.copy(numeric = value))
+      override def path = OptField[TypoPath, PgtestnullRow](_path, "path", None, Some("path"), x => x.path, (row, value) => row.copy(path = value))
+      override def point = OptField[TypoPoint, PgtestnullRow](_path, "point", None, Some("point"), x => x.point, (row, value) => row.copy(point = value))
+      override def polygon = OptField[TypoPolygon, PgtestnullRow](_path, "polygon", None, Some("polygon"), x => x.polygon, (row, value) => row.copy(polygon = value))
+      override def text = OptField[String, PgtestnullRow](_path, "text", None, None, x => x.text, (row, value) => row.copy(text = value))
+      override def time = OptField[TypoLocalTime, PgtestnullRow](_path, "time", Some("text"), Some("time"), x => x.time, (row, value) => row.copy(time = value))
+      override def timestamp = OptField[TypoLocalDateTime, PgtestnullRow](_path, "timestamp", Some("text"), Some("timestamp"), x => x.timestamp, (row, value) => row.copy(timestamp = value))
+      override def timestampz = OptField[TypoInstant, PgtestnullRow](_path, "timestampz", Some("text"), Some("timestamptz"), x => x.timestampz, (row, value) => row.copy(timestampz = value))
+      override def timez = OptField[TypoOffsetTime, PgtestnullRow](_path, "timez", Some("text"), Some("timetz"), x => x.timez, (row, value) => row.copy(timez = value))
+      override def uuid = OptField[TypoUUID, PgtestnullRow](_path, "uuid", None, Some("uuid"), x => x.uuid, (row, value) => row.copy(uuid = value))
+      override def varchar = OptField[String, PgtestnullRow](_path, "varchar", None, None, x => x.varchar, (row, value) => row.copy(varchar = value))
+      override def vector = OptField[TypoVector, PgtestnullRow](_path, "vector", Some("float4[]"), Some("vector"), x => x.vector, (row, value) => row.copy(vector = value))
+      override def xml = OptField[TypoXml, PgtestnullRow](_path, "xml", None, Some("xml"), x => x.xml, (row, value) => row.copy(xml = value))
+      override def boxes = OptField[Array[TypoBox], PgtestnullRow](_path, "boxes", None, Some("_box"), x => x.boxes, (row, value) => row.copy(boxes = value))
+      override def bpchares = OptField[Array[/* bpchar */ String], PgtestnullRow](_path, "bpchares", None, Some("_bpchar"), x => x.bpchares, (row, value) => row.copy(bpchares = value))
+      override def chares = OptField[Array[/* bpchar */ String], PgtestnullRow](_path, "chares", None, Some("_bpchar"), x => x.chares, (row, value) => row.copy(chares = value))
+      override def circlees = OptField[Array[TypoCircle], PgtestnullRow](_path, "circlees", None, Some("_circle"), x => x.circlees, (row, value) => row.copy(circlees = value))
+      override def datees = OptField[Array[TypoLocalDate], PgtestnullRow](_path, "datees", Some("text[]"), Some("_date"), x => x.datees, (row, value) => row.copy(datees = value))
+      override def float4es = OptField[Array[Float], PgtestnullRow](_path, "float4es", None, Some("_float4"), x => x.float4es, (row, value) => row.copy(float4es = value))
+      override def float8es = OptField[Array[Double], PgtestnullRow](_path, "float8es", None, Some("_float8"), x => x.float8es, (row, value) => row.copy(float8es = value))
+      override def inetes = OptField[Array[TypoInet], PgtestnullRow](_path, "inetes", None, Some("_inet"), x => x.inetes, (row, value) => row.copy(inetes = value))
+      override def int2es = OptField[Array[TypoShort], PgtestnullRow](_path, "int2es", None, Some("_int2"), x => x.int2es, (row, value) => row.copy(int2es = value))
+      override def int2vectores = OptField[Array[TypoInt2Vector], PgtestnullRow](_path, "int2vectores", None, Some("_int2vector"), x => x.int2vectores, (row, value) => row.copy(int2vectores = value))
+      override def int4es = OptField[Array[Int], PgtestnullRow](_path, "int4es", None, Some("_int4"), x => x.int4es, (row, value) => row.copy(int4es = value))
+      override def int8es = OptField[Array[Long], PgtestnullRow](_path, "int8es", None, Some("_int8"), x => x.int8es, (row, value) => row.copy(int8es = value))
+      override def intervales = OptField[Array[TypoInterval], PgtestnullRow](_path, "intervales", None, Some("_interval"), x => x.intervales, (row, value) => row.copy(intervales = value))
+      override def jsones = OptField[Array[TypoJson], PgtestnullRow](_path, "jsones", None, Some("_json"), x => x.jsones, (row, value) => row.copy(jsones = value))
+      override def jsonbes = OptField[Array[TypoJsonb], PgtestnullRow](_path, "jsonbes", None, Some("_jsonb"), x => x.jsonbes, (row, value) => row.copy(jsonbes = value))
+      override def linees = OptField[Array[TypoLine], PgtestnullRow](_path, "linees", None, Some("_line"), x => x.linees, (row, value) => row.copy(linees = value))
+      override def lseges = OptField[Array[TypoLineSegment], PgtestnullRow](_path, "lseges", None, Some("_lseg"), x => x.lseges, (row, value) => row.copy(lseges = value))
+      override def moneyes = OptField[Array[TypoMoney], PgtestnullRow](_path, "moneyes", Some("numeric[]"), Some("_money"), x => x.moneyes, (row, value) => row.copy(moneyes = value))
+      override def myenumes = OptField[Array[Myenum], PgtestnullRow](_path, "myenumes", None, Some("_myenum"), x => x.myenumes, (row, value) => row.copy(myenumes = value))
+      override def namees = OptField[Array[String], PgtestnullRow](_path, "namees", None, Some("_name"), x => x.namees, (row, value) => row.copy(namees = value))
+      override def numerices = OptField[Array[BigDecimal], PgtestnullRow](_path, "numerices", None, Some("_numeric"), x => x.numerices, (row, value) => row.copy(numerices = value))
+      override def pathes = OptField[Array[TypoPath], PgtestnullRow](_path, "pathes", None, Some("_path"), x => x.pathes, (row, value) => row.copy(pathes = value))
+      override def pointes = OptField[Array[TypoPoint], PgtestnullRow](_path, "pointes", None, Some("_point"), x => x.pointes, (row, value) => row.copy(pointes = value))
+      override def polygones = OptField[Array[TypoPolygon], PgtestnullRow](_path, "polygones", None, Some("_polygon"), x => x.polygones, (row, value) => row.copy(polygones = value))
+      override def textes = OptField[Array[String], PgtestnullRow](_path, "textes", None, Some("_text"), x => x.textes, (row, value) => row.copy(textes = value))
+      override def timees = OptField[Array[TypoLocalTime], PgtestnullRow](_path, "timees", Some("text[]"), Some("_time"), x => x.timees, (row, value) => row.copy(timees = value))
+      override def timestampes = OptField[Array[TypoLocalDateTime], PgtestnullRow](_path, "timestampes", Some("text[]"), Some("_timestamp"), x => x.timestampes, (row, value) => row.copy(timestampes = value))
+      override def timestampzes = OptField[Array[TypoInstant], PgtestnullRow](_path, "timestampzes", Some("text[]"), Some("_timestamptz"), x => x.timestampzes, (row, value) => row.copy(timestampzes = value))
+      override def timezes = OptField[Array[TypoOffsetTime], PgtestnullRow](_path, "timezes", Some("text[]"), Some("_timetz"), x => x.timezes, (row, value) => row.copy(timezes = value))
+      override def uuides = OptField[Array[TypoUUID], PgtestnullRow](_path, "uuides", None, Some("_uuid"), x => x.uuides, (row, value) => row.copy(uuides = value))
+      override def varchares = OptField[Array[String], PgtestnullRow](_path, "varchares", None, Some("_varchar"), x => x.varchares, (row, value) => row.copy(varchares = value))
+      override def xmles = OptField[Array[TypoXml], PgtestnullRow](_path, "xmles", None, Some("_xml"), x => x.xmles, (row, value) => row.copy(xmles = value))
     }
   
-    override val columns: List[FieldLikeNoHkt[?, Row]] =
-      List[FieldLikeNoHkt[?, Row]](fields.bool, fields.box, fields.bpchar, fields.bytea, fields.char, fields.circle, fields.date, fields.float4, fields.float8, fields.hstore, fields.inet, fields.int2, fields.int2vector, fields.int4, fields.int8, fields.interval, fields.json, fields.jsonb, fields.line, fields.lseg, fields.money, fields.mydomain, fields.myenum, fields.name, fields.numeric, fields.path, fields.point, fields.polygon, fields.text, fields.time, fields.timestamp, fields.timestampz, fields.timez, fields.uuid, fields.varchar, fields.vector, fields.xml, fields.boxes, fields.bpchares, fields.chares, fields.circlees, fields.datees, fields.float4es, fields.float8es, fields.inetes, fields.int2es, fields.int2vectores, fields.int4es, fields.int8es, fields.intervales, fields.jsones, fields.jsonbes, fields.linees, fields.lseges, fields.moneyes, fields.myenumes, fields.namees, fields.numerices, fields.pathes, fields.pointes, fields.polygones, fields.textes, fields.timees, fields.timestampes, fields.timestampzes, fields.timezes, fields.uuides, fields.varchares, fields.xmles)
+    override lazy val columns: List[FieldLikeNoHkt[?, PgtestnullRow]] =
+      List[FieldLikeNoHkt[?, PgtestnullRow]](fields.bool, fields.box, fields.bpchar, fields.bytea, fields.char, fields.circle, fields.date, fields.float4, fields.float8, fields.hstore, fields.inet, fields.int2, fields.int2vector, fields.int4, fields.int8, fields.interval, fields.json, fields.jsonb, fields.line, fields.lseg, fields.money, fields.mydomain, fields.myenum, fields.name, fields.numeric, fields.path, fields.point, fields.polygon, fields.text, fields.time, fields.timestamp, fields.timestampz, fields.timez, fields.uuid, fields.varchar, fields.vector, fields.xml, fields.boxes, fields.bpchares, fields.chares, fields.circlees, fields.datees, fields.float4es, fields.float8es, fields.inetes, fields.int2es, fields.int2vectores, fields.int4es, fields.int8es, fields.intervales, fields.jsones, fields.jsonbes, fields.linees, fields.lseges, fields.moneyes, fields.myenumes, fields.namees, fields.numerices, fields.pathes, fields.pointes, fields.polygones, fields.textes, fields.timees, fields.timestampes, fields.timestampzes, fields.timezes, fields.uuides, fields.varchares, fields.xmles)
   
-    override def copy[NewRow](prefix: Option[String], extract: NewRow => PgtestnullRow, merge: (NewRow, PgtestnullRow) => NewRow): Impl[NewRow] =
-      new Impl(prefix, extract, merge)
+    override def copy(path: List[Path]): Impl =
+      new Impl(path)
   }
   
 }

--- a/typo-tester-anorm/generated-and-checked-in/adventureworks/public/users/UsersFields.scala
+++ b/typo-tester-anorm/generated-and-checked-in/adventureworks/public/users/UsersFields.scala
@@ -9,44 +9,45 @@ package users
 
 import adventureworks.customtypes.TypoInstant
 import adventureworks.customtypes.TypoUnknownCitext
+import typo.dsl.Path
 import typo.dsl.SqlExpr.Field
 import typo.dsl.SqlExpr.FieldLikeNoHkt
 import typo.dsl.SqlExpr.IdField
 import typo.dsl.SqlExpr.OptField
 import typo.dsl.Structure.Relation
 
-trait UsersFields[Row] {
-  val userId: IdField[UsersId, Row]
-  val name: Field[String, Row]
-  val lastName: OptField[String, Row]
-  val email: Field[TypoUnknownCitext, Row]
-  val password: Field[String, Row]
-  val createdAt: Field[TypoInstant, Row]
-  val verifiedOn: OptField[TypoInstant, Row]
+trait UsersFields {
+  def userId: IdField[UsersId, UsersRow]
+  def name: Field[String, UsersRow]
+  def lastName: OptField[String, UsersRow]
+  def email: Field[TypoUnknownCitext, UsersRow]
+  def password: Field[String, UsersRow]
+  def createdAt: Field[TypoInstant, UsersRow]
+  def verifiedOn: OptField[TypoInstant, UsersRow]
 }
 
 object UsersFields {
-  val structure: Relation[UsersFields, UsersRow, UsersRow] = 
-    new Impl(None, identity, (_, x) => x)
+  lazy val structure: Relation[UsersFields, UsersRow] =
+    new Impl(Nil)
     
-  private final class Impl[Row](val prefix: Option[String], val extract: Row => UsersRow, val merge: (Row, UsersRow) => Row)
-    extends Relation[UsersFields, UsersRow, Row] { 
+  private final class Impl(val _path: List[Path])
+    extends Relation[UsersFields, UsersRow] {
   
-    override val fields: UsersFields[Row] = new UsersFields[Row] {
-      override val userId = new IdField[UsersId, Row](prefix, "user_id", None, Some("uuid"))(x => extract(x).userId, (row, value) => merge(row, extract(row).copy(userId = value)))
-      override val name = new Field[String, Row](prefix, "name", None, None)(x => extract(x).name, (row, value) => merge(row, extract(row).copy(name = value)))
-      override val lastName = new OptField[String, Row](prefix, "last_name", None, None)(x => extract(x).lastName, (row, value) => merge(row, extract(row).copy(lastName = value)))
-      override val email = new Field[TypoUnknownCitext, Row](prefix, "email", Some("text"), Some("citext"))(x => extract(x).email, (row, value) => merge(row, extract(row).copy(email = value)))
-      override val password = new Field[String, Row](prefix, "password", None, None)(x => extract(x).password, (row, value) => merge(row, extract(row).copy(password = value)))
-      override val createdAt = new Field[TypoInstant, Row](prefix, "created_at", Some("text"), Some("timestamptz"))(x => extract(x).createdAt, (row, value) => merge(row, extract(row).copy(createdAt = value)))
-      override val verifiedOn = new OptField[TypoInstant, Row](prefix, "verified_on", Some("text"), Some("timestamptz"))(x => extract(x).verifiedOn, (row, value) => merge(row, extract(row).copy(verifiedOn = value)))
+    override lazy val fields: UsersFields = new UsersFields {
+      override def userId = IdField[UsersId, UsersRow](_path, "user_id", None, Some("uuid"), x => x.userId, (row, value) => row.copy(userId = value))
+      override def name = Field[String, UsersRow](_path, "name", None, None, x => x.name, (row, value) => row.copy(name = value))
+      override def lastName = OptField[String, UsersRow](_path, "last_name", None, None, x => x.lastName, (row, value) => row.copy(lastName = value))
+      override def email = Field[TypoUnknownCitext, UsersRow](_path, "email", Some("text"), Some("citext"), x => x.email, (row, value) => row.copy(email = value))
+      override def password = Field[String, UsersRow](_path, "password", None, None, x => x.password, (row, value) => row.copy(password = value))
+      override def createdAt = Field[TypoInstant, UsersRow](_path, "created_at", Some("text"), Some("timestamptz"), x => x.createdAt, (row, value) => row.copy(createdAt = value))
+      override def verifiedOn = OptField[TypoInstant, UsersRow](_path, "verified_on", Some("text"), Some("timestamptz"), x => x.verifiedOn, (row, value) => row.copy(verifiedOn = value))
     }
   
-    override val columns: List[FieldLikeNoHkt[?, Row]] =
-      List[FieldLikeNoHkt[?, Row]](fields.userId, fields.name, fields.lastName, fields.email, fields.password, fields.createdAt, fields.verifiedOn)
+    override lazy val columns: List[FieldLikeNoHkt[?, UsersRow]] =
+      List[FieldLikeNoHkt[?, UsersRow]](fields.userId, fields.name, fields.lastName, fields.email, fields.password, fields.createdAt, fields.verifiedOn)
   
-    override def copy[NewRow](prefix: Option[String], extract: NewRow => UsersRow, merge: (NewRow, UsersRow) => NewRow): Impl[NewRow] =
-      new Impl(prefix, extract, merge)
+    override def copy(path: List[Path]): Impl =
+      new Impl(path)
   }
   
 }

--- a/typo-tester-anorm/generated-and-checked-in/adventureworks/public/users/UsersRepoMock.scala
+++ b/typo-tester-anorm/generated-and-checked-in/adventureworks/public/users/UsersRepoMock.scala
@@ -23,7 +23,7 @@ import typo.dsl.UpdateParams
 class UsersRepoMock(toRow: Function1[UsersRowUnsaved, UsersRow],
                     map: scala.collection.mutable.Map[UsersId, UsersRow] = scala.collection.mutable.Map.empty) extends UsersRepo {
   override def delete: DeleteBuilder[UsersFields, UsersRow] = {
-    DeleteBuilderMock(DeleteParams.empty, UsersFields.structure.fields, map)
+    DeleteBuilderMock(DeleteParams.empty, UsersFields.structure, map)
   }
   override def deleteById(userId: UsersId)(implicit c: Connection): Boolean = {
     map.remove(userId).isDefined
@@ -76,7 +76,7 @@ class UsersRepoMock(toRow: Function1[UsersRowUnsaved, UsersRow],
     map.values.find(v => email == v.email)
   }
   override def update: UpdateBuilder[UsersFields, UsersRow] = {
-    UpdateBuilderMock(UpdateParams.empty, UsersFields.structure.fields, map)
+    UpdateBuilderMock(UpdateParams.empty, UsersFields.structure, map)
   }
   override def update(row: UsersRow)(implicit c: Connection): Boolean = {
     map.get(row.userId) match {

--- a/typo-tester-anorm/generated-and-checked-in/adventureworks/purchasing/productvendor/ProductvendorFields.scala
+++ b/typo-tester-anorm/generated-and-checked-in/adventureworks/purchasing/productvendor/ProductvendorFields.scala
@@ -11,52 +11,53 @@ import adventureworks.customtypes.TypoLocalDateTime
 import adventureworks.person.businessentity.BusinessentityId
 import adventureworks.production.product.ProductId
 import adventureworks.production.unitmeasure.UnitmeasureId
+import typo.dsl.Path
 import typo.dsl.SqlExpr.Field
 import typo.dsl.SqlExpr.FieldLikeNoHkt
 import typo.dsl.SqlExpr.IdField
 import typo.dsl.SqlExpr.OptField
 import typo.dsl.Structure.Relation
 
-trait ProductvendorFields[Row] {
-  val productid: IdField[ProductId, Row]
-  val businessentityid: IdField[BusinessentityId, Row]
-  val averageleadtime: Field[Int, Row]
-  val standardprice: Field[BigDecimal, Row]
-  val lastreceiptcost: OptField[BigDecimal, Row]
-  val lastreceiptdate: OptField[TypoLocalDateTime, Row]
-  val minorderqty: Field[Int, Row]
-  val maxorderqty: Field[Int, Row]
-  val onorderqty: OptField[Int, Row]
-  val unitmeasurecode: Field[UnitmeasureId, Row]
-  val modifieddate: Field[TypoLocalDateTime, Row]
+trait ProductvendorFields {
+  def productid: IdField[ProductId, ProductvendorRow]
+  def businessentityid: IdField[BusinessentityId, ProductvendorRow]
+  def averageleadtime: Field[Int, ProductvendorRow]
+  def standardprice: Field[BigDecimal, ProductvendorRow]
+  def lastreceiptcost: OptField[BigDecimal, ProductvendorRow]
+  def lastreceiptdate: OptField[TypoLocalDateTime, ProductvendorRow]
+  def minorderqty: Field[Int, ProductvendorRow]
+  def maxorderqty: Field[Int, ProductvendorRow]
+  def onorderqty: OptField[Int, ProductvendorRow]
+  def unitmeasurecode: Field[UnitmeasureId, ProductvendorRow]
+  def modifieddate: Field[TypoLocalDateTime, ProductvendorRow]
 }
 
 object ProductvendorFields {
-  val structure: Relation[ProductvendorFields, ProductvendorRow, ProductvendorRow] = 
-    new Impl(None, identity, (_, x) => x)
+  lazy val structure: Relation[ProductvendorFields, ProductvendorRow] =
+    new Impl(Nil)
     
-  private final class Impl[Row](val prefix: Option[String], val extract: Row => ProductvendorRow, val merge: (Row, ProductvendorRow) => Row)
-    extends Relation[ProductvendorFields, ProductvendorRow, Row] { 
+  private final class Impl(val _path: List[Path])
+    extends Relation[ProductvendorFields, ProductvendorRow] {
   
-    override val fields: ProductvendorFields[Row] = new ProductvendorFields[Row] {
-      override val productid = new IdField[ProductId, Row](prefix, "productid", None, Some("int4"))(x => extract(x).productid, (row, value) => merge(row, extract(row).copy(productid = value)))
-      override val businessentityid = new IdField[BusinessentityId, Row](prefix, "businessentityid", None, Some("int4"))(x => extract(x).businessentityid, (row, value) => merge(row, extract(row).copy(businessentityid = value)))
-      override val averageleadtime = new Field[Int, Row](prefix, "averageleadtime", None, Some("int4"))(x => extract(x).averageleadtime, (row, value) => merge(row, extract(row).copy(averageleadtime = value)))
-      override val standardprice = new Field[BigDecimal, Row](prefix, "standardprice", None, Some("numeric"))(x => extract(x).standardprice, (row, value) => merge(row, extract(row).copy(standardprice = value)))
-      override val lastreceiptcost = new OptField[BigDecimal, Row](prefix, "lastreceiptcost", None, Some("numeric"))(x => extract(x).lastreceiptcost, (row, value) => merge(row, extract(row).copy(lastreceiptcost = value)))
-      override val lastreceiptdate = new OptField[TypoLocalDateTime, Row](prefix, "lastreceiptdate", Some("text"), Some("timestamp"))(x => extract(x).lastreceiptdate, (row, value) => merge(row, extract(row).copy(lastreceiptdate = value)))
-      override val minorderqty = new Field[Int, Row](prefix, "minorderqty", None, Some("int4"))(x => extract(x).minorderqty, (row, value) => merge(row, extract(row).copy(minorderqty = value)))
-      override val maxorderqty = new Field[Int, Row](prefix, "maxorderqty", None, Some("int4"))(x => extract(x).maxorderqty, (row, value) => merge(row, extract(row).copy(maxorderqty = value)))
-      override val onorderqty = new OptField[Int, Row](prefix, "onorderqty", None, Some("int4"))(x => extract(x).onorderqty, (row, value) => merge(row, extract(row).copy(onorderqty = value)))
-      override val unitmeasurecode = new Field[UnitmeasureId, Row](prefix, "unitmeasurecode", None, Some("bpchar"))(x => extract(x).unitmeasurecode, (row, value) => merge(row, extract(row).copy(unitmeasurecode = value)))
-      override val modifieddate = new Field[TypoLocalDateTime, Row](prefix, "modifieddate", Some("text"), Some("timestamp"))(x => extract(x).modifieddate, (row, value) => merge(row, extract(row).copy(modifieddate = value)))
+    override lazy val fields: ProductvendorFields = new ProductvendorFields {
+      override def productid = IdField[ProductId, ProductvendorRow](_path, "productid", None, Some("int4"), x => x.productid, (row, value) => row.copy(productid = value))
+      override def businessentityid = IdField[BusinessentityId, ProductvendorRow](_path, "businessentityid", None, Some("int4"), x => x.businessentityid, (row, value) => row.copy(businessentityid = value))
+      override def averageleadtime = Field[Int, ProductvendorRow](_path, "averageleadtime", None, Some("int4"), x => x.averageleadtime, (row, value) => row.copy(averageleadtime = value))
+      override def standardprice = Field[BigDecimal, ProductvendorRow](_path, "standardprice", None, Some("numeric"), x => x.standardprice, (row, value) => row.copy(standardprice = value))
+      override def lastreceiptcost = OptField[BigDecimal, ProductvendorRow](_path, "lastreceiptcost", None, Some("numeric"), x => x.lastreceiptcost, (row, value) => row.copy(lastreceiptcost = value))
+      override def lastreceiptdate = OptField[TypoLocalDateTime, ProductvendorRow](_path, "lastreceiptdate", Some("text"), Some("timestamp"), x => x.lastreceiptdate, (row, value) => row.copy(lastreceiptdate = value))
+      override def minorderqty = Field[Int, ProductvendorRow](_path, "minorderqty", None, Some("int4"), x => x.minorderqty, (row, value) => row.copy(minorderqty = value))
+      override def maxorderqty = Field[Int, ProductvendorRow](_path, "maxorderqty", None, Some("int4"), x => x.maxorderqty, (row, value) => row.copy(maxorderqty = value))
+      override def onorderqty = OptField[Int, ProductvendorRow](_path, "onorderqty", None, Some("int4"), x => x.onorderqty, (row, value) => row.copy(onorderqty = value))
+      override def unitmeasurecode = Field[UnitmeasureId, ProductvendorRow](_path, "unitmeasurecode", None, Some("bpchar"), x => x.unitmeasurecode, (row, value) => row.copy(unitmeasurecode = value))
+      override def modifieddate = Field[TypoLocalDateTime, ProductvendorRow](_path, "modifieddate", Some("text"), Some("timestamp"), x => x.modifieddate, (row, value) => row.copy(modifieddate = value))
     }
   
-    override val columns: List[FieldLikeNoHkt[?, Row]] =
-      List[FieldLikeNoHkt[?, Row]](fields.productid, fields.businessentityid, fields.averageleadtime, fields.standardprice, fields.lastreceiptcost, fields.lastreceiptdate, fields.minorderqty, fields.maxorderqty, fields.onorderqty, fields.unitmeasurecode, fields.modifieddate)
+    override lazy val columns: List[FieldLikeNoHkt[?, ProductvendorRow]] =
+      List[FieldLikeNoHkt[?, ProductvendorRow]](fields.productid, fields.businessentityid, fields.averageleadtime, fields.standardprice, fields.lastreceiptcost, fields.lastreceiptdate, fields.minorderqty, fields.maxorderqty, fields.onorderqty, fields.unitmeasurecode, fields.modifieddate)
   
-    override def copy[NewRow](prefix: Option[String], extract: NewRow => ProductvendorRow, merge: (NewRow, ProductvendorRow) => NewRow): Impl[NewRow] =
-      new Impl(prefix, extract, merge)
+    override def copy(path: List[Path]): Impl =
+      new Impl(path)
   }
   
 }

--- a/typo-tester-anorm/generated-and-checked-in/adventureworks/purchasing/productvendor/ProductvendorRepoMock.scala
+++ b/typo-tester-anorm/generated-and-checked-in/adventureworks/purchasing/productvendor/ProductvendorRepoMock.scala
@@ -22,7 +22,7 @@ import typo.dsl.UpdateParams
 class ProductvendorRepoMock(toRow: Function1[ProductvendorRowUnsaved, ProductvendorRow],
                             map: scala.collection.mutable.Map[ProductvendorId, ProductvendorRow] = scala.collection.mutable.Map.empty) extends ProductvendorRepo {
   override def delete: DeleteBuilder[ProductvendorFields, ProductvendorRow] = {
-    DeleteBuilderMock(DeleteParams.empty, ProductvendorFields.structure.fields, map)
+    DeleteBuilderMock(DeleteParams.empty, ProductvendorFields.structure, map)
   }
   override def deleteById(compositeId: ProductvendorId)(implicit c: Connection): Boolean = {
     map.remove(compositeId).isDefined
@@ -72,7 +72,7 @@ class ProductvendorRepoMock(toRow: Function1[ProductvendorRowUnsaved, Productven
     compositeIds.view.flatMap(id => byId.get(id).map(x => (id, x))).toMap
   }
   override def update: UpdateBuilder[ProductvendorFields, ProductvendorRow] = {
-    UpdateBuilderMock(UpdateParams.empty, ProductvendorFields.structure.fields, map)
+    UpdateBuilderMock(UpdateParams.empty, ProductvendorFields.structure, map)
   }
   override def update(row: ProductvendorRow)(implicit c: Connection): Boolean = {
     map.get(row.compositeId) match {

--- a/typo-tester-anorm/generated-and-checked-in/adventureworks/purchasing/purchaseorderdetail/PurchaseorderdetailFields.scala
+++ b/typo-tester-anorm/generated-and-checked-in/adventureworks/purchasing/purchaseorderdetail/PurchaseorderdetailFields.scala
@@ -11,47 +11,48 @@ import adventureworks.customtypes.TypoLocalDateTime
 import adventureworks.customtypes.TypoShort
 import adventureworks.production.product.ProductId
 import adventureworks.purchasing.purchaseorderheader.PurchaseorderheaderId
+import typo.dsl.Path
 import typo.dsl.SqlExpr.Field
 import typo.dsl.SqlExpr.FieldLikeNoHkt
 import typo.dsl.SqlExpr.IdField
 import typo.dsl.Structure.Relation
 
-trait PurchaseorderdetailFields[Row] {
-  val purchaseorderid: IdField[PurchaseorderheaderId, Row]
-  val purchaseorderdetailid: IdField[Int, Row]
-  val duedate: Field[TypoLocalDateTime, Row]
-  val orderqty: Field[TypoShort, Row]
-  val productid: Field[ProductId, Row]
-  val unitprice: Field[BigDecimal, Row]
-  val receivedqty: Field[BigDecimal, Row]
-  val rejectedqty: Field[BigDecimal, Row]
-  val modifieddate: Field[TypoLocalDateTime, Row]
+trait PurchaseorderdetailFields {
+  def purchaseorderid: IdField[PurchaseorderheaderId, PurchaseorderdetailRow]
+  def purchaseorderdetailid: IdField[Int, PurchaseorderdetailRow]
+  def duedate: Field[TypoLocalDateTime, PurchaseorderdetailRow]
+  def orderqty: Field[TypoShort, PurchaseorderdetailRow]
+  def productid: Field[ProductId, PurchaseorderdetailRow]
+  def unitprice: Field[BigDecimal, PurchaseorderdetailRow]
+  def receivedqty: Field[BigDecimal, PurchaseorderdetailRow]
+  def rejectedqty: Field[BigDecimal, PurchaseorderdetailRow]
+  def modifieddate: Field[TypoLocalDateTime, PurchaseorderdetailRow]
 }
 
 object PurchaseorderdetailFields {
-  val structure: Relation[PurchaseorderdetailFields, PurchaseorderdetailRow, PurchaseorderdetailRow] = 
-    new Impl(None, identity, (_, x) => x)
+  lazy val structure: Relation[PurchaseorderdetailFields, PurchaseorderdetailRow] =
+    new Impl(Nil)
     
-  private final class Impl[Row](val prefix: Option[String], val extract: Row => PurchaseorderdetailRow, val merge: (Row, PurchaseorderdetailRow) => Row)
-    extends Relation[PurchaseorderdetailFields, PurchaseorderdetailRow, Row] { 
+  private final class Impl(val _path: List[Path])
+    extends Relation[PurchaseorderdetailFields, PurchaseorderdetailRow] {
   
-    override val fields: PurchaseorderdetailFields[Row] = new PurchaseorderdetailFields[Row] {
-      override val purchaseorderid = new IdField[PurchaseorderheaderId, Row](prefix, "purchaseorderid", None, Some("int4"))(x => extract(x).purchaseorderid, (row, value) => merge(row, extract(row).copy(purchaseorderid = value)))
-      override val purchaseorderdetailid = new IdField[Int, Row](prefix, "purchaseorderdetailid", None, Some("int4"))(x => extract(x).purchaseorderdetailid, (row, value) => merge(row, extract(row).copy(purchaseorderdetailid = value)))
-      override val duedate = new Field[TypoLocalDateTime, Row](prefix, "duedate", Some("text"), Some("timestamp"))(x => extract(x).duedate, (row, value) => merge(row, extract(row).copy(duedate = value)))
-      override val orderqty = new Field[TypoShort, Row](prefix, "orderqty", None, Some("int2"))(x => extract(x).orderqty, (row, value) => merge(row, extract(row).copy(orderqty = value)))
-      override val productid = new Field[ProductId, Row](prefix, "productid", None, Some("int4"))(x => extract(x).productid, (row, value) => merge(row, extract(row).copy(productid = value)))
-      override val unitprice = new Field[BigDecimal, Row](prefix, "unitprice", None, Some("numeric"))(x => extract(x).unitprice, (row, value) => merge(row, extract(row).copy(unitprice = value)))
-      override val receivedqty = new Field[BigDecimal, Row](prefix, "receivedqty", None, Some("numeric"))(x => extract(x).receivedqty, (row, value) => merge(row, extract(row).copy(receivedqty = value)))
-      override val rejectedqty = new Field[BigDecimal, Row](prefix, "rejectedqty", None, Some("numeric"))(x => extract(x).rejectedqty, (row, value) => merge(row, extract(row).copy(rejectedqty = value)))
-      override val modifieddate = new Field[TypoLocalDateTime, Row](prefix, "modifieddate", Some("text"), Some("timestamp"))(x => extract(x).modifieddate, (row, value) => merge(row, extract(row).copy(modifieddate = value)))
+    override lazy val fields: PurchaseorderdetailFields = new PurchaseorderdetailFields {
+      override def purchaseorderid = IdField[PurchaseorderheaderId, PurchaseorderdetailRow](_path, "purchaseorderid", None, Some("int4"), x => x.purchaseorderid, (row, value) => row.copy(purchaseorderid = value))
+      override def purchaseorderdetailid = IdField[Int, PurchaseorderdetailRow](_path, "purchaseorderdetailid", None, Some("int4"), x => x.purchaseorderdetailid, (row, value) => row.copy(purchaseorderdetailid = value))
+      override def duedate = Field[TypoLocalDateTime, PurchaseorderdetailRow](_path, "duedate", Some("text"), Some("timestamp"), x => x.duedate, (row, value) => row.copy(duedate = value))
+      override def orderqty = Field[TypoShort, PurchaseorderdetailRow](_path, "orderqty", None, Some("int2"), x => x.orderqty, (row, value) => row.copy(orderqty = value))
+      override def productid = Field[ProductId, PurchaseorderdetailRow](_path, "productid", None, Some("int4"), x => x.productid, (row, value) => row.copy(productid = value))
+      override def unitprice = Field[BigDecimal, PurchaseorderdetailRow](_path, "unitprice", None, Some("numeric"), x => x.unitprice, (row, value) => row.copy(unitprice = value))
+      override def receivedqty = Field[BigDecimal, PurchaseorderdetailRow](_path, "receivedqty", None, Some("numeric"), x => x.receivedqty, (row, value) => row.copy(receivedqty = value))
+      override def rejectedqty = Field[BigDecimal, PurchaseorderdetailRow](_path, "rejectedqty", None, Some("numeric"), x => x.rejectedqty, (row, value) => row.copy(rejectedqty = value))
+      override def modifieddate = Field[TypoLocalDateTime, PurchaseorderdetailRow](_path, "modifieddate", Some("text"), Some("timestamp"), x => x.modifieddate, (row, value) => row.copy(modifieddate = value))
     }
   
-    override val columns: List[FieldLikeNoHkt[?, Row]] =
-      List[FieldLikeNoHkt[?, Row]](fields.purchaseorderid, fields.purchaseorderdetailid, fields.duedate, fields.orderqty, fields.productid, fields.unitprice, fields.receivedqty, fields.rejectedqty, fields.modifieddate)
+    override lazy val columns: List[FieldLikeNoHkt[?, PurchaseorderdetailRow]] =
+      List[FieldLikeNoHkt[?, PurchaseorderdetailRow]](fields.purchaseorderid, fields.purchaseorderdetailid, fields.duedate, fields.orderqty, fields.productid, fields.unitprice, fields.receivedqty, fields.rejectedqty, fields.modifieddate)
   
-    override def copy[NewRow](prefix: Option[String], extract: NewRow => PurchaseorderdetailRow, merge: (NewRow, PurchaseorderdetailRow) => NewRow): Impl[NewRow] =
-      new Impl(prefix, extract, merge)
+    override def copy(path: List[Path]): Impl =
+      new Impl(path)
   }
   
 }

--- a/typo-tester-anorm/generated-and-checked-in/adventureworks/purchasing/purchaseorderheader/PurchaseorderheaderFields.scala
+++ b/typo-tester-anorm/generated-and-checked-in/adventureworks/purchasing/purchaseorderheader/PurchaseorderheaderFields.scala
@@ -11,54 +11,55 @@ import adventureworks.customtypes.TypoLocalDateTime
 import adventureworks.customtypes.TypoShort
 import adventureworks.person.businessentity.BusinessentityId
 import adventureworks.purchasing.shipmethod.ShipmethodId
+import typo.dsl.Path
 import typo.dsl.SqlExpr.Field
 import typo.dsl.SqlExpr.FieldLikeNoHkt
 import typo.dsl.SqlExpr.IdField
 import typo.dsl.SqlExpr.OptField
 import typo.dsl.Structure.Relation
 
-trait PurchaseorderheaderFields[Row] {
-  val purchaseorderid: IdField[PurchaseorderheaderId, Row]
-  val revisionnumber: Field[TypoShort, Row]
-  val status: Field[TypoShort, Row]
-  val employeeid: Field[BusinessentityId, Row]
-  val vendorid: Field[BusinessentityId, Row]
-  val shipmethodid: Field[ShipmethodId, Row]
-  val orderdate: Field[TypoLocalDateTime, Row]
-  val shipdate: OptField[TypoLocalDateTime, Row]
-  val subtotal: Field[BigDecimal, Row]
-  val taxamt: Field[BigDecimal, Row]
-  val freight: Field[BigDecimal, Row]
-  val modifieddate: Field[TypoLocalDateTime, Row]
+trait PurchaseorderheaderFields {
+  def purchaseorderid: IdField[PurchaseorderheaderId, PurchaseorderheaderRow]
+  def revisionnumber: Field[TypoShort, PurchaseorderheaderRow]
+  def status: Field[TypoShort, PurchaseorderheaderRow]
+  def employeeid: Field[BusinessentityId, PurchaseorderheaderRow]
+  def vendorid: Field[BusinessentityId, PurchaseorderheaderRow]
+  def shipmethodid: Field[ShipmethodId, PurchaseorderheaderRow]
+  def orderdate: Field[TypoLocalDateTime, PurchaseorderheaderRow]
+  def shipdate: OptField[TypoLocalDateTime, PurchaseorderheaderRow]
+  def subtotal: Field[BigDecimal, PurchaseorderheaderRow]
+  def taxamt: Field[BigDecimal, PurchaseorderheaderRow]
+  def freight: Field[BigDecimal, PurchaseorderheaderRow]
+  def modifieddate: Field[TypoLocalDateTime, PurchaseorderheaderRow]
 }
 
 object PurchaseorderheaderFields {
-  val structure: Relation[PurchaseorderheaderFields, PurchaseorderheaderRow, PurchaseorderheaderRow] = 
-    new Impl(None, identity, (_, x) => x)
+  lazy val structure: Relation[PurchaseorderheaderFields, PurchaseorderheaderRow] =
+    new Impl(Nil)
     
-  private final class Impl[Row](val prefix: Option[String], val extract: Row => PurchaseorderheaderRow, val merge: (Row, PurchaseorderheaderRow) => Row)
-    extends Relation[PurchaseorderheaderFields, PurchaseorderheaderRow, Row] { 
+  private final class Impl(val _path: List[Path])
+    extends Relation[PurchaseorderheaderFields, PurchaseorderheaderRow] {
   
-    override val fields: PurchaseorderheaderFields[Row] = new PurchaseorderheaderFields[Row] {
-      override val purchaseorderid = new IdField[PurchaseorderheaderId, Row](prefix, "purchaseorderid", None, Some("int4"))(x => extract(x).purchaseorderid, (row, value) => merge(row, extract(row).copy(purchaseorderid = value)))
-      override val revisionnumber = new Field[TypoShort, Row](prefix, "revisionnumber", None, Some("int2"))(x => extract(x).revisionnumber, (row, value) => merge(row, extract(row).copy(revisionnumber = value)))
-      override val status = new Field[TypoShort, Row](prefix, "status", None, Some("int2"))(x => extract(x).status, (row, value) => merge(row, extract(row).copy(status = value)))
-      override val employeeid = new Field[BusinessentityId, Row](prefix, "employeeid", None, Some("int4"))(x => extract(x).employeeid, (row, value) => merge(row, extract(row).copy(employeeid = value)))
-      override val vendorid = new Field[BusinessentityId, Row](prefix, "vendorid", None, Some("int4"))(x => extract(x).vendorid, (row, value) => merge(row, extract(row).copy(vendorid = value)))
-      override val shipmethodid = new Field[ShipmethodId, Row](prefix, "shipmethodid", None, Some("int4"))(x => extract(x).shipmethodid, (row, value) => merge(row, extract(row).copy(shipmethodid = value)))
-      override val orderdate = new Field[TypoLocalDateTime, Row](prefix, "orderdate", Some("text"), Some("timestamp"))(x => extract(x).orderdate, (row, value) => merge(row, extract(row).copy(orderdate = value)))
-      override val shipdate = new OptField[TypoLocalDateTime, Row](prefix, "shipdate", Some("text"), Some("timestamp"))(x => extract(x).shipdate, (row, value) => merge(row, extract(row).copy(shipdate = value)))
-      override val subtotal = new Field[BigDecimal, Row](prefix, "subtotal", None, Some("numeric"))(x => extract(x).subtotal, (row, value) => merge(row, extract(row).copy(subtotal = value)))
-      override val taxamt = new Field[BigDecimal, Row](prefix, "taxamt", None, Some("numeric"))(x => extract(x).taxamt, (row, value) => merge(row, extract(row).copy(taxamt = value)))
-      override val freight = new Field[BigDecimal, Row](prefix, "freight", None, Some("numeric"))(x => extract(x).freight, (row, value) => merge(row, extract(row).copy(freight = value)))
-      override val modifieddate = new Field[TypoLocalDateTime, Row](prefix, "modifieddate", Some("text"), Some("timestamp"))(x => extract(x).modifieddate, (row, value) => merge(row, extract(row).copy(modifieddate = value)))
+    override lazy val fields: PurchaseorderheaderFields = new PurchaseorderheaderFields {
+      override def purchaseorderid = IdField[PurchaseorderheaderId, PurchaseorderheaderRow](_path, "purchaseorderid", None, Some("int4"), x => x.purchaseorderid, (row, value) => row.copy(purchaseorderid = value))
+      override def revisionnumber = Field[TypoShort, PurchaseorderheaderRow](_path, "revisionnumber", None, Some("int2"), x => x.revisionnumber, (row, value) => row.copy(revisionnumber = value))
+      override def status = Field[TypoShort, PurchaseorderheaderRow](_path, "status", None, Some("int2"), x => x.status, (row, value) => row.copy(status = value))
+      override def employeeid = Field[BusinessentityId, PurchaseorderheaderRow](_path, "employeeid", None, Some("int4"), x => x.employeeid, (row, value) => row.copy(employeeid = value))
+      override def vendorid = Field[BusinessentityId, PurchaseorderheaderRow](_path, "vendorid", None, Some("int4"), x => x.vendorid, (row, value) => row.copy(vendorid = value))
+      override def shipmethodid = Field[ShipmethodId, PurchaseorderheaderRow](_path, "shipmethodid", None, Some("int4"), x => x.shipmethodid, (row, value) => row.copy(shipmethodid = value))
+      override def orderdate = Field[TypoLocalDateTime, PurchaseorderheaderRow](_path, "orderdate", Some("text"), Some("timestamp"), x => x.orderdate, (row, value) => row.copy(orderdate = value))
+      override def shipdate = OptField[TypoLocalDateTime, PurchaseorderheaderRow](_path, "shipdate", Some("text"), Some("timestamp"), x => x.shipdate, (row, value) => row.copy(shipdate = value))
+      override def subtotal = Field[BigDecimal, PurchaseorderheaderRow](_path, "subtotal", None, Some("numeric"), x => x.subtotal, (row, value) => row.copy(subtotal = value))
+      override def taxamt = Field[BigDecimal, PurchaseorderheaderRow](_path, "taxamt", None, Some("numeric"), x => x.taxamt, (row, value) => row.copy(taxamt = value))
+      override def freight = Field[BigDecimal, PurchaseorderheaderRow](_path, "freight", None, Some("numeric"), x => x.freight, (row, value) => row.copy(freight = value))
+      override def modifieddate = Field[TypoLocalDateTime, PurchaseorderheaderRow](_path, "modifieddate", Some("text"), Some("timestamp"), x => x.modifieddate, (row, value) => row.copy(modifieddate = value))
     }
   
-    override val columns: List[FieldLikeNoHkt[?, Row]] =
-      List[FieldLikeNoHkt[?, Row]](fields.purchaseorderid, fields.revisionnumber, fields.status, fields.employeeid, fields.vendorid, fields.shipmethodid, fields.orderdate, fields.shipdate, fields.subtotal, fields.taxamt, fields.freight, fields.modifieddate)
+    override lazy val columns: List[FieldLikeNoHkt[?, PurchaseorderheaderRow]] =
+      List[FieldLikeNoHkt[?, PurchaseorderheaderRow]](fields.purchaseorderid, fields.revisionnumber, fields.status, fields.employeeid, fields.vendorid, fields.shipmethodid, fields.orderdate, fields.shipdate, fields.subtotal, fields.taxamt, fields.freight, fields.modifieddate)
   
-    override def copy[NewRow](prefix: Option[String], extract: NewRow => PurchaseorderheaderRow, merge: (NewRow, PurchaseorderheaderRow) => NewRow): Impl[NewRow] =
-      new Impl(prefix, extract, merge)
+    override def copy(path: List[Path]): Impl =
+      new Impl(path)
   }
   
 }

--- a/typo-tester-anorm/generated-and-checked-in/adventureworks/purchasing/purchaseorderheader/PurchaseorderheaderRepoMock.scala
+++ b/typo-tester-anorm/generated-and-checked-in/adventureworks/purchasing/purchaseorderheader/PurchaseorderheaderRepoMock.scala
@@ -22,7 +22,7 @@ import typo.dsl.UpdateParams
 class PurchaseorderheaderRepoMock(toRow: Function1[PurchaseorderheaderRowUnsaved, PurchaseorderheaderRow],
                                   map: scala.collection.mutable.Map[PurchaseorderheaderId, PurchaseorderheaderRow] = scala.collection.mutable.Map.empty) extends PurchaseorderheaderRepo {
   override def delete: DeleteBuilder[PurchaseorderheaderFields, PurchaseorderheaderRow] = {
-    DeleteBuilderMock(DeleteParams.empty, PurchaseorderheaderFields.structure.fields, map)
+    DeleteBuilderMock(DeleteParams.empty, PurchaseorderheaderFields.structure, map)
   }
   override def deleteById(purchaseorderid: PurchaseorderheaderId)(implicit c: Connection): Boolean = {
     map.remove(purchaseorderid).isDefined
@@ -72,7 +72,7 @@ class PurchaseorderheaderRepoMock(toRow: Function1[PurchaseorderheaderRowUnsaved
     purchaseorderids.view.flatMap(id => byId.get(id).map(x => (id, x))).toMap
   }
   override def update: UpdateBuilder[PurchaseorderheaderFields, PurchaseorderheaderRow] = {
-    UpdateBuilderMock(UpdateParams.empty, PurchaseorderheaderFields.structure.fields, map)
+    UpdateBuilderMock(UpdateParams.empty, PurchaseorderheaderFields.structure, map)
   }
   override def update(row: PurchaseorderheaderRow)(implicit c: Connection): Boolean = {
     map.get(row.purchaseorderid) match {

--- a/typo-tester-anorm/generated-and-checked-in/adventureworks/purchasing/shipmethod/ShipmethodFields.scala
+++ b/typo-tester-anorm/generated-and-checked-in/adventureworks/purchasing/shipmethod/ShipmethodFields.scala
@@ -10,41 +10,42 @@ package shipmethod
 import adventureworks.customtypes.TypoLocalDateTime
 import adventureworks.customtypes.TypoUUID
 import adventureworks.public.Name
+import typo.dsl.Path
 import typo.dsl.SqlExpr.Field
 import typo.dsl.SqlExpr.FieldLikeNoHkt
 import typo.dsl.SqlExpr.IdField
 import typo.dsl.Structure.Relation
 
-trait ShipmethodFields[Row] {
-  val shipmethodid: IdField[ShipmethodId, Row]
-  val name: Field[Name, Row]
-  val shipbase: Field[BigDecimal, Row]
-  val shiprate: Field[BigDecimal, Row]
-  val rowguid: Field[TypoUUID, Row]
-  val modifieddate: Field[TypoLocalDateTime, Row]
+trait ShipmethodFields {
+  def shipmethodid: IdField[ShipmethodId, ShipmethodRow]
+  def name: Field[Name, ShipmethodRow]
+  def shipbase: Field[BigDecimal, ShipmethodRow]
+  def shiprate: Field[BigDecimal, ShipmethodRow]
+  def rowguid: Field[TypoUUID, ShipmethodRow]
+  def modifieddate: Field[TypoLocalDateTime, ShipmethodRow]
 }
 
 object ShipmethodFields {
-  val structure: Relation[ShipmethodFields, ShipmethodRow, ShipmethodRow] = 
-    new Impl(None, identity, (_, x) => x)
+  lazy val structure: Relation[ShipmethodFields, ShipmethodRow] =
+    new Impl(Nil)
     
-  private final class Impl[Row](val prefix: Option[String], val extract: Row => ShipmethodRow, val merge: (Row, ShipmethodRow) => Row)
-    extends Relation[ShipmethodFields, ShipmethodRow, Row] { 
+  private final class Impl(val _path: List[Path])
+    extends Relation[ShipmethodFields, ShipmethodRow] {
   
-    override val fields: ShipmethodFields[Row] = new ShipmethodFields[Row] {
-      override val shipmethodid = new IdField[ShipmethodId, Row](prefix, "shipmethodid", None, Some("int4"))(x => extract(x).shipmethodid, (row, value) => merge(row, extract(row).copy(shipmethodid = value)))
-      override val name = new Field[Name, Row](prefix, "name", None, Some("varchar"))(x => extract(x).name, (row, value) => merge(row, extract(row).copy(name = value)))
-      override val shipbase = new Field[BigDecimal, Row](prefix, "shipbase", None, Some("numeric"))(x => extract(x).shipbase, (row, value) => merge(row, extract(row).copy(shipbase = value)))
-      override val shiprate = new Field[BigDecimal, Row](prefix, "shiprate", None, Some("numeric"))(x => extract(x).shiprate, (row, value) => merge(row, extract(row).copy(shiprate = value)))
-      override val rowguid = new Field[TypoUUID, Row](prefix, "rowguid", None, Some("uuid"))(x => extract(x).rowguid, (row, value) => merge(row, extract(row).copy(rowguid = value)))
-      override val modifieddate = new Field[TypoLocalDateTime, Row](prefix, "modifieddate", Some("text"), Some("timestamp"))(x => extract(x).modifieddate, (row, value) => merge(row, extract(row).copy(modifieddate = value)))
+    override lazy val fields: ShipmethodFields = new ShipmethodFields {
+      override def shipmethodid = IdField[ShipmethodId, ShipmethodRow](_path, "shipmethodid", None, Some("int4"), x => x.shipmethodid, (row, value) => row.copy(shipmethodid = value))
+      override def name = Field[Name, ShipmethodRow](_path, "name", None, Some("varchar"), x => x.name, (row, value) => row.copy(name = value))
+      override def shipbase = Field[BigDecimal, ShipmethodRow](_path, "shipbase", None, Some("numeric"), x => x.shipbase, (row, value) => row.copy(shipbase = value))
+      override def shiprate = Field[BigDecimal, ShipmethodRow](_path, "shiprate", None, Some("numeric"), x => x.shiprate, (row, value) => row.copy(shiprate = value))
+      override def rowguid = Field[TypoUUID, ShipmethodRow](_path, "rowguid", None, Some("uuid"), x => x.rowguid, (row, value) => row.copy(rowguid = value))
+      override def modifieddate = Field[TypoLocalDateTime, ShipmethodRow](_path, "modifieddate", Some("text"), Some("timestamp"), x => x.modifieddate, (row, value) => row.copy(modifieddate = value))
     }
   
-    override val columns: List[FieldLikeNoHkt[?, Row]] =
-      List[FieldLikeNoHkt[?, Row]](fields.shipmethodid, fields.name, fields.shipbase, fields.shiprate, fields.rowguid, fields.modifieddate)
+    override lazy val columns: List[FieldLikeNoHkt[?, ShipmethodRow]] =
+      List[FieldLikeNoHkt[?, ShipmethodRow]](fields.shipmethodid, fields.name, fields.shipbase, fields.shiprate, fields.rowguid, fields.modifieddate)
   
-    override def copy[NewRow](prefix: Option[String], extract: NewRow => ShipmethodRow, merge: (NewRow, ShipmethodRow) => NewRow): Impl[NewRow] =
-      new Impl(prefix, extract, merge)
+    override def copy(path: List[Path]): Impl =
+      new Impl(path)
   }
   
 }

--- a/typo-tester-anorm/generated-and-checked-in/adventureworks/purchasing/shipmethod/ShipmethodRepoMock.scala
+++ b/typo-tester-anorm/generated-and-checked-in/adventureworks/purchasing/shipmethod/ShipmethodRepoMock.scala
@@ -22,7 +22,7 @@ import typo.dsl.UpdateParams
 class ShipmethodRepoMock(toRow: Function1[ShipmethodRowUnsaved, ShipmethodRow],
                          map: scala.collection.mutable.Map[ShipmethodId, ShipmethodRow] = scala.collection.mutable.Map.empty) extends ShipmethodRepo {
   override def delete: DeleteBuilder[ShipmethodFields, ShipmethodRow] = {
-    DeleteBuilderMock(DeleteParams.empty, ShipmethodFields.structure.fields, map)
+    DeleteBuilderMock(DeleteParams.empty, ShipmethodFields.structure, map)
   }
   override def deleteById(shipmethodid: ShipmethodId)(implicit c: Connection): Boolean = {
     map.remove(shipmethodid).isDefined
@@ -72,7 +72,7 @@ class ShipmethodRepoMock(toRow: Function1[ShipmethodRowUnsaved, ShipmethodRow],
     shipmethodids.view.flatMap(id => byId.get(id).map(x => (id, x))).toMap
   }
   override def update: UpdateBuilder[ShipmethodFields, ShipmethodRow] = {
-    UpdateBuilderMock(UpdateParams.empty, ShipmethodFields.structure.fields, map)
+    UpdateBuilderMock(UpdateParams.empty, ShipmethodFields.structure, map)
   }
   override def update(row: ShipmethodRow)(implicit c: Connection): Boolean = {
     map.get(row.shipmethodid) match {

--- a/typo-tester-anorm/generated-and-checked-in/adventureworks/purchasing/vendor/VendorFields.scala
+++ b/typo-tester-anorm/generated-and-checked-in/adventureworks/purchasing/vendor/VendorFields.scala
@@ -13,46 +13,47 @@ import adventureworks.person.businessentity.BusinessentityId
 import adventureworks.public.AccountNumber
 import adventureworks.public.Flag
 import adventureworks.public.Name
+import typo.dsl.Path
 import typo.dsl.SqlExpr.Field
 import typo.dsl.SqlExpr.FieldLikeNoHkt
 import typo.dsl.SqlExpr.IdField
 import typo.dsl.SqlExpr.OptField
 import typo.dsl.Structure.Relation
 
-trait VendorFields[Row] {
-  val businessentityid: IdField[BusinessentityId, Row]
-  val accountnumber: Field[AccountNumber, Row]
-  val name: Field[Name, Row]
-  val creditrating: Field[TypoShort, Row]
-  val preferredvendorstatus: Field[Flag, Row]
-  val activeflag: Field[Flag, Row]
-  val purchasingwebserviceurl: OptField[/* max 1024 chars */ String, Row]
-  val modifieddate: Field[TypoLocalDateTime, Row]
+trait VendorFields {
+  def businessentityid: IdField[BusinessentityId, VendorRow]
+  def accountnumber: Field[AccountNumber, VendorRow]
+  def name: Field[Name, VendorRow]
+  def creditrating: Field[TypoShort, VendorRow]
+  def preferredvendorstatus: Field[Flag, VendorRow]
+  def activeflag: Field[Flag, VendorRow]
+  def purchasingwebserviceurl: OptField[/* max 1024 chars */ String, VendorRow]
+  def modifieddate: Field[TypoLocalDateTime, VendorRow]
 }
 
 object VendorFields {
-  val structure: Relation[VendorFields, VendorRow, VendorRow] = 
-    new Impl(None, identity, (_, x) => x)
+  lazy val structure: Relation[VendorFields, VendorRow] =
+    new Impl(Nil)
     
-  private final class Impl[Row](val prefix: Option[String], val extract: Row => VendorRow, val merge: (Row, VendorRow) => Row)
-    extends Relation[VendorFields, VendorRow, Row] { 
+  private final class Impl(val _path: List[Path])
+    extends Relation[VendorFields, VendorRow] {
   
-    override val fields: VendorFields[Row] = new VendorFields[Row] {
-      override val businessentityid = new IdField[BusinessentityId, Row](prefix, "businessentityid", None, Some("int4"))(x => extract(x).businessentityid, (row, value) => merge(row, extract(row).copy(businessentityid = value)))
-      override val accountnumber = new Field[AccountNumber, Row](prefix, "accountnumber", None, Some("varchar"))(x => extract(x).accountnumber, (row, value) => merge(row, extract(row).copy(accountnumber = value)))
-      override val name = new Field[Name, Row](prefix, "name", None, Some("varchar"))(x => extract(x).name, (row, value) => merge(row, extract(row).copy(name = value)))
-      override val creditrating = new Field[TypoShort, Row](prefix, "creditrating", None, Some("int2"))(x => extract(x).creditrating, (row, value) => merge(row, extract(row).copy(creditrating = value)))
-      override val preferredvendorstatus = new Field[Flag, Row](prefix, "preferredvendorstatus", None, Some("bool"))(x => extract(x).preferredvendorstatus, (row, value) => merge(row, extract(row).copy(preferredvendorstatus = value)))
-      override val activeflag = new Field[Flag, Row](prefix, "activeflag", None, Some("bool"))(x => extract(x).activeflag, (row, value) => merge(row, extract(row).copy(activeflag = value)))
-      override val purchasingwebserviceurl = new OptField[/* max 1024 chars */ String, Row](prefix, "purchasingwebserviceurl", None, None)(x => extract(x).purchasingwebserviceurl, (row, value) => merge(row, extract(row).copy(purchasingwebserviceurl = value)))
-      override val modifieddate = new Field[TypoLocalDateTime, Row](prefix, "modifieddate", Some("text"), Some("timestamp"))(x => extract(x).modifieddate, (row, value) => merge(row, extract(row).copy(modifieddate = value)))
+    override lazy val fields: VendorFields = new VendorFields {
+      override def businessentityid = IdField[BusinessentityId, VendorRow](_path, "businessentityid", None, Some("int4"), x => x.businessentityid, (row, value) => row.copy(businessentityid = value))
+      override def accountnumber = Field[AccountNumber, VendorRow](_path, "accountnumber", None, Some("varchar"), x => x.accountnumber, (row, value) => row.copy(accountnumber = value))
+      override def name = Field[Name, VendorRow](_path, "name", None, Some("varchar"), x => x.name, (row, value) => row.copy(name = value))
+      override def creditrating = Field[TypoShort, VendorRow](_path, "creditrating", None, Some("int2"), x => x.creditrating, (row, value) => row.copy(creditrating = value))
+      override def preferredvendorstatus = Field[Flag, VendorRow](_path, "preferredvendorstatus", None, Some("bool"), x => x.preferredvendorstatus, (row, value) => row.copy(preferredvendorstatus = value))
+      override def activeflag = Field[Flag, VendorRow](_path, "activeflag", None, Some("bool"), x => x.activeflag, (row, value) => row.copy(activeflag = value))
+      override def purchasingwebserviceurl = OptField[/* max 1024 chars */ String, VendorRow](_path, "purchasingwebserviceurl", None, None, x => x.purchasingwebserviceurl, (row, value) => row.copy(purchasingwebserviceurl = value))
+      override def modifieddate = Field[TypoLocalDateTime, VendorRow](_path, "modifieddate", Some("text"), Some("timestamp"), x => x.modifieddate, (row, value) => row.copy(modifieddate = value))
     }
   
-    override val columns: List[FieldLikeNoHkt[?, Row]] =
-      List[FieldLikeNoHkt[?, Row]](fields.businessentityid, fields.accountnumber, fields.name, fields.creditrating, fields.preferredvendorstatus, fields.activeflag, fields.purchasingwebserviceurl, fields.modifieddate)
+    override lazy val columns: List[FieldLikeNoHkt[?, VendorRow]] =
+      List[FieldLikeNoHkt[?, VendorRow]](fields.businessentityid, fields.accountnumber, fields.name, fields.creditrating, fields.preferredvendorstatus, fields.activeflag, fields.purchasingwebserviceurl, fields.modifieddate)
   
-    override def copy[NewRow](prefix: Option[String], extract: NewRow => VendorRow, merge: (NewRow, VendorRow) => NewRow): Impl[NewRow] =
-      new Impl(prefix, extract, merge)
+    override def copy(path: List[Path]): Impl =
+      new Impl(path)
   }
   
 }

--- a/typo-tester-anorm/generated-and-checked-in/adventureworks/purchasing/vendor/VendorRepoMock.scala
+++ b/typo-tester-anorm/generated-and-checked-in/adventureworks/purchasing/vendor/VendorRepoMock.scala
@@ -23,7 +23,7 @@ import typo.dsl.UpdateParams
 class VendorRepoMock(toRow: Function1[VendorRowUnsaved, VendorRow],
                      map: scala.collection.mutable.Map[BusinessentityId, VendorRow] = scala.collection.mutable.Map.empty) extends VendorRepo {
   override def delete: DeleteBuilder[VendorFields, VendorRow] = {
-    DeleteBuilderMock(DeleteParams.empty, VendorFields.structure.fields, map)
+    DeleteBuilderMock(DeleteParams.empty, VendorFields.structure, map)
   }
   override def deleteById(businessentityid: BusinessentityId)(implicit c: Connection): Boolean = {
     map.remove(businessentityid).isDefined
@@ -73,7 +73,7 @@ class VendorRepoMock(toRow: Function1[VendorRowUnsaved, VendorRow],
     businessentityids.view.flatMap(id => byId.get(id).map(x => (id, x))).toMap
   }
   override def update: UpdateBuilder[VendorFields, VendorRow] = {
-    UpdateBuilderMock(UpdateParams.empty, VendorFields.structure.fields, map)
+    UpdateBuilderMock(UpdateParams.empty, VendorFields.structure, map)
   }
   override def update(row: VendorRow)(implicit c: Connection): Boolean = {
     map.get(row.businessentityid) match {

--- a/typo-tester-anorm/generated-and-checked-in/adventureworks/purchasing/vvendorwithaddresses/VvendorwithaddressesViewFields.scala
+++ b/typo-tester-anorm/generated-and-checked-in/adventureworks/purchasing/vvendorwithaddresses/VvendorwithaddressesViewFields.scala
@@ -9,47 +9,48 @@ package vvendorwithaddresses
 
 import adventureworks.person.businessentity.BusinessentityId
 import adventureworks.public.Name
+import typo.dsl.Path
 import typo.dsl.SqlExpr.Field
 import typo.dsl.SqlExpr.FieldLikeNoHkt
 import typo.dsl.SqlExpr.OptField
 import typo.dsl.Structure.Relation
 
-trait VvendorwithaddressesViewFields[Row] {
-  val businessentityid: Field[BusinessentityId, Row]
-  val name: Field[Name, Row]
-  val addresstype: Field[Name, Row]
-  val addressline1: Field[/* max 60 chars */ String, Row]
-  val addressline2: OptField[/* max 60 chars */ String, Row]
-  val city: Field[/* max 30 chars */ String, Row]
-  val stateprovincename: Field[Name, Row]
-  val postalcode: Field[/* max 15 chars */ String, Row]
-  val countryregionname: Field[Name, Row]
+trait VvendorwithaddressesViewFields {
+  def businessentityid: Field[BusinessentityId, VvendorwithaddressesViewRow]
+  def name: Field[Name, VvendorwithaddressesViewRow]
+  def addresstype: Field[Name, VvendorwithaddressesViewRow]
+  def addressline1: Field[/* max 60 chars */ String, VvendorwithaddressesViewRow]
+  def addressline2: OptField[/* max 60 chars */ String, VvendorwithaddressesViewRow]
+  def city: Field[/* max 30 chars */ String, VvendorwithaddressesViewRow]
+  def stateprovincename: Field[Name, VvendorwithaddressesViewRow]
+  def postalcode: Field[/* max 15 chars */ String, VvendorwithaddressesViewRow]
+  def countryregionname: Field[Name, VvendorwithaddressesViewRow]
 }
 
 object VvendorwithaddressesViewFields {
-  val structure: Relation[VvendorwithaddressesViewFields, VvendorwithaddressesViewRow, VvendorwithaddressesViewRow] = 
-    new Impl(None, identity, (_, x) => x)
+  lazy val structure: Relation[VvendorwithaddressesViewFields, VvendorwithaddressesViewRow] =
+    new Impl(Nil)
     
-  private final class Impl[Row](val prefix: Option[String], val extract: Row => VvendorwithaddressesViewRow, val merge: (Row, VvendorwithaddressesViewRow) => Row)
-    extends Relation[VvendorwithaddressesViewFields, VvendorwithaddressesViewRow, Row] { 
+  private final class Impl(val _path: List[Path])
+    extends Relation[VvendorwithaddressesViewFields, VvendorwithaddressesViewRow] {
   
-    override val fields: VvendorwithaddressesViewFields[Row] = new VvendorwithaddressesViewFields[Row] {
-      override val businessentityid = new Field[BusinessentityId, Row](prefix, "businessentityid", None, None)(x => extract(x).businessentityid, (row, value) => merge(row, extract(row).copy(businessentityid = value)))
-      override val name = new Field[Name, Row](prefix, "name", None, None)(x => extract(x).name, (row, value) => merge(row, extract(row).copy(name = value)))
-      override val addresstype = new Field[Name, Row](prefix, "addresstype", None, None)(x => extract(x).addresstype, (row, value) => merge(row, extract(row).copy(addresstype = value)))
-      override val addressline1 = new Field[/* max 60 chars */ String, Row](prefix, "addressline1", None, None)(x => extract(x).addressline1, (row, value) => merge(row, extract(row).copy(addressline1 = value)))
-      override val addressline2 = new OptField[/* max 60 chars */ String, Row](prefix, "addressline2", None, None)(x => extract(x).addressline2, (row, value) => merge(row, extract(row).copy(addressline2 = value)))
-      override val city = new Field[/* max 30 chars */ String, Row](prefix, "city", None, None)(x => extract(x).city, (row, value) => merge(row, extract(row).copy(city = value)))
-      override val stateprovincename = new Field[Name, Row](prefix, "stateprovincename", None, None)(x => extract(x).stateprovincename, (row, value) => merge(row, extract(row).copy(stateprovincename = value)))
-      override val postalcode = new Field[/* max 15 chars */ String, Row](prefix, "postalcode", None, None)(x => extract(x).postalcode, (row, value) => merge(row, extract(row).copy(postalcode = value)))
-      override val countryregionname = new Field[Name, Row](prefix, "countryregionname", None, None)(x => extract(x).countryregionname, (row, value) => merge(row, extract(row).copy(countryregionname = value)))
+    override lazy val fields: VvendorwithaddressesViewFields = new VvendorwithaddressesViewFields {
+      override def businessentityid = Field[BusinessentityId, VvendorwithaddressesViewRow](_path, "businessentityid", None, None, x => x.businessentityid, (row, value) => row.copy(businessentityid = value))
+      override def name = Field[Name, VvendorwithaddressesViewRow](_path, "name", None, None, x => x.name, (row, value) => row.copy(name = value))
+      override def addresstype = Field[Name, VvendorwithaddressesViewRow](_path, "addresstype", None, None, x => x.addresstype, (row, value) => row.copy(addresstype = value))
+      override def addressline1 = Field[/* max 60 chars */ String, VvendorwithaddressesViewRow](_path, "addressline1", None, None, x => x.addressline1, (row, value) => row.copy(addressline1 = value))
+      override def addressline2 = OptField[/* max 60 chars */ String, VvendorwithaddressesViewRow](_path, "addressline2", None, None, x => x.addressline2, (row, value) => row.copy(addressline2 = value))
+      override def city = Field[/* max 30 chars */ String, VvendorwithaddressesViewRow](_path, "city", None, None, x => x.city, (row, value) => row.copy(city = value))
+      override def stateprovincename = Field[Name, VvendorwithaddressesViewRow](_path, "stateprovincename", None, None, x => x.stateprovincename, (row, value) => row.copy(stateprovincename = value))
+      override def postalcode = Field[/* max 15 chars */ String, VvendorwithaddressesViewRow](_path, "postalcode", None, None, x => x.postalcode, (row, value) => row.copy(postalcode = value))
+      override def countryregionname = Field[Name, VvendorwithaddressesViewRow](_path, "countryregionname", None, None, x => x.countryregionname, (row, value) => row.copy(countryregionname = value))
     }
   
-    override val columns: List[FieldLikeNoHkt[?, Row]] =
-      List[FieldLikeNoHkt[?, Row]](fields.businessentityid, fields.name, fields.addresstype, fields.addressline1, fields.addressline2, fields.city, fields.stateprovincename, fields.postalcode, fields.countryregionname)
+    override lazy val columns: List[FieldLikeNoHkt[?, VvendorwithaddressesViewRow]] =
+      List[FieldLikeNoHkt[?, VvendorwithaddressesViewRow]](fields.businessentityid, fields.name, fields.addresstype, fields.addressline1, fields.addressline2, fields.city, fields.stateprovincename, fields.postalcode, fields.countryregionname)
   
-    override def copy[NewRow](prefix: Option[String], extract: NewRow => VvendorwithaddressesViewRow, merge: (NewRow, VvendorwithaddressesViewRow) => NewRow): Impl[NewRow] =
-      new Impl(prefix, extract, merge)
+    override def copy(path: List[Path]): Impl =
+      new Impl(path)
   }
   
 }

--- a/typo-tester-anorm/generated-and-checked-in/adventureworks/purchasing/vvendorwithcontacts/VvendorwithcontactsViewFields.scala
+++ b/typo-tester-anorm/generated-and-checked-in/adventureworks/purchasing/vvendorwithcontacts/VvendorwithcontactsViewFields.scala
@@ -11,53 +11,54 @@ import adventureworks.person.businessentity.BusinessentityId
 import adventureworks.public.Name
 import adventureworks.public.Phone
 import adventureworks.userdefined.FirstName
+import typo.dsl.Path
 import typo.dsl.SqlExpr.Field
 import typo.dsl.SqlExpr.FieldLikeNoHkt
 import typo.dsl.SqlExpr.OptField
 import typo.dsl.Structure.Relation
 
-trait VvendorwithcontactsViewFields[Row] {
-  val businessentityid: Field[BusinessentityId, Row]
-  val name: Field[Name, Row]
-  val contacttype: Field[Name, Row]
-  val title: OptField[/* max 8 chars */ String, Row]
-  val firstname: Field[/* user-picked */ FirstName, Row]
-  val middlename: OptField[Name, Row]
-  val lastname: Field[Name, Row]
-  val suffix: OptField[/* max 10 chars */ String, Row]
-  val phonenumber: OptField[Phone, Row]
-  val phonenumbertype: OptField[Name, Row]
-  val emailaddress: OptField[/* max 50 chars */ String, Row]
-  val emailpromotion: Field[Int, Row]
+trait VvendorwithcontactsViewFields {
+  def businessentityid: Field[BusinessentityId, VvendorwithcontactsViewRow]
+  def name: Field[Name, VvendorwithcontactsViewRow]
+  def contacttype: Field[Name, VvendorwithcontactsViewRow]
+  def title: OptField[/* max 8 chars */ String, VvendorwithcontactsViewRow]
+  def firstname: Field[/* user-picked */ FirstName, VvendorwithcontactsViewRow]
+  def middlename: OptField[Name, VvendorwithcontactsViewRow]
+  def lastname: Field[Name, VvendorwithcontactsViewRow]
+  def suffix: OptField[/* max 10 chars */ String, VvendorwithcontactsViewRow]
+  def phonenumber: OptField[Phone, VvendorwithcontactsViewRow]
+  def phonenumbertype: OptField[Name, VvendorwithcontactsViewRow]
+  def emailaddress: OptField[/* max 50 chars */ String, VvendorwithcontactsViewRow]
+  def emailpromotion: Field[Int, VvendorwithcontactsViewRow]
 }
 
 object VvendorwithcontactsViewFields {
-  val structure: Relation[VvendorwithcontactsViewFields, VvendorwithcontactsViewRow, VvendorwithcontactsViewRow] = 
-    new Impl(None, identity, (_, x) => x)
+  lazy val structure: Relation[VvendorwithcontactsViewFields, VvendorwithcontactsViewRow] =
+    new Impl(Nil)
     
-  private final class Impl[Row](val prefix: Option[String], val extract: Row => VvendorwithcontactsViewRow, val merge: (Row, VvendorwithcontactsViewRow) => Row)
-    extends Relation[VvendorwithcontactsViewFields, VvendorwithcontactsViewRow, Row] { 
+  private final class Impl(val _path: List[Path])
+    extends Relation[VvendorwithcontactsViewFields, VvendorwithcontactsViewRow] {
   
-    override val fields: VvendorwithcontactsViewFields[Row] = new VvendorwithcontactsViewFields[Row] {
-      override val businessentityid = new Field[BusinessentityId, Row](prefix, "businessentityid", None, None)(x => extract(x).businessentityid, (row, value) => merge(row, extract(row).copy(businessentityid = value)))
-      override val name = new Field[Name, Row](prefix, "name", None, None)(x => extract(x).name, (row, value) => merge(row, extract(row).copy(name = value)))
-      override val contacttype = new Field[Name, Row](prefix, "contacttype", None, None)(x => extract(x).contacttype, (row, value) => merge(row, extract(row).copy(contacttype = value)))
-      override val title = new OptField[/* max 8 chars */ String, Row](prefix, "title", None, None)(x => extract(x).title, (row, value) => merge(row, extract(row).copy(title = value)))
-      override val firstname = new Field[/* user-picked */ FirstName, Row](prefix, "firstname", None, None)(x => extract(x).firstname, (row, value) => merge(row, extract(row).copy(firstname = value)))
-      override val middlename = new OptField[Name, Row](prefix, "middlename", None, None)(x => extract(x).middlename, (row, value) => merge(row, extract(row).copy(middlename = value)))
-      override val lastname = new Field[Name, Row](prefix, "lastname", None, None)(x => extract(x).lastname, (row, value) => merge(row, extract(row).copy(lastname = value)))
-      override val suffix = new OptField[/* max 10 chars */ String, Row](prefix, "suffix", None, None)(x => extract(x).suffix, (row, value) => merge(row, extract(row).copy(suffix = value)))
-      override val phonenumber = new OptField[Phone, Row](prefix, "phonenumber", None, None)(x => extract(x).phonenumber, (row, value) => merge(row, extract(row).copy(phonenumber = value)))
-      override val phonenumbertype = new OptField[Name, Row](prefix, "phonenumbertype", None, None)(x => extract(x).phonenumbertype, (row, value) => merge(row, extract(row).copy(phonenumbertype = value)))
-      override val emailaddress = new OptField[/* max 50 chars */ String, Row](prefix, "emailaddress", None, None)(x => extract(x).emailaddress, (row, value) => merge(row, extract(row).copy(emailaddress = value)))
-      override val emailpromotion = new Field[Int, Row](prefix, "emailpromotion", None, None)(x => extract(x).emailpromotion, (row, value) => merge(row, extract(row).copy(emailpromotion = value)))
+    override lazy val fields: VvendorwithcontactsViewFields = new VvendorwithcontactsViewFields {
+      override def businessentityid = Field[BusinessentityId, VvendorwithcontactsViewRow](_path, "businessentityid", None, None, x => x.businessentityid, (row, value) => row.copy(businessentityid = value))
+      override def name = Field[Name, VvendorwithcontactsViewRow](_path, "name", None, None, x => x.name, (row, value) => row.copy(name = value))
+      override def contacttype = Field[Name, VvendorwithcontactsViewRow](_path, "contacttype", None, None, x => x.contacttype, (row, value) => row.copy(contacttype = value))
+      override def title = OptField[/* max 8 chars */ String, VvendorwithcontactsViewRow](_path, "title", None, None, x => x.title, (row, value) => row.copy(title = value))
+      override def firstname = Field[/* user-picked */ FirstName, VvendorwithcontactsViewRow](_path, "firstname", None, None, x => x.firstname, (row, value) => row.copy(firstname = value))
+      override def middlename = OptField[Name, VvendorwithcontactsViewRow](_path, "middlename", None, None, x => x.middlename, (row, value) => row.copy(middlename = value))
+      override def lastname = Field[Name, VvendorwithcontactsViewRow](_path, "lastname", None, None, x => x.lastname, (row, value) => row.copy(lastname = value))
+      override def suffix = OptField[/* max 10 chars */ String, VvendorwithcontactsViewRow](_path, "suffix", None, None, x => x.suffix, (row, value) => row.copy(suffix = value))
+      override def phonenumber = OptField[Phone, VvendorwithcontactsViewRow](_path, "phonenumber", None, None, x => x.phonenumber, (row, value) => row.copy(phonenumber = value))
+      override def phonenumbertype = OptField[Name, VvendorwithcontactsViewRow](_path, "phonenumbertype", None, None, x => x.phonenumbertype, (row, value) => row.copy(phonenumbertype = value))
+      override def emailaddress = OptField[/* max 50 chars */ String, VvendorwithcontactsViewRow](_path, "emailaddress", None, None, x => x.emailaddress, (row, value) => row.copy(emailaddress = value))
+      override def emailpromotion = Field[Int, VvendorwithcontactsViewRow](_path, "emailpromotion", None, None, x => x.emailpromotion, (row, value) => row.copy(emailpromotion = value))
     }
   
-    override val columns: List[FieldLikeNoHkt[?, Row]] =
-      List[FieldLikeNoHkt[?, Row]](fields.businessentityid, fields.name, fields.contacttype, fields.title, fields.firstname, fields.middlename, fields.lastname, fields.suffix, fields.phonenumber, fields.phonenumbertype, fields.emailaddress, fields.emailpromotion)
+    override lazy val columns: List[FieldLikeNoHkt[?, VvendorwithcontactsViewRow]] =
+      List[FieldLikeNoHkt[?, VvendorwithcontactsViewRow]](fields.businessentityid, fields.name, fields.contacttype, fields.title, fields.firstname, fields.middlename, fields.lastname, fields.suffix, fields.phonenumber, fields.phonenumbertype, fields.emailaddress, fields.emailpromotion)
   
-    override def copy[NewRow](prefix: Option[String], extract: NewRow => VvendorwithcontactsViewRow, merge: (NewRow, VvendorwithcontactsViewRow) => NewRow): Impl[NewRow] =
-      new Impl(prefix, extract, merge)
+    override def copy(path: List[Path]): Impl =
+      new Impl(path)
   }
   
 }

--- a/typo-tester-anorm/generated-and-checked-in/adventureworks/sa/c/CViewFields.scala
+++ b/typo-tester-anorm/generated-and-checked-in/adventureworks/sa/c/CViewFields.scala
@@ -12,43 +12,44 @@ import adventureworks.customtypes.TypoUUID
 import adventureworks.person.businessentity.BusinessentityId
 import adventureworks.sales.customer.CustomerId
 import adventureworks.sales.salesterritory.SalesterritoryId
+import typo.dsl.Path
 import typo.dsl.SqlExpr.Field
 import typo.dsl.SqlExpr.FieldLikeNoHkt
 import typo.dsl.SqlExpr.OptField
 import typo.dsl.Structure.Relation
 
-trait CViewFields[Row] {
-  val id: Field[CustomerId, Row]
-  val customerid: Field[CustomerId, Row]
-  val personid: OptField[BusinessentityId, Row]
-  val storeid: OptField[BusinessentityId, Row]
-  val territoryid: OptField[SalesterritoryId, Row]
-  val rowguid: Field[TypoUUID, Row]
-  val modifieddate: Field[TypoLocalDateTime, Row]
+trait CViewFields {
+  def id: Field[CustomerId, CViewRow]
+  def customerid: Field[CustomerId, CViewRow]
+  def personid: OptField[BusinessentityId, CViewRow]
+  def storeid: OptField[BusinessentityId, CViewRow]
+  def territoryid: OptField[SalesterritoryId, CViewRow]
+  def rowguid: Field[TypoUUID, CViewRow]
+  def modifieddate: Field[TypoLocalDateTime, CViewRow]
 }
 
 object CViewFields {
-  val structure: Relation[CViewFields, CViewRow, CViewRow] = 
-    new Impl(None, identity, (_, x) => x)
+  lazy val structure: Relation[CViewFields, CViewRow] =
+    new Impl(Nil)
     
-  private final class Impl[Row](val prefix: Option[String], val extract: Row => CViewRow, val merge: (Row, CViewRow) => Row)
-    extends Relation[CViewFields, CViewRow, Row] { 
+  private final class Impl(val _path: List[Path])
+    extends Relation[CViewFields, CViewRow] {
   
-    override val fields: CViewFields[Row] = new CViewFields[Row] {
-      override val id = new Field[CustomerId, Row](prefix, "id", None, None)(x => extract(x).id, (row, value) => merge(row, extract(row).copy(id = value)))
-      override val customerid = new Field[CustomerId, Row](prefix, "customerid", None, None)(x => extract(x).customerid, (row, value) => merge(row, extract(row).copy(customerid = value)))
-      override val personid = new OptField[BusinessentityId, Row](prefix, "personid", None, None)(x => extract(x).personid, (row, value) => merge(row, extract(row).copy(personid = value)))
-      override val storeid = new OptField[BusinessentityId, Row](prefix, "storeid", None, None)(x => extract(x).storeid, (row, value) => merge(row, extract(row).copy(storeid = value)))
-      override val territoryid = new OptField[SalesterritoryId, Row](prefix, "territoryid", None, None)(x => extract(x).territoryid, (row, value) => merge(row, extract(row).copy(territoryid = value)))
-      override val rowguid = new Field[TypoUUID, Row](prefix, "rowguid", None, None)(x => extract(x).rowguid, (row, value) => merge(row, extract(row).copy(rowguid = value)))
-      override val modifieddate = new Field[TypoLocalDateTime, Row](prefix, "modifieddate", Some("text"), None)(x => extract(x).modifieddate, (row, value) => merge(row, extract(row).copy(modifieddate = value)))
+    override lazy val fields: CViewFields = new CViewFields {
+      override def id = Field[CustomerId, CViewRow](_path, "id", None, None, x => x.id, (row, value) => row.copy(id = value))
+      override def customerid = Field[CustomerId, CViewRow](_path, "customerid", None, None, x => x.customerid, (row, value) => row.copy(customerid = value))
+      override def personid = OptField[BusinessentityId, CViewRow](_path, "personid", None, None, x => x.personid, (row, value) => row.copy(personid = value))
+      override def storeid = OptField[BusinessentityId, CViewRow](_path, "storeid", None, None, x => x.storeid, (row, value) => row.copy(storeid = value))
+      override def territoryid = OptField[SalesterritoryId, CViewRow](_path, "territoryid", None, None, x => x.territoryid, (row, value) => row.copy(territoryid = value))
+      override def rowguid = Field[TypoUUID, CViewRow](_path, "rowguid", None, None, x => x.rowguid, (row, value) => row.copy(rowguid = value))
+      override def modifieddate = Field[TypoLocalDateTime, CViewRow](_path, "modifieddate", Some("text"), None, x => x.modifieddate, (row, value) => row.copy(modifieddate = value))
     }
   
-    override val columns: List[FieldLikeNoHkt[?, Row]] =
-      List[FieldLikeNoHkt[?, Row]](fields.id, fields.customerid, fields.personid, fields.storeid, fields.territoryid, fields.rowguid, fields.modifieddate)
+    override lazy val columns: List[FieldLikeNoHkt[?, CViewRow]] =
+      List[FieldLikeNoHkt[?, CViewRow]](fields.id, fields.customerid, fields.personid, fields.storeid, fields.territoryid, fields.rowguid, fields.modifieddate)
   
-    override def copy[NewRow](prefix: Option[String], extract: NewRow => CViewRow, merge: (NewRow, CViewRow) => NewRow): Impl[NewRow] =
-      new Impl(prefix, extract, merge)
+    override def copy(path: List[Path]): Impl =
+      new Impl(path)
   }
   
 }

--- a/typo-tester-anorm/generated-and-checked-in/adventureworks/sa/cc/CcViewFields.scala
+++ b/typo-tester-anorm/generated-and-checked-in/adventureworks/sa/cc/CcViewFields.scala
@@ -10,42 +10,43 @@ package cc
 import adventureworks.customtypes.TypoLocalDateTime
 import adventureworks.customtypes.TypoShort
 import adventureworks.userdefined.CustomCreditcardId
+import typo.dsl.Path
 import typo.dsl.SqlExpr.Field
 import typo.dsl.SqlExpr.FieldLikeNoHkt
 import typo.dsl.Structure.Relation
 
-trait CcViewFields[Row] {
-  val id: Field[/* user-picked */ CustomCreditcardId, Row]
-  val creditcardid: Field[/* user-picked */ CustomCreditcardId, Row]
-  val cardtype: Field[/* max 50 chars */ String, Row]
-  val cardnumber: Field[/* max 25 chars */ String, Row]
-  val expmonth: Field[TypoShort, Row]
-  val expyear: Field[TypoShort, Row]
-  val modifieddate: Field[TypoLocalDateTime, Row]
+trait CcViewFields {
+  def id: Field[/* user-picked */ CustomCreditcardId, CcViewRow]
+  def creditcardid: Field[/* user-picked */ CustomCreditcardId, CcViewRow]
+  def cardtype: Field[/* max 50 chars */ String, CcViewRow]
+  def cardnumber: Field[/* max 25 chars */ String, CcViewRow]
+  def expmonth: Field[TypoShort, CcViewRow]
+  def expyear: Field[TypoShort, CcViewRow]
+  def modifieddate: Field[TypoLocalDateTime, CcViewRow]
 }
 
 object CcViewFields {
-  val structure: Relation[CcViewFields, CcViewRow, CcViewRow] = 
-    new Impl(None, identity, (_, x) => x)
+  lazy val structure: Relation[CcViewFields, CcViewRow] =
+    new Impl(Nil)
     
-  private final class Impl[Row](val prefix: Option[String], val extract: Row => CcViewRow, val merge: (Row, CcViewRow) => Row)
-    extends Relation[CcViewFields, CcViewRow, Row] { 
+  private final class Impl(val _path: List[Path])
+    extends Relation[CcViewFields, CcViewRow] {
   
-    override val fields: CcViewFields[Row] = new CcViewFields[Row] {
-      override val id = new Field[/* user-picked */ CustomCreditcardId, Row](prefix, "id", None, None)(x => extract(x).id, (row, value) => merge(row, extract(row).copy(id = value)))
-      override val creditcardid = new Field[/* user-picked */ CustomCreditcardId, Row](prefix, "creditcardid", None, None)(x => extract(x).creditcardid, (row, value) => merge(row, extract(row).copy(creditcardid = value)))
-      override val cardtype = new Field[/* max 50 chars */ String, Row](prefix, "cardtype", None, None)(x => extract(x).cardtype, (row, value) => merge(row, extract(row).copy(cardtype = value)))
-      override val cardnumber = new Field[/* max 25 chars */ String, Row](prefix, "cardnumber", None, None)(x => extract(x).cardnumber, (row, value) => merge(row, extract(row).copy(cardnumber = value)))
-      override val expmonth = new Field[TypoShort, Row](prefix, "expmonth", None, None)(x => extract(x).expmonth, (row, value) => merge(row, extract(row).copy(expmonth = value)))
-      override val expyear = new Field[TypoShort, Row](prefix, "expyear", None, None)(x => extract(x).expyear, (row, value) => merge(row, extract(row).copy(expyear = value)))
-      override val modifieddate = new Field[TypoLocalDateTime, Row](prefix, "modifieddate", Some("text"), None)(x => extract(x).modifieddate, (row, value) => merge(row, extract(row).copy(modifieddate = value)))
+    override lazy val fields: CcViewFields = new CcViewFields {
+      override def id = Field[/* user-picked */ CustomCreditcardId, CcViewRow](_path, "id", None, None, x => x.id, (row, value) => row.copy(id = value))
+      override def creditcardid = Field[/* user-picked */ CustomCreditcardId, CcViewRow](_path, "creditcardid", None, None, x => x.creditcardid, (row, value) => row.copy(creditcardid = value))
+      override def cardtype = Field[/* max 50 chars */ String, CcViewRow](_path, "cardtype", None, None, x => x.cardtype, (row, value) => row.copy(cardtype = value))
+      override def cardnumber = Field[/* max 25 chars */ String, CcViewRow](_path, "cardnumber", None, None, x => x.cardnumber, (row, value) => row.copy(cardnumber = value))
+      override def expmonth = Field[TypoShort, CcViewRow](_path, "expmonth", None, None, x => x.expmonth, (row, value) => row.copy(expmonth = value))
+      override def expyear = Field[TypoShort, CcViewRow](_path, "expyear", None, None, x => x.expyear, (row, value) => row.copy(expyear = value))
+      override def modifieddate = Field[TypoLocalDateTime, CcViewRow](_path, "modifieddate", Some("text"), None, x => x.modifieddate, (row, value) => row.copy(modifieddate = value))
     }
   
-    override val columns: List[FieldLikeNoHkt[?, Row]] =
-      List[FieldLikeNoHkt[?, Row]](fields.id, fields.creditcardid, fields.cardtype, fields.cardnumber, fields.expmonth, fields.expyear, fields.modifieddate)
+    override lazy val columns: List[FieldLikeNoHkt[?, CcViewRow]] =
+      List[FieldLikeNoHkt[?, CcViewRow]](fields.id, fields.creditcardid, fields.cardtype, fields.cardnumber, fields.expmonth, fields.expyear, fields.modifieddate)
   
-    override def copy[NewRow](prefix: Option[String], extract: NewRow => CcViewRow, merge: (NewRow, CcViewRow) => NewRow): Impl[NewRow] =
-      new Impl(prefix, extract, merge)
+    override def copy(path: List[Path]): Impl =
+      new Impl(path)
   }
   
 }

--- a/typo-tester-anorm/generated-and-checked-in/adventureworks/sa/cr/CrViewFields.scala
+++ b/typo-tester-anorm/generated-and-checked-in/adventureworks/sa/cr/CrViewFields.scala
@@ -10,42 +10,43 @@ package cr
 import adventureworks.customtypes.TypoLocalDateTime
 import adventureworks.sales.currency.CurrencyId
 import adventureworks.sales.currencyrate.CurrencyrateId
+import typo.dsl.Path
 import typo.dsl.SqlExpr.Field
 import typo.dsl.SqlExpr.FieldLikeNoHkt
 import typo.dsl.Structure.Relation
 
-trait CrViewFields[Row] {
-  val currencyrateid: Field[CurrencyrateId, Row]
-  val currencyratedate: Field[TypoLocalDateTime, Row]
-  val fromcurrencycode: Field[CurrencyId, Row]
-  val tocurrencycode: Field[CurrencyId, Row]
-  val averagerate: Field[BigDecimal, Row]
-  val endofdayrate: Field[BigDecimal, Row]
-  val modifieddate: Field[TypoLocalDateTime, Row]
+trait CrViewFields {
+  def currencyrateid: Field[CurrencyrateId, CrViewRow]
+  def currencyratedate: Field[TypoLocalDateTime, CrViewRow]
+  def fromcurrencycode: Field[CurrencyId, CrViewRow]
+  def tocurrencycode: Field[CurrencyId, CrViewRow]
+  def averagerate: Field[BigDecimal, CrViewRow]
+  def endofdayrate: Field[BigDecimal, CrViewRow]
+  def modifieddate: Field[TypoLocalDateTime, CrViewRow]
 }
 
 object CrViewFields {
-  val structure: Relation[CrViewFields, CrViewRow, CrViewRow] = 
-    new Impl(None, identity, (_, x) => x)
+  lazy val structure: Relation[CrViewFields, CrViewRow] =
+    new Impl(Nil)
     
-  private final class Impl[Row](val prefix: Option[String], val extract: Row => CrViewRow, val merge: (Row, CrViewRow) => Row)
-    extends Relation[CrViewFields, CrViewRow, Row] { 
+  private final class Impl(val _path: List[Path])
+    extends Relation[CrViewFields, CrViewRow] {
   
-    override val fields: CrViewFields[Row] = new CrViewFields[Row] {
-      override val currencyrateid = new Field[CurrencyrateId, Row](prefix, "currencyrateid", None, None)(x => extract(x).currencyrateid, (row, value) => merge(row, extract(row).copy(currencyrateid = value)))
-      override val currencyratedate = new Field[TypoLocalDateTime, Row](prefix, "currencyratedate", Some("text"), None)(x => extract(x).currencyratedate, (row, value) => merge(row, extract(row).copy(currencyratedate = value)))
-      override val fromcurrencycode = new Field[CurrencyId, Row](prefix, "fromcurrencycode", None, None)(x => extract(x).fromcurrencycode, (row, value) => merge(row, extract(row).copy(fromcurrencycode = value)))
-      override val tocurrencycode = new Field[CurrencyId, Row](prefix, "tocurrencycode", None, None)(x => extract(x).tocurrencycode, (row, value) => merge(row, extract(row).copy(tocurrencycode = value)))
-      override val averagerate = new Field[BigDecimal, Row](prefix, "averagerate", None, None)(x => extract(x).averagerate, (row, value) => merge(row, extract(row).copy(averagerate = value)))
-      override val endofdayrate = new Field[BigDecimal, Row](prefix, "endofdayrate", None, None)(x => extract(x).endofdayrate, (row, value) => merge(row, extract(row).copy(endofdayrate = value)))
-      override val modifieddate = new Field[TypoLocalDateTime, Row](prefix, "modifieddate", Some("text"), None)(x => extract(x).modifieddate, (row, value) => merge(row, extract(row).copy(modifieddate = value)))
+    override lazy val fields: CrViewFields = new CrViewFields {
+      override def currencyrateid = Field[CurrencyrateId, CrViewRow](_path, "currencyrateid", None, None, x => x.currencyrateid, (row, value) => row.copy(currencyrateid = value))
+      override def currencyratedate = Field[TypoLocalDateTime, CrViewRow](_path, "currencyratedate", Some("text"), None, x => x.currencyratedate, (row, value) => row.copy(currencyratedate = value))
+      override def fromcurrencycode = Field[CurrencyId, CrViewRow](_path, "fromcurrencycode", None, None, x => x.fromcurrencycode, (row, value) => row.copy(fromcurrencycode = value))
+      override def tocurrencycode = Field[CurrencyId, CrViewRow](_path, "tocurrencycode", None, None, x => x.tocurrencycode, (row, value) => row.copy(tocurrencycode = value))
+      override def averagerate = Field[BigDecimal, CrViewRow](_path, "averagerate", None, None, x => x.averagerate, (row, value) => row.copy(averagerate = value))
+      override def endofdayrate = Field[BigDecimal, CrViewRow](_path, "endofdayrate", None, None, x => x.endofdayrate, (row, value) => row.copy(endofdayrate = value))
+      override def modifieddate = Field[TypoLocalDateTime, CrViewRow](_path, "modifieddate", Some("text"), None, x => x.modifieddate, (row, value) => row.copy(modifieddate = value))
     }
   
-    override val columns: List[FieldLikeNoHkt[?, Row]] =
-      List[FieldLikeNoHkt[?, Row]](fields.currencyrateid, fields.currencyratedate, fields.fromcurrencycode, fields.tocurrencycode, fields.averagerate, fields.endofdayrate, fields.modifieddate)
+    override lazy val columns: List[FieldLikeNoHkt[?, CrViewRow]] =
+      List[FieldLikeNoHkt[?, CrViewRow]](fields.currencyrateid, fields.currencyratedate, fields.fromcurrencycode, fields.tocurrencycode, fields.averagerate, fields.endofdayrate, fields.modifieddate)
   
-    override def copy[NewRow](prefix: Option[String], extract: NewRow => CrViewRow, merge: (NewRow, CrViewRow) => NewRow): Impl[NewRow] =
-      new Impl(prefix, extract, merge)
+    override def copy(path: List[Path]): Impl =
+      new Impl(path)
   }
   
 }

--- a/typo-tester-anorm/generated-and-checked-in/adventureworks/sa/crc/CrcViewFields.scala
+++ b/typo-tester-anorm/generated-and-checked-in/adventureworks/sa/crc/CrcViewFields.scala
@@ -10,34 +10,35 @@ package crc
 import adventureworks.customtypes.TypoLocalDateTime
 import adventureworks.person.countryregion.CountryregionId
 import adventureworks.sales.currency.CurrencyId
+import typo.dsl.Path
 import typo.dsl.SqlExpr.Field
 import typo.dsl.SqlExpr.FieldLikeNoHkt
 import typo.dsl.Structure.Relation
 
-trait CrcViewFields[Row] {
-  val countryregioncode: Field[CountryregionId, Row]
-  val currencycode: Field[CurrencyId, Row]
-  val modifieddate: Field[TypoLocalDateTime, Row]
+trait CrcViewFields {
+  def countryregioncode: Field[CountryregionId, CrcViewRow]
+  def currencycode: Field[CurrencyId, CrcViewRow]
+  def modifieddate: Field[TypoLocalDateTime, CrcViewRow]
 }
 
 object CrcViewFields {
-  val structure: Relation[CrcViewFields, CrcViewRow, CrcViewRow] = 
-    new Impl(None, identity, (_, x) => x)
+  lazy val structure: Relation[CrcViewFields, CrcViewRow] =
+    new Impl(Nil)
     
-  private final class Impl[Row](val prefix: Option[String], val extract: Row => CrcViewRow, val merge: (Row, CrcViewRow) => Row)
-    extends Relation[CrcViewFields, CrcViewRow, Row] { 
+  private final class Impl(val _path: List[Path])
+    extends Relation[CrcViewFields, CrcViewRow] {
   
-    override val fields: CrcViewFields[Row] = new CrcViewFields[Row] {
-      override val countryregioncode = new Field[CountryregionId, Row](prefix, "countryregioncode", None, None)(x => extract(x).countryregioncode, (row, value) => merge(row, extract(row).copy(countryregioncode = value)))
-      override val currencycode = new Field[CurrencyId, Row](prefix, "currencycode", None, None)(x => extract(x).currencycode, (row, value) => merge(row, extract(row).copy(currencycode = value)))
-      override val modifieddate = new Field[TypoLocalDateTime, Row](prefix, "modifieddate", Some("text"), None)(x => extract(x).modifieddate, (row, value) => merge(row, extract(row).copy(modifieddate = value)))
+    override lazy val fields: CrcViewFields = new CrcViewFields {
+      override def countryregioncode = Field[CountryregionId, CrcViewRow](_path, "countryregioncode", None, None, x => x.countryregioncode, (row, value) => row.copy(countryregioncode = value))
+      override def currencycode = Field[CurrencyId, CrcViewRow](_path, "currencycode", None, None, x => x.currencycode, (row, value) => row.copy(currencycode = value))
+      override def modifieddate = Field[TypoLocalDateTime, CrcViewRow](_path, "modifieddate", Some("text"), None, x => x.modifieddate, (row, value) => row.copy(modifieddate = value))
     }
   
-    override val columns: List[FieldLikeNoHkt[?, Row]] =
-      List[FieldLikeNoHkt[?, Row]](fields.countryregioncode, fields.currencycode, fields.modifieddate)
+    override lazy val columns: List[FieldLikeNoHkt[?, CrcViewRow]] =
+      List[FieldLikeNoHkt[?, CrcViewRow]](fields.countryregioncode, fields.currencycode, fields.modifieddate)
   
-    override def copy[NewRow](prefix: Option[String], extract: NewRow => CrcViewRow, merge: (NewRow, CrcViewRow) => NewRow): Impl[NewRow] =
-      new Impl(prefix, extract, merge)
+    override def copy(path: List[Path]): Impl =
+      new Impl(path)
   }
   
 }

--- a/typo-tester-anorm/generated-and-checked-in/adventureworks/sa/cu/CuViewFields.scala
+++ b/typo-tester-anorm/generated-and-checked-in/adventureworks/sa/cu/CuViewFields.scala
@@ -10,36 +10,37 @@ package cu
 import adventureworks.customtypes.TypoLocalDateTime
 import adventureworks.public.Name
 import adventureworks.sales.currency.CurrencyId
+import typo.dsl.Path
 import typo.dsl.SqlExpr.Field
 import typo.dsl.SqlExpr.FieldLikeNoHkt
 import typo.dsl.Structure.Relation
 
-trait CuViewFields[Row] {
-  val id: Field[CurrencyId, Row]
-  val currencycode: Field[CurrencyId, Row]
-  val name: Field[Name, Row]
-  val modifieddate: Field[TypoLocalDateTime, Row]
+trait CuViewFields {
+  def id: Field[CurrencyId, CuViewRow]
+  def currencycode: Field[CurrencyId, CuViewRow]
+  def name: Field[Name, CuViewRow]
+  def modifieddate: Field[TypoLocalDateTime, CuViewRow]
 }
 
 object CuViewFields {
-  val structure: Relation[CuViewFields, CuViewRow, CuViewRow] = 
-    new Impl(None, identity, (_, x) => x)
+  lazy val structure: Relation[CuViewFields, CuViewRow] =
+    new Impl(Nil)
     
-  private final class Impl[Row](val prefix: Option[String], val extract: Row => CuViewRow, val merge: (Row, CuViewRow) => Row)
-    extends Relation[CuViewFields, CuViewRow, Row] { 
+  private final class Impl(val _path: List[Path])
+    extends Relation[CuViewFields, CuViewRow] {
   
-    override val fields: CuViewFields[Row] = new CuViewFields[Row] {
-      override val id = new Field[CurrencyId, Row](prefix, "id", None, None)(x => extract(x).id, (row, value) => merge(row, extract(row).copy(id = value)))
-      override val currencycode = new Field[CurrencyId, Row](prefix, "currencycode", None, None)(x => extract(x).currencycode, (row, value) => merge(row, extract(row).copy(currencycode = value)))
-      override val name = new Field[Name, Row](prefix, "name", None, None)(x => extract(x).name, (row, value) => merge(row, extract(row).copy(name = value)))
-      override val modifieddate = new Field[TypoLocalDateTime, Row](prefix, "modifieddate", Some("text"), None)(x => extract(x).modifieddate, (row, value) => merge(row, extract(row).copy(modifieddate = value)))
+    override lazy val fields: CuViewFields = new CuViewFields {
+      override def id = Field[CurrencyId, CuViewRow](_path, "id", None, None, x => x.id, (row, value) => row.copy(id = value))
+      override def currencycode = Field[CurrencyId, CuViewRow](_path, "currencycode", None, None, x => x.currencycode, (row, value) => row.copy(currencycode = value))
+      override def name = Field[Name, CuViewRow](_path, "name", None, None, x => x.name, (row, value) => row.copy(name = value))
+      override def modifieddate = Field[TypoLocalDateTime, CuViewRow](_path, "modifieddate", Some("text"), None, x => x.modifieddate, (row, value) => row.copy(modifieddate = value))
     }
   
-    override val columns: List[FieldLikeNoHkt[?, Row]] =
-      List[FieldLikeNoHkt[?, Row]](fields.id, fields.currencycode, fields.name, fields.modifieddate)
+    override lazy val columns: List[FieldLikeNoHkt[?, CuViewRow]] =
+      List[FieldLikeNoHkt[?, CuViewRow]](fields.id, fields.currencycode, fields.name, fields.modifieddate)
   
-    override def copy[NewRow](prefix: Option[String], extract: NewRow => CuViewRow, merge: (NewRow, CuViewRow) => NewRow): Impl[NewRow] =
-      new Impl(prefix, extract, merge)
+    override def copy(path: List[Path]): Impl =
+      new Impl(path)
   }
   
 }

--- a/typo-tester-anorm/generated-and-checked-in/adventureworks/sa/pcc/PccViewFields.scala
+++ b/typo-tester-anorm/generated-and-checked-in/adventureworks/sa/pcc/PccViewFields.scala
@@ -10,36 +10,37 @@ package pcc
 import adventureworks.customtypes.TypoLocalDateTime
 import adventureworks.person.businessentity.BusinessentityId
 import adventureworks.userdefined.CustomCreditcardId
+import typo.dsl.Path
 import typo.dsl.SqlExpr.Field
 import typo.dsl.SqlExpr.FieldLikeNoHkt
 import typo.dsl.Structure.Relation
 
-trait PccViewFields[Row] {
-  val id: Field[BusinessentityId, Row]
-  val businessentityid: Field[BusinessentityId, Row]
-  val creditcardid: Field[/* user-picked */ CustomCreditcardId, Row]
-  val modifieddate: Field[TypoLocalDateTime, Row]
+trait PccViewFields {
+  def id: Field[BusinessentityId, PccViewRow]
+  def businessentityid: Field[BusinessentityId, PccViewRow]
+  def creditcardid: Field[/* user-picked */ CustomCreditcardId, PccViewRow]
+  def modifieddate: Field[TypoLocalDateTime, PccViewRow]
 }
 
 object PccViewFields {
-  val structure: Relation[PccViewFields, PccViewRow, PccViewRow] = 
-    new Impl(None, identity, (_, x) => x)
+  lazy val structure: Relation[PccViewFields, PccViewRow] =
+    new Impl(Nil)
     
-  private final class Impl[Row](val prefix: Option[String], val extract: Row => PccViewRow, val merge: (Row, PccViewRow) => Row)
-    extends Relation[PccViewFields, PccViewRow, Row] { 
+  private final class Impl(val _path: List[Path])
+    extends Relation[PccViewFields, PccViewRow] {
   
-    override val fields: PccViewFields[Row] = new PccViewFields[Row] {
-      override val id = new Field[BusinessentityId, Row](prefix, "id", None, None)(x => extract(x).id, (row, value) => merge(row, extract(row).copy(id = value)))
-      override val businessentityid = new Field[BusinessentityId, Row](prefix, "businessentityid", None, None)(x => extract(x).businessentityid, (row, value) => merge(row, extract(row).copy(businessentityid = value)))
-      override val creditcardid = new Field[/* user-picked */ CustomCreditcardId, Row](prefix, "creditcardid", None, None)(x => extract(x).creditcardid, (row, value) => merge(row, extract(row).copy(creditcardid = value)))
-      override val modifieddate = new Field[TypoLocalDateTime, Row](prefix, "modifieddate", Some("text"), None)(x => extract(x).modifieddate, (row, value) => merge(row, extract(row).copy(modifieddate = value)))
+    override lazy val fields: PccViewFields = new PccViewFields {
+      override def id = Field[BusinessentityId, PccViewRow](_path, "id", None, None, x => x.id, (row, value) => row.copy(id = value))
+      override def businessentityid = Field[BusinessentityId, PccViewRow](_path, "businessentityid", None, None, x => x.businessentityid, (row, value) => row.copy(businessentityid = value))
+      override def creditcardid = Field[/* user-picked */ CustomCreditcardId, PccViewRow](_path, "creditcardid", None, None, x => x.creditcardid, (row, value) => row.copy(creditcardid = value))
+      override def modifieddate = Field[TypoLocalDateTime, PccViewRow](_path, "modifieddate", Some("text"), None, x => x.modifieddate, (row, value) => row.copy(modifieddate = value))
     }
   
-    override val columns: List[FieldLikeNoHkt[?, Row]] =
-      List[FieldLikeNoHkt[?, Row]](fields.id, fields.businessentityid, fields.creditcardid, fields.modifieddate)
+    override lazy val columns: List[FieldLikeNoHkt[?, PccViewRow]] =
+      List[FieldLikeNoHkt[?, PccViewRow]](fields.id, fields.businessentityid, fields.creditcardid, fields.modifieddate)
   
-    override def copy[NewRow](prefix: Option[String], extract: NewRow => PccViewRow, merge: (NewRow, PccViewRow) => NewRow): Impl[NewRow] =
-      new Impl(prefix, extract, merge)
+    override def copy(path: List[Path]): Impl =
+      new Impl(path)
   }
   
 }

--- a/typo-tester-anorm/generated-and-checked-in/adventureworks/sa/s/SViewFields.scala
+++ b/typo-tester-anorm/generated-and-checked-in/adventureworks/sa/s/SViewFields.scala
@@ -12,43 +12,44 @@ import adventureworks.customtypes.TypoUUID
 import adventureworks.customtypes.TypoXml
 import adventureworks.person.businessentity.BusinessentityId
 import adventureworks.public.Name
+import typo.dsl.Path
 import typo.dsl.SqlExpr.Field
 import typo.dsl.SqlExpr.FieldLikeNoHkt
 import typo.dsl.SqlExpr.OptField
 import typo.dsl.Structure.Relation
 
-trait SViewFields[Row] {
-  val id: Field[BusinessentityId, Row]
-  val businessentityid: Field[BusinessentityId, Row]
-  val name: Field[Name, Row]
-  val salespersonid: OptField[BusinessentityId, Row]
-  val demographics: OptField[TypoXml, Row]
-  val rowguid: Field[TypoUUID, Row]
-  val modifieddate: Field[TypoLocalDateTime, Row]
+trait SViewFields {
+  def id: Field[BusinessentityId, SViewRow]
+  def businessentityid: Field[BusinessentityId, SViewRow]
+  def name: Field[Name, SViewRow]
+  def salespersonid: OptField[BusinessentityId, SViewRow]
+  def demographics: OptField[TypoXml, SViewRow]
+  def rowguid: Field[TypoUUID, SViewRow]
+  def modifieddate: Field[TypoLocalDateTime, SViewRow]
 }
 
 object SViewFields {
-  val structure: Relation[SViewFields, SViewRow, SViewRow] = 
-    new Impl(None, identity, (_, x) => x)
+  lazy val structure: Relation[SViewFields, SViewRow] =
+    new Impl(Nil)
     
-  private final class Impl[Row](val prefix: Option[String], val extract: Row => SViewRow, val merge: (Row, SViewRow) => Row)
-    extends Relation[SViewFields, SViewRow, Row] { 
+  private final class Impl(val _path: List[Path])
+    extends Relation[SViewFields, SViewRow] {
   
-    override val fields: SViewFields[Row] = new SViewFields[Row] {
-      override val id = new Field[BusinessentityId, Row](prefix, "id", None, None)(x => extract(x).id, (row, value) => merge(row, extract(row).copy(id = value)))
-      override val businessentityid = new Field[BusinessentityId, Row](prefix, "businessentityid", None, None)(x => extract(x).businessentityid, (row, value) => merge(row, extract(row).copy(businessentityid = value)))
-      override val name = new Field[Name, Row](prefix, "name", None, None)(x => extract(x).name, (row, value) => merge(row, extract(row).copy(name = value)))
-      override val salespersonid = new OptField[BusinessentityId, Row](prefix, "salespersonid", None, None)(x => extract(x).salespersonid, (row, value) => merge(row, extract(row).copy(salespersonid = value)))
-      override val demographics = new OptField[TypoXml, Row](prefix, "demographics", None, None)(x => extract(x).demographics, (row, value) => merge(row, extract(row).copy(demographics = value)))
-      override val rowguid = new Field[TypoUUID, Row](prefix, "rowguid", None, None)(x => extract(x).rowguid, (row, value) => merge(row, extract(row).copy(rowguid = value)))
-      override val modifieddate = new Field[TypoLocalDateTime, Row](prefix, "modifieddate", Some("text"), None)(x => extract(x).modifieddate, (row, value) => merge(row, extract(row).copy(modifieddate = value)))
+    override lazy val fields: SViewFields = new SViewFields {
+      override def id = Field[BusinessentityId, SViewRow](_path, "id", None, None, x => x.id, (row, value) => row.copy(id = value))
+      override def businessentityid = Field[BusinessentityId, SViewRow](_path, "businessentityid", None, None, x => x.businessentityid, (row, value) => row.copy(businessentityid = value))
+      override def name = Field[Name, SViewRow](_path, "name", None, None, x => x.name, (row, value) => row.copy(name = value))
+      override def salespersonid = OptField[BusinessentityId, SViewRow](_path, "salespersonid", None, None, x => x.salespersonid, (row, value) => row.copy(salespersonid = value))
+      override def demographics = OptField[TypoXml, SViewRow](_path, "demographics", None, None, x => x.demographics, (row, value) => row.copy(demographics = value))
+      override def rowguid = Field[TypoUUID, SViewRow](_path, "rowguid", None, None, x => x.rowguid, (row, value) => row.copy(rowguid = value))
+      override def modifieddate = Field[TypoLocalDateTime, SViewRow](_path, "modifieddate", Some("text"), None, x => x.modifieddate, (row, value) => row.copy(modifieddate = value))
     }
   
-    override val columns: List[FieldLikeNoHkt[?, Row]] =
-      List[FieldLikeNoHkt[?, Row]](fields.id, fields.businessentityid, fields.name, fields.salespersonid, fields.demographics, fields.rowguid, fields.modifieddate)
+    override lazy val columns: List[FieldLikeNoHkt[?, SViewRow]] =
+      List[FieldLikeNoHkt[?, SViewRow]](fields.id, fields.businessentityid, fields.name, fields.salespersonid, fields.demographics, fields.rowguid, fields.modifieddate)
   
-    override def copy[NewRow](prefix: Option[String], extract: NewRow => SViewRow, merge: (NewRow, SViewRow) => NewRow): Impl[NewRow] =
-      new Impl(prefix, extract, merge)
+    override def copy(path: List[Path]): Impl =
+      new Impl(path)
   }
   
 }

--- a/typo-tester-anorm/generated-and-checked-in/adventureworks/sa/sci/SciViewFields.scala
+++ b/typo-tester-anorm/generated-and-checked-in/adventureworks/sa/sci/SciViewFields.scala
@@ -10,42 +10,43 @@ package sci
 import adventureworks.customtypes.TypoLocalDateTime
 import adventureworks.production.product.ProductId
 import adventureworks.sales.shoppingcartitem.ShoppingcartitemId
+import typo.dsl.Path
 import typo.dsl.SqlExpr.Field
 import typo.dsl.SqlExpr.FieldLikeNoHkt
 import typo.dsl.Structure.Relation
 
-trait SciViewFields[Row] {
-  val id: Field[ShoppingcartitemId, Row]
-  val shoppingcartitemid: Field[ShoppingcartitemId, Row]
-  val shoppingcartid: Field[/* max 50 chars */ String, Row]
-  val quantity: Field[Int, Row]
-  val productid: Field[ProductId, Row]
-  val datecreated: Field[TypoLocalDateTime, Row]
-  val modifieddate: Field[TypoLocalDateTime, Row]
+trait SciViewFields {
+  def id: Field[ShoppingcartitemId, SciViewRow]
+  def shoppingcartitemid: Field[ShoppingcartitemId, SciViewRow]
+  def shoppingcartid: Field[/* max 50 chars */ String, SciViewRow]
+  def quantity: Field[Int, SciViewRow]
+  def productid: Field[ProductId, SciViewRow]
+  def datecreated: Field[TypoLocalDateTime, SciViewRow]
+  def modifieddate: Field[TypoLocalDateTime, SciViewRow]
 }
 
 object SciViewFields {
-  val structure: Relation[SciViewFields, SciViewRow, SciViewRow] = 
-    new Impl(None, identity, (_, x) => x)
+  lazy val structure: Relation[SciViewFields, SciViewRow] =
+    new Impl(Nil)
     
-  private final class Impl[Row](val prefix: Option[String], val extract: Row => SciViewRow, val merge: (Row, SciViewRow) => Row)
-    extends Relation[SciViewFields, SciViewRow, Row] { 
+  private final class Impl(val _path: List[Path])
+    extends Relation[SciViewFields, SciViewRow] {
   
-    override val fields: SciViewFields[Row] = new SciViewFields[Row] {
-      override val id = new Field[ShoppingcartitemId, Row](prefix, "id", None, None)(x => extract(x).id, (row, value) => merge(row, extract(row).copy(id = value)))
-      override val shoppingcartitemid = new Field[ShoppingcartitemId, Row](prefix, "shoppingcartitemid", None, None)(x => extract(x).shoppingcartitemid, (row, value) => merge(row, extract(row).copy(shoppingcartitemid = value)))
-      override val shoppingcartid = new Field[/* max 50 chars */ String, Row](prefix, "shoppingcartid", None, None)(x => extract(x).shoppingcartid, (row, value) => merge(row, extract(row).copy(shoppingcartid = value)))
-      override val quantity = new Field[Int, Row](prefix, "quantity", None, None)(x => extract(x).quantity, (row, value) => merge(row, extract(row).copy(quantity = value)))
-      override val productid = new Field[ProductId, Row](prefix, "productid", None, None)(x => extract(x).productid, (row, value) => merge(row, extract(row).copy(productid = value)))
-      override val datecreated = new Field[TypoLocalDateTime, Row](prefix, "datecreated", Some("text"), None)(x => extract(x).datecreated, (row, value) => merge(row, extract(row).copy(datecreated = value)))
-      override val modifieddate = new Field[TypoLocalDateTime, Row](prefix, "modifieddate", Some("text"), None)(x => extract(x).modifieddate, (row, value) => merge(row, extract(row).copy(modifieddate = value)))
+    override lazy val fields: SciViewFields = new SciViewFields {
+      override def id = Field[ShoppingcartitemId, SciViewRow](_path, "id", None, None, x => x.id, (row, value) => row.copy(id = value))
+      override def shoppingcartitemid = Field[ShoppingcartitemId, SciViewRow](_path, "shoppingcartitemid", None, None, x => x.shoppingcartitemid, (row, value) => row.copy(shoppingcartitemid = value))
+      override def shoppingcartid = Field[/* max 50 chars */ String, SciViewRow](_path, "shoppingcartid", None, None, x => x.shoppingcartid, (row, value) => row.copy(shoppingcartid = value))
+      override def quantity = Field[Int, SciViewRow](_path, "quantity", None, None, x => x.quantity, (row, value) => row.copy(quantity = value))
+      override def productid = Field[ProductId, SciViewRow](_path, "productid", None, None, x => x.productid, (row, value) => row.copy(productid = value))
+      override def datecreated = Field[TypoLocalDateTime, SciViewRow](_path, "datecreated", Some("text"), None, x => x.datecreated, (row, value) => row.copy(datecreated = value))
+      override def modifieddate = Field[TypoLocalDateTime, SciViewRow](_path, "modifieddate", Some("text"), None, x => x.modifieddate, (row, value) => row.copy(modifieddate = value))
     }
   
-    override val columns: List[FieldLikeNoHkt[?, Row]] =
-      List[FieldLikeNoHkt[?, Row]](fields.id, fields.shoppingcartitemid, fields.shoppingcartid, fields.quantity, fields.productid, fields.datecreated, fields.modifieddate)
+    override lazy val columns: List[FieldLikeNoHkt[?, SciViewRow]] =
+      List[FieldLikeNoHkt[?, SciViewRow]](fields.id, fields.shoppingcartitemid, fields.shoppingcartid, fields.quantity, fields.productid, fields.datecreated, fields.modifieddate)
   
-    override def copy[NewRow](prefix: Option[String], extract: NewRow => SciViewRow, merge: (NewRow, SciViewRow) => NewRow): Impl[NewRow] =
-      new Impl(prefix, extract, merge)
+    override def copy(path: List[Path]): Impl =
+      new Impl(path)
   }
   
 }

--- a/typo-tester-anorm/generated-and-checked-in/adventureworks/sa/so/SoViewFields.scala
+++ b/typo-tester-anorm/generated-and-checked-in/adventureworks/sa/so/SoViewFields.scala
@@ -10,53 +10,54 @@ package so
 import adventureworks.customtypes.TypoLocalDateTime
 import adventureworks.customtypes.TypoUUID
 import adventureworks.sales.specialoffer.SpecialofferId
+import typo.dsl.Path
 import typo.dsl.SqlExpr.Field
 import typo.dsl.SqlExpr.FieldLikeNoHkt
 import typo.dsl.SqlExpr.OptField
 import typo.dsl.Structure.Relation
 
-trait SoViewFields[Row] {
-  val id: Field[SpecialofferId, Row]
-  val specialofferid: Field[SpecialofferId, Row]
-  val description: Field[/* max 255 chars */ String, Row]
-  val discountpct: Field[BigDecimal, Row]
-  val `type`: Field[/* max 50 chars */ String, Row]
-  val category: Field[/* max 50 chars */ String, Row]
-  val startdate: Field[TypoLocalDateTime, Row]
-  val enddate: Field[TypoLocalDateTime, Row]
-  val minqty: Field[Int, Row]
-  val maxqty: OptField[Int, Row]
-  val rowguid: Field[TypoUUID, Row]
-  val modifieddate: Field[TypoLocalDateTime, Row]
+trait SoViewFields {
+  def id: Field[SpecialofferId, SoViewRow]
+  def specialofferid: Field[SpecialofferId, SoViewRow]
+  def description: Field[/* max 255 chars */ String, SoViewRow]
+  def discountpct: Field[BigDecimal, SoViewRow]
+  def `type`: Field[/* max 50 chars */ String, SoViewRow]
+  def category: Field[/* max 50 chars */ String, SoViewRow]
+  def startdate: Field[TypoLocalDateTime, SoViewRow]
+  def enddate: Field[TypoLocalDateTime, SoViewRow]
+  def minqty: Field[Int, SoViewRow]
+  def maxqty: OptField[Int, SoViewRow]
+  def rowguid: Field[TypoUUID, SoViewRow]
+  def modifieddate: Field[TypoLocalDateTime, SoViewRow]
 }
 
 object SoViewFields {
-  val structure: Relation[SoViewFields, SoViewRow, SoViewRow] = 
-    new Impl(None, identity, (_, x) => x)
+  lazy val structure: Relation[SoViewFields, SoViewRow] =
+    new Impl(Nil)
     
-  private final class Impl[Row](val prefix: Option[String], val extract: Row => SoViewRow, val merge: (Row, SoViewRow) => Row)
-    extends Relation[SoViewFields, SoViewRow, Row] { 
+  private final class Impl(val _path: List[Path])
+    extends Relation[SoViewFields, SoViewRow] {
   
-    override val fields: SoViewFields[Row] = new SoViewFields[Row] {
-      override val id = new Field[SpecialofferId, Row](prefix, "id", None, None)(x => extract(x).id, (row, value) => merge(row, extract(row).copy(id = value)))
-      override val specialofferid = new Field[SpecialofferId, Row](prefix, "specialofferid", None, None)(x => extract(x).specialofferid, (row, value) => merge(row, extract(row).copy(specialofferid = value)))
-      override val description = new Field[/* max 255 chars */ String, Row](prefix, "description", None, None)(x => extract(x).description, (row, value) => merge(row, extract(row).copy(description = value)))
-      override val discountpct = new Field[BigDecimal, Row](prefix, "discountpct", None, None)(x => extract(x).discountpct, (row, value) => merge(row, extract(row).copy(discountpct = value)))
-      override val `type` = new Field[/* max 50 chars */ String, Row](prefix, "type", None, None)(x => extract(x).`type`, (row, value) => merge(row, extract(row).copy(`type` = value)))
-      override val category = new Field[/* max 50 chars */ String, Row](prefix, "category", None, None)(x => extract(x).category, (row, value) => merge(row, extract(row).copy(category = value)))
-      override val startdate = new Field[TypoLocalDateTime, Row](prefix, "startdate", Some("text"), None)(x => extract(x).startdate, (row, value) => merge(row, extract(row).copy(startdate = value)))
-      override val enddate = new Field[TypoLocalDateTime, Row](prefix, "enddate", Some("text"), None)(x => extract(x).enddate, (row, value) => merge(row, extract(row).copy(enddate = value)))
-      override val minqty = new Field[Int, Row](prefix, "minqty", None, None)(x => extract(x).minqty, (row, value) => merge(row, extract(row).copy(minqty = value)))
-      override val maxqty = new OptField[Int, Row](prefix, "maxqty", None, None)(x => extract(x).maxqty, (row, value) => merge(row, extract(row).copy(maxqty = value)))
-      override val rowguid = new Field[TypoUUID, Row](prefix, "rowguid", None, None)(x => extract(x).rowguid, (row, value) => merge(row, extract(row).copy(rowguid = value)))
-      override val modifieddate = new Field[TypoLocalDateTime, Row](prefix, "modifieddate", Some("text"), None)(x => extract(x).modifieddate, (row, value) => merge(row, extract(row).copy(modifieddate = value)))
+    override lazy val fields: SoViewFields = new SoViewFields {
+      override def id = Field[SpecialofferId, SoViewRow](_path, "id", None, None, x => x.id, (row, value) => row.copy(id = value))
+      override def specialofferid = Field[SpecialofferId, SoViewRow](_path, "specialofferid", None, None, x => x.specialofferid, (row, value) => row.copy(specialofferid = value))
+      override def description = Field[/* max 255 chars */ String, SoViewRow](_path, "description", None, None, x => x.description, (row, value) => row.copy(description = value))
+      override def discountpct = Field[BigDecimal, SoViewRow](_path, "discountpct", None, None, x => x.discountpct, (row, value) => row.copy(discountpct = value))
+      override def `type` = Field[/* max 50 chars */ String, SoViewRow](_path, "type", None, None, x => x.`type`, (row, value) => row.copy(`type` = value))
+      override def category = Field[/* max 50 chars */ String, SoViewRow](_path, "category", None, None, x => x.category, (row, value) => row.copy(category = value))
+      override def startdate = Field[TypoLocalDateTime, SoViewRow](_path, "startdate", Some("text"), None, x => x.startdate, (row, value) => row.copy(startdate = value))
+      override def enddate = Field[TypoLocalDateTime, SoViewRow](_path, "enddate", Some("text"), None, x => x.enddate, (row, value) => row.copy(enddate = value))
+      override def minqty = Field[Int, SoViewRow](_path, "minqty", None, None, x => x.minqty, (row, value) => row.copy(minqty = value))
+      override def maxqty = OptField[Int, SoViewRow](_path, "maxqty", None, None, x => x.maxqty, (row, value) => row.copy(maxqty = value))
+      override def rowguid = Field[TypoUUID, SoViewRow](_path, "rowguid", None, None, x => x.rowguid, (row, value) => row.copy(rowguid = value))
+      override def modifieddate = Field[TypoLocalDateTime, SoViewRow](_path, "modifieddate", Some("text"), None, x => x.modifieddate, (row, value) => row.copy(modifieddate = value))
     }
   
-    override val columns: List[FieldLikeNoHkt[?, Row]] =
-      List[FieldLikeNoHkt[?, Row]](fields.id, fields.specialofferid, fields.description, fields.discountpct, fields.`type`, fields.category, fields.startdate, fields.enddate, fields.minqty, fields.maxqty, fields.rowguid, fields.modifieddate)
+    override lazy val columns: List[FieldLikeNoHkt[?, SoViewRow]] =
+      List[FieldLikeNoHkt[?, SoViewRow]](fields.id, fields.specialofferid, fields.description, fields.discountpct, fields.`type`, fields.category, fields.startdate, fields.enddate, fields.minqty, fields.maxqty, fields.rowguid, fields.modifieddate)
   
-    override def copy[NewRow](prefix: Option[String], extract: NewRow => SoViewRow, merge: (NewRow, SoViewRow) => NewRow): Impl[NewRow] =
-      new Impl(prefix, extract, merge)
+    override def copy(path: List[Path]): Impl =
+      new Impl(path)
   }
   
 }

--- a/typo-tester-anorm/generated-and-checked-in/adventureworks/sa/sod/SodViewFields.scala
+++ b/typo-tester-anorm/generated-and-checked-in/adventureworks/sa/sod/SodViewFields.scala
@@ -13,51 +13,52 @@ import adventureworks.customtypes.TypoUUID
 import adventureworks.production.product.ProductId
 import adventureworks.sales.salesorderheader.SalesorderheaderId
 import adventureworks.sales.specialoffer.SpecialofferId
+import typo.dsl.Path
 import typo.dsl.SqlExpr.Field
 import typo.dsl.SqlExpr.FieldLikeNoHkt
 import typo.dsl.SqlExpr.OptField
 import typo.dsl.Structure.Relation
 
-trait SodViewFields[Row] {
-  val id: Field[Int, Row]
-  val salesorderid: Field[SalesorderheaderId, Row]
-  val salesorderdetailid: Field[Int, Row]
-  val carriertrackingnumber: OptField[/* max 25 chars */ String, Row]
-  val orderqty: Field[TypoShort, Row]
-  val productid: Field[ProductId, Row]
-  val specialofferid: Field[SpecialofferId, Row]
-  val unitprice: Field[BigDecimal, Row]
-  val unitpricediscount: Field[BigDecimal, Row]
-  val rowguid: Field[TypoUUID, Row]
-  val modifieddate: Field[TypoLocalDateTime, Row]
+trait SodViewFields {
+  def id: Field[Int, SodViewRow]
+  def salesorderid: Field[SalesorderheaderId, SodViewRow]
+  def salesorderdetailid: Field[Int, SodViewRow]
+  def carriertrackingnumber: OptField[/* max 25 chars */ String, SodViewRow]
+  def orderqty: Field[TypoShort, SodViewRow]
+  def productid: Field[ProductId, SodViewRow]
+  def specialofferid: Field[SpecialofferId, SodViewRow]
+  def unitprice: Field[BigDecimal, SodViewRow]
+  def unitpricediscount: Field[BigDecimal, SodViewRow]
+  def rowguid: Field[TypoUUID, SodViewRow]
+  def modifieddate: Field[TypoLocalDateTime, SodViewRow]
 }
 
 object SodViewFields {
-  val structure: Relation[SodViewFields, SodViewRow, SodViewRow] = 
-    new Impl(None, identity, (_, x) => x)
+  lazy val structure: Relation[SodViewFields, SodViewRow] =
+    new Impl(Nil)
     
-  private final class Impl[Row](val prefix: Option[String], val extract: Row => SodViewRow, val merge: (Row, SodViewRow) => Row)
-    extends Relation[SodViewFields, SodViewRow, Row] { 
+  private final class Impl(val _path: List[Path])
+    extends Relation[SodViewFields, SodViewRow] {
   
-    override val fields: SodViewFields[Row] = new SodViewFields[Row] {
-      override val id = new Field[Int, Row](prefix, "id", None, None)(x => extract(x).id, (row, value) => merge(row, extract(row).copy(id = value)))
-      override val salesorderid = new Field[SalesorderheaderId, Row](prefix, "salesorderid", None, None)(x => extract(x).salesorderid, (row, value) => merge(row, extract(row).copy(salesorderid = value)))
-      override val salesorderdetailid = new Field[Int, Row](prefix, "salesorderdetailid", None, None)(x => extract(x).salesorderdetailid, (row, value) => merge(row, extract(row).copy(salesorderdetailid = value)))
-      override val carriertrackingnumber = new OptField[/* max 25 chars */ String, Row](prefix, "carriertrackingnumber", None, None)(x => extract(x).carriertrackingnumber, (row, value) => merge(row, extract(row).copy(carriertrackingnumber = value)))
-      override val orderqty = new Field[TypoShort, Row](prefix, "orderqty", None, None)(x => extract(x).orderqty, (row, value) => merge(row, extract(row).copy(orderqty = value)))
-      override val productid = new Field[ProductId, Row](prefix, "productid", None, None)(x => extract(x).productid, (row, value) => merge(row, extract(row).copy(productid = value)))
-      override val specialofferid = new Field[SpecialofferId, Row](prefix, "specialofferid", None, None)(x => extract(x).specialofferid, (row, value) => merge(row, extract(row).copy(specialofferid = value)))
-      override val unitprice = new Field[BigDecimal, Row](prefix, "unitprice", None, None)(x => extract(x).unitprice, (row, value) => merge(row, extract(row).copy(unitprice = value)))
-      override val unitpricediscount = new Field[BigDecimal, Row](prefix, "unitpricediscount", None, None)(x => extract(x).unitpricediscount, (row, value) => merge(row, extract(row).copy(unitpricediscount = value)))
-      override val rowguid = new Field[TypoUUID, Row](prefix, "rowguid", None, None)(x => extract(x).rowguid, (row, value) => merge(row, extract(row).copy(rowguid = value)))
-      override val modifieddate = new Field[TypoLocalDateTime, Row](prefix, "modifieddate", Some("text"), None)(x => extract(x).modifieddate, (row, value) => merge(row, extract(row).copy(modifieddate = value)))
+    override lazy val fields: SodViewFields = new SodViewFields {
+      override def id = Field[Int, SodViewRow](_path, "id", None, None, x => x.id, (row, value) => row.copy(id = value))
+      override def salesorderid = Field[SalesorderheaderId, SodViewRow](_path, "salesorderid", None, None, x => x.salesorderid, (row, value) => row.copy(salesorderid = value))
+      override def salesorderdetailid = Field[Int, SodViewRow](_path, "salesorderdetailid", None, None, x => x.salesorderdetailid, (row, value) => row.copy(salesorderdetailid = value))
+      override def carriertrackingnumber = OptField[/* max 25 chars */ String, SodViewRow](_path, "carriertrackingnumber", None, None, x => x.carriertrackingnumber, (row, value) => row.copy(carriertrackingnumber = value))
+      override def orderqty = Field[TypoShort, SodViewRow](_path, "orderqty", None, None, x => x.orderqty, (row, value) => row.copy(orderqty = value))
+      override def productid = Field[ProductId, SodViewRow](_path, "productid", None, None, x => x.productid, (row, value) => row.copy(productid = value))
+      override def specialofferid = Field[SpecialofferId, SodViewRow](_path, "specialofferid", None, None, x => x.specialofferid, (row, value) => row.copy(specialofferid = value))
+      override def unitprice = Field[BigDecimal, SodViewRow](_path, "unitprice", None, None, x => x.unitprice, (row, value) => row.copy(unitprice = value))
+      override def unitpricediscount = Field[BigDecimal, SodViewRow](_path, "unitpricediscount", None, None, x => x.unitpricediscount, (row, value) => row.copy(unitpricediscount = value))
+      override def rowguid = Field[TypoUUID, SodViewRow](_path, "rowguid", None, None, x => x.rowguid, (row, value) => row.copy(rowguid = value))
+      override def modifieddate = Field[TypoLocalDateTime, SodViewRow](_path, "modifieddate", Some("text"), None, x => x.modifieddate, (row, value) => row.copy(modifieddate = value))
     }
   
-    override val columns: List[FieldLikeNoHkt[?, Row]] =
-      List[FieldLikeNoHkt[?, Row]](fields.id, fields.salesorderid, fields.salesorderdetailid, fields.carriertrackingnumber, fields.orderqty, fields.productid, fields.specialofferid, fields.unitprice, fields.unitpricediscount, fields.rowguid, fields.modifieddate)
+    override lazy val columns: List[FieldLikeNoHkt[?, SodViewRow]] =
+      List[FieldLikeNoHkt[?, SodViewRow]](fields.id, fields.salesorderid, fields.salesorderdetailid, fields.carriertrackingnumber, fields.orderqty, fields.productid, fields.specialofferid, fields.unitprice, fields.unitpricediscount, fields.rowguid, fields.modifieddate)
   
-    override def copy[NewRow](prefix: Option[String], extract: NewRow => SodViewRow, merge: (NewRow, SodViewRow) => NewRow): Impl[NewRow] =
-      new Impl(prefix, extract, merge)
+    override def copy(path: List[Path]): Impl =
+      new Impl(path)
   }
   
 }

--- a/typo-tester-anorm/generated-and-checked-in/adventureworks/sa/soh/SohViewFields.scala
+++ b/typo-tester-anorm/generated-and-checked-in/adventureworks/sa/soh/SohViewFields.scala
@@ -21,81 +21,82 @@ import adventureworks.sales.customer.CustomerId
 import adventureworks.sales.salesorderheader.SalesorderheaderId
 import adventureworks.sales.salesterritory.SalesterritoryId
 import adventureworks.userdefined.CustomCreditcardId
+import typo.dsl.Path
 import typo.dsl.SqlExpr.Field
 import typo.dsl.SqlExpr.FieldLikeNoHkt
 import typo.dsl.SqlExpr.OptField
 import typo.dsl.Structure.Relation
 
-trait SohViewFields[Row] {
-  val id: Field[SalesorderheaderId, Row]
-  val salesorderid: Field[SalesorderheaderId, Row]
-  val revisionnumber: Field[TypoShort, Row]
-  val orderdate: Field[TypoLocalDateTime, Row]
-  val duedate: Field[TypoLocalDateTime, Row]
-  val shipdate: OptField[TypoLocalDateTime, Row]
-  val status: Field[TypoShort, Row]
-  val onlineorderflag: Field[Flag, Row]
-  val purchaseordernumber: OptField[OrderNumber, Row]
-  val accountnumber: OptField[AccountNumber, Row]
-  val customerid: Field[CustomerId, Row]
-  val salespersonid: OptField[BusinessentityId, Row]
-  val territoryid: OptField[SalesterritoryId, Row]
-  val billtoaddressid: Field[AddressId, Row]
-  val shiptoaddressid: Field[AddressId, Row]
-  val shipmethodid: Field[ShipmethodId, Row]
-  val creditcardid: OptField[/* user-picked */ CustomCreditcardId, Row]
-  val creditcardapprovalcode: OptField[/* max 15 chars */ String, Row]
-  val currencyrateid: OptField[CurrencyrateId, Row]
-  val subtotal: Field[BigDecimal, Row]
-  val taxamt: Field[BigDecimal, Row]
-  val freight: Field[BigDecimal, Row]
-  val totaldue: OptField[BigDecimal, Row]
-  val comment: OptField[/* max 128 chars */ String, Row]
-  val rowguid: Field[TypoUUID, Row]
-  val modifieddate: Field[TypoLocalDateTime, Row]
+trait SohViewFields {
+  def id: Field[SalesorderheaderId, SohViewRow]
+  def salesorderid: Field[SalesorderheaderId, SohViewRow]
+  def revisionnumber: Field[TypoShort, SohViewRow]
+  def orderdate: Field[TypoLocalDateTime, SohViewRow]
+  def duedate: Field[TypoLocalDateTime, SohViewRow]
+  def shipdate: OptField[TypoLocalDateTime, SohViewRow]
+  def status: Field[TypoShort, SohViewRow]
+  def onlineorderflag: Field[Flag, SohViewRow]
+  def purchaseordernumber: OptField[OrderNumber, SohViewRow]
+  def accountnumber: OptField[AccountNumber, SohViewRow]
+  def customerid: Field[CustomerId, SohViewRow]
+  def salespersonid: OptField[BusinessentityId, SohViewRow]
+  def territoryid: OptField[SalesterritoryId, SohViewRow]
+  def billtoaddressid: Field[AddressId, SohViewRow]
+  def shiptoaddressid: Field[AddressId, SohViewRow]
+  def shipmethodid: Field[ShipmethodId, SohViewRow]
+  def creditcardid: OptField[/* user-picked */ CustomCreditcardId, SohViewRow]
+  def creditcardapprovalcode: OptField[/* max 15 chars */ String, SohViewRow]
+  def currencyrateid: OptField[CurrencyrateId, SohViewRow]
+  def subtotal: Field[BigDecimal, SohViewRow]
+  def taxamt: Field[BigDecimal, SohViewRow]
+  def freight: Field[BigDecimal, SohViewRow]
+  def totaldue: OptField[BigDecimal, SohViewRow]
+  def comment: OptField[/* max 128 chars */ String, SohViewRow]
+  def rowguid: Field[TypoUUID, SohViewRow]
+  def modifieddate: Field[TypoLocalDateTime, SohViewRow]
 }
 
 object SohViewFields {
-  val structure: Relation[SohViewFields, SohViewRow, SohViewRow] = 
-    new Impl(None, identity, (_, x) => x)
+  lazy val structure: Relation[SohViewFields, SohViewRow] =
+    new Impl(Nil)
     
-  private final class Impl[Row](val prefix: Option[String], val extract: Row => SohViewRow, val merge: (Row, SohViewRow) => Row)
-    extends Relation[SohViewFields, SohViewRow, Row] { 
+  private final class Impl(val _path: List[Path])
+    extends Relation[SohViewFields, SohViewRow] {
   
-    override val fields: SohViewFields[Row] = new SohViewFields[Row] {
-      override val id = new Field[SalesorderheaderId, Row](prefix, "id", None, None)(x => extract(x).id, (row, value) => merge(row, extract(row).copy(id = value)))
-      override val salesorderid = new Field[SalesorderheaderId, Row](prefix, "salesorderid", None, None)(x => extract(x).salesorderid, (row, value) => merge(row, extract(row).copy(salesorderid = value)))
-      override val revisionnumber = new Field[TypoShort, Row](prefix, "revisionnumber", None, None)(x => extract(x).revisionnumber, (row, value) => merge(row, extract(row).copy(revisionnumber = value)))
-      override val orderdate = new Field[TypoLocalDateTime, Row](prefix, "orderdate", Some("text"), None)(x => extract(x).orderdate, (row, value) => merge(row, extract(row).copy(orderdate = value)))
-      override val duedate = new Field[TypoLocalDateTime, Row](prefix, "duedate", Some("text"), None)(x => extract(x).duedate, (row, value) => merge(row, extract(row).copy(duedate = value)))
-      override val shipdate = new OptField[TypoLocalDateTime, Row](prefix, "shipdate", Some("text"), None)(x => extract(x).shipdate, (row, value) => merge(row, extract(row).copy(shipdate = value)))
-      override val status = new Field[TypoShort, Row](prefix, "status", None, None)(x => extract(x).status, (row, value) => merge(row, extract(row).copy(status = value)))
-      override val onlineorderflag = new Field[Flag, Row](prefix, "onlineorderflag", None, None)(x => extract(x).onlineorderflag, (row, value) => merge(row, extract(row).copy(onlineorderflag = value)))
-      override val purchaseordernumber = new OptField[OrderNumber, Row](prefix, "purchaseordernumber", None, None)(x => extract(x).purchaseordernumber, (row, value) => merge(row, extract(row).copy(purchaseordernumber = value)))
-      override val accountnumber = new OptField[AccountNumber, Row](prefix, "accountnumber", None, None)(x => extract(x).accountnumber, (row, value) => merge(row, extract(row).copy(accountnumber = value)))
-      override val customerid = new Field[CustomerId, Row](prefix, "customerid", None, None)(x => extract(x).customerid, (row, value) => merge(row, extract(row).copy(customerid = value)))
-      override val salespersonid = new OptField[BusinessentityId, Row](prefix, "salespersonid", None, None)(x => extract(x).salespersonid, (row, value) => merge(row, extract(row).copy(salespersonid = value)))
-      override val territoryid = new OptField[SalesterritoryId, Row](prefix, "territoryid", None, None)(x => extract(x).territoryid, (row, value) => merge(row, extract(row).copy(territoryid = value)))
-      override val billtoaddressid = new Field[AddressId, Row](prefix, "billtoaddressid", None, None)(x => extract(x).billtoaddressid, (row, value) => merge(row, extract(row).copy(billtoaddressid = value)))
-      override val shiptoaddressid = new Field[AddressId, Row](prefix, "shiptoaddressid", None, None)(x => extract(x).shiptoaddressid, (row, value) => merge(row, extract(row).copy(shiptoaddressid = value)))
-      override val shipmethodid = new Field[ShipmethodId, Row](prefix, "shipmethodid", None, None)(x => extract(x).shipmethodid, (row, value) => merge(row, extract(row).copy(shipmethodid = value)))
-      override val creditcardid = new OptField[/* user-picked */ CustomCreditcardId, Row](prefix, "creditcardid", None, None)(x => extract(x).creditcardid, (row, value) => merge(row, extract(row).copy(creditcardid = value)))
-      override val creditcardapprovalcode = new OptField[/* max 15 chars */ String, Row](prefix, "creditcardapprovalcode", None, None)(x => extract(x).creditcardapprovalcode, (row, value) => merge(row, extract(row).copy(creditcardapprovalcode = value)))
-      override val currencyrateid = new OptField[CurrencyrateId, Row](prefix, "currencyrateid", None, None)(x => extract(x).currencyrateid, (row, value) => merge(row, extract(row).copy(currencyrateid = value)))
-      override val subtotal = new Field[BigDecimal, Row](prefix, "subtotal", None, None)(x => extract(x).subtotal, (row, value) => merge(row, extract(row).copy(subtotal = value)))
-      override val taxamt = new Field[BigDecimal, Row](prefix, "taxamt", None, None)(x => extract(x).taxamt, (row, value) => merge(row, extract(row).copy(taxamt = value)))
-      override val freight = new Field[BigDecimal, Row](prefix, "freight", None, None)(x => extract(x).freight, (row, value) => merge(row, extract(row).copy(freight = value)))
-      override val totaldue = new OptField[BigDecimal, Row](prefix, "totaldue", None, None)(x => extract(x).totaldue, (row, value) => merge(row, extract(row).copy(totaldue = value)))
-      override val comment = new OptField[/* max 128 chars */ String, Row](prefix, "comment", None, None)(x => extract(x).comment, (row, value) => merge(row, extract(row).copy(comment = value)))
-      override val rowguid = new Field[TypoUUID, Row](prefix, "rowguid", None, None)(x => extract(x).rowguid, (row, value) => merge(row, extract(row).copy(rowguid = value)))
-      override val modifieddate = new Field[TypoLocalDateTime, Row](prefix, "modifieddate", Some("text"), None)(x => extract(x).modifieddate, (row, value) => merge(row, extract(row).copy(modifieddate = value)))
+    override lazy val fields: SohViewFields = new SohViewFields {
+      override def id = Field[SalesorderheaderId, SohViewRow](_path, "id", None, None, x => x.id, (row, value) => row.copy(id = value))
+      override def salesorderid = Field[SalesorderheaderId, SohViewRow](_path, "salesorderid", None, None, x => x.salesorderid, (row, value) => row.copy(salesorderid = value))
+      override def revisionnumber = Field[TypoShort, SohViewRow](_path, "revisionnumber", None, None, x => x.revisionnumber, (row, value) => row.copy(revisionnumber = value))
+      override def orderdate = Field[TypoLocalDateTime, SohViewRow](_path, "orderdate", Some("text"), None, x => x.orderdate, (row, value) => row.copy(orderdate = value))
+      override def duedate = Field[TypoLocalDateTime, SohViewRow](_path, "duedate", Some("text"), None, x => x.duedate, (row, value) => row.copy(duedate = value))
+      override def shipdate = OptField[TypoLocalDateTime, SohViewRow](_path, "shipdate", Some("text"), None, x => x.shipdate, (row, value) => row.copy(shipdate = value))
+      override def status = Field[TypoShort, SohViewRow](_path, "status", None, None, x => x.status, (row, value) => row.copy(status = value))
+      override def onlineorderflag = Field[Flag, SohViewRow](_path, "onlineorderflag", None, None, x => x.onlineorderflag, (row, value) => row.copy(onlineorderflag = value))
+      override def purchaseordernumber = OptField[OrderNumber, SohViewRow](_path, "purchaseordernumber", None, None, x => x.purchaseordernumber, (row, value) => row.copy(purchaseordernumber = value))
+      override def accountnumber = OptField[AccountNumber, SohViewRow](_path, "accountnumber", None, None, x => x.accountnumber, (row, value) => row.copy(accountnumber = value))
+      override def customerid = Field[CustomerId, SohViewRow](_path, "customerid", None, None, x => x.customerid, (row, value) => row.copy(customerid = value))
+      override def salespersonid = OptField[BusinessentityId, SohViewRow](_path, "salespersonid", None, None, x => x.salespersonid, (row, value) => row.copy(salespersonid = value))
+      override def territoryid = OptField[SalesterritoryId, SohViewRow](_path, "territoryid", None, None, x => x.territoryid, (row, value) => row.copy(territoryid = value))
+      override def billtoaddressid = Field[AddressId, SohViewRow](_path, "billtoaddressid", None, None, x => x.billtoaddressid, (row, value) => row.copy(billtoaddressid = value))
+      override def shiptoaddressid = Field[AddressId, SohViewRow](_path, "shiptoaddressid", None, None, x => x.shiptoaddressid, (row, value) => row.copy(shiptoaddressid = value))
+      override def shipmethodid = Field[ShipmethodId, SohViewRow](_path, "shipmethodid", None, None, x => x.shipmethodid, (row, value) => row.copy(shipmethodid = value))
+      override def creditcardid = OptField[/* user-picked */ CustomCreditcardId, SohViewRow](_path, "creditcardid", None, None, x => x.creditcardid, (row, value) => row.copy(creditcardid = value))
+      override def creditcardapprovalcode = OptField[/* max 15 chars */ String, SohViewRow](_path, "creditcardapprovalcode", None, None, x => x.creditcardapprovalcode, (row, value) => row.copy(creditcardapprovalcode = value))
+      override def currencyrateid = OptField[CurrencyrateId, SohViewRow](_path, "currencyrateid", None, None, x => x.currencyrateid, (row, value) => row.copy(currencyrateid = value))
+      override def subtotal = Field[BigDecimal, SohViewRow](_path, "subtotal", None, None, x => x.subtotal, (row, value) => row.copy(subtotal = value))
+      override def taxamt = Field[BigDecimal, SohViewRow](_path, "taxamt", None, None, x => x.taxamt, (row, value) => row.copy(taxamt = value))
+      override def freight = Field[BigDecimal, SohViewRow](_path, "freight", None, None, x => x.freight, (row, value) => row.copy(freight = value))
+      override def totaldue = OptField[BigDecimal, SohViewRow](_path, "totaldue", None, None, x => x.totaldue, (row, value) => row.copy(totaldue = value))
+      override def comment = OptField[/* max 128 chars */ String, SohViewRow](_path, "comment", None, None, x => x.comment, (row, value) => row.copy(comment = value))
+      override def rowguid = Field[TypoUUID, SohViewRow](_path, "rowguid", None, None, x => x.rowguid, (row, value) => row.copy(rowguid = value))
+      override def modifieddate = Field[TypoLocalDateTime, SohViewRow](_path, "modifieddate", Some("text"), None, x => x.modifieddate, (row, value) => row.copy(modifieddate = value))
     }
   
-    override val columns: List[FieldLikeNoHkt[?, Row]] =
-      List[FieldLikeNoHkt[?, Row]](fields.id, fields.salesorderid, fields.revisionnumber, fields.orderdate, fields.duedate, fields.shipdate, fields.status, fields.onlineorderflag, fields.purchaseordernumber, fields.accountnumber, fields.customerid, fields.salespersonid, fields.territoryid, fields.billtoaddressid, fields.shiptoaddressid, fields.shipmethodid, fields.creditcardid, fields.creditcardapprovalcode, fields.currencyrateid, fields.subtotal, fields.taxamt, fields.freight, fields.totaldue, fields.comment, fields.rowguid, fields.modifieddate)
+    override lazy val columns: List[FieldLikeNoHkt[?, SohViewRow]] =
+      List[FieldLikeNoHkt[?, SohViewRow]](fields.id, fields.salesorderid, fields.revisionnumber, fields.orderdate, fields.duedate, fields.shipdate, fields.status, fields.onlineorderflag, fields.purchaseordernumber, fields.accountnumber, fields.customerid, fields.salespersonid, fields.territoryid, fields.billtoaddressid, fields.shiptoaddressid, fields.shipmethodid, fields.creditcardid, fields.creditcardapprovalcode, fields.currencyrateid, fields.subtotal, fields.taxamt, fields.freight, fields.totaldue, fields.comment, fields.rowguid, fields.modifieddate)
   
-    override def copy[NewRow](prefix: Option[String], extract: NewRow => SohViewRow, merge: (NewRow, SohViewRow) => NewRow): Impl[NewRow] =
-      new Impl(prefix, extract, merge)
+    override def copy(path: List[Path]): Impl =
+      new Impl(path)
   }
   
 }

--- a/typo-tester-anorm/generated-and-checked-in/adventureworks/sa/sohsr/SohsrViewFields.scala
+++ b/typo-tester-anorm/generated-and-checked-in/adventureworks/sa/sohsr/SohsrViewFields.scala
@@ -10,34 +10,35 @@ package sohsr
 import adventureworks.customtypes.TypoLocalDateTime
 import adventureworks.sales.salesorderheader.SalesorderheaderId
 import adventureworks.sales.salesreason.SalesreasonId
+import typo.dsl.Path
 import typo.dsl.SqlExpr.Field
 import typo.dsl.SqlExpr.FieldLikeNoHkt
 import typo.dsl.Structure.Relation
 
-trait SohsrViewFields[Row] {
-  val salesorderid: Field[SalesorderheaderId, Row]
-  val salesreasonid: Field[SalesreasonId, Row]
-  val modifieddate: Field[TypoLocalDateTime, Row]
+trait SohsrViewFields {
+  def salesorderid: Field[SalesorderheaderId, SohsrViewRow]
+  def salesreasonid: Field[SalesreasonId, SohsrViewRow]
+  def modifieddate: Field[TypoLocalDateTime, SohsrViewRow]
 }
 
 object SohsrViewFields {
-  val structure: Relation[SohsrViewFields, SohsrViewRow, SohsrViewRow] = 
-    new Impl(None, identity, (_, x) => x)
+  lazy val structure: Relation[SohsrViewFields, SohsrViewRow] =
+    new Impl(Nil)
     
-  private final class Impl[Row](val prefix: Option[String], val extract: Row => SohsrViewRow, val merge: (Row, SohsrViewRow) => Row)
-    extends Relation[SohsrViewFields, SohsrViewRow, Row] { 
+  private final class Impl(val _path: List[Path])
+    extends Relation[SohsrViewFields, SohsrViewRow] {
   
-    override val fields: SohsrViewFields[Row] = new SohsrViewFields[Row] {
-      override val salesorderid = new Field[SalesorderheaderId, Row](prefix, "salesorderid", None, None)(x => extract(x).salesorderid, (row, value) => merge(row, extract(row).copy(salesorderid = value)))
-      override val salesreasonid = new Field[SalesreasonId, Row](prefix, "salesreasonid", None, None)(x => extract(x).salesreasonid, (row, value) => merge(row, extract(row).copy(salesreasonid = value)))
-      override val modifieddate = new Field[TypoLocalDateTime, Row](prefix, "modifieddate", Some("text"), None)(x => extract(x).modifieddate, (row, value) => merge(row, extract(row).copy(modifieddate = value)))
+    override lazy val fields: SohsrViewFields = new SohsrViewFields {
+      override def salesorderid = Field[SalesorderheaderId, SohsrViewRow](_path, "salesorderid", None, None, x => x.salesorderid, (row, value) => row.copy(salesorderid = value))
+      override def salesreasonid = Field[SalesreasonId, SohsrViewRow](_path, "salesreasonid", None, None, x => x.salesreasonid, (row, value) => row.copy(salesreasonid = value))
+      override def modifieddate = Field[TypoLocalDateTime, SohsrViewRow](_path, "modifieddate", Some("text"), None, x => x.modifieddate, (row, value) => row.copy(modifieddate = value))
     }
   
-    override val columns: List[FieldLikeNoHkt[?, Row]] =
-      List[FieldLikeNoHkt[?, Row]](fields.salesorderid, fields.salesreasonid, fields.modifieddate)
+    override lazy val columns: List[FieldLikeNoHkt[?, SohsrViewRow]] =
+      List[FieldLikeNoHkt[?, SohsrViewRow]](fields.salesorderid, fields.salesreasonid, fields.modifieddate)
   
-    override def copy[NewRow](prefix: Option[String], extract: NewRow => SohsrViewRow, merge: (NewRow, SohsrViewRow) => NewRow): Impl[NewRow] =
-      new Impl(prefix, extract, merge)
+    override def copy(path: List[Path]): Impl =
+      new Impl(path)
   }
   
 }

--- a/typo-tester-anorm/generated-and-checked-in/adventureworks/sa/sop/SopViewFields.scala
+++ b/typo-tester-anorm/generated-and-checked-in/adventureworks/sa/sop/SopViewFields.scala
@@ -11,38 +11,39 @@ import adventureworks.customtypes.TypoLocalDateTime
 import adventureworks.customtypes.TypoUUID
 import adventureworks.production.product.ProductId
 import adventureworks.sales.specialoffer.SpecialofferId
+import typo.dsl.Path
 import typo.dsl.SqlExpr.Field
 import typo.dsl.SqlExpr.FieldLikeNoHkt
 import typo.dsl.Structure.Relation
 
-trait SopViewFields[Row] {
-  val id: Field[SpecialofferId, Row]
-  val specialofferid: Field[SpecialofferId, Row]
-  val productid: Field[ProductId, Row]
-  val rowguid: Field[TypoUUID, Row]
-  val modifieddate: Field[TypoLocalDateTime, Row]
+trait SopViewFields {
+  def id: Field[SpecialofferId, SopViewRow]
+  def specialofferid: Field[SpecialofferId, SopViewRow]
+  def productid: Field[ProductId, SopViewRow]
+  def rowguid: Field[TypoUUID, SopViewRow]
+  def modifieddate: Field[TypoLocalDateTime, SopViewRow]
 }
 
 object SopViewFields {
-  val structure: Relation[SopViewFields, SopViewRow, SopViewRow] = 
-    new Impl(None, identity, (_, x) => x)
+  lazy val structure: Relation[SopViewFields, SopViewRow] =
+    new Impl(Nil)
     
-  private final class Impl[Row](val prefix: Option[String], val extract: Row => SopViewRow, val merge: (Row, SopViewRow) => Row)
-    extends Relation[SopViewFields, SopViewRow, Row] { 
+  private final class Impl(val _path: List[Path])
+    extends Relation[SopViewFields, SopViewRow] {
   
-    override val fields: SopViewFields[Row] = new SopViewFields[Row] {
-      override val id = new Field[SpecialofferId, Row](prefix, "id", None, None)(x => extract(x).id, (row, value) => merge(row, extract(row).copy(id = value)))
-      override val specialofferid = new Field[SpecialofferId, Row](prefix, "specialofferid", None, None)(x => extract(x).specialofferid, (row, value) => merge(row, extract(row).copy(specialofferid = value)))
-      override val productid = new Field[ProductId, Row](prefix, "productid", None, None)(x => extract(x).productid, (row, value) => merge(row, extract(row).copy(productid = value)))
-      override val rowguid = new Field[TypoUUID, Row](prefix, "rowguid", None, None)(x => extract(x).rowguid, (row, value) => merge(row, extract(row).copy(rowguid = value)))
-      override val modifieddate = new Field[TypoLocalDateTime, Row](prefix, "modifieddate", Some("text"), None)(x => extract(x).modifieddate, (row, value) => merge(row, extract(row).copy(modifieddate = value)))
+    override lazy val fields: SopViewFields = new SopViewFields {
+      override def id = Field[SpecialofferId, SopViewRow](_path, "id", None, None, x => x.id, (row, value) => row.copy(id = value))
+      override def specialofferid = Field[SpecialofferId, SopViewRow](_path, "specialofferid", None, None, x => x.specialofferid, (row, value) => row.copy(specialofferid = value))
+      override def productid = Field[ProductId, SopViewRow](_path, "productid", None, None, x => x.productid, (row, value) => row.copy(productid = value))
+      override def rowguid = Field[TypoUUID, SopViewRow](_path, "rowguid", None, None, x => x.rowguid, (row, value) => row.copy(rowguid = value))
+      override def modifieddate = Field[TypoLocalDateTime, SopViewRow](_path, "modifieddate", Some("text"), None, x => x.modifieddate, (row, value) => row.copy(modifieddate = value))
     }
   
-    override val columns: List[FieldLikeNoHkt[?, Row]] =
-      List[FieldLikeNoHkt[?, Row]](fields.id, fields.specialofferid, fields.productid, fields.rowguid, fields.modifieddate)
+    override lazy val columns: List[FieldLikeNoHkt[?, SopViewRow]] =
+      List[FieldLikeNoHkt[?, SopViewRow]](fields.id, fields.specialofferid, fields.productid, fields.rowguid, fields.modifieddate)
   
-    override def copy[NewRow](prefix: Option[String], extract: NewRow => SopViewRow, merge: (NewRow, SopViewRow) => NewRow): Impl[NewRow] =
-      new Impl(prefix, extract, merge)
+    override def copy(path: List[Path]): Impl =
+      new Impl(path)
   }
   
 }

--- a/typo-tester-anorm/generated-and-checked-in/adventureworks/sa/sp/SpViewFields.scala
+++ b/typo-tester-anorm/generated-and-checked-in/adventureworks/sa/sp/SpViewFields.scala
@@ -11,49 +11,50 @@ import adventureworks.customtypes.TypoLocalDateTime
 import adventureworks.customtypes.TypoUUID
 import adventureworks.person.businessentity.BusinessentityId
 import adventureworks.sales.salesterritory.SalesterritoryId
+import typo.dsl.Path
 import typo.dsl.SqlExpr.Field
 import typo.dsl.SqlExpr.FieldLikeNoHkt
 import typo.dsl.SqlExpr.OptField
 import typo.dsl.Structure.Relation
 
-trait SpViewFields[Row] {
-  val id: Field[BusinessentityId, Row]
-  val businessentityid: Field[BusinessentityId, Row]
-  val territoryid: OptField[SalesterritoryId, Row]
-  val salesquota: OptField[BigDecimal, Row]
-  val bonus: Field[BigDecimal, Row]
-  val commissionpct: Field[BigDecimal, Row]
-  val salesytd: Field[BigDecimal, Row]
-  val saleslastyear: Field[BigDecimal, Row]
-  val rowguid: Field[TypoUUID, Row]
-  val modifieddate: Field[TypoLocalDateTime, Row]
+trait SpViewFields {
+  def id: Field[BusinessentityId, SpViewRow]
+  def businessentityid: Field[BusinessentityId, SpViewRow]
+  def territoryid: OptField[SalesterritoryId, SpViewRow]
+  def salesquota: OptField[BigDecimal, SpViewRow]
+  def bonus: Field[BigDecimal, SpViewRow]
+  def commissionpct: Field[BigDecimal, SpViewRow]
+  def salesytd: Field[BigDecimal, SpViewRow]
+  def saleslastyear: Field[BigDecimal, SpViewRow]
+  def rowguid: Field[TypoUUID, SpViewRow]
+  def modifieddate: Field[TypoLocalDateTime, SpViewRow]
 }
 
 object SpViewFields {
-  val structure: Relation[SpViewFields, SpViewRow, SpViewRow] = 
-    new Impl(None, identity, (_, x) => x)
+  lazy val structure: Relation[SpViewFields, SpViewRow] =
+    new Impl(Nil)
     
-  private final class Impl[Row](val prefix: Option[String], val extract: Row => SpViewRow, val merge: (Row, SpViewRow) => Row)
-    extends Relation[SpViewFields, SpViewRow, Row] { 
+  private final class Impl(val _path: List[Path])
+    extends Relation[SpViewFields, SpViewRow] {
   
-    override val fields: SpViewFields[Row] = new SpViewFields[Row] {
-      override val id = new Field[BusinessentityId, Row](prefix, "id", None, None)(x => extract(x).id, (row, value) => merge(row, extract(row).copy(id = value)))
-      override val businessentityid = new Field[BusinessentityId, Row](prefix, "businessentityid", None, None)(x => extract(x).businessentityid, (row, value) => merge(row, extract(row).copy(businessentityid = value)))
-      override val territoryid = new OptField[SalesterritoryId, Row](prefix, "territoryid", None, None)(x => extract(x).territoryid, (row, value) => merge(row, extract(row).copy(territoryid = value)))
-      override val salesquota = new OptField[BigDecimal, Row](prefix, "salesquota", None, None)(x => extract(x).salesquota, (row, value) => merge(row, extract(row).copy(salesquota = value)))
-      override val bonus = new Field[BigDecimal, Row](prefix, "bonus", None, None)(x => extract(x).bonus, (row, value) => merge(row, extract(row).copy(bonus = value)))
-      override val commissionpct = new Field[BigDecimal, Row](prefix, "commissionpct", None, None)(x => extract(x).commissionpct, (row, value) => merge(row, extract(row).copy(commissionpct = value)))
-      override val salesytd = new Field[BigDecimal, Row](prefix, "salesytd", None, None)(x => extract(x).salesytd, (row, value) => merge(row, extract(row).copy(salesytd = value)))
-      override val saleslastyear = new Field[BigDecimal, Row](prefix, "saleslastyear", None, None)(x => extract(x).saleslastyear, (row, value) => merge(row, extract(row).copy(saleslastyear = value)))
-      override val rowguid = new Field[TypoUUID, Row](prefix, "rowguid", None, None)(x => extract(x).rowguid, (row, value) => merge(row, extract(row).copy(rowguid = value)))
-      override val modifieddate = new Field[TypoLocalDateTime, Row](prefix, "modifieddate", Some("text"), None)(x => extract(x).modifieddate, (row, value) => merge(row, extract(row).copy(modifieddate = value)))
+    override lazy val fields: SpViewFields = new SpViewFields {
+      override def id = Field[BusinessentityId, SpViewRow](_path, "id", None, None, x => x.id, (row, value) => row.copy(id = value))
+      override def businessentityid = Field[BusinessentityId, SpViewRow](_path, "businessentityid", None, None, x => x.businessentityid, (row, value) => row.copy(businessentityid = value))
+      override def territoryid = OptField[SalesterritoryId, SpViewRow](_path, "territoryid", None, None, x => x.territoryid, (row, value) => row.copy(territoryid = value))
+      override def salesquota = OptField[BigDecimal, SpViewRow](_path, "salesquota", None, None, x => x.salesquota, (row, value) => row.copy(salesquota = value))
+      override def bonus = Field[BigDecimal, SpViewRow](_path, "bonus", None, None, x => x.bonus, (row, value) => row.copy(bonus = value))
+      override def commissionpct = Field[BigDecimal, SpViewRow](_path, "commissionpct", None, None, x => x.commissionpct, (row, value) => row.copy(commissionpct = value))
+      override def salesytd = Field[BigDecimal, SpViewRow](_path, "salesytd", None, None, x => x.salesytd, (row, value) => row.copy(salesytd = value))
+      override def saleslastyear = Field[BigDecimal, SpViewRow](_path, "saleslastyear", None, None, x => x.saleslastyear, (row, value) => row.copy(saleslastyear = value))
+      override def rowguid = Field[TypoUUID, SpViewRow](_path, "rowguid", None, None, x => x.rowguid, (row, value) => row.copy(rowguid = value))
+      override def modifieddate = Field[TypoLocalDateTime, SpViewRow](_path, "modifieddate", Some("text"), None, x => x.modifieddate, (row, value) => row.copy(modifieddate = value))
     }
   
-    override val columns: List[FieldLikeNoHkt[?, Row]] =
-      List[FieldLikeNoHkt[?, Row]](fields.id, fields.businessentityid, fields.territoryid, fields.salesquota, fields.bonus, fields.commissionpct, fields.salesytd, fields.saleslastyear, fields.rowguid, fields.modifieddate)
+    override lazy val columns: List[FieldLikeNoHkt[?, SpViewRow]] =
+      List[FieldLikeNoHkt[?, SpViewRow]](fields.id, fields.businessentityid, fields.territoryid, fields.salesquota, fields.bonus, fields.commissionpct, fields.salesytd, fields.saleslastyear, fields.rowguid, fields.modifieddate)
   
-    override def copy[NewRow](prefix: Option[String], extract: NewRow => SpViewRow, merge: (NewRow, SpViewRow) => NewRow): Impl[NewRow] =
-      new Impl(prefix, extract, merge)
+    override def copy(path: List[Path]): Impl =
+      new Impl(path)
   }
   
 }

--- a/typo-tester-anorm/generated-and-checked-in/adventureworks/sa/spqh/SpqhViewFields.scala
+++ b/typo-tester-anorm/generated-and-checked-in/adventureworks/sa/spqh/SpqhViewFields.scala
@@ -10,40 +10,41 @@ package spqh
 import adventureworks.customtypes.TypoLocalDateTime
 import adventureworks.customtypes.TypoUUID
 import adventureworks.person.businessentity.BusinessentityId
+import typo.dsl.Path
 import typo.dsl.SqlExpr.Field
 import typo.dsl.SqlExpr.FieldLikeNoHkt
 import typo.dsl.Structure.Relation
 
-trait SpqhViewFields[Row] {
-  val id: Field[BusinessentityId, Row]
-  val businessentityid: Field[BusinessentityId, Row]
-  val quotadate: Field[TypoLocalDateTime, Row]
-  val salesquota: Field[BigDecimal, Row]
-  val rowguid: Field[TypoUUID, Row]
-  val modifieddate: Field[TypoLocalDateTime, Row]
+trait SpqhViewFields {
+  def id: Field[BusinessentityId, SpqhViewRow]
+  def businessentityid: Field[BusinessentityId, SpqhViewRow]
+  def quotadate: Field[TypoLocalDateTime, SpqhViewRow]
+  def salesquota: Field[BigDecimal, SpqhViewRow]
+  def rowguid: Field[TypoUUID, SpqhViewRow]
+  def modifieddate: Field[TypoLocalDateTime, SpqhViewRow]
 }
 
 object SpqhViewFields {
-  val structure: Relation[SpqhViewFields, SpqhViewRow, SpqhViewRow] = 
-    new Impl(None, identity, (_, x) => x)
+  lazy val structure: Relation[SpqhViewFields, SpqhViewRow] =
+    new Impl(Nil)
     
-  private final class Impl[Row](val prefix: Option[String], val extract: Row => SpqhViewRow, val merge: (Row, SpqhViewRow) => Row)
-    extends Relation[SpqhViewFields, SpqhViewRow, Row] { 
+  private final class Impl(val _path: List[Path])
+    extends Relation[SpqhViewFields, SpqhViewRow] {
   
-    override val fields: SpqhViewFields[Row] = new SpqhViewFields[Row] {
-      override val id = new Field[BusinessentityId, Row](prefix, "id", None, None)(x => extract(x).id, (row, value) => merge(row, extract(row).copy(id = value)))
-      override val businessentityid = new Field[BusinessentityId, Row](prefix, "businessentityid", None, None)(x => extract(x).businessentityid, (row, value) => merge(row, extract(row).copy(businessentityid = value)))
-      override val quotadate = new Field[TypoLocalDateTime, Row](prefix, "quotadate", Some("text"), None)(x => extract(x).quotadate, (row, value) => merge(row, extract(row).copy(quotadate = value)))
-      override val salesquota = new Field[BigDecimal, Row](prefix, "salesquota", None, None)(x => extract(x).salesquota, (row, value) => merge(row, extract(row).copy(salesquota = value)))
-      override val rowguid = new Field[TypoUUID, Row](prefix, "rowguid", None, None)(x => extract(x).rowguid, (row, value) => merge(row, extract(row).copy(rowguid = value)))
-      override val modifieddate = new Field[TypoLocalDateTime, Row](prefix, "modifieddate", Some("text"), None)(x => extract(x).modifieddate, (row, value) => merge(row, extract(row).copy(modifieddate = value)))
+    override lazy val fields: SpqhViewFields = new SpqhViewFields {
+      override def id = Field[BusinessentityId, SpqhViewRow](_path, "id", None, None, x => x.id, (row, value) => row.copy(id = value))
+      override def businessentityid = Field[BusinessentityId, SpqhViewRow](_path, "businessentityid", None, None, x => x.businessentityid, (row, value) => row.copy(businessentityid = value))
+      override def quotadate = Field[TypoLocalDateTime, SpqhViewRow](_path, "quotadate", Some("text"), None, x => x.quotadate, (row, value) => row.copy(quotadate = value))
+      override def salesquota = Field[BigDecimal, SpqhViewRow](_path, "salesquota", None, None, x => x.salesquota, (row, value) => row.copy(salesquota = value))
+      override def rowguid = Field[TypoUUID, SpqhViewRow](_path, "rowguid", None, None, x => x.rowguid, (row, value) => row.copy(rowguid = value))
+      override def modifieddate = Field[TypoLocalDateTime, SpqhViewRow](_path, "modifieddate", Some("text"), None, x => x.modifieddate, (row, value) => row.copy(modifieddate = value))
     }
   
-    override val columns: List[FieldLikeNoHkt[?, Row]] =
-      List[FieldLikeNoHkt[?, Row]](fields.id, fields.businessentityid, fields.quotadate, fields.salesquota, fields.rowguid, fields.modifieddate)
+    override lazy val columns: List[FieldLikeNoHkt[?, SpqhViewRow]] =
+      List[FieldLikeNoHkt[?, SpqhViewRow]](fields.id, fields.businessentityid, fields.quotadate, fields.salesquota, fields.rowguid, fields.modifieddate)
   
-    override def copy[NewRow](prefix: Option[String], extract: NewRow => SpqhViewRow, merge: (NewRow, SpqhViewRow) => NewRow): Impl[NewRow] =
-      new Impl(prefix, extract, merge)
+    override def copy(path: List[Path]): Impl =
+      new Impl(path)
   }
   
 }

--- a/typo-tester-anorm/generated-and-checked-in/adventureworks/sa/sr/SrViewFields.scala
+++ b/typo-tester-anorm/generated-and-checked-in/adventureworks/sa/sr/SrViewFields.scala
@@ -10,38 +10,39 @@ package sr
 import adventureworks.customtypes.TypoLocalDateTime
 import adventureworks.public.Name
 import adventureworks.sales.salesreason.SalesreasonId
+import typo.dsl.Path
 import typo.dsl.SqlExpr.Field
 import typo.dsl.SqlExpr.FieldLikeNoHkt
 import typo.dsl.Structure.Relation
 
-trait SrViewFields[Row] {
-  val id: Field[SalesreasonId, Row]
-  val salesreasonid: Field[SalesreasonId, Row]
-  val name: Field[Name, Row]
-  val reasontype: Field[Name, Row]
-  val modifieddate: Field[TypoLocalDateTime, Row]
+trait SrViewFields {
+  def id: Field[SalesreasonId, SrViewRow]
+  def salesreasonid: Field[SalesreasonId, SrViewRow]
+  def name: Field[Name, SrViewRow]
+  def reasontype: Field[Name, SrViewRow]
+  def modifieddate: Field[TypoLocalDateTime, SrViewRow]
 }
 
 object SrViewFields {
-  val structure: Relation[SrViewFields, SrViewRow, SrViewRow] = 
-    new Impl(None, identity, (_, x) => x)
+  lazy val structure: Relation[SrViewFields, SrViewRow] =
+    new Impl(Nil)
     
-  private final class Impl[Row](val prefix: Option[String], val extract: Row => SrViewRow, val merge: (Row, SrViewRow) => Row)
-    extends Relation[SrViewFields, SrViewRow, Row] { 
+  private final class Impl(val _path: List[Path])
+    extends Relation[SrViewFields, SrViewRow] {
   
-    override val fields: SrViewFields[Row] = new SrViewFields[Row] {
-      override val id = new Field[SalesreasonId, Row](prefix, "id", None, None)(x => extract(x).id, (row, value) => merge(row, extract(row).copy(id = value)))
-      override val salesreasonid = new Field[SalesreasonId, Row](prefix, "salesreasonid", None, None)(x => extract(x).salesreasonid, (row, value) => merge(row, extract(row).copy(salesreasonid = value)))
-      override val name = new Field[Name, Row](prefix, "name", None, None)(x => extract(x).name, (row, value) => merge(row, extract(row).copy(name = value)))
-      override val reasontype = new Field[Name, Row](prefix, "reasontype", None, None)(x => extract(x).reasontype, (row, value) => merge(row, extract(row).copy(reasontype = value)))
-      override val modifieddate = new Field[TypoLocalDateTime, Row](prefix, "modifieddate", Some("text"), None)(x => extract(x).modifieddate, (row, value) => merge(row, extract(row).copy(modifieddate = value)))
+    override lazy val fields: SrViewFields = new SrViewFields {
+      override def id = Field[SalesreasonId, SrViewRow](_path, "id", None, None, x => x.id, (row, value) => row.copy(id = value))
+      override def salesreasonid = Field[SalesreasonId, SrViewRow](_path, "salesreasonid", None, None, x => x.salesreasonid, (row, value) => row.copy(salesreasonid = value))
+      override def name = Field[Name, SrViewRow](_path, "name", None, None, x => x.name, (row, value) => row.copy(name = value))
+      override def reasontype = Field[Name, SrViewRow](_path, "reasontype", None, None, x => x.reasontype, (row, value) => row.copy(reasontype = value))
+      override def modifieddate = Field[TypoLocalDateTime, SrViewRow](_path, "modifieddate", Some("text"), None, x => x.modifieddate, (row, value) => row.copy(modifieddate = value))
     }
   
-    override val columns: List[FieldLikeNoHkt[?, Row]] =
-      List[FieldLikeNoHkt[?, Row]](fields.id, fields.salesreasonid, fields.name, fields.reasontype, fields.modifieddate)
+    override lazy val columns: List[FieldLikeNoHkt[?, SrViewRow]] =
+      List[FieldLikeNoHkt[?, SrViewRow]](fields.id, fields.salesreasonid, fields.name, fields.reasontype, fields.modifieddate)
   
-    override def copy[NewRow](prefix: Option[String], extract: NewRow => SrViewRow, merge: (NewRow, SrViewRow) => NewRow): Impl[NewRow] =
-      new Impl(prefix, extract, merge)
+    override def copy(path: List[Path]): Impl =
+      new Impl(path)
   }
   
 }

--- a/typo-tester-anorm/generated-and-checked-in/adventureworks/sa/st/StViewFields.scala
+++ b/typo-tester-anorm/generated-and-checked-in/adventureworks/sa/st/StViewFields.scala
@@ -12,50 +12,51 @@ import adventureworks.customtypes.TypoUUID
 import adventureworks.person.countryregion.CountryregionId
 import adventureworks.public.Name
 import adventureworks.sales.salesterritory.SalesterritoryId
+import typo.dsl.Path
 import typo.dsl.SqlExpr.Field
 import typo.dsl.SqlExpr.FieldLikeNoHkt
 import typo.dsl.Structure.Relation
 
-trait StViewFields[Row] {
-  val id: Field[SalesterritoryId, Row]
-  val territoryid: Field[SalesterritoryId, Row]
-  val name: Field[Name, Row]
-  val countryregioncode: Field[CountryregionId, Row]
-  val group: Field[/* max 50 chars */ String, Row]
-  val salesytd: Field[BigDecimal, Row]
-  val saleslastyear: Field[BigDecimal, Row]
-  val costytd: Field[BigDecimal, Row]
-  val costlastyear: Field[BigDecimal, Row]
-  val rowguid: Field[TypoUUID, Row]
-  val modifieddate: Field[TypoLocalDateTime, Row]
+trait StViewFields {
+  def id: Field[SalesterritoryId, StViewRow]
+  def territoryid: Field[SalesterritoryId, StViewRow]
+  def name: Field[Name, StViewRow]
+  def countryregioncode: Field[CountryregionId, StViewRow]
+  def group: Field[/* max 50 chars */ String, StViewRow]
+  def salesytd: Field[BigDecimal, StViewRow]
+  def saleslastyear: Field[BigDecimal, StViewRow]
+  def costytd: Field[BigDecimal, StViewRow]
+  def costlastyear: Field[BigDecimal, StViewRow]
+  def rowguid: Field[TypoUUID, StViewRow]
+  def modifieddate: Field[TypoLocalDateTime, StViewRow]
 }
 
 object StViewFields {
-  val structure: Relation[StViewFields, StViewRow, StViewRow] = 
-    new Impl(None, identity, (_, x) => x)
+  lazy val structure: Relation[StViewFields, StViewRow] =
+    new Impl(Nil)
     
-  private final class Impl[Row](val prefix: Option[String], val extract: Row => StViewRow, val merge: (Row, StViewRow) => Row)
-    extends Relation[StViewFields, StViewRow, Row] { 
+  private final class Impl(val _path: List[Path])
+    extends Relation[StViewFields, StViewRow] {
   
-    override val fields: StViewFields[Row] = new StViewFields[Row] {
-      override val id = new Field[SalesterritoryId, Row](prefix, "id", None, None)(x => extract(x).id, (row, value) => merge(row, extract(row).copy(id = value)))
-      override val territoryid = new Field[SalesterritoryId, Row](prefix, "territoryid", None, None)(x => extract(x).territoryid, (row, value) => merge(row, extract(row).copy(territoryid = value)))
-      override val name = new Field[Name, Row](prefix, "name", None, None)(x => extract(x).name, (row, value) => merge(row, extract(row).copy(name = value)))
-      override val countryregioncode = new Field[CountryregionId, Row](prefix, "countryregioncode", None, None)(x => extract(x).countryregioncode, (row, value) => merge(row, extract(row).copy(countryregioncode = value)))
-      override val group = new Field[/* max 50 chars */ String, Row](prefix, "group", None, None)(x => extract(x).group, (row, value) => merge(row, extract(row).copy(group = value)))
-      override val salesytd = new Field[BigDecimal, Row](prefix, "salesytd", None, None)(x => extract(x).salesytd, (row, value) => merge(row, extract(row).copy(salesytd = value)))
-      override val saleslastyear = new Field[BigDecimal, Row](prefix, "saleslastyear", None, None)(x => extract(x).saleslastyear, (row, value) => merge(row, extract(row).copy(saleslastyear = value)))
-      override val costytd = new Field[BigDecimal, Row](prefix, "costytd", None, None)(x => extract(x).costytd, (row, value) => merge(row, extract(row).copy(costytd = value)))
-      override val costlastyear = new Field[BigDecimal, Row](prefix, "costlastyear", None, None)(x => extract(x).costlastyear, (row, value) => merge(row, extract(row).copy(costlastyear = value)))
-      override val rowguid = new Field[TypoUUID, Row](prefix, "rowguid", None, None)(x => extract(x).rowguid, (row, value) => merge(row, extract(row).copy(rowguid = value)))
-      override val modifieddate = new Field[TypoLocalDateTime, Row](prefix, "modifieddate", Some("text"), None)(x => extract(x).modifieddate, (row, value) => merge(row, extract(row).copy(modifieddate = value)))
+    override lazy val fields: StViewFields = new StViewFields {
+      override def id = Field[SalesterritoryId, StViewRow](_path, "id", None, None, x => x.id, (row, value) => row.copy(id = value))
+      override def territoryid = Field[SalesterritoryId, StViewRow](_path, "territoryid", None, None, x => x.territoryid, (row, value) => row.copy(territoryid = value))
+      override def name = Field[Name, StViewRow](_path, "name", None, None, x => x.name, (row, value) => row.copy(name = value))
+      override def countryregioncode = Field[CountryregionId, StViewRow](_path, "countryregioncode", None, None, x => x.countryregioncode, (row, value) => row.copy(countryregioncode = value))
+      override def group = Field[/* max 50 chars */ String, StViewRow](_path, "group", None, None, x => x.group, (row, value) => row.copy(group = value))
+      override def salesytd = Field[BigDecimal, StViewRow](_path, "salesytd", None, None, x => x.salesytd, (row, value) => row.copy(salesytd = value))
+      override def saleslastyear = Field[BigDecimal, StViewRow](_path, "saleslastyear", None, None, x => x.saleslastyear, (row, value) => row.copy(saleslastyear = value))
+      override def costytd = Field[BigDecimal, StViewRow](_path, "costytd", None, None, x => x.costytd, (row, value) => row.copy(costytd = value))
+      override def costlastyear = Field[BigDecimal, StViewRow](_path, "costlastyear", None, None, x => x.costlastyear, (row, value) => row.copy(costlastyear = value))
+      override def rowguid = Field[TypoUUID, StViewRow](_path, "rowguid", None, None, x => x.rowguid, (row, value) => row.copy(rowguid = value))
+      override def modifieddate = Field[TypoLocalDateTime, StViewRow](_path, "modifieddate", Some("text"), None, x => x.modifieddate, (row, value) => row.copy(modifieddate = value))
     }
   
-    override val columns: List[FieldLikeNoHkt[?, Row]] =
-      List[FieldLikeNoHkt[?, Row]](fields.id, fields.territoryid, fields.name, fields.countryregioncode, fields.group, fields.salesytd, fields.saleslastyear, fields.costytd, fields.costlastyear, fields.rowguid, fields.modifieddate)
+    override lazy val columns: List[FieldLikeNoHkt[?, StViewRow]] =
+      List[FieldLikeNoHkt[?, StViewRow]](fields.id, fields.territoryid, fields.name, fields.countryregioncode, fields.group, fields.salesytd, fields.saleslastyear, fields.costytd, fields.costlastyear, fields.rowguid, fields.modifieddate)
   
-    override def copy[NewRow](prefix: Option[String], extract: NewRow => StViewRow, merge: (NewRow, StViewRow) => NewRow): Impl[NewRow] =
-      new Impl(prefix, extract, merge)
+    override def copy(path: List[Path]): Impl =
+      new Impl(path)
   }
   
 }

--- a/typo-tester-anorm/generated-and-checked-in/adventureworks/sa/sth/SthViewFields.scala
+++ b/typo-tester-anorm/generated-and-checked-in/adventureworks/sa/sth/SthViewFields.scala
@@ -11,43 +11,44 @@ import adventureworks.customtypes.TypoLocalDateTime
 import adventureworks.customtypes.TypoUUID
 import adventureworks.person.businessentity.BusinessentityId
 import adventureworks.sales.salesterritory.SalesterritoryId
+import typo.dsl.Path
 import typo.dsl.SqlExpr.Field
 import typo.dsl.SqlExpr.FieldLikeNoHkt
 import typo.dsl.SqlExpr.OptField
 import typo.dsl.Structure.Relation
 
-trait SthViewFields[Row] {
-  val id: Field[SalesterritoryId, Row]
-  val businessentityid: Field[BusinessentityId, Row]
-  val territoryid: Field[SalesterritoryId, Row]
-  val startdate: Field[TypoLocalDateTime, Row]
-  val enddate: OptField[TypoLocalDateTime, Row]
-  val rowguid: Field[TypoUUID, Row]
-  val modifieddate: Field[TypoLocalDateTime, Row]
+trait SthViewFields {
+  def id: Field[SalesterritoryId, SthViewRow]
+  def businessentityid: Field[BusinessentityId, SthViewRow]
+  def territoryid: Field[SalesterritoryId, SthViewRow]
+  def startdate: Field[TypoLocalDateTime, SthViewRow]
+  def enddate: OptField[TypoLocalDateTime, SthViewRow]
+  def rowguid: Field[TypoUUID, SthViewRow]
+  def modifieddate: Field[TypoLocalDateTime, SthViewRow]
 }
 
 object SthViewFields {
-  val structure: Relation[SthViewFields, SthViewRow, SthViewRow] = 
-    new Impl(None, identity, (_, x) => x)
+  lazy val structure: Relation[SthViewFields, SthViewRow] =
+    new Impl(Nil)
     
-  private final class Impl[Row](val prefix: Option[String], val extract: Row => SthViewRow, val merge: (Row, SthViewRow) => Row)
-    extends Relation[SthViewFields, SthViewRow, Row] { 
+  private final class Impl(val _path: List[Path])
+    extends Relation[SthViewFields, SthViewRow] {
   
-    override val fields: SthViewFields[Row] = new SthViewFields[Row] {
-      override val id = new Field[SalesterritoryId, Row](prefix, "id", None, None)(x => extract(x).id, (row, value) => merge(row, extract(row).copy(id = value)))
-      override val businessentityid = new Field[BusinessentityId, Row](prefix, "businessentityid", None, None)(x => extract(x).businessentityid, (row, value) => merge(row, extract(row).copy(businessentityid = value)))
-      override val territoryid = new Field[SalesterritoryId, Row](prefix, "territoryid", None, None)(x => extract(x).territoryid, (row, value) => merge(row, extract(row).copy(territoryid = value)))
-      override val startdate = new Field[TypoLocalDateTime, Row](prefix, "startdate", Some("text"), None)(x => extract(x).startdate, (row, value) => merge(row, extract(row).copy(startdate = value)))
-      override val enddate = new OptField[TypoLocalDateTime, Row](prefix, "enddate", Some("text"), None)(x => extract(x).enddate, (row, value) => merge(row, extract(row).copy(enddate = value)))
-      override val rowguid = new Field[TypoUUID, Row](prefix, "rowguid", None, None)(x => extract(x).rowguid, (row, value) => merge(row, extract(row).copy(rowguid = value)))
-      override val modifieddate = new Field[TypoLocalDateTime, Row](prefix, "modifieddate", Some("text"), None)(x => extract(x).modifieddate, (row, value) => merge(row, extract(row).copy(modifieddate = value)))
+    override lazy val fields: SthViewFields = new SthViewFields {
+      override def id = Field[SalesterritoryId, SthViewRow](_path, "id", None, None, x => x.id, (row, value) => row.copy(id = value))
+      override def businessentityid = Field[BusinessentityId, SthViewRow](_path, "businessentityid", None, None, x => x.businessentityid, (row, value) => row.copy(businessentityid = value))
+      override def territoryid = Field[SalesterritoryId, SthViewRow](_path, "territoryid", None, None, x => x.territoryid, (row, value) => row.copy(territoryid = value))
+      override def startdate = Field[TypoLocalDateTime, SthViewRow](_path, "startdate", Some("text"), None, x => x.startdate, (row, value) => row.copy(startdate = value))
+      override def enddate = OptField[TypoLocalDateTime, SthViewRow](_path, "enddate", Some("text"), None, x => x.enddate, (row, value) => row.copy(enddate = value))
+      override def rowguid = Field[TypoUUID, SthViewRow](_path, "rowguid", None, None, x => x.rowguid, (row, value) => row.copy(rowguid = value))
+      override def modifieddate = Field[TypoLocalDateTime, SthViewRow](_path, "modifieddate", Some("text"), None, x => x.modifieddate, (row, value) => row.copy(modifieddate = value))
     }
   
-    override val columns: List[FieldLikeNoHkt[?, Row]] =
-      List[FieldLikeNoHkt[?, Row]](fields.id, fields.businessentityid, fields.territoryid, fields.startdate, fields.enddate, fields.rowguid, fields.modifieddate)
+    override lazy val columns: List[FieldLikeNoHkt[?, SthViewRow]] =
+      List[FieldLikeNoHkt[?, SthViewRow]](fields.id, fields.businessentityid, fields.territoryid, fields.startdate, fields.enddate, fields.rowguid, fields.modifieddate)
   
-    override def copy[NewRow](prefix: Option[String], extract: NewRow => SthViewRow, merge: (NewRow, SthViewRow) => NewRow): Impl[NewRow] =
-      new Impl(prefix, extract, merge)
+    override def copy(path: List[Path]): Impl =
+      new Impl(path)
   }
   
 }

--- a/typo-tester-anorm/generated-and-checked-in/adventureworks/sa/tr/TrViewFields.scala
+++ b/typo-tester-anorm/generated-and-checked-in/adventureworks/sa/tr/TrViewFields.scala
@@ -13,44 +13,45 @@ import adventureworks.customtypes.TypoUUID
 import adventureworks.person.stateprovince.StateprovinceId
 import adventureworks.public.Name
 import adventureworks.sales.salestaxrate.SalestaxrateId
+import typo.dsl.Path
 import typo.dsl.SqlExpr.Field
 import typo.dsl.SqlExpr.FieldLikeNoHkt
 import typo.dsl.Structure.Relation
 
-trait TrViewFields[Row] {
-  val id: Field[SalestaxrateId, Row]
-  val salestaxrateid: Field[SalestaxrateId, Row]
-  val stateprovinceid: Field[StateprovinceId, Row]
-  val taxtype: Field[TypoShort, Row]
-  val taxrate: Field[BigDecimal, Row]
-  val name: Field[Name, Row]
-  val rowguid: Field[TypoUUID, Row]
-  val modifieddate: Field[TypoLocalDateTime, Row]
+trait TrViewFields {
+  def id: Field[SalestaxrateId, TrViewRow]
+  def salestaxrateid: Field[SalestaxrateId, TrViewRow]
+  def stateprovinceid: Field[StateprovinceId, TrViewRow]
+  def taxtype: Field[TypoShort, TrViewRow]
+  def taxrate: Field[BigDecimal, TrViewRow]
+  def name: Field[Name, TrViewRow]
+  def rowguid: Field[TypoUUID, TrViewRow]
+  def modifieddate: Field[TypoLocalDateTime, TrViewRow]
 }
 
 object TrViewFields {
-  val structure: Relation[TrViewFields, TrViewRow, TrViewRow] = 
-    new Impl(None, identity, (_, x) => x)
+  lazy val structure: Relation[TrViewFields, TrViewRow] =
+    new Impl(Nil)
     
-  private final class Impl[Row](val prefix: Option[String], val extract: Row => TrViewRow, val merge: (Row, TrViewRow) => Row)
-    extends Relation[TrViewFields, TrViewRow, Row] { 
+  private final class Impl(val _path: List[Path])
+    extends Relation[TrViewFields, TrViewRow] {
   
-    override val fields: TrViewFields[Row] = new TrViewFields[Row] {
-      override val id = new Field[SalestaxrateId, Row](prefix, "id", None, None)(x => extract(x).id, (row, value) => merge(row, extract(row).copy(id = value)))
-      override val salestaxrateid = new Field[SalestaxrateId, Row](prefix, "salestaxrateid", None, None)(x => extract(x).salestaxrateid, (row, value) => merge(row, extract(row).copy(salestaxrateid = value)))
-      override val stateprovinceid = new Field[StateprovinceId, Row](prefix, "stateprovinceid", None, None)(x => extract(x).stateprovinceid, (row, value) => merge(row, extract(row).copy(stateprovinceid = value)))
-      override val taxtype = new Field[TypoShort, Row](prefix, "taxtype", None, None)(x => extract(x).taxtype, (row, value) => merge(row, extract(row).copy(taxtype = value)))
-      override val taxrate = new Field[BigDecimal, Row](prefix, "taxrate", None, None)(x => extract(x).taxrate, (row, value) => merge(row, extract(row).copy(taxrate = value)))
-      override val name = new Field[Name, Row](prefix, "name", None, None)(x => extract(x).name, (row, value) => merge(row, extract(row).copy(name = value)))
-      override val rowguid = new Field[TypoUUID, Row](prefix, "rowguid", None, None)(x => extract(x).rowguid, (row, value) => merge(row, extract(row).copy(rowguid = value)))
-      override val modifieddate = new Field[TypoLocalDateTime, Row](prefix, "modifieddate", Some("text"), None)(x => extract(x).modifieddate, (row, value) => merge(row, extract(row).copy(modifieddate = value)))
+    override lazy val fields: TrViewFields = new TrViewFields {
+      override def id = Field[SalestaxrateId, TrViewRow](_path, "id", None, None, x => x.id, (row, value) => row.copy(id = value))
+      override def salestaxrateid = Field[SalestaxrateId, TrViewRow](_path, "salestaxrateid", None, None, x => x.salestaxrateid, (row, value) => row.copy(salestaxrateid = value))
+      override def stateprovinceid = Field[StateprovinceId, TrViewRow](_path, "stateprovinceid", None, None, x => x.stateprovinceid, (row, value) => row.copy(stateprovinceid = value))
+      override def taxtype = Field[TypoShort, TrViewRow](_path, "taxtype", None, None, x => x.taxtype, (row, value) => row.copy(taxtype = value))
+      override def taxrate = Field[BigDecimal, TrViewRow](_path, "taxrate", None, None, x => x.taxrate, (row, value) => row.copy(taxrate = value))
+      override def name = Field[Name, TrViewRow](_path, "name", None, None, x => x.name, (row, value) => row.copy(name = value))
+      override def rowguid = Field[TypoUUID, TrViewRow](_path, "rowguid", None, None, x => x.rowguid, (row, value) => row.copy(rowguid = value))
+      override def modifieddate = Field[TypoLocalDateTime, TrViewRow](_path, "modifieddate", Some("text"), None, x => x.modifieddate, (row, value) => row.copy(modifieddate = value))
     }
   
-    override val columns: List[FieldLikeNoHkt[?, Row]] =
-      List[FieldLikeNoHkt[?, Row]](fields.id, fields.salestaxrateid, fields.stateprovinceid, fields.taxtype, fields.taxrate, fields.name, fields.rowguid, fields.modifieddate)
+    override lazy val columns: List[FieldLikeNoHkt[?, TrViewRow]] =
+      List[FieldLikeNoHkt[?, TrViewRow]](fields.id, fields.salestaxrateid, fields.stateprovinceid, fields.taxtype, fields.taxrate, fields.name, fields.rowguid, fields.modifieddate)
   
-    override def copy[NewRow](prefix: Option[String], extract: NewRow => TrViewRow, merge: (NewRow, TrViewRow) => NewRow): Impl[NewRow] =
-      new Impl(prefix, extract, merge)
+    override def copy(path: List[Path]): Impl =
+      new Impl(path)
   }
   
 }

--- a/typo-tester-anorm/generated-and-checked-in/adventureworks/sales/countryregioncurrency/CountryregioncurrencyFields.scala
+++ b/typo-tester-anorm/generated-and-checked-in/adventureworks/sales/countryregioncurrency/CountryregioncurrencyFields.scala
@@ -10,35 +10,36 @@ package countryregioncurrency
 import adventureworks.customtypes.TypoLocalDateTime
 import adventureworks.person.countryregion.CountryregionId
 import adventureworks.sales.currency.CurrencyId
+import typo.dsl.Path
 import typo.dsl.SqlExpr.Field
 import typo.dsl.SqlExpr.FieldLikeNoHkt
 import typo.dsl.SqlExpr.IdField
 import typo.dsl.Structure.Relation
 
-trait CountryregioncurrencyFields[Row] {
-  val countryregioncode: IdField[CountryregionId, Row]
-  val currencycode: IdField[CurrencyId, Row]
-  val modifieddate: Field[TypoLocalDateTime, Row]
+trait CountryregioncurrencyFields {
+  def countryregioncode: IdField[CountryregionId, CountryregioncurrencyRow]
+  def currencycode: IdField[CurrencyId, CountryregioncurrencyRow]
+  def modifieddate: Field[TypoLocalDateTime, CountryregioncurrencyRow]
 }
 
 object CountryregioncurrencyFields {
-  val structure: Relation[CountryregioncurrencyFields, CountryregioncurrencyRow, CountryregioncurrencyRow] = 
-    new Impl(None, identity, (_, x) => x)
+  lazy val structure: Relation[CountryregioncurrencyFields, CountryregioncurrencyRow] =
+    new Impl(Nil)
     
-  private final class Impl[Row](val prefix: Option[String], val extract: Row => CountryregioncurrencyRow, val merge: (Row, CountryregioncurrencyRow) => Row)
-    extends Relation[CountryregioncurrencyFields, CountryregioncurrencyRow, Row] { 
+  private final class Impl(val _path: List[Path])
+    extends Relation[CountryregioncurrencyFields, CountryregioncurrencyRow] {
   
-    override val fields: CountryregioncurrencyFields[Row] = new CountryregioncurrencyFields[Row] {
-      override val countryregioncode = new IdField[CountryregionId, Row](prefix, "countryregioncode", None, None)(x => extract(x).countryregioncode, (row, value) => merge(row, extract(row).copy(countryregioncode = value)))
-      override val currencycode = new IdField[CurrencyId, Row](prefix, "currencycode", None, Some("bpchar"))(x => extract(x).currencycode, (row, value) => merge(row, extract(row).copy(currencycode = value)))
-      override val modifieddate = new Field[TypoLocalDateTime, Row](prefix, "modifieddate", Some("text"), Some("timestamp"))(x => extract(x).modifieddate, (row, value) => merge(row, extract(row).copy(modifieddate = value)))
+    override lazy val fields: CountryregioncurrencyFields = new CountryregioncurrencyFields {
+      override def countryregioncode = IdField[CountryregionId, CountryregioncurrencyRow](_path, "countryregioncode", None, None, x => x.countryregioncode, (row, value) => row.copy(countryregioncode = value))
+      override def currencycode = IdField[CurrencyId, CountryregioncurrencyRow](_path, "currencycode", None, Some("bpchar"), x => x.currencycode, (row, value) => row.copy(currencycode = value))
+      override def modifieddate = Field[TypoLocalDateTime, CountryregioncurrencyRow](_path, "modifieddate", Some("text"), Some("timestamp"), x => x.modifieddate, (row, value) => row.copy(modifieddate = value))
     }
   
-    override val columns: List[FieldLikeNoHkt[?, Row]] =
-      List[FieldLikeNoHkt[?, Row]](fields.countryregioncode, fields.currencycode, fields.modifieddate)
+    override lazy val columns: List[FieldLikeNoHkt[?, CountryregioncurrencyRow]] =
+      List[FieldLikeNoHkt[?, CountryregioncurrencyRow]](fields.countryregioncode, fields.currencycode, fields.modifieddate)
   
-    override def copy[NewRow](prefix: Option[String], extract: NewRow => CountryregioncurrencyRow, merge: (NewRow, CountryregioncurrencyRow) => NewRow): Impl[NewRow] =
-      new Impl(prefix, extract, merge)
+    override def copy(path: List[Path]): Impl =
+      new Impl(path)
   }
   
 }

--- a/typo-tester-anorm/generated-and-checked-in/adventureworks/sales/countryregioncurrency/CountryregioncurrencyRepoMock.scala
+++ b/typo-tester-anorm/generated-and-checked-in/adventureworks/sales/countryregioncurrency/CountryregioncurrencyRepoMock.scala
@@ -22,7 +22,7 @@ import typo.dsl.UpdateParams
 class CountryregioncurrencyRepoMock(toRow: Function1[CountryregioncurrencyRowUnsaved, CountryregioncurrencyRow],
                                     map: scala.collection.mutable.Map[CountryregioncurrencyId, CountryregioncurrencyRow] = scala.collection.mutable.Map.empty) extends CountryregioncurrencyRepo {
   override def delete: DeleteBuilder[CountryregioncurrencyFields, CountryregioncurrencyRow] = {
-    DeleteBuilderMock(DeleteParams.empty, CountryregioncurrencyFields.structure.fields, map)
+    DeleteBuilderMock(DeleteParams.empty, CountryregioncurrencyFields.structure, map)
   }
   override def deleteById(compositeId: CountryregioncurrencyId)(implicit c: Connection): Boolean = {
     map.remove(compositeId).isDefined
@@ -72,7 +72,7 @@ class CountryregioncurrencyRepoMock(toRow: Function1[CountryregioncurrencyRowUns
     compositeIds.view.flatMap(id => byId.get(id).map(x => (id, x))).toMap
   }
   override def update: UpdateBuilder[CountryregioncurrencyFields, CountryregioncurrencyRow] = {
-    UpdateBuilderMock(UpdateParams.empty, CountryregioncurrencyFields.structure.fields, map)
+    UpdateBuilderMock(UpdateParams.empty, CountryregioncurrencyFields.structure, map)
   }
   override def update(row: CountryregioncurrencyRow)(implicit c: Connection): Boolean = {
     map.get(row.compositeId) match {

--- a/typo-tester-anorm/generated-and-checked-in/adventureworks/sales/creditcard/CreditcardFields.scala
+++ b/typo-tester-anorm/generated-and-checked-in/adventureworks/sales/creditcard/CreditcardFields.scala
@@ -10,41 +10,42 @@ package creditcard
 import adventureworks.customtypes.TypoLocalDateTime
 import adventureworks.customtypes.TypoShort
 import adventureworks.userdefined.CustomCreditcardId
+import typo.dsl.Path
 import typo.dsl.SqlExpr.Field
 import typo.dsl.SqlExpr.FieldLikeNoHkt
 import typo.dsl.SqlExpr.IdField
 import typo.dsl.Structure.Relation
 
-trait CreditcardFields[Row] {
-  val creditcardid: IdField[/* user-picked */ CustomCreditcardId, Row]
-  val cardtype: Field[/* max 50 chars */ String, Row]
-  val cardnumber: Field[/* max 25 chars */ String, Row]
-  val expmonth: Field[TypoShort, Row]
-  val expyear: Field[TypoShort, Row]
-  val modifieddate: Field[TypoLocalDateTime, Row]
+trait CreditcardFields {
+  def creditcardid: IdField[/* user-picked */ CustomCreditcardId, CreditcardRow]
+  def cardtype: Field[/* max 50 chars */ String, CreditcardRow]
+  def cardnumber: Field[/* max 25 chars */ String, CreditcardRow]
+  def expmonth: Field[TypoShort, CreditcardRow]
+  def expyear: Field[TypoShort, CreditcardRow]
+  def modifieddate: Field[TypoLocalDateTime, CreditcardRow]
 }
 
 object CreditcardFields {
-  val structure: Relation[CreditcardFields, CreditcardRow, CreditcardRow] = 
-    new Impl(None, identity, (_, x) => x)
+  lazy val structure: Relation[CreditcardFields, CreditcardRow] =
+    new Impl(Nil)
     
-  private final class Impl[Row](val prefix: Option[String], val extract: Row => CreditcardRow, val merge: (Row, CreditcardRow) => Row)
-    extends Relation[CreditcardFields, CreditcardRow, Row] { 
+  private final class Impl(val _path: List[Path])
+    extends Relation[CreditcardFields, CreditcardRow] {
   
-    override val fields: CreditcardFields[Row] = new CreditcardFields[Row] {
-      override val creditcardid = new IdField[/* user-picked */ CustomCreditcardId, Row](prefix, "creditcardid", None, Some("int4"))(x => extract(x).creditcardid, (row, value) => merge(row, extract(row).copy(creditcardid = value)))
-      override val cardtype = new Field[/* max 50 chars */ String, Row](prefix, "cardtype", None, None)(x => extract(x).cardtype, (row, value) => merge(row, extract(row).copy(cardtype = value)))
-      override val cardnumber = new Field[/* max 25 chars */ String, Row](prefix, "cardnumber", None, None)(x => extract(x).cardnumber, (row, value) => merge(row, extract(row).copy(cardnumber = value)))
-      override val expmonth = new Field[TypoShort, Row](prefix, "expmonth", None, Some("int2"))(x => extract(x).expmonth, (row, value) => merge(row, extract(row).copy(expmonth = value)))
-      override val expyear = new Field[TypoShort, Row](prefix, "expyear", None, Some("int2"))(x => extract(x).expyear, (row, value) => merge(row, extract(row).copy(expyear = value)))
-      override val modifieddate = new Field[TypoLocalDateTime, Row](prefix, "modifieddate", Some("text"), Some("timestamp"))(x => extract(x).modifieddate, (row, value) => merge(row, extract(row).copy(modifieddate = value)))
+    override lazy val fields: CreditcardFields = new CreditcardFields {
+      override def creditcardid = IdField[/* user-picked */ CustomCreditcardId, CreditcardRow](_path, "creditcardid", None, Some("int4"), x => x.creditcardid, (row, value) => row.copy(creditcardid = value))
+      override def cardtype = Field[/* max 50 chars */ String, CreditcardRow](_path, "cardtype", None, None, x => x.cardtype, (row, value) => row.copy(cardtype = value))
+      override def cardnumber = Field[/* max 25 chars */ String, CreditcardRow](_path, "cardnumber", None, None, x => x.cardnumber, (row, value) => row.copy(cardnumber = value))
+      override def expmonth = Field[TypoShort, CreditcardRow](_path, "expmonth", None, Some("int2"), x => x.expmonth, (row, value) => row.copy(expmonth = value))
+      override def expyear = Field[TypoShort, CreditcardRow](_path, "expyear", None, Some("int2"), x => x.expyear, (row, value) => row.copy(expyear = value))
+      override def modifieddate = Field[TypoLocalDateTime, CreditcardRow](_path, "modifieddate", Some("text"), Some("timestamp"), x => x.modifieddate, (row, value) => row.copy(modifieddate = value))
     }
   
-    override val columns: List[FieldLikeNoHkt[?, Row]] =
-      List[FieldLikeNoHkt[?, Row]](fields.creditcardid, fields.cardtype, fields.cardnumber, fields.expmonth, fields.expyear, fields.modifieddate)
+    override lazy val columns: List[FieldLikeNoHkt[?, CreditcardRow]] =
+      List[FieldLikeNoHkt[?, CreditcardRow]](fields.creditcardid, fields.cardtype, fields.cardnumber, fields.expmonth, fields.expyear, fields.modifieddate)
   
-    override def copy[NewRow](prefix: Option[String], extract: NewRow => CreditcardRow, merge: (NewRow, CreditcardRow) => NewRow): Impl[NewRow] =
-      new Impl(prefix, extract, merge)
+    override def copy(path: List[Path]): Impl =
+      new Impl(path)
   }
   
 }

--- a/typo-tester-anorm/generated-and-checked-in/adventureworks/sales/creditcard/CreditcardRepoMock.scala
+++ b/typo-tester-anorm/generated-and-checked-in/adventureworks/sales/creditcard/CreditcardRepoMock.scala
@@ -24,7 +24,7 @@ import typo.dsl.UpdateParams
 class CreditcardRepoMock(toRow: Function1[CreditcardRowUnsaved, CreditcardRow],
                          map: scala.collection.mutable.Map[/* user-picked */ CustomCreditcardId, CreditcardRow] = scala.collection.mutable.Map.empty) extends CreditcardRepo {
   override def delete: DeleteBuilder[CreditcardFields, CreditcardRow] = {
-    DeleteBuilderMock(DeleteParams.empty, CreditcardFields.structure.fields, map)
+    DeleteBuilderMock(DeleteParams.empty, CreditcardFields.structure, map)
   }
   override def deleteById(creditcardid: /* user-picked */ CustomCreditcardId)(implicit c: Connection): Boolean = {
     map.remove(creditcardid).isDefined
@@ -74,7 +74,7 @@ class CreditcardRepoMock(toRow: Function1[CreditcardRowUnsaved, CreditcardRow],
     creditcardids.view.flatMap(id => byId.get(id).map(x => (id, x))).toMap
   }
   override def update: UpdateBuilder[CreditcardFields, CreditcardRow] = {
-    UpdateBuilderMock(UpdateParams.empty, CreditcardFields.structure.fields, map)
+    UpdateBuilderMock(UpdateParams.empty, CreditcardFields.structure, map)
   }
   override def update(row: CreditcardRow)(implicit c: Connection): Boolean = {
     map.get(row.creditcardid) match {

--- a/typo-tester-anorm/generated-and-checked-in/adventureworks/sales/currency/CurrencyFields.scala
+++ b/typo-tester-anorm/generated-and-checked-in/adventureworks/sales/currency/CurrencyFields.scala
@@ -9,35 +9,36 @@ package currency
 
 import adventureworks.customtypes.TypoLocalDateTime
 import adventureworks.public.Name
+import typo.dsl.Path
 import typo.dsl.SqlExpr.Field
 import typo.dsl.SqlExpr.FieldLikeNoHkt
 import typo.dsl.SqlExpr.IdField
 import typo.dsl.Structure.Relation
 
-trait CurrencyFields[Row] {
-  val currencycode: IdField[CurrencyId, Row]
-  val name: Field[Name, Row]
-  val modifieddate: Field[TypoLocalDateTime, Row]
+trait CurrencyFields {
+  def currencycode: IdField[CurrencyId, CurrencyRow]
+  def name: Field[Name, CurrencyRow]
+  def modifieddate: Field[TypoLocalDateTime, CurrencyRow]
 }
 
 object CurrencyFields {
-  val structure: Relation[CurrencyFields, CurrencyRow, CurrencyRow] = 
-    new Impl(None, identity, (_, x) => x)
+  lazy val structure: Relation[CurrencyFields, CurrencyRow] =
+    new Impl(Nil)
     
-  private final class Impl[Row](val prefix: Option[String], val extract: Row => CurrencyRow, val merge: (Row, CurrencyRow) => Row)
-    extends Relation[CurrencyFields, CurrencyRow, Row] { 
+  private final class Impl(val _path: List[Path])
+    extends Relation[CurrencyFields, CurrencyRow] {
   
-    override val fields: CurrencyFields[Row] = new CurrencyFields[Row] {
-      override val currencycode = new IdField[CurrencyId, Row](prefix, "currencycode", None, Some("bpchar"))(x => extract(x).currencycode, (row, value) => merge(row, extract(row).copy(currencycode = value)))
-      override val name = new Field[Name, Row](prefix, "name", None, Some("varchar"))(x => extract(x).name, (row, value) => merge(row, extract(row).copy(name = value)))
-      override val modifieddate = new Field[TypoLocalDateTime, Row](prefix, "modifieddate", Some("text"), Some("timestamp"))(x => extract(x).modifieddate, (row, value) => merge(row, extract(row).copy(modifieddate = value)))
+    override lazy val fields: CurrencyFields = new CurrencyFields {
+      override def currencycode = IdField[CurrencyId, CurrencyRow](_path, "currencycode", None, Some("bpchar"), x => x.currencycode, (row, value) => row.copy(currencycode = value))
+      override def name = Field[Name, CurrencyRow](_path, "name", None, Some("varchar"), x => x.name, (row, value) => row.copy(name = value))
+      override def modifieddate = Field[TypoLocalDateTime, CurrencyRow](_path, "modifieddate", Some("text"), Some("timestamp"), x => x.modifieddate, (row, value) => row.copy(modifieddate = value))
     }
   
-    override val columns: List[FieldLikeNoHkt[?, Row]] =
-      List[FieldLikeNoHkt[?, Row]](fields.currencycode, fields.name, fields.modifieddate)
+    override lazy val columns: List[FieldLikeNoHkt[?, CurrencyRow]] =
+      List[FieldLikeNoHkt[?, CurrencyRow]](fields.currencycode, fields.name, fields.modifieddate)
   
-    override def copy[NewRow](prefix: Option[String], extract: NewRow => CurrencyRow, merge: (NewRow, CurrencyRow) => NewRow): Impl[NewRow] =
-      new Impl(prefix, extract, merge)
+    override def copy(path: List[Path]): Impl =
+      new Impl(path)
   }
   
 }

--- a/typo-tester-anorm/generated-and-checked-in/adventureworks/sales/currency/CurrencyRepoMock.scala
+++ b/typo-tester-anorm/generated-and-checked-in/adventureworks/sales/currency/CurrencyRepoMock.scala
@@ -22,7 +22,7 @@ import typo.dsl.UpdateParams
 class CurrencyRepoMock(toRow: Function1[CurrencyRowUnsaved, CurrencyRow],
                        map: scala.collection.mutable.Map[CurrencyId, CurrencyRow] = scala.collection.mutable.Map.empty) extends CurrencyRepo {
   override def delete: DeleteBuilder[CurrencyFields, CurrencyRow] = {
-    DeleteBuilderMock(DeleteParams.empty, CurrencyFields.structure.fields, map)
+    DeleteBuilderMock(DeleteParams.empty, CurrencyFields.structure, map)
   }
   override def deleteById(currencycode: CurrencyId)(implicit c: Connection): Boolean = {
     map.remove(currencycode).isDefined
@@ -72,7 +72,7 @@ class CurrencyRepoMock(toRow: Function1[CurrencyRowUnsaved, CurrencyRow],
     currencycodes.view.flatMap(id => byId.get(id).map(x => (id, x))).toMap
   }
   override def update: UpdateBuilder[CurrencyFields, CurrencyRow] = {
-    UpdateBuilderMock(UpdateParams.empty, CurrencyFields.structure.fields, map)
+    UpdateBuilderMock(UpdateParams.empty, CurrencyFields.structure, map)
   }
   override def update(row: CurrencyRow)(implicit c: Connection): Boolean = {
     map.get(row.currencycode) match {

--- a/typo-tester-anorm/generated-and-checked-in/adventureworks/sales/currencyrate/CurrencyrateFields.scala
+++ b/typo-tester-anorm/generated-and-checked-in/adventureworks/sales/currencyrate/CurrencyrateFields.scala
@@ -9,43 +9,44 @@ package currencyrate
 
 import adventureworks.customtypes.TypoLocalDateTime
 import adventureworks.sales.currency.CurrencyId
+import typo.dsl.Path
 import typo.dsl.SqlExpr.Field
 import typo.dsl.SqlExpr.FieldLikeNoHkt
 import typo.dsl.SqlExpr.IdField
 import typo.dsl.Structure.Relation
 
-trait CurrencyrateFields[Row] {
-  val currencyrateid: IdField[CurrencyrateId, Row]
-  val currencyratedate: Field[TypoLocalDateTime, Row]
-  val fromcurrencycode: Field[CurrencyId, Row]
-  val tocurrencycode: Field[CurrencyId, Row]
-  val averagerate: Field[BigDecimal, Row]
-  val endofdayrate: Field[BigDecimal, Row]
-  val modifieddate: Field[TypoLocalDateTime, Row]
+trait CurrencyrateFields {
+  def currencyrateid: IdField[CurrencyrateId, CurrencyrateRow]
+  def currencyratedate: Field[TypoLocalDateTime, CurrencyrateRow]
+  def fromcurrencycode: Field[CurrencyId, CurrencyrateRow]
+  def tocurrencycode: Field[CurrencyId, CurrencyrateRow]
+  def averagerate: Field[BigDecimal, CurrencyrateRow]
+  def endofdayrate: Field[BigDecimal, CurrencyrateRow]
+  def modifieddate: Field[TypoLocalDateTime, CurrencyrateRow]
 }
 
 object CurrencyrateFields {
-  val structure: Relation[CurrencyrateFields, CurrencyrateRow, CurrencyrateRow] = 
-    new Impl(None, identity, (_, x) => x)
+  lazy val structure: Relation[CurrencyrateFields, CurrencyrateRow] =
+    new Impl(Nil)
     
-  private final class Impl[Row](val prefix: Option[String], val extract: Row => CurrencyrateRow, val merge: (Row, CurrencyrateRow) => Row)
-    extends Relation[CurrencyrateFields, CurrencyrateRow, Row] { 
+  private final class Impl(val _path: List[Path])
+    extends Relation[CurrencyrateFields, CurrencyrateRow] {
   
-    override val fields: CurrencyrateFields[Row] = new CurrencyrateFields[Row] {
-      override val currencyrateid = new IdField[CurrencyrateId, Row](prefix, "currencyrateid", None, Some("int4"))(x => extract(x).currencyrateid, (row, value) => merge(row, extract(row).copy(currencyrateid = value)))
-      override val currencyratedate = new Field[TypoLocalDateTime, Row](prefix, "currencyratedate", Some("text"), Some("timestamp"))(x => extract(x).currencyratedate, (row, value) => merge(row, extract(row).copy(currencyratedate = value)))
-      override val fromcurrencycode = new Field[CurrencyId, Row](prefix, "fromcurrencycode", None, Some("bpchar"))(x => extract(x).fromcurrencycode, (row, value) => merge(row, extract(row).copy(fromcurrencycode = value)))
-      override val tocurrencycode = new Field[CurrencyId, Row](prefix, "tocurrencycode", None, Some("bpchar"))(x => extract(x).tocurrencycode, (row, value) => merge(row, extract(row).copy(tocurrencycode = value)))
-      override val averagerate = new Field[BigDecimal, Row](prefix, "averagerate", None, Some("numeric"))(x => extract(x).averagerate, (row, value) => merge(row, extract(row).copy(averagerate = value)))
-      override val endofdayrate = new Field[BigDecimal, Row](prefix, "endofdayrate", None, Some("numeric"))(x => extract(x).endofdayrate, (row, value) => merge(row, extract(row).copy(endofdayrate = value)))
-      override val modifieddate = new Field[TypoLocalDateTime, Row](prefix, "modifieddate", Some("text"), Some("timestamp"))(x => extract(x).modifieddate, (row, value) => merge(row, extract(row).copy(modifieddate = value)))
+    override lazy val fields: CurrencyrateFields = new CurrencyrateFields {
+      override def currencyrateid = IdField[CurrencyrateId, CurrencyrateRow](_path, "currencyrateid", None, Some("int4"), x => x.currencyrateid, (row, value) => row.copy(currencyrateid = value))
+      override def currencyratedate = Field[TypoLocalDateTime, CurrencyrateRow](_path, "currencyratedate", Some("text"), Some("timestamp"), x => x.currencyratedate, (row, value) => row.copy(currencyratedate = value))
+      override def fromcurrencycode = Field[CurrencyId, CurrencyrateRow](_path, "fromcurrencycode", None, Some("bpchar"), x => x.fromcurrencycode, (row, value) => row.copy(fromcurrencycode = value))
+      override def tocurrencycode = Field[CurrencyId, CurrencyrateRow](_path, "tocurrencycode", None, Some("bpchar"), x => x.tocurrencycode, (row, value) => row.copy(tocurrencycode = value))
+      override def averagerate = Field[BigDecimal, CurrencyrateRow](_path, "averagerate", None, Some("numeric"), x => x.averagerate, (row, value) => row.copy(averagerate = value))
+      override def endofdayrate = Field[BigDecimal, CurrencyrateRow](_path, "endofdayrate", None, Some("numeric"), x => x.endofdayrate, (row, value) => row.copy(endofdayrate = value))
+      override def modifieddate = Field[TypoLocalDateTime, CurrencyrateRow](_path, "modifieddate", Some("text"), Some("timestamp"), x => x.modifieddate, (row, value) => row.copy(modifieddate = value))
     }
   
-    override val columns: List[FieldLikeNoHkt[?, Row]] =
-      List[FieldLikeNoHkt[?, Row]](fields.currencyrateid, fields.currencyratedate, fields.fromcurrencycode, fields.tocurrencycode, fields.averagerate, fields.endofdayrate, fields.modifieddate)
+    override lazy val columns: List[FieldLikeNoHkt[?, CurrencyrateRow]] =
+      List[FieldLikeNoHkt[?, CurrencyrateRow]](fields.currencyrateid, fields.currencyratedate, fields.fromcurrencycode, fields.tocurrencycode, fields.averagerate, fields.endofdayrate, fields.modifieddate)
   
-    override def copy[NewRow](prefix: Option[String], extract: NewRow => CurrencyrateRow, merge: (NewRow, CurrencyrateRow) => NewRow): Impl[NewRow] =
-      new Impl(prefix, extract, merge)
+    override def copy(path: List[Path]): Impl =
+      new Impl(path)
   }
   
 }

--- a/typo-tester-anorm/generated-and-checked-in/adventureworks/sales/currencyrate/CurrencyrateRepoMock.scala
+++ b/typo-tester-anorm/generated-and-checked-in/adventureworks/sales/currencyrate/CurrencyrateRepoMock.scala
@@ -22,7 +22,7 @@ import typo.dsl.UpdateParams
 class CurrencyrateRepoMock(toRow: Function1[CurrencyrateRowUnsaved, CurrencyrateRow],
                            map: scala.collection.mutable.Map[CurrencyrateId, CurrencyrateRow] = scala.collection.mutable.Map.empty) extends CurrencyrateRepo {
   override def delete: DeleteBuilder[CurrencyrateFields, CurrencyrateRow] = {
-    DeleteBuilderMock(DeleteParams.empty, CurrencyrateFields.structure.fields, map)
+    DeleteBuilderMock(DeleteParams.empty, CurrencyrateFields.structure, map)
   }
   override def deleteById(currencyrateid: CurrencyrateId)(implicit c: Connection): Boolean = {
     map.remove(currencyrateid).isDefined
@@ -72,7 +72,7 @@ class CurrencyrateRepoMock(toRow: Function1[CurrencyrateRowUnsaved, Currencyrate
     currencyrateids.view.flatMap(id => byId.get(id).map(x => (id, x))).toMap
   }
   override def update: UpdateBuilder[CurrencyrateFields, CurrencyrateRow] = {
-    UpdateBuilderMock(UpdateParams.empty, CurrencyrateFields.structure.fields, map)
+    UpdateBuilderMock(UpdateParams.empty, CurrencyrateFields.structure, map)
   }
   override def update(row: CurrencyrateRow)(implicit c: Connection): Boolean = {
     map.get(row.currencyrateid) match {

--- a/typo-tester-anorm/generated-and-checked-in/adventureworks/sales/customer/CustomerFields.scala
+++ b/typo-tester-anorm/generated-and-checked-in/adventureworks/sales/customer/CustomerFields.scala
@@ -11,42 +11,43 @@ import adventureworks.customtypes.TypoLocalDateTime
 import adventureworks.customtypes.TypoUUID
 import adventureworks.person.businessentity.BusinessentityId
 import adventureworks.sales.salesterritory.SalesterritoryId
+import typo.dsl.Path
 import typo.dsl.SqlExpr.Field
 import typo.dsl.SqlExpr.FieldLikeNoHkt
 import typo.dsl.SqlExpr.IdField
 import typo.dsl.SqlExpr.OptField
 import typo.dsl.Structure.Relation
 
-trait CustomerFields[Row] {
-  val customerid: IdField[CustomerId, Row]
-  val personid: OptField[BusinessentityId, Row]
-  val storeid: OptField[BusinessentityId, Row]
-  val territoryid: OptField[SalesterritoryId, Row]
-  val rowguid: Field[TypoUUID, Row]
-  val modifieddate: Field[TypoLocalDateTime, Row]
+trait CustomerFields {
+  def customerid: IdField[CustomerId, CustomerRow]
+  def personid: OptField[BusinessentityId, CustomerRow]
+  def storeid: OptField[BusinessentityId, CustomerRow]
+  def territoryid: OptField[SalesterritoryId, CustomerRow]
+  def rowguid: Field[TypoUUID, CustomerRow]
+  def modifieddate: Field[TypoLocalDateTime, CustomerRow]
 }
 
 object CustomerFields {
-  val structure: Relation[CustomerFields, CustomerRow, CustomerRow] = 
-    new Impl(None, identity, (_, x) => x)
+  lazy val structure: Relation[CustomerFields, CustomerRow] =
+    new Impl(Nil)
     
-  private final class Impl[Row](val prefix: Option[String], val extract: Row => CustomerRow, val merge: (Row, CustomerRow) => Row)
-    extends Relation[CustomerFields, CustomerRow, Row] { 
+  private final class Impl(val _path: List[Path])
+    extends Relation[CustomerFields, CustomerRow] {
   
-    override val fields: CustomerFields[Row] = new CustomerFields[Row] {
-      override val customerid = new IdField[CustomerId, Row](prefix, "customerid", None, Some("int4"))(x => extract(x).customerid, (row, value) => merge(row, extract(row).copy(customerid = value)))
-      override val personid = new OptField[BusinessentityId, Row](prefix, "personid", None, Some("int4"))(x => extract(x).personid, (row, value) => merge(row, extract(row).copy(personid = value)))
-      override val storeid = new OptField[BusinessentityId, Row](prefix, "storeid", None, Some("int4"))(x => extract(x).storeid, (row, value) => merge(row, extract(row).copy(storeid = value)))
-      override val territoryid = new OptField[SalesterritoryId, Row](prefix, "territoryid", None, Some("int4"))(x => extract(x).territoryid, (row, value) => merge(row, extract(row).copy(territoryid = value)))
-      override val rowguid = new Field[TypoUUID, Row](prefix, "rowguid", None, Some("uuid"))(x => extract(x).rowguid, (row, value) => merge(row, extract(row).copy(rowguid = value)))
-      override val modifieddate = new Field[TypoLocalDateTime, Row](prefix, "modifieddate", Some("text"), Some("timestamp"))(x => extract(x).modifieddate, (row, value) => merge(row, extract(row).copy(modifieddate = value)))
+    override lazy val fields: CustomerFields = new CustomerFields {
+      override def customerid = IdField[CustomerId, CustomerRow](_path, "customerid", None, Some("int4"), x => x.customerid, (row, value) => row.copy(customerid = value))
+      override def personid = OptField[BusinessentityId, CustomerRow](_path, "personid", None, Some("int4"), x => x.personid, (row, value) => row.copy(personid = value))
+      override def storeid = OptField[BusinessentityId, CustomerRow](_path, "storeid", None, Some("int4"), x => x.storeid, (row, value) => row.copy(storeid = value))
+      override def territoryid = OptField[SalesterritoryId, CustomerRow](_path, "territoryid", None, Some("int4"), x => x.territoryid, (row, value) => row.copy(territoryid = value))
+      override def rowguid = Field[TypoUUID, CustomerRow](_path, "rowguid", None, Some("uuid"), x => x.rowguid, (row, value) => row.copy(rowguid = value))
+      override def modifieddate = Field[TypoLocalDateTime, CustomerRow](_path, "modifieddate", Some("text"), Some("timestamp"), x => x.modifieddate, (row, value) => row.copy(modifieddate = value))
     }
   
-    override val columns: List[FieldLikeNoHkt[?, Row]] =
-      List[FieldLikeNoHkt[?, Row]](fields.customerid, fields.personid, fields.storeid, fields.territoryid, fields.rowguid, fields.modifieddate)
+    override lazy val columns: List[FieldLikeNoHkt[?, CustomerRow]] =
+      List[FieldLikeNoHkt[?, CustomerRow]](fields.customerid, fields.personid, fields.storeid, fields.territoryid, fields.rowguid, fields.modifieddate)
   
-    override def copy[NewRow](prefix: Option[String], extract: NewRow => CustomerRow, merge: (NewRow, CustomerRow) => NewRow): Impl[NewRow] =
-      new Impl(prefix, extract, merge)
+    override def copy(path: List[Path]): Impl =
+      new Impl(path)
   }
   
 }

--- a/typo-tester-anorm/generated-and-checked-in/adventureworks/sales/customer/CustomerRepoMock.scala
+++ b/typo-tester-anorm/generated-and-checked-in/adventureworks/sales/customer/CustomerRepoMock.scala
@@ -22,7 +22,7 @@ import typo.dsl.UpdateParams
 class CustomerRepoMock(toRow: Function1[CustomerRowUnsaved, CustomerRow],
                        map: scala.collection.mutable.Map[CustomerId, CustomerRow] = scala.collection.mutable.Map.empty) extends CustomerRepo {
   override def delete: DeleteBuilder[CustomerFields, CustomerRow] = {
-    DeleteBuilderMock(DeleteParams.empty, CustomerFields.structure.fields, map)
+    DeleteBuilderMock(DeleteParams.empty, CustomerFields.structure, map)
   }
   override def deleteById(customerid: CustomerId)(implicit c: Connection): Boolean = {
     map.remove(customerid).isDefined
@@ -72,7 +72,7 @@ class CustomerRepoMock(toRow: Function1[CustomerRowUnsaved, CustomerRow],
     customerids.view.flatMap(id => byId.get(id).map(x => (id, x))).toMap
   }
   override def update: UpdateBuilder[CustomerFields, CustomerRow] = {
-    UpdateBuilderMock(UpdateParams.empty, CustomerFields.structure.fields, map)
+    UpdateBuilderMock(UpdateParams.empty, CustomerFields.structure, map)
   }
   override def update(row: CustomerRow)(implicit c: Connection): Boolean = {
     map.get(row.customerid) match {

--- a/typo-tester-anorm/generated-and-checked-in/adventureworks/sales/personcreditcard/PersoncreditcardFields.scala
+++ b/typo-tester-anorm/generated-and-checked-in/adventureworks/sales/personcreditcard/PersoncreditcardFields.scala
@@ -10,35 +10,36 @@ package personcreditcard
 import adventureworks.customtypes.TypoLocalDateTime
 import adventureworks.person.businessentity.BusinessentityId
 import adventureworks.userdefined.CustomCreditcardId
+import typo.dsl.Path
 import typo.dsl.SqlExpr.Field
 import typo.dsl.SqlExpr.FieldLikeNoHkt
 import typo.dsl.SqlExpr.IdField
 import typo.dsl.Structure.Relation
 
-trait PersoncreditcardFields[Row] {
-  val businessentityid: IdField[BusinessentityId, Row]
-  val creditcardid: IdField[/* user-picked */ CustomCreditcardId, Row]
-  val modifieddate: Field[TypoLocalDateTime, Row]
+trait PersoncreditcardFields {
+  def businessentityid: IdField[BusinessentityId, PersoncreditcardRow]
+  def creditcardid: IdField[/* user-picked */ CustomCreditcardId, PersoncreditcardRow]
+  def modifieddate: Field[TypoLocalDateTime, PersoncreditcardRow]
 }
 
 object PersoncreditcardFields {
-  val structure: Relation[PersoncreditcardFields, PersoncreditcardRow, PersoncreditcardRow] = 
-    new Impl(None, identity, (_, x) => x)
+  lazy val structure: Relation[PersoncreditcardFields, PersoncreditcardRow] =
+    new Impl(Nil)
     
-  private final class Impl[Row](val prefix: Option[String], val extract: Row => PersoncreditcardRow, val merge: (Row, PersoncreditcardRow) => Row)
-    extends Relation[PersoncreditcardFields, PersoncreditcardRow, Row] { 
+  private final class Impl(val _path: List[Path])
+    extends Relation[PersoncreditcardFields, PersoncreditcardRow] {
   
-    override val fields: PersoncreditcardFields[Row] = new PersoncreditcardFields[Row] {
-      override val businessentityid = new IdField[BusinessentityId, Row](prefix, "businessentityid", None, Some("int4"))(x => extract(x).businessentityid, (row, value) => merge(row, extract(row).copy(businessentityid = value)))
-      override val creditcardid = new IdField[/* user-picked */ CustomCreditcardId, Row](prefix, "creditcardid", None, Some("int4"))(x => extract(x).creditcardid, (row, value) => merge(row, extract(row).copy(creditcardid = value)))
-      override val modifieddate = new Field[TypoLocalDateTime, Row](prefix, "modifieddate", Some("text"), Some("timestamp"))(x => extract(x).modifieddate, (row, value) => merge(row, extract(row).copy(modifieddate = value)))
+    override lazy val fields: PersoncreditcardFields = new PersoncreditcardFields {
+      override def businessentityid = IdField[BusinessentityId, PersoncreditcardRow](_path, "businessentityid", None, Some("int4"), x => x.businessentityid, (row, value) => row.copy(businessentityid = value))
+      override def creditcardid = IdField[/* user-picked */ CustomCreditcardId, PersoncreditcardRow](_path, "creditcardid", None, Some("int4"), x => x.creditcardid, (row, value) => row.copy(creditcardid = value))
+      override def modifieddate = Field[TypoLocalDateTime, PersoncreditcardRow](_path, "modifieddate", Some("text"), Some("timestamp"), x => x.modifieddate, (row, value) => row.copy(modifieddate = value))
     }
   
-    override val columns: List[FieldLikeNoHkt[?, Row]] =
-      List[FieldLikeNoHkt[?, Row]](fields.businessentityid, fields.creditcardid, fields.modifieddate)
+    override lazy val columns: List[FieldLikeNoHkt[?, PersoncreditcardRow]] =
+      List[FieldLikeNoHkt[?, PersoncreditcardRow]](fields.businessentityid, fields.creditcardid, fields.modifieddate)
   
-    override def copy[NewRow](prefix: Option[String], extract: NewRow => PersoncreditcardRow, merge: (NewRow, PersoncreditcardRow) => NewRow): Impl[NewRow] =
-      new Impl(prefix, extract, merge)
+    override def copy(path: List[Path]): Impl =
+      new Impl(path)
   }
   
 }

--- a/typo-tester-anorm/generated-and-checked-in/adventureworks/sales/personcreditcard/PersoncreditcardRepoMock.scala
+++ b/typo-tester-anorm/generated-and-checked-in/adventureworks/sales/personcreditcard/PersoncreditcardRepoMock.scala
@@ -24,7 +24,7 @@ import typo.dsl.UpdateParams
 class PersoncreditcardRepoMock(toRow: Function1[PersoncreditcardRowUnsaved, PersoncreditcardRow],
                                map: scala.collection.mutable.Map[PersoncreditcardId, PersoncreditcardRow] = scala.collection.mutable.Map.empty) extends PersoncreditcardRepo {
   override def delete: DeleteBuilder[PersoncreditcardFields, PersoncreditcardRow] = {
-    DeleteBuilderMock(DeleteParams.empty, PersoncreditcardFields.structure.fields, map)
+    DeleteBuilderMock(DeleteParams.empty, PersoncreditcardFields.structure, map)
   }
   override def deleteById(compositeId: PersoncreditcardId)(implicit c: Connection): Boolean = {
     map.remove(compositeId).isDefined
@@ -74,7 +74,7 @@ class PersoncreditcardRepoMock(toRow: Function1[PersoncreditcardRowUnsaved, Pers
     compositeIds.view.flatMap(id => byId.get(id).map(x => (id, x))).toMap
   }
   override def update: UpdateBuilder[PersoncreditcardFields, PersoncreditcardRow] = {
-    UpdateBuilderMock(UpdateParams.empty, PersoncreditcardFields.structure.fields, map)
+    UpdateBuilderMock(UpdateParams.empty, PersoncreditcardFields.structure, map)
   }
   override def update(row: PersoncreditcardRow)(implicit c: Connection): Boolean = {
     map.get(row.compositeId) match {

--- a/typo-tester-anorm/generated-and-checked-in/adventureworks/sales/salesorderdetail/SalesorderdetailFields.scala
+++ b/typo-tester-anorm/generated-and-checked-in/adventureworks/sales/salesorderdetail/SalesorderdetailFields.scala
@@ -13,50 +13,51 @@ import adventureworks.customtypes.TypoUUID
 import adventureworks.production.product.ProductId
 import adventureworks.sales.salesorderheader.SalesorderheaderId
 import adventureworks.sales.specialoffer.SpecialofferId
+import typo.dsl.Path
 import typo.dsl.SqlExpr.Field
 import typo.dsl.SqlExpr.FieldLikeNoHkt
 import typo.dsl.SqlExpr.IdField
 import typo.dsl.SqlExpr.OptField
 import typo.dsl.Structure.Relation
 
-trait SalesorderdetailFields[Row] {
-  val salesorderid: IdField[SalesorderheaderId, Row]
-  val salesorderdetailid: IdField[Int, Row]
-  val carriertrackingnumber: OptField[/* max 25 chars */ String, Row]
-  val orderqty: Field[TypoShort, Row]
-  val productid: Field[ProductId, Row]
-  val specialofferid: Field[SpecialofferId, Row]
-  val unitprice: Field[BigDecimal, Row]
-  val unitpricediscount: Field[BigDecimal, Row]
-  val rowguid: Field[TypoUUID, Row]
-  val modifieddate: Field[TypoLocalDateTime, Row]
+trait SalesorderdetailFields {
+  def salesorderid: IdField[SalesorderheaderId, SalesorderdetailRow]
+  def salesorderdetailid: IdField[Int, SalesorderdetailRow]
+  def carriertrackingnumber: OptField[/* max 25 chars */ String, SalesorderdetailRow]
+  def orderqty: Field[TypoShort, SalesorderdetailRow]
+  def productid: Field[ProductId, SalesorderdetailRow]
+  def specialofferid: Field[SpecialofferId, SalesorderdetailRow]
+  def unitprice: Field[BigDecimal, SalesorderdetailRow]
+  def unitpricediscount: Field[BigDecimal, SalesorderdetailRow]
+  def rowguid: Field[TypoUUID, SalesorderdetailRow]
+  def modifieddate: Field[TypoLocalDateTime, SalesorderdetailRow]
 }
 
 object SalesorderdetailFields {
-  val structure: Relation[SalesorderdetailFields, SalesorderdetailRow, SalesorderdetailRow] = 
-    new Impl(None, identity, (_, x) => x)
+  lazy val structure: Relation[SalesorderdetailFields, SalesorderdetailRow] =
+    new Impl(Nil)
     
-  private final class Impl[Row](val prefix: Option[String], val extract: Row => SalesorderdetailRow, val merge: (Row, SalesorderdetailRow) => Row)
-    extends Relation[SalesorderdetailFields, SalesorderdetailRow, Row] { 
+  private final class Impl(val _path: List[Path])
+    extends Relation[SalesorderdetailFields, SalesorderdetailRow] {
   
-    override val fields: SalesorderdetailFields[Row] = new SalesorderdetailFields[Row] {
-      override val salesorderid = new IdField[SalesorderheaderId, Row](prefix, "salesorderid", None, Some("int4"))(x => extract(x).salesorderid, (row, value) => merge(row, extract(row).copy(salesorderid = value)))
-      override val salesorderdetailid = new IdField[Int, Row](prefix, "salesorderdetailid", None, Some("int4"))(x => extract(x).salesorderdetailid, (row, value) => merge(row, extract(row).copy(salesorderdetailid = value)))
-      override val carriertrackingnumber = new OptField[/* max 25 chars */ String, Row](prefix, "carriertrackingnumber", None, None)(x => extract(x).carriertrackingnumber, (row, value) => merge(row, extract(row).copy(carriertrackingnumber = value)))
-      override val orderqty = new Field[TypoShort, Row](prefix, "orderqty", None, Some("int2"))(x => extract(x).orderqty, (row, value) => merge(row, extract(row).copy(orderqty = value)))
-      override val productid = new Field[ProductId, Row](prefix, "productid", None, Some("int4"))(x => extract(x).productid, (row, value) => merge(row, extract(row).copy(productid = value)))
-      override val specialofferid = new Field[SpecialofferId, Row](prefix, "specialofferid", None, Some("int4"))(x => extract(x).specialofferid, (row, value) => merge(row, extract(row).copy(specialofferid = value)))
-      override val unitprice = new Field[BigDecimal, Row](prefix, "unitprice", None, Some("numeric"))(x => extract(x).unitprice, (row, value) => merge(row, extract(row).copy(unitprice = value)))
-      override val unitpricediscount = new Field[BigDecimal, Row](prefix, "unitpricediscount", None, Some("numeric"))(x => extract(x).unitpricediscount, (row, value) => merge(row, extract(row).copy(unitpricediscount = value)))
-      override val rowguid = new Field[TypoUUID, Row](prefix, "rowguid", None, Some("uuid"))(x => extract(x).rowguid, (row, value) => merge(row, extract(row).copy(rowguid = value)))
-      override val modifieddate = new Field[TypoLocalDateTime, Row](prefix, "modifieddate", Some("text"), Some("timestamp"))(x => extract(x).modifieddate, (row, value) => merge(row, extract(row).copy(modifieddate = value)))
+    override lazy val fields: SalesorderdetailFields = new SalesorderdetailFields {
+      override def salesorderid = IdField[SalesorderheaderId, SalesorderdetailRow](_path, "salesorderid", None, Some("int4"), x => x.salesorderid, (row, value) => row.copy(salesorderid = value))
+      override def salesorderdetailid = IdField[Int, SalesorderdetailRow](_path, "salesorderdetailid", None, Some("int4"), x => x.salesorderdetailid, (row, value) => row.copy(salesorderdetailid = value))
+      override def carriertrackingnumber = OptField[/* max 25 chars */ String, SalesorderdetailRow](_path, "carriertrackingnumber", None, None, x => x.carriertrackingnumber, (row, value) => row.copy(carriertrackingnumber = value))
+      override def orderqty = Field[TypoShort, SalesorderdetailRow](_path, "orderqty", None, Some("int2"), x => x.orderqty, (row, value) => row.copy(orderqty = value))
+      override def productid = Field[ProductId, SalesorderdetailRow](_path, "productid", None, Some("int4"), x => x.productid, (row, value) => row.copy(productid = value))
+      override def specialofferid = Field[SpecialofferId, SalesorderdetailRow](_path, "specialofferid", None, Some("int4"), x => x.specialofferid, (row, value) => row.copy(specialofferid = value))
+      override def unitprice = Field[BigDecimal, SalesorderdetailRow](_path, "unitprice", None, Some("numeric"), x => x.unitprice, (row, value) => row.copy(unitprice = value))
+      override def unitpricediscount = Field[BigDecimal, SalesorderdetailRow](_path, "unitpricediscount", None, Some("numeric"), x => x.unitpricediscount, (row, value) => row.copy(unitpricediscount = value))
+      override def rowguid = Field[TypoUUID, SalesorderdetailRow](_path, "rowguid", None, Some("uuid"), x => x.rowguid, (row, value) => row.copy(rowguid = value))
+      override def modifieddate = Field[TypoLocalDateTime, SalesorderdetailRow](_path, "modifieddate", Some("text"), Some("timestamp"), x => x.modifieddate, (row, value) => row.copy(modifieddate = value))
     }
   
-    override val columns: List[FieldLikeNoHkt[?, Row]] =
-      List[FieldLikeNoHkt[?, Row]](fields.salesorderid, fields.salesorderdetailid, fields.carriertrackingnumber, fields.orderqty, fields.productid, fields.specialofferid, fields.unitprice, fields.unitpricediscount, fields.rowguid, fields.modifieddate)
+    override lazy val columns: List[FieldLikeNoHkt[?, SalesorderdetailRow]] =
+      List[FieldLikeNoHkt[?, SalesorderdetailRow]](fields.salesorderid, fields.salesorderdetailid, fields.carriertrackingnumber, fields.orderqty, fields.productid, fields.specialofferid, fields.unitprice, fields.unitpricediscount, fields.rowguid, fields.modifieddate)
   
-    override def copy[NewRow](prefix: Option[String], extract: NewRow => SalesorderdetailRow, merge: (NewRow, SalesorderdetailRow) => NewRow): Impl[NewRow] =
-      new Impl(prefix, extract, merge)
+    override def copy(path: List[Path]): Impl =
+      new Impl(path)
   }
   
 }

--- a/typo-tester-anorm/generated-and-checked-in/adventureworks/sales/salesorderdetail/SalesorderdetailRepoMock.scala
+++ b/typo-tester-anorm/generated-and-checked-in/adventureworks/sales/salesorderdetail/SalesorderdetailRepoMock.scala
@@ -22,7 +22,7 @@ import typo.dsl.UpdateParams
 class SalesorderdetailRepoMock(toRow: Function1[SalesorderdetailRowUnsaved, SalesorderdetailRow],
                                map: scala.collection.mutable.Map[SalesorderdetailId, SalesorderdetailRow] = scala.collection.mutable.Map.empty) extends SalesorderdetailRepo {
   override def delete: DeleteBuilder[SalesorderdetailFields, SalesorderdetailRow] = {
-    DeleteBuilderMock(DeleteParams.empty, SalesorderdetailFields.structure.fields, map)
+    DeleteBuilderMock(DeleteParams.empty, SalesorderdetailFields.structure, map)
   }
   override def deleteById(compositeId: SalesorderdetailId)(implicit c: Connection): Boolean = {
     map.remove(compositeId).isDefined
@@ -72,7 +72,7 @@ class SalesorderdetailRepoMock(toRow: Function1[SalesorderdetailRowUnsaved, Sale
     compositeIds.view.flatMap(id => byId.get(id).map(x => (id, x))).toMap
   }
   override def update: UpdateBuilder[SalesorderdetailFields, SalesorderdetailRow] = {
-    UpdateBuilderMock(UpdateParams.empty, SalesorderdetailFields.structure.fields, map)
+    UpdateBuilderMock(UpdateParams.empty, SalesorderdetailFields.structure, map)
   }
   override def update(row: SalesorderdetailRow)(implicit c: Connection): Boolean = {
     map.get(row.compositeId) match {

--- a/typo-tester-anorm/generated-and-checked-in/adventureworks/sales/salesorderheader/SalesorderheaderFields.scala
+++ b/typo-tester-anorm/generated-and-checked-in/adventureworks/sales/salesorderheader/SalesorderheaderFields.scala
@@ -20,80 +20,81 @@ import adventureworks.sales.currencyrate.CurrencyrateId
 import adventureworks.sales.customer.CustomerId
 import adventureworks.sales.salesterritory.SalesterritoryId
 import adventureworks.userdefined.CustomCreditcardId
+import typo.dsl.Path
 import typo.dsl.SqlExpr.Field
 import typo.dsl.SqlExpr.FieldLikeNoHkt
 import typo.dsl.SqlExpr.IdField
 import typo.dsl.SqlExpr.OptField
 import typo.dsl.Structure.Relation
 
-trait SalesorderheaderFields[Row] {
-  val salesorderid: IdField[SalesorderheaderId, Row]
-  val revisionnumber: Field[TypoShort, Row]
-  val orderdate: Field[TypoLocalDateTime, Row]
-  val duedate: Field[TypoLocalDateTime, Row]
-  val shipdate: OptField[TypoLocalDateTime, Row]
-  val status: Field[TypoShort, Row]
-  val onlineorderflag: Field[Flag, Row]
-  val purchaseordernumber: OptField[OrderNumber, Row]
-  val accountnumber: OptField[AccountNumber, Row]
-  val customerid: Field[CustomerId, Row]
-  val salespersonid: OptField[BusinessentityId, Row]
-  val territoryid: OptField[SalesterritoryId, Row]
-  val billtoaddressid: Field[AddressId, Row]
-  val shiptoaddressid: Field[AddressId, Row]
-  val shipmethodid: Field[ShipmethodId, Row]
-  val creditcardid: OptField[/* user-picked */ CustomCreditcardId, Row]
-  val creditcardapprovalcode: OptField[/* max 15 chars */ String, Row]
-  val currencyrateid: OptField[CurrencyrateId, Row]
-  val subtotal: Field[BigDecimal, Row]
-  val taxamt: Field[BigDecimal, Row]
-  val freight: Field[BigDecimal, Row]
-  val totaldue: OptField[BigDecimal, Row]
-  val comment: OptField[/* max 128 chars */ String, Row]
-  val rowguid: Field[TypoUUID, Row]
-  val modifieddate: Field[TypoLocalDateTime, Row]
+trait SalesorderheaderFields {
+  def salesorderid: IdField[SalesorderheaderId, SalesorderheaderRow]
+  def revisionnumber: Field[TypoShort, SalesorderheaderRow]
+  def orderdate: Field[TypoLocalDateTime, SalesorderheaderRow]
+  def duedate: Field[TypoLocalDateTime, SalesorderheaderRow]
+  def shipdate: OptField[TypoLocalDateTime, SalesorderheaderRow]
+  def status: Field[TypoShort, SalesorderheaderRow]
+  def onlineorderflag: Field[Flag, SalesorderheaderRow]
+  def purchaseordernumber: OptField[OrderNumber, SalesorderheaderRow]
+  def accountnumber: OptField[AccountNumber, SalesorderheaderRow]
+  def customerid: Field[CustomerId, SalesorderheaderRow]
+  def salespersonid: OptField[BusinessentityId, SalesorderheaderRow]
+  def territoryid: OptField[SalesterritoryId, SalesorderheaderRow]
+  def billtoaddressid: Field[AddressId, SalesorderheaderRow]
+  def shiptoaddressid: Field[AddressId, SalesorderheaderRow]
+  def shipmethodid: Field[ShipmethodId, SalesorderheaderRow]
+  def creditcardid: OptField[/* user-picked */ CustomCreditcardId, SalesorderheaderRow]
+  def creditcardapprovalcode: OptField[/* max 15 chars */ String, SalesorderheaderRow]
+  def currencyrateid: OptField[CurrencyrateId, SalesorderheaderRow]
+  def subtotal: Field[BigDecimal, SalesorderheaderRow]
+  def taxamt: Field[BigDecimal, SalesorderheaderRow]
+  def freight: Field[BigDecimal, SalesorderheaderRow]
+  def totaldue: OptField[BigDecimal, SalesorderheaderRow]
+  def comment: OptField[/* max 128 chars */ String, SalesorderheaderRow]
+  def rowguid: Field[TypoUUID, SalesorderheaderRow]
+  def modifieddate: Field[TypoLocalDateTime, SalesorderheaderRow]
 }
 
 object SalesorderheaderFields {
-  val structure: Relation[SalesorderheaderFields, SalesorderheaderRow, SalesorderheaderRow] = 
-    new Impl(None, identity, (_, x) => x)
+  lazy val structure: Relation[SalesorderheaderFields, SalesorderheaderRow] =
+    new Impl(Nil)
     
-  private final class Impl[Row](val prefix: Option[String], val extract: Row => SalesorderheaderRow, val merge: (Row, SalesorderheaderRow) => Row)
-    extends Relation[SalesorderheaderFields, SalesorderheaderRow, Row] { 
+  private final class Impl(val _path: List[Path])
+    extends Relation[SalesorderheaderFields, SalesorderheaderRow] {
   
-    override val fields: SalesorderheaderFields[Row] = new SalesorderheaderFields[Row] {
-      override val salesorderid = new IdField[SalesorderheaderId, Row](prefix, "salesorderid", None, Some("int4"))(x => extract(x).salesorderid, (row, value) => merge(row, extract(row).copy(salesorderid = value)))
-      override val revisionnumber = new Field[TypoShort, Row](prefix, "revisionnumber", None, Some("int2"))(x => extract(x).revisionnumber, (row, value) => merge(row, extract(row).copy(revisionnumber = value)))
-      override val orderdate = new Field[TypoLocalDateTime, Row](prefix, "orderdate", Some("text"), Some("timestamp"))(x => extract(x).orderdate, (row, value) => merge(row, extract(row).copy(orderdate = value)))
-      override val duedate = new Field[TypoLocalDateTime, Row](prefix, "duedate", Some("text"), Some("timestamp"))(x => extract(x).duedate, (row, value) => merge(row, extract(row).copy(duedate = value)))
-      override val shipdate = new OptField[TypoLocalDateTime, Row](prefix, "shipdate", Some("text"), Some("timestamp"))(x => extract(x).shipdate, (row, value) => merge(row, extract(row).copy(shipdate = value)))
-      override val status = new Field[TypoShort, Row](prefix, "status", None, Some("int2"))(x => extract(x).status, (row, value) => merge(row, extract(row).copy(status = value)))
-      override val onlineorderflag = new Field[Flag, Row](prefix, "onlineorderflag", None, Some("bool"))(x => extract(x).onlineorderflag, (row, value) => merge(row, extract(row).copy(onlineorderflag = value)))
-      override val purchaseordernumber = new OptField[OrderNumber, Row](prefix, "purchaseordernumber", None, Some("varchar"))(x => extract(x).purchaseordernumber, (row, value) => merge(row, extract(row).copy(purchaseordernumber = value)))
-      override val accountnumber = new OptField[AccountNumber, Row](prefix, "accountnumber", None, Some("varchar"))(x => extract(x).accountnumber, (row, value) => merge(row, extract(row).copy(accountnumber = value)))
-      override val customerid = new Field[CustomerId, Row](prefix, "customerid", None, Some("int4"))(x => extract(x).customerid, (row, value) => merge(row, extract(row).copy(customerid = value)))
-      override val salespersonid = new OptField[BusinessentityId, Row](prefix, "salespersonid", None, Some("int4"))(x => extract(x).salespersonid, (row, value) => merge(row, extract(row).copy(salespersonid = value)))
-      override val territoryid = new OptField[SalesterritoryId, Row](prefix, "territoryid", None, Some("int4"))(x => extract(x).territoryid, (row, value) => merge(row, extract(row).copy(territoryid = value)))
-      override val billtoaddressid = new Field[AddressId, Row](prefix, "billtoaddressid", None, Some("int4"))(x => extract(x).billtoaddressid, (row, value) => merge(row, extract(row).copy(billtoaddressid = value)))
-      override val shiptoaddressid = new Field[AddressId, Row](prefix, "shiptoaddressid", None, Some("int4"))(x => extract(x).shiptoaddressid, (row, value) => merge(row, extract(row).copy(shiptoaddressid = value)))
-      override val shipmethodid = new Field[ShipmethodId, Row](prefix, "shipmethodid", None, Some("int4"))(x => extract(x).shipmethodid, (row, value) => merge(row, extract(row).copy(shipmethodid = value)))
-      override val creditcardid = new OptField[/* user-picked */ CustomCreditcardId, Row](prefix, "creditcardid", None, Some("int4"))(x => extract(x).creditcardid, (row, value) => merge(row, extract(row).copy(creditcardid = value)))
-      override val creditcardapprovalcode = new OptField[/* max 15 chars */ String, Row](prefix, "creditcardapprovalcode", None, None)(x => extract(x).creditcardapprovalcode, (row, value) => merge(row, extract(row).copy(creditcardapprovalcode = value)))
-      override val currencyrateid = new OptField[CurrencyrateId, Row](prefix, "currencyrateid", None, Some("int4"))(x => extract(x).currencyrateid, (row, value) => merge(row, extract(row).copy(currencyrateid = value)))
-      override val subtotal = new Field[BigDecimal, Row](prefix, "subtotal", None, Some("numeric"))(x => extract(x).subtotal, (row, value) => merge(row, extract(row).copy(subtotal = value)))
-      override val taxamt = new Field[BigDecimal, Row](prefix, "taxamt", None, Some("numeric"))(x => extract(x).taxamt, (row, value) => merge(row, extract(row).copy(taxamt = value)))
-      override val freight = new Field[BigDecimal, Row](prefix, "freight", None, Some("numeric"))(x => extract(x).freight, (row, value) => merge(row, extract(row).copy(freight = value)))
-      override val totaldue = new OptField[BigDecimal, Row](prefix, "totaldue", None, Some("numeric"))(x => extract(x).totaldue, (row, value) => merge(row, extract(row).copy(totaldue = value)))
-      override val comment = new OptField[/* max 128 chars */ String, Row](prefix, "comment", None, None)(x => extract(x).comment, (row, value) => merge(row, extract(row).copy(comment = value)))
-      override val rowguid = new Field[TypoUUID, Row](prefix, "rowguid", None, Some("uuid"))(x => extract(x).rowguid, (row, value) => merge(row, extract(row).copy(rowguid = value)))
-      override val modifieddate = new Field[TypoLocalDateTime, Row](prefix, "modifieddate", Some("text"), Some("timestamp"))(x => extract(x).modifieddate, (row, value) => merge(row, extract(row).copy(modifieddate = value)))
+    override lazy val fields: SalesorderheaderFields = new SalesorderheaderFields {
+      override def salesorderid = IdField[SalesorderheaderId, SalesorderheaderRow](_path, "salesorderid", None, Some("int4"), x => x.salesorderid, (row, value) => row.copy(salesorderid = value))
+      override def revisionnumber = Field[TypoShort, SalesorderheaderRow](_path, "revisionnumber", None, Some("int2"), x => x.revisionnumber, (row, value) => row.copy(revisionnumber = value))
+      override def orderdate = Field[TypoLocalDateTime, SalesorderheaderRow](_path, "orderdate", Some("text"), Some("timestamp"), x => x.orderdate, (row, value) => row.copy(orderdate = value))
+      override def duedate = Field[TypoLocalDateTime, SalesorderheaderRow](_path, "duedate", Some("text"), Some("timestamp"), x => x.duedate, (row, value) => row.copy(duedate = value))
+      override def shipdate = OptField[TypoLocalDateTime, SalesorderheaderRow](_path, "shipdate", Some("text"), Some("timestamp"), x => x.shipdate, (row, value) => row.copy(shipdate = value))
+      override def status = Field[TypoShort, SalesorderheaderRow](_path, "status", None, Some("int2"), x => x.status, (row, value) => row.copy(status = value))
+      override def onlineorderflag = Field[Flag, SalesorderheaderRow](_path, "onlineorderflag", None, Some("bool"), x => x.onlineorderflag, (row, value) => row.copy(onlineorderflag = value))
+      override def purchaseordernumber = OptField[OrderNumber, SalesorderheaderRow](_path, "purchaseordernumber", None, Some("varchar"), x => x.purchaseordernumber, (row, value) => row.copy(purchaseordernumber = value))
+      override def accountnumber = OptField[AccountNumber, SalesorderheaderRow](_path, "accountnumber", None, Some("varchar"), x => x.accountnumber, (row, value) => row.copy(accountnumber = value))
+      override def customerid = Field[CustomerId, SalesorderheaderRow](_path, "customerid", None, Some("int4"), x => x.customerid, (row, value) => row.copy(customerid = value))
+      override def salespersonid = OptField[BusinessentityId, SalesorderheaderRow](_path, "salespersonid", None, Some("int4"), x => x.salespersonid, (row, value) => row.copy(salespersonid = value))
+      override def territoryid = OptField[SalesterritoryId, SalesorderheaderRow](_path, "territoryid", None, Some("int4"), x => x.territoryid, (row, value) => row.copy(territoryid = value))
+      override def billtoaddressid = Field[AddressId, SalesorderheaderRow](_path, "billtoaddressid", None, Some("int4"), x => x.billtoaddressid, (row, value) => row.copy(billtoaddressid = value))
+      override def shiptoaddressid = Field[AddressId, SalesorderheaderRow](_path, "shiptoaddressid", None, Some("int4"), x => x.shiptoaddressid, (row, value) => row.copy(shiptoaddressid = value))
+      override def shipmethodid = Field[ShipmethodId, SalesorderheaderRow](_path, "shipmethodid", None, Some("int4"), x => x.shipmethodid, (row, value) => row.copy(shipmethodid = value))
+      override def creditcardid = OptField[/* user-picked */ CustomCreditcardId, SalesorderheaderRow](_path, "creditcardid", None, Some("int4"), x => x.creditcardid, (row, value) => row.copy(creditcardid = value))
+      override def creditcardapprovalcode = OptField[/* max 15 chars */ String, SalesorderheaderRow](_path, "creditcardapprovalcode", None, None, x => x.creditcardapprovalcode, (row, value) => row.copy(creditcardapprovalcode = value))
+      override def currencyrateid = OptField[CurrencyrateId, SalesorderheaderRow](_path, "currencyrateid", None, Some("int4"), x => x.currencyrateid, (row, value) => row.copy(currencyrateid = value))
+      override def subtotal = Field[BigDecimal, SalesorderheaderRow](_path, "subtotal", None, Some("numeric"), x => x.subtotal, (row, value) => row.copy(subtotal = value))
+      override def taxamt = Field[BigDecimal, SalesorderheaderRow](_path, "taxamt", None, Some("numeric"), x => x.taxamt, (row, value) => row.copy(taxamt = value))
+      override def freight = Field[BigDecimal, SalesorderheaderRow](_path, "freight", None, Some("numeric"), x => x.freight, (row, value) => row.copy(freight = value))
+      override def totaldue = OptField[BigDecimal, SalesorderheaderRow](_path, "totaldue", None, Some("numeric"), x => x.totaldue, (row, value) => row.copy(totaldue = value))
+      override def comment = OptField[/* max 128 chars */ String, SalesorderheaderRow](_path, "comment", None, None, x => x.comment, (row, value) => row.copy(comment = value))
+      override def rowguid = Field[TypoUUID, SalesorderheaderRow](_path, "rowguid", None, Some("uuid"), x => x.rowguid, (row, value) => row.copy(rowguid = value))
+      override def modifieddate = Field[TypoLocalDateTime, SalesorderheaderRow](_path, "modifieddate", Some("text"), Some("timestamp"), x => x.modifieddate, (row, value) => row.copy(modifieddate = value))
     }
   
-    override val columns: List[FieldLikeNoHkt[?, Row]] =
-      List[FieldLikeNoHkt[?, Row]](fields.salesorderid, fields.revisionnumber, fields.orderdate, fields.duedate, fields.shipdate, fields.status, fields.onlineorderflag, fields.purchaseordernumber, fields.accountnumber, fields.customerid, fields.salespersonid, fields.territoryid, fields.billtoaddressid, fields.shiptoaddressid, fields.shipmethodid, fields.creditcardid, fields.creditcardapprovalcode, fields.currencyrateid, fields.subtotal, fields.taxamt, fields.freight, fields.totaldue, fields.comment, fields.rowguid, fields.modifieddate)
+    override lazy val columns: List[FieldLikeNoHkt[?, SalesorderheaderRow]] =
+      List[FieldLikeNoHkt[?, SalesorderheaderRow]](fields.salesorderid, fields.revisionnumber, fields.orderdate, fields.duedate, fields.shipdate, fields.status, fields.onlineorderflag, fields.purchaseordernumber, fields.accountnumber, fields.customerid, fields.salespersonid, fields.territoryid, fields.billtoaddressid, fields.shiptoaddressid, fields.shipmethodid, fields.creditcardid, fields.creditcardapprovalcode, fields.currencyrateid, fields.subtotal, fields.taxamt, fields.freight, fields.totaldue, fields.comment, fields.rowguid, fields.modifieddate)
   
-    override def copy[NewRow](prefix: Option[String], extract: NewRow => SalesorderheaderRow, merge: (NewRow, SalesorderheaderRow) => NewRow): Impl[NewRow] =
-      new Impl(prefix, extract, merge)
+    override def copy(path: List[Path]): Impl =
+      new Impl(path)
   }
   
 }

--- a/typo-tester-anorm/generated-and-checked-in/adventureworks/sales/salesorderheader/SalesorderheaderRepoMock.scala
+++ b/typo-tester-anorm/generated-and-checked-in/adventureworks/sales/salesorderheader/SalesorderheaderRepoMock.scala
@@ -22,7 +22,7 @@ import typo.dsl.UpdateParams
 class SalesorderheaderRepoMock(toRow: Function1[SalesorderheaderRowUnsaved, SalesorderheaderRow],
                                map: scala.collection.mutable.Map[SalesorderheaderId, SalesorderheaderRow] = scala.collection.mutable.Map.empty) extends SalesorderheaderRepo {
   override def delete: DeleteBuilder[SalesorderheaderFields, SalesorderheaderRow] = {
-    DeleteBuilderMock(DeleteParams.empty, SalesorderheaderFields.structure.fields, map)
+    DeleteBuilderMock(DeleteParams.empty, SalesorderheaderFields.structure, map)
   }
   override def deleteById(salesorderid: SalesorderheaderId)(implicit c: Connection): Boolean = {
     map.remove(salesorderid).isDefined
@@ -72,7 +72,7 @@ class SalesorderheaderRepoMock(toRow: Function1[SalesorderheaderRowUnsaved, Sale
     salesorderids.view.flatMap(id => byId.get(id).map(x => (id, x))).toMap
   }
   override def update: UpdateBuilder[SalesorderheaderFields, SalesorderheaderRow] = {
-    UpdateBuilderMock(UpdateParams.empty, SalesorderheaderFields.structure.fields, map)
+    UpdateBuilderMock(UpdateParams.empty, SalesorderheaderFields.structure, map)
   }
   override def update(row: SalesorderheaderRow)(implicit c: Connection): Boolean = {
     map.get(row.salesorderid) match {

--- a/typo-tester-anorm/generated-and-checked-in/adventureworks/sales/salesorderheadersalesreason/SalesorderheadersalesreasonFields.scala
+++ b/typo-tester-anorm/generated-and-checked-in/adventureworks/sales/salesorderheadersalesreason/SalesorderheadersalesreasonFields.scala
@@ -10,35 +10,36 @@ package salesorderheadersalesreason
 import adventureworks.customtypes.TypoLocalDateTime
 import adventureworks.sales.salesorderheader.SalesorderheaderId
 import adventureworks.sales.salesreason.SalesreasonId
+import typo.dsl.Path
 import typo.dsl.SqlExpr.Field
 import typo.dsl.SqlExpr.FieldLikeNoHkt
 import typo.dsl.SqlExpr.IdField
 import typo.dsl.Structure.Relation
 
-trait SalesorderheadersalesreasonFields[Row] {
-  val salesorderid: IdField[SalesorderheaderId, Row]
-  val salesreasonid: IdField[SalesreasonId, Row]
-  val modifieddate: Field[TypoLocalDateTime, Row]
+trait SalesorderheadersalesreasonFields {
+  def salesorderid: IdField[SalesorderheaderId, SalesorderheadersalesreasonRow]
+  def salesreasonid: IdField[SalesreasonId, SalesorderheadersalesreasonRow]
+  def modifieddate: Field[TypoLocalDateTime, SalesorderheadersalesreasonRow]
 }
 
 object SalesorderheadersalesreasonFields {
-  val structure: Relation[SalesorderheadersalesreasonFields, SalesorderheadersalesreasonRow, SalesorderheadersalesreasonRow] = 
-    new Impl(None, identity, (_, x) => x)
+  lazy val structure: Relation[SalesorderheadersalesreasonFields, SalesorderheadersalesreasonRow] =
+    new Impl(Nil)
     
-  private final class Impl[Row](val prefix: Option[String], val extract: Row => SalesorderheadersalesreasonRow, val merge: (Row, SalesorderheadersalesreasonRow) => Row)
-    extends Relation[SalesorderheadersalesreasonFields, SalesorderheadersalesreasonRow, Row] { 
+  private final class Impl(val _path: List[Path])
+    extends Relation[SalesorderheadersalesreasonFields, SalesorderheadersalesreasonRow] {
   
-    override val fields: SalesorderheadersalesreasonFields[Row] = new SalesorderheadersalesreasonFields[Row] {
-      override val salesorderid = new IdField[SalesorderheaderId, Row](prefix, "salesorderid", None, Some("int4"))(x => extract(x).salesorderid, (row, value) => merge(row, extract(row).copy(salesorderid = value)))
-      override val salesreasonid = new IdField[SalesreasonId, Row](prefix, "salesreasonid", None, Some("int4"))(x => extract(x).salesreasonid, (row, value) => merge(row, extract(row).copy(salesreasonid = value)))
-      override val modifieddate = new Field[TypoLocalDateTime, Row](prefix, "modifieddate", Some("text"), Some("timestamp"))(x => extract(x).modifieddate, (row, value) => merge(row, extract(row).copy(modifieddate = value)))
+    override lazy val fields: SalesorderheadersalesreasonFields = new SalesorderheadersalesreasonFields {
+      override def salesorderid = IdField[SalesorderheaderId, SalesorderheadersalesreasonRow](_path, "salesorderid", None, Some("int4"), x => x.salesorderid, (row, value) => row.copy(salesorderid = value))
+      override def salesreasonid = IdField[SalesreasonId, SalesorderheadersalesreasonRow](_path, "salesreasonid", None, Some("int4"), x => x.salesreasonid, (row, value) => row.copy(salesreasonid = value))
+      override def modifieddate = Field[TypoLocalDateTime, SalesorderheadersalesreasonRow](_path, "modifieddate", Some("text"), Some("timestamp"), x => x.modifieddate, (row, value) => row.copy(modifieddate = value))
     }
   
-    override val columns: List[FieldLikeNoHkt[?, Row]] =
-      List[FieldLikeNoHkt[?, Row]](fields.salesorderid, fields.salesreasonid, fields.modifieddate)
+    override lazy val columns: List[FieldLikeNoHkt[?, SalesorderheadersalesreasonRow]] =
+      List[FieldLikeNoHkt[?, SalesorderheadersalesreasonRow]](fields.salesorderid, fields.salesreasonid, fields.modifieddate)
   
-    override def copy[NewRow](prefix: Option[String], extract: NewRow => SalesorderheadersalesreasonRow, merge: (NewRow, SalesorderheadersalesreasonRow) => NewRow): Impl[NewRow] =
-      new Impl(prefix, extract, merge)
+    override def copy(path: List[Path]): Impl =
+      new Impl(path)
   }
   
 }

--- a/typo-tester-anorm/generated-and-checked-in/adventureworks/sales/salesorderheadersalesreason/SalesorderheadersalesreasonRepoMock.scala
+++ b/typo-tester-anorm/generated-and-checked-in/adventureworks/sales/salesorderheadersalesreason/SalesorderheadersalesreasonRepoMock.scala
@@ -22,7 +22,7 @@ import typo.dsl.UpdateParams
 class SalesorderheadersalesreasonRepoMock(toRow: Function1[SalesorderheadersalesreasonRowUnsaved, SalesorderheadersalesreasonRow],
                                           map: scala.collection.mutable.Map[SalesorderheadersalesreasonId, SalesorderheadersalesreasonRow] = scala.collection.mutable.Map.empty) extends SalesorderheadersalesreasonRepo {
   override def delete: DeleteBuilder[SalesorderheadersalesreasonFields, SalesorderheadersalesreasonRow] = {
-    DeleteBuilderMock(DeleteParams.empty, SalesorderheadersalesreasonFields.structure.fields, map)
+    DeleteBuilderMock(DeleteParams.empty, SalesorderheadersalesreasonFields.structure, map)
   }
   override def deleteById(compositeId: SalesorderheadersalesreasonId)(implicit c: Connection): Boolean = {
     map.remove(compositeId).isDefined
@@ -72,7 +72,7 @@ class SalesorderheadersalesreasonRepoMock(toRow: Function1[Salesorderheadersales
     compositeIds.view.flatMap(id => byId.get(id).map(x => (id, x))).toMap
   }
   override def update: UpdateBuilder[SalesorderheadersalesreasonFields, SalesorderheadersalesreasonRow] = {
-    UpdateBuilderMock(UpdateParams.empty, SalesorderheadersalesreasonFields.structure.fields, map)
+    UpdateBuilderMock(UpdateParams.empty, SalesorderheadersalesreasonFields.structure, map)
   }
   override def update(row: SalesorderheadersalesreasonRow)(implicit c: Connection): Boolean = {
     map.get(row.compositeId) match {

--- a/typo-tester-anorm/generated-and-checked-in/adventureworks/sales/salesperson/SalespersonFields.scala
+++ b/typo-tester-anorm/generated-and-checked-in/adventureworks/sales/salesperson/SalespersonFields.scala
@@ -11,48 +11,49 @@ import adventureworks.customtypes.TypoLocalDateTime
 import adventureworks.customtypes.TypoUUID
 import adventureworks.person.businessentity.BusinessentityId
 import adventureworks.sales.salesterritory.SalesterritoryId
+import typo.dsl.Path
 import typo.dsl.SqlExpr.Field
 import typo.dsl.SqlExpr.FieldLikeNoHkt
 import typo.dsl.SqlExpr.IdField
 import typo.dsl.SqlExpr.OptField
 import typo.dsl.Structure.Relation
 
-trait SalespersonFields[Row] {
-  val businessentityid: IdField[BusinessentityId, Row]
-  val territoryid: OptField[SalesterritoryId, Row]
-  val salesquota: OptField[BigDecimal, Row]
-  val bonus: Field[BigDecimal, Row]
-  val commissionpct: Field[BigDecimal, Row]
-  val salesytd: Field[BigDecimal, Row]
-  val saleslastyear: Field[BigDecimal, Row]
-  val rowguid: Field[TypoUUID, Row]
-  val modifieddate: Field[TypoLocalDateTime, Row]
+trait SalespersonFields {
+  def businessentityid: IdField[BusinessentityId, SalespersonRow]
+  def territoryid: OptField[SalesterritoryId, SalespersonRow]
+  def salesquota: OptField[BigDecimal, SalespersonRow]
+  def bonus: Field[BigDecimal, SalespersonRow]
+  def commissionpct: Field[BigDecimal, SalespersonRow]
+  def salesytd: Field[BigDecimal, SalespersonRow]
+  def saleslastyear: Field[BigDecimal, SalespersonRow]
+  def rowguid: Field[TypoUUID, SalespersonRow]
+  def modifieddate: Field[TypoLocalDateTime, SalespersonRow]
 }
 
 object SalespersonFields {
-  val structure: Relation[SalespersonFields, SalespersonRow, SalespersonRow] = 
-    new Impl(None, identity, (_, x) => x)
+  lazy val structure: Relation[SalespersonFields, SalespersonRow] =
+    new Impl(Nil)
     
-  private final class Impl[Row](val prefix: Option[String], val extract: Row => SalespersonRow, val merge: (Row, SalespersonRow) => Row)
-    extends Relation[SalespersonFields, SalespersonRow, Row] { 
+  private final class Impl(val _path: List[Path])
+    extends Relation[SalespersonFields, SalespersonRow] {
   
-    override val fields: SalespersonFields[Row] = new SalespersonFields[Row] {
-      override val businessentityid = new IdField[BusinessentityId, Row](prefix, "businessentityid", None, Some("int4"))(x => extract(x).businessentityid, (row, value) => merge(row, extract(row).copy(businessentityid = value)))
-      override val territoryid = new OptField[SalesterritoryId, Row](prefix, "territoryid", None, Some("int4"))(x => extract(x).territoryid, (row, value) => merge(row, extract(row).copy(territoryid = value)))
-      override val salesquota = new OptField[BigDecimal, Row](prefix, "salesquota", None, Some("numeric"))(x => extract(x).salesquota, (row, value) => merge(row, extract(row).copy(salesquota = value)))
-      override val bonus = new Field[BigDecimal, Row](prefix, "bonus", None, Some("numeric"))(x => extract(x).bonus, (row, value) => merge(row, extract(row).copy(bonus = value)))
-      override val commissionpct = new Field[BigDecimal, Row](prefix, "commissionpct", None, Some("numeric"))(x => extract(x).commissionpct, (row, value) => merge(row, extract(row).copy(commissionpct = value)))
-      override val salesytd = new Field[BigDecimal, Row](prefix, "salesytd", None, Some("numeric"))(x => extract(x).salesytd, (row, value) => merge(row, extract(row).copy(salesytd = value)))
-      override val saleslastyear = new Field[BigDecimal, Row](prefix, "saleslastyear", None, Some("numeric"))(x => extract(x).saleslastyear, (row, value) => merge(row, extract(row).copy(saleslastyear = value)))
-      override val rowguid = new Field[TypoUUID, Row](prefix, "rowguid", None, Some("uuid"))(x => extract(x).rowguid, (row, value) => merge(row, extract(row).copy(rowguid = value)))
-      override val modifieddate = new Field[TypoLocalDateTime, Row](prefix, "modifieddate", Some("text"), Some("timestamp"))(x => extract(x).modifieddate, (row, value) => merge(row, extract(row).copy(modifieddate = value)))
+    override lazy val fields: SalespersonFields = new SalespersonFields {
+      override def businessentityid = IdField[BusinessentityId, SalespersonRow](_path, "businessentityid", None, Some("int4"), x => x.businessentityid, (row, value) => row.copy(businessentityid = value))
+      override def territoryid = OptField[SalesterritoryId, SalespersonRow](_path, "territoryid", None, Some("int4"), x => x.territoryid, (row, value) => row.copy(territoryid = value))
+      override def salesquota = OptField[BigDecimal, SalespersonRow](_path, "salesquota", None, Some("numeric"), x => x.salesquota, (row, value) => row.copy(salesquota = value))
+      override def bonus = Field[BigDecimal, SalespersonRow](_path, "bonus", None, Some("numeric"), x => x.bonus, (row, value) => row.copy(bonus = value))
+      override def commissionpct = Field[BigDecimal, SalespersonRow](_path, "commissionpct", None, Some("numeric"), x => x.commissionpct, (row, value) => row.copy(commissionpct = value))
+      override def salesytd = Field[BigDecimal, SalespersonRow](_path, "salesytd", None, Some("numeric"), x => x.salesytd, (row, value) => row.copy(salesytd = value))
+      override def saleslastyear = Field[BigDecimal, SalespersonRow](_path, "saleslastyear", None, Some("numeric"), x => x.saleslastyear, (row, value) => row.copy(saleslastyear = value))
+      override def rowguid = Field[TypoUUID, SalespersonRow](_path, "rowguid", None, Some("uuid"), x => x.rowguid, (row, value) => row.copy(rowguid = value))
+      override def modifieddate = Field[TypoLocalDateTime, SalespersonRow](_path, "modifieddate", Some("text"), Some("timestamp"), x => x.modifieddate, (row, value) => row.copy(modifieddate = value))
     }
   
-    override val columns: List[FieldLikeNoHkt[?, Row]] =
-      List[FieldLikeNoHkt[?, Row]](fields.businessentityid, fields.territoryid, fields.salesquota, fields.bonus, fields.commissionpct, fields.salesytd, fields.saleslastyear, fields.rowguid, fields.modifieddate)
+    override lazy val columns: List[FieldLikeNoHkt[?, SalespersonRow]] =
+      List[FieldLikeNoHkt[?, SalespersonRow]](fields.businessentityid, fields.territoryid, fields.salesquota, fields.bonus, fields.commissionpct, fields.salesytd, fields.saleslastyear, fields.rowguid, fields.modifieddate)
   
-    override def copy[NewRow](prefix: Option[String], extract: NewRow => SalespersonRow, merge: (NewRow, SalespersonRow) => NewRow): Impl[NewRow] =
-      new Impl(prefix, extract, merge)
+    override def copy(path: List[Path]): Impl =
+      new Impl(path)
   }
   
 }

--- a/typo-tester-anorm/generated-and-checked-in/adventureworks/sales/salesperson/SalespersonRepoMock.scala
+++ b/typo-tester-anorm/generated-and-checked-in/adventureworks/sales/salesperson/SalespersonRepoMock.scala
@@ -23,7 +23,7 @@ import typo.dsl.UpdateParams
 class SalespersonRepoMock(toRow: Function1[SalespersonRowUnsaved, SalespersonRow],
                           map: scala.collection.mutable.Map[BusinessentityId, SalespersonRow] = scala.collection.mutable.Map.empty) extends SalespersonRepo {
   override def delete: DeleteBuilder[SalespersonFields, SalespersonRow] = {
-    DeleteBuilderMock(DeleteParams.empty, SalespersonFields.structure.fields, map)
+    DeleteBuilderMock(DeleteParams.empty, SalespersonFields.structure, map)
   }
   override def deleteById(businessentityid: BusinessentityId)(implicit c: Connection): Boolean = {
     map.remove(businessentityid).isDefined
@@ -73,7 +73,7 @@ class SalespersonRepoMock(toRow: Function1[SalespersonRowUnsaved, SalespersonRow
     businessentityids.view.flatMap(id => byId.get(id).map(x => (id, x))).toMap
   }
   override def update: UpdateBuilder[SalespersonFields, SalespersonRow] = {
-    UpdateBuilderMock(UpdateParams.empty, SalespersonFields.structure.fields, map)
+    UpdateBuilderMock(UpdateParams.empty, SalespersonFields.structure, map)
   }
   override def update(row: SalespersonRow)(implicit c: Connection): Boolean = {
     map.get(row.businessentityid) match {

--- a/typo-tester-anorm/generated-and-checked-in/adventureworks/sales/salespersonquotahistory/SalespersonquotahistoryFields.scala
+++ b/typo-tester-anorm/generated-and-checked-in/adventureworks/sales/salespersonquotahistory/SalespersonquotahistoryFields.scala
@@ -10,39 +10,40 @@ package salespersonquotahistory
 import adventureworks.customtypes.TypoLocalDateTime
 import adventureworks.customtypes.TypoUUID
 import adventureworks.person.businessentity.BusinessentityId
+import typo.dsl.Path
 import typo.dsl.SqlExpr.Field
 import typo.dsl.SqlExpr.FieldLikeNoHkt
 import typo.dsl.SqlExpr.IdField
 import typo.dsl.Structure.Relation
 
-trait SalespersonquotahistoryFields[Row] {
-  val businessentityid: IdField[BusinessentityId, Row]
-  val quotadate: IdField[TypoLocalDateTime, Row]
-  val salesquota: Field[BigDecimal, Row]
-  val rowguid: Field[TypoUUID, Row]
-  val modifieddate: Field[TypoLocalDateTime, Row]
+trait SalespersonquotahistoryFields {
+  def businessentityid: IdField[BusinessentityId, SalespersonquotahistoryRow]
+  def quotadate: IdField[TypoLocalDateTime, SalespersonquotahistoryRow]
+  def salesquota: Field[BigDecimal, SalespersonquotahistoryRow]
+  def rowguid: Field[TypoUUID, SalespersonquotahistoryRow]
+  def modifieddate: Field[TypoLocalDateTime, SalespersonquotahistoryRow]
 }
 
 object SalespersonquotahistoryFields {
-  val structure: Relation[SalespersonquotahistoryFields, SalespersonquotahistoryRow, SalespersonquotahistoryRow] = 
-    new Impl(None, identity, (_, x) => x)
+  lazy val structure: Relation[SalespersonquotahistoryFields, SalespersonquotahistoryRow] =
+    new Impl(Nil)
     
-  private final class Impl[Row](val prefix: Option[String], val extract: Row => SalespersonquotahistoryRow, val merge: (Row, SalespersonquotahistoryRow) => Row)
-    extends Relation[SalespersonquotahistoryFields, SalespersonquotahistoryRow, Row] { 
+  private final class Impl(val _path: List[Path])
+    extends Relation[SalespersonquotahistoryFields, SalespersonquotahistoryRow] {
   
-    override val fields: SalespersonquotahistoryFields[Row] = new SalespersonquotahistoryFields[Row] {
-      override val businessentityid = new IdField[BusinessentityId, Row](prefix, "businessentityid", None, Some("int4"))(x => extract(x).businessentityid, (row, value) => merge(row, extract(row).copy(businessentityid = value)))
-      override val quotadate = new IdField[TypoLocalDateTime, Row](prefix, "quotadate", Some("text"), Some("timestamp"))(x => extract(x).quotadate, (row, value) => merge(row, extract(row).copy(quotadate = value)))
-      override val salesquota = new Field[BigDecimal, Row](prefix, "salesquota", None, Some("numeric"))(x => extract(x).salesquota, (row, value) => merge(row, extract(row).copy(salesquota = value)))
-      override val rowguid = new Field[TypoUUID, Row](prefix, "rowguid", None, Some("uuid"))(x => extract(x).rowguid, (row, value) => merge(row, extract(row).copy(rowguid = value)))
-      override val modifieddate = new Field[TypoLocalDateTime, Row](prefix, "modifieddate", Some("text"), Some("timestamp"))(x => extract(x).modifieddate, (row, value) => merge(row, extract(row).copy(modifieddate = value)))
+    override lazy val fields: SalespersonquotahistoryFields = new SalespersonquotahistoryFields {
+      override def businessentityid = IdField[BusinessentityId, SalespersonquotahistoryRow](_path, "businessentityid", None, Some("int4"), x => x.businessentityid, (row, value) => row.copy(businessentityid = value))
+      override def quotadate = IdField[TypoLocalDateTime, SalespersonquotahistoryRow](_path, "quotadate", Some("text"), Some("timestamp"), x => x.quotadate, (row, value) => row.copy(quotadate = value))
+      override def salesquota = Field[BigDecimal, SalespersonquotahistoryRow](_path, "salesquota", None, Some("numeric"), x => x.salesquota, (row, value) => row.copy(salesquota = value))
+      override def rowguid = Field[TypoUUID, SalespersonquotahistoryRow](_path, "rowguid", None, Some("uuid"), x => x.rowguid, (row, value) => row.copy(rowguid = value))
+      override def modifieddate = Field[TypoLocalDateTime, SalespersonquotahistoryRow](_path, "modifieddate", Some("text"), Some("timestamp"), x => x.modifieddate, (row, value) => row.copy(modifieddate = value))
     }
   
-    override val columns: List[FieldLikeNoHkt[?, Row]] =
-      List[FieldLikeNoHkt[?, Row]](fields.businessentityid, fields.quotadate, fields.salesquota, fields.rowguid, fields.modifieddate)
+    override lazy val columns: List[FieldLikeNoHkt[?, SalespersonquotahistoryRow]] =
+      List[FieldLikeNoHkt[?, SalespersonquotahistoryRow]](fields.businessentityid, fields.quotadate, fields.salesquota, fields.rowguid, fields.modifieddate)
   
-    override def copy[NewRow](prefix: Option[String], extract: NewRow => SalespersonquotahistoryRow, merge: (NewRow, SalespersonquotahistoryRow) => NewRow): Impl[NewRow] =
-      new Impl(prefix, extract, merge)
+    override def copy(path: List[Path]): Impl =
+      new Impl(path)
   }
   
 }

--- a/typo-tester-anorm/generated-and-checked-in/adventureworks/sales/salespersonquotahistory/SalespersonquotahistoryRepoMock.scala
+++ b/typo-tester-anorm/generated-and-checked-in/adventureworks/sales/salespersonquotahistory/SalespersonquotahistoryRepoMock.scala
@@ -22,7 +22,7 @@ import typo.dsl.UpdateParams
 class SalespersonquotahistoryRepoMock(toRow: Function1[SalespersonquotahistoryRowUnsaved, SalespersonquotahistoryRow],
                                       map: scala.collection.mutable.Map[SalespersonquotahistoryId, SalespersonquotahistoryRow] = scala.collection.mutable.Map.empty) extends SalespersonquotahistoryRepo {
   override def delete: DeleteBuilder[SalespersonquotahistoryFields, SalespersonquotahistoryRow] = {
-    DeleteBuilderMock(DeleteParams.empty, SalespersonquotahistoryFields.structure.fields, map)
+    DeleteBuilderMock(DeleteParams.empty, SalespersonquotahistoryFields.structure, map)
   }
   override def deleteById(compositeId: SalespersonquotahistoryId)(implicit c: Connection): Boolean = {
     map.remove(compositeId).isDefined
@@ -72,7 +72,7 @@ class SalespersonquotahistoryRepoMock(toRow: Function1[SalespersonquotahistoryRo
     compositeIds.view.flatMap(id => byId.get(id).map(x => (id, x))).toMap
   }
   override def update: UpdateBuilder[SalespersonquotahistoryFields, SalespersonquotahistoryRow] = {
-    UpdateBuilderMock(UpdateParams.empty, SalespersonquotahistoryFields.structure.fields, map)
+    UpdateBuilderMock(UpdateParams.empty, SalespersonquotahistoryFields.structure, map)
   }
   override def update(row: SalespersonquotahistoryRow)(implicit c: Connection): Boolean = {
     map.get(row.compositeId) match {

--- a/typo-tester-anorm/generated-and-checked-in/adventureworks/sales/salesreason/SalesreasonFields.scala
+++ b/typo-tester-anorm/generated-and-checked-in/adventureworks/sales/salesreason/SalesreasonFields.scala
@@ -9,37 +9,38 @@ package salesreason
 
 import adventureworks.customtypes.TypoLocalDateTime
 import adventureworks.public.Name
+import typo.dsl.Path
 import typo.dsl.SqlExpr.Field
 import typo.dsl.SqlExpr.FieldLikeNoHkt
 import typo.dsl.SqlExpr.IdField
 import typo.dsl.Structure.Relation
 
-trait SalesreasonFields[Row] {
-  val salesreasonid: IdField[SalesreasonId, Row]
-  val name: Field[Name, Row]
-  val reasontype: Field[Name, Row]
-  val modifieddate: Field[TypoLocalDateTime, Row]
+trait SalesreasonFields {
+  def salesreasonid: IdField[SalesreasonId, SalesreasonRow]
+  def name: Field[Name, SalesreasonRow]
+  def reasontype: Field[Name, SalesreasonRow]
+  def modifieddate: Field[TypoLocalDateTime, SalesreasonRow]
 }
 
 object SalesreasonFields {
-  val structure: Relation[SalesreasonFields, SalesreasonRow, SalesreasonRow] = 
-    new Impl(None, identity, (_, x) => x)
+  lazy val structure: Relation[SalesreasonFields, SalesreasonRow] =
+    new Impl(Nil)
     
-  private final class Impl[Row](val prefix: Option[String], val extract: Row => SalesreasonRow, val merge: (Row, SalesreasonRow) => Row)
-    extends Relation[SalesreasonFields, SalesreasonRow, Row] { 
+  private final class Impl(val _path: List[Path])
+    extends Relation[SalesreasonFields, SalesreasonRow] {
   
-    override val fields: SalesreasonFields[Row] = new SalesreasonFields[Row] {
-      override val salesreasonid = new IdField[SalesreasonId, Row](prefix, "salesreasonid", None, Some("int4"))(x => extract(x).salesreasonid, (row, value) => merge(row, extract(row).copy(salesreasonid = value)))
-      override val name = new Field[Name, Row](prefix, "name", None, Some("varchar"))(x => extract(x).name, (row, value) => merge(row, extract(row).copy(name = value)))
-      override val reasontype = new Field[Name, Row](prefix, "reasontype", None, Some("varchar"))(x => extract(x).reasontype, (row, value) => merge(row, extract(row).copy(reasontype = value)))
-      override val modifieddate = new Field[TypoLocalDateTime, Row](prefix, "modifieddate", Some("text"), Some("timestamp"))(x => extract(x).modifieddate, (row, value) => merge(row, extract(row).copy(modifieddate = value)))
+    override lazy val fields: SalesreasonFields = new SalesreasonFields {
+      override def salesreasonid = IdField[SalesreasonId, SalesreasonRow](_path, "salesreasonid", None, Some("int4"), x => x.salesreasonid, (row, value) => row.copy(salesreasonid = value))
+      override def name = Field[Name, SalesreasonRow](_path, "name", None, Some("varchar"), x => x.name, (row, value) => row.copy(name = value))
+      override def reasontype = Field[Name, SalesreasonRow](_path, "reasontype", None, Some("varchar"), x => x.reasontype, (row, value) => row.copy(reasontype = value))
+      override def modifieddate = Field[TypoLocalDateTime, SalesreasonRow](_path, "modifieddate", Some("text"), Some("timestamp"), x => x.modifieddate, (row, value) => row.copy(modifieddate = value))
     }
   
-    override val columns: List[FieldLikeNoHkt[?, Row]] =
-      List[FieldLikeNoHkt[?, Row]](fields.salesreasonid, fields.name, fields.reasontype, fields.modifieddate)
+    override lazy val columns: List[FieldLikeNoHkt[?, SalesreasonRow]] =
+      List[FieldLikeNoHkt[?, SalesreasonRow]](fields.salesreasonid, fields.name, fields.reasontype, fields.modifieddate)
   
-    override def copy[NewRow](prefix: Option[String], extract: NewRow => SalesreasonRow, merge: (NewRow, SalesreasonRow) => NewRow): Impl[NewRow] =
-      new Impl(prefix, extract, merge)
+    override def copy(path: List[Path]): Impl =
+      new Impl(path)
   }
   
 }

--- a/typo-tester-anorm/generated-and-checked-in/adventureworks/sales/salesreason/SalesreasonRepoMock.scala
+++ b/typo-tester-anorm/generated-and-checked-in/adventureworks/sales/salesreason/SalesreasonRepoMock.scala
@@ -22,7 +22,7 @@ import typo.dsl.UpdateParams
 class SalesreasonRepoMock(toRow: Function1[SalesreasonRowUnsaved, SalesreasonRow],
                           map: scala.collection.mutable.Map[SalesreasonId, SalesreasonRow] = scala.collection.mutable.Map.empty) extends SalesreasonRepo {
   override def delete: DeleteBuilder[SalesreasonFields, SalesreasonRow] = {
-    DeleteBuilderMock(DeleteParams.empty, SalesreasonFields.structure.fields, map)
+    DeleteBuilderMock(DeleteParams.empty, SalesreasonFields.structure, map)
   }
   override def deleteById(salesreasonid: SalesreasonId)(implicit c: Connection): Boolean = {
     map.remove(salesreasonid).isDefined
@@ -72,7 +72,7 @@ class SalesreasonRepoMock(toRow: Function1[SalesreasonRowUnsaved, SalesreasonRow
     salesreasonids.view.flatMap(id => byId.get(id).map(x => (id, x))).toMap
   }
   override def update: UpdateBuilder[SalesreasonFields, SalesreasonRow] = {
-    UpdateBuilderMock(UpdateParams.empty, SalesreasonFields.structure.fields, map)
+    UpdateBuilderMock(UpdateParams.empty, SalesreasonFields.structure, map)
   }
   override def update(row: SalesreasonRow)(implicit c: Connection): Boolean = {
     map.get(row.salesreasonid) match {

--- a/typo-tester-anorm/generated-and-checked-in/adventureworks/sales/salestaxrate/SalestaxrateFields.scala
+++ b/typo-tester-anorm/generated-and-checked-in/adventureworks/sales/salestaxrate/SalestaxrateFields.scala
@@ -12,43 +12,44 @@ import adventureworks.customtypes.TypoShort
 import adventureworks.customtypes.TypoUUID
 import adventureworks.person.stateprovince.StateprovinceId
 import adventureworks.public.Name
+import typo.dsl.Path
 import typo.dsl.SqlExpr.Field
 import typo.dsl.SqlExpr.FieldLikeNoHkt
 import typo.dsl.SqlExpr.IdField
 import typo.dsl.Structure.Relation
 
-trait SalestaxrateFields[Row] {
-  val salestaxrateid: IdField[SalestaxrateId, Row]
-  val stateprovinceid: Field[StateprovinceId, Row]
-  val taxtype: Field[TypoShort, Row]
-  val taxrate: Field[BigDecimal, Row]
-  val name: Field[Name, Row]
-  val rowguid: Field[TypoUUID, Row]
-  val modifieddate: Field[TypoLocalDateTime, Row]
+trait SalestaxrateFields {
+  def salestaxrateid: IdField[SalestaxrateId, SalestaxrateRow]
+  def stateprovinceid: Field[StateprovinceId, SalestaxrateRow]
+  def taxtype: Field[TypoShort, SalestaxrateRow]
+  def taxrate: Field[BigDecimal, SalestaxrateRow]
+  def name: Field[Name, SalestaxrateRow]
+  def rowguid: Field[TypoUUID, SalestaxrateRow]
+  def modifieddate: Field[TypoLocalDateTime, SalestaxrateRow]
 }
 
 object SalestaxrateFields {
-  val structure: Relation[SalestaxrateFields, SalestaxrateRow, SalestaxrateRow] = 
-    new Impl(None, identity, (_, x) => x)
+  lazy val structure: Relation[SalestaxrateFields, SalestaxrateRow] =
+    new Impl(Nil)
     
-  private final class Impl[Row](val prefix: Option[String], val extract: Row => SalestaxrateRow, val merge: (Row, SalestaxrateRow) => Row)
-    extends Relation[SalestaxrateFields, SalestaxrateRow, Row] { 
+  private final class Impl(val _path: List[Path])
+    extends Relation[SalestaxrateFields, SalestaxrateRow] {
   
-    override val fields: SalestaxrateFields[Row] = new SalestaxrateFields[Row] {
-      override val salestaxrateid = new IdField[SalestaxrateId, Row](prefix, "salestaxrateid", None, Some("int4"))(x => extract(x).salestaxrateid, (row, value) => merge(row, extract(row).copy(salestaxrateid = value)))
-      override val stateprovinceid = new Field[StateprovinceId, Row](prefix, "stateprovinceid", None, Some("int4"))(x => extract(x).stateprovinceid, (row, value) => merge(row, extract(row).copy(stateprovinceid = value)))
-      override val taxtype = new Field[TypoShort, Row](prefix, "taxtype", None, Some("int2"))(x => extract(x).taxtype, (row, value) => merge(row, extract(row).copy(taxtype = value)))
-      override val taxrate = new Field[BigDecimal, Row](prefix, "taxrate", None, Some("numeric"))(x => extract(x).taxrate, (row, value) => merge(row, extract(row).copy(taxrate = value)))
-      override val name = new Field[Name, Row](prefix, "name", None, Some("varchar"))(x => extract(x).name, (row, value) => merge(row, extract(row).copy(name = value)))
-      override val rowguid = new Field[TypoUUID, Row](prefix, "rowguid", None, Some("uuid"))(x => extract(x).rowguid, (row, value) => merge(row, extract(row).copy(rowguid = value)))
-      override val modifieddate = new Field[TypoLocalDateTime, Row](prefix, "modifieddate", Some("text"), Some("timestamp"))(x => extract(x).modifieddate, (row, value) => merge(row, extract(row).copy(modifieddate = value)))
+    override lazy val fields: SalestaxrateFields = new SalestaxrateFields {
+      override def salestaxrateid = IdField[SalestaxrateId, SalestaxrateRow](_path, "salestaxrateid", None, Some("int4"), x => x.salestaxrateid, (row, value) => row.copy(salestaxrateid = value))
+      override def stateprovinceid = Field[StateprovinceId, SalestaxrateRow](_path, "stateprovinceid", None, Some("int4"), x => x.stateprovinceid, (row, value) => row.copy(stateprovinceid = value))
+      override def taxtype = Field[TypoShort, SalestaxrateRow](_path, "taxtype", None, Some("int2"), x => x.taxtype, (row, value) => row.copy(taxtype = value))
+      override def taxrate = Field[BigDecimal, SalestaxrateRow](_path, "taxrate", None, Some("numeric"), x => x.taxrate, (row, value) => row.copy(taxrate = value))
+      override def name = Field[Name, SalestaxrateRow](_path, "name", None, Some("varchar"), x => x.name, (row, value) => row.copy(name = value))
+      override def rowguid = Field[TypoUUID, SalestaxrateRow](_path, "rowguid", None, Some("uuid"), x => x.rowguid, (row, value) => row.copy(rowguid = value))
+      override def modifieddate = Field[TypoLocalDateTime, SalestaxrateRow](_path, "modifieddate", Some("text"), Some("timestamp"), x => x.modifieddate, (row, value) => row.copy(modifieddate = value))
     }
   
-    override val columns: List[FieldLikeNoHkt[?, Row]] =
-      List[FieldLikeNoHkt[?, Row]](fields.salestaxrateid, fields.stateprovinceid, fields.taxtype, fields.taxrate, fields.name, fields.rowguid, fields.modifieddate)
+    override lazy val columns: List[FieldLikeNoHkt[?, SalestaxrateRow]] =
+      List[FieldLikeNoHkt[?, SalestaxrateRow]](fields.salestaxrateid, fields.stateprovinceid, fields.taxtype, fields.taxrate, fields.name, fields.rowguid, fields.modifieddate)
   
-    override def copy[NewRow](prefix: Option[String], extract: NewRow => SalestaxrateRow, merge: (NewRow, SalestaxrateRow) => NewRow): Impl[NewRow] =
-      new Impl(prefix, extract, merge)
+    override def copy(path: List[Path]): Impl =
+      new Impl(path)
   }
   
 }

--- a/typo-tester-anorm/generated-and-checked-in/adventureworks/sales/salestaxrate/SalestaxrateRepoMock.scala
+++ b/typo-tester-anorm/generated-and-checked-in/adventureworks/sales/salestaxrate/SalestaxrateRepoMock.scala
@@ -22,7 +22,7 @@ import typo.dsl.UpdateParams
 class SalestaxrateRepoMock(toRow: Function1[SalestaxrateRowUnsaved, SalestaxrateRow],
                            map: scala.collection.mutable.Map[SalestaxrateId, SalestaxrateRow] = scala.collection.mutable.Map.empty) extends SalestaxrateRepo {
   override def delete: DeleteBuilder[SalestaxrateFields, SalestaxrateRow] = {
-    DeleteBuilderMock(DeleteParams.empty, SalestaxrateFields.structure.fields, map)
+    DeleteBuilderMock(DeleteParams.empty, SalestaxrateFields.structure, map)
   }
   override def deleteById(salestaxrateid: SalestaxrateId)(implicit c: Connection): Boolean = {
     map.remove(salestaxrateid).isDefined
@@ -72,7 +72,7 @@ class SalestaxrateRepoMock(toRow: Function1[SalestaxrateRowUnsaved, Salestaxrate
     salestaxrateids.view.flatMap(id => byId.get(id).map(x => (id, x))).toMap
   }
   override def update: UpdateBuilder[SalestaxrateFields, SalestaxrateRow] = {
-    UpdateBuilderMock(UpdateParams.empty, SalestaxrateFields.structure.fields, map)
+    UpdateBuilderMock(UpdateParams.empty, SalestaxrateFields.structure, map)
   }
   override def update(row: SalestaxrateRow)(implicit c: Connection): Boolean = {
     map.get(row.salestaxrateid) match {

--- a/typo-tester-anorm/generated-and-checked-in/adventureworks/sales/salesterritory/SalesterritoryFields.scala
+++ b/typo-tester-anorm/generated-and-checked-in/adventureworks/sales/salesterritory/SalesterritoryFields.scala
@@ -11,49 +11,50 @@ import adventureworks.customtypes.TypoLocalDateTime
 import adventureworks.customtypes.TypoUUID
 import adventureworks.person.countryregion.CountryregionId
 import adventureworks.public.Name
+import typo.dsl.Path
 import typo.dsl.SqlExpr.Field
 import typo.dsl.SqlExpr.FieldLikeNoHkt
 import typo.dsl.SqlExpr.IdField
 import typo.dsl.Structure.Relation
 
-trait SalesterritoryFields[Row] {
-  val territoryid: IdField[SalesterritoryId, Row]
-  val name: Field[Name, Row]
-  val countryregioncode: Field[CountryregionId, Row]
-  val group: Field[/* max 50 chars */ String, Row]
-  val salesytd: Field[BigDecimal, Row]
-  val saleslastyear: Field[BigDecimal, Row]
-  val costytd: Field[BigDecimal, Row]
-  val costlastyear: Field[BigDecimal, Row]
-  val rowguid: Field[TypoUUID, Row]
-  val modifieddate: Field[TypoLocalDateTime, Row]
+trait SalesterritoryFields {
+  def territoryid: IdField[SalesterritoryId, SalesterritoryRow]
+  def name: Field[Name, SalesterritoryRow]
+  def countryregioncode: Field[CountryregionId, SalesterritoryRow]
+  def group: Field[/* max 50 chars */ String, SalesterritoryRow]
+  def salesytd: Field[BigDecimal, SalesterritoryRow]
+  def saleslastyear: Field[BigDecimal, SalesterritoryRow]
+  def costytd: Field[BigDecimal, SalesterritoryRow]
+  def costlastyear: Field[BigDecimal, SalesterritoryRow]
+  def rowguid: Field[TypoUUID, SalesterritoryRow]
+  def modifieddate: Field[TypoLocalDateTime, SalesterritoryRow]
 }
 
 object SalesterritoryFields {
-  val structure: Relation[SalesterritoryFields, SalesterritoryRow, SalesterritoryRow] = 
-    new Impl(None, identity, (_, x) => x)
+  lazy val structure: Relation[SalesterritoryFields, SalesterritoryRow] =
+    new Impl(Nil)
     
-  private final class Impl[Row](val prefix: Option[String], val extract: Row => SalesterritoryRow, val merge: (Row, SalesterritoryRow) => Row)
-    extends Relation[SalesterritoryFields, SalesterritoryRow, Row] { 
+  private final class Impl(val _path: List[Path])
+    extends Relation[SalesterritoryFields, SalesterritoryRow] {
   
-    override val fields: SalesterritoryFields[Row] = new SalesterritoryFields[Row] {
-      override val territoryid = new IdField[SalesterritoryId, Row](prefix, "territoryid", None, Some("int4"))(x => extract(x).territoryid, (row, value) => merge(row, extract(row).copy(territoryid = value)))
-      override val name = new Field[Name, Row](prefix, "name", None, Some("varchar"))(x => extract(x).name, (row, value) => merge(row, extract(row).copy(name = value)))
-      override val countryregioncode = new Field[CountryregionId, Row](prefix, "countryregioncode", None, None)(x => extract(x).countryregioncode, (row, value) => merge(row, extract(row).copy(countryregioncode = value)))
-      override val group = new Field[/* max 50 chars */ String, Row](prefix, "group", None, None)(x => extract(x).group, (row, value) => merge(row, extract(row).copy(group = value)))
-      override val salesytd = new Field[BigDecimal, Row](prefix, "salesytd", None, Some("numeric"))(x => extract(x).salesytd, (row, value) => merge(row, extract(row).copy(salesytd = value)))
-      override val saleslastyear = new Field[BigDecimal, Row](prefix, "saleslastyear", None, Some("numeric"))(x => extract(x).saleslastyear, (row, value) => merge(row, extract(row).copy(saleslastyear = value)))
-      override val costytd = new Field[BigDecimal, Row](prefix, "costytd", None, Some("numeric"))(x => extract(x).costytd, (row, value) => merge(row, extract(row).copy(costytd = value)))
-      override val costlastyear = new Field[BigDecimal, Row](prefix, "costlastyear", None, Some("numeric"))(x => extract(x).costlastyear, (row, value) => merge(row, extract(row).copy(costlastyear = value)))
-      override val rowguid = new Field[TypoUUID, Row](prefix, "rowguid", None, Some("uuid"))(x => extract(x).rowguid, (row, value) => merge(row, extract(row).copy(rowguid = value)))
-      override val modifieddate = new Field[TypoLocalDateTime, Row](prefix, "modifieddate", Some("text"), Some("timestamp"))(x => extract(x).modifieddate, (row, value) => merge(row, extract(row).copy(modifieddate = value)))
+    override lazy val fields: SalesterritoryFields = new SalesterritoryFields {
+      override def territoryid = IdField[SalesterritoryId, SalesterritoryRow](_path, "territoryid", None, Some("int4"), x => x.territoryid, (row, value) => row.copy(territoryid = value))
+      override def name = Field[Name, SalesterritoryRow](_path, "name", None, Some("varchar"), x => x.name, (row, value) => row.copy(name = value))
+      override def countryregioncode = Field[CountryregionId, SalesterritoryRow](_path, "countryregioncode", None, None, x => x.countryregioncode, (row, value) => row.copy(countryregioncode = value))
+      override def group = Field[/* max 50 chars */ String, SalesterritoryRow](_path, "group", None, None, x => x.group, (row, value) => row.copy(group = value))
+      override def salesytd = Field[BigDecimal, SalesterritoryRow](_path, "salesytd", None, Some("numeric"), x => x.salesytd, (row, value) => row.copy(salesytd = value))
+      override def saleslastyear = Field[BigDecimal, SalesterritoryRow](_path, "saleslastyear", None, Some("numeric"), x => x.saleslastyear, (row, value) => row.copy(saleslastyear = value))
+      override def costytd = Field[BigDecimal, SalesterritoryRow](_path, "costytd", None, Some("numeric"), x => x.costytd, (row, value) => row.copy(costytd = value))
+      override def costlastyear = Field[BigDecimal, SalesterritoryRow](_path, "costlastyear", None, Some("numeric"), x => x.costlastyear, (row, value) => row.copy(costlastyear = value))
+      override def rowguid = Field[TypoUUID, SalesterritoryRow](_path, "rowguid", None, Some("uuid"), x => x.rowguid, (row, value) => row.copy(rowguid = value))
+      override def modifieddate = Field[TypoLocalDateTime, SalesterritoryRow](_path, "modifieddate", Some("text"), Some("timestamp"), x => x.modifieddate, (row, value) => row.copy(modifieddate = value))
     }
   
-    override val columns: List[FieldLikeNoHkt[?, Row]] =
-      List[FieldLikeNoHkt[?, Row]](fields.territoryid, fields.name, fields.countryregioncode, fields.group, fields.salesytd, fields.saleslastyear, fields.costytd, fields.costlastyear, fields.rowguid, fields.modifieddate)
+    override lazy val columns: List[FieldLikeNoHkt[?, SalesterritoryRow]] =
+      List[FieldLikeNoHkt[?, SalesterritoryRow]](fields.territoryid, fields.name, fields.countryregioncode, fields.group, fields.salesytd, fields.saleslastyear, fields.costytd, fields.costlastyear, fields.rowguid, fields.modifieddate)
   
-    override def copy[NewRow](prefix: Option[String], extract: NewRow => SalesterritoryRow, merge: (NewRow, SalesterritoryRow) => NewRow): Impl[NewRow] =
-      new Impl(prefix, extract, merge)
+    override def copy(path: List[Path]): Impl =
+      new Impl(path)
   }
   
 }

--- a/typo-tester-anorm/generated-and-checked-in/adventureworks/sales/salesterritory/SalesterritoryRepoMock.scala
+++ b/typo-tester-anorm/generated-and-checked-in/adventureworks/sales/salesterritory/SalesterritoryRepoMock.scala
@@ -22,7 +22,7 @@ import typo.dsl.UpdateParams
 class SalesterritoryRepoMock(toRow: Function1[SalesterritoryRowUnsaved, SalesterritoryRow],
                              map: scala.collection.mutable.Map[SalesterritoryId, SalesterritoryRow] = scala.collection.mutable.Map.empty) extends SalesterritoryRepo {
   override def delete: DeleteBuilder[SalesterritoryFields, SalesterritoryRow] = {
-    DeleteBuilderMock(DeleteParams.empty, SalesterritoryFields.structure.fields, map)
+    DeleteBuilderMock(DeleteParams.empty, SalesterritoryFields.structure, map)
   }
   override def deleteById(territoryid: SalesterritoryId)(implicit c: Connection): Boolean = {
     map.remove(territoryid).isDefined
@@ -72,7 +72,7 @@ class SalesterritoryRepoMock(toRow: Function1[SalesterritoryRowUnsaved, Salester
     territoryids.view.flatMap(id => byId.get(id).map(x => (id, x))).toMap
   }
   override def update: UpdateBuilder[SalesterritoryFields, SalesterritoryRow] = {
-    UpdateBuilderMock(UpdateParams.empty, SalesterritoryFields.structure.fields, map)
+    UpdateBuilderMock(UpdateParams.empty, SalesterritoryFields.structure, map)
   }
   override def update(row: SalesterritoryRow)(implicit c: Connection): Boolean = {
     map.get(row.territoryid) match {

--- a/typo-tester-anorm/generated-and-checked-in/adventureworks/sales/salesterritoryhistory/SalesterritoryhistoryFields.scala
+++ b/typo-tester-anorm/generated-and-checked-in/adventureworks/sales/salesterritoryhistory/SalesterritoryhistoryFields.scala
@@ -11,42 +11,43 @@ import adventureworks.customtypes.TypoLocalDateTime
 import adventureworks.customtypes.TypoUUID
 import adventureworks.person.businessentity.BusinessentityId
 import adventureworks.sales.salesterritory.SalesterritoryId
+import typo.dsl.Path
 import typo.dsl.SqlExpr.Field
 import typo.dsl.SqlExpr.FieldLikeNoHkt
 import typo.dsl.SqlExpr.IdField
 import typo.dsl.SqlExpr.OptField
 import typo.dsl.Structure.Relation
 
-trait SalesterritoryhistoryFields[Row] {
-  val businessentityid: IdField[BusinessentityId, Row]
-  val territoryid: IdField[SalesterritoryId, Row]
-  val startdate: IdField[TypoLocalDateTime, Row]
-  val enddate: OptField[TypoLocalDateTime, Row]
-  val rowguid: Field[TypoUUID, Row]
-  val modifieddate: Field[TypoLocalDateTime, Row]
+trait SalesterritoryhistoryFields {
+  def businessentityid: IdField[BusinessentityId, SalesterritoryhistoryRow]
+  def territoryid: IdField[SalesterritoryId, SalesterritoryhistoryRow]
+  def startdate: IdField[TypoLocalDateTime, SalesterritoryhistoryRow]
+  def enddate: OptField[TypoLocalDateTime, SalesterritoryhistoryRow]
+  def rowguid: Field[TypoUUID, SalesterritoryhistoryRow]
+  def modifieddate: Field[TypoLocalDateTime, SalesterritoryhistoryRow]
 }
 
 object SalesterritoryhistoryFields {
-  val structure: Relation[SalesterritoryhistoryFields, SalesterritoryhistoryRow, SalesterritoryhistoryRow] = 
-    new Impl(None, identity, (_, x) => x)
+  lazy val structure: Relation[SalesterritoryhistoryFields, SalesterritoryhistoryRow] =
+    new Impl(Nil)
     
-  private final class Impl[Row](val prefix: Option[String], val extract: Row => SalesterritoryhistoryRow, val merge: (Row, SalesterritoryhistoryRow) => Row)
-    extends Relation[SalesterritoryhistoryFields, SalesterritoryhistoryRow, Row] { 
+  private final class Impl(val _path: List[Path])
+    extends Relation[SalesterritoryhistoryFields, SalesterritoryhistoryRow] {
   
-    override val fields: SalesterritoryhistoryFields[Row] = new SalesterritoryhistoryFields[Row] {
-      override val businessentityid = new IdField[BusinessentityId, Row](prefix, "businessentityid", None, Some("int4"))(x => extract(x).businessentityid, (row, value) => merge(row, extract(row).copy(businessentityid = value)))
-      override val territoryid = new IdField[SalesterritoryId, Row](prefix, "territoryid", None, Some("int4"))(x => extract(x).territoryid, (row, value) => merge(row, extract(row).copy(territoryid = value)))
-      override val startdate = new IdField[TypoLocalDateTime, Row](prefix, "startdate", Some("text"), Some("timestamp"))(x => extract(x).startdate, (row, value) => merge(row, extract(row).copy(startdate = value)))
-      override val enddate = new OptField[TypoLocalDateTime, Row](prefix, "enddate", Some("text"), Some("timestamp"))(x => extract(x).enddate, (row, value) => merge(row, extract(row).copy(enddate = value)))
-      override val rowguid = new Field[TypoUUID, Row](prefix, "rowguid", None, Some("uuid"))(x => extract(x).rowguid, (row, value) => merge(row, extract(row).copy(rowguid = value)))
-      override val modifieddate = new Field[TypoLocalDateTime, Row](prefix, "modifieddate", Some("text"), Some("timestamp"))(x => extract(x).modifieddate, (row, value) => merge(row, extract(row).copy(modifieddate = value)))
+    override lazy val fields: SalesterritoryhistoryFields = new SalesterritoryhistoryFields {
+      override def businessentityid = IdField[BusinessentityId, SalesterritoryhistoryRow](_path, "businessentityid", None, Some("int4"), x => x.businessentityid, (row, value) => row.copy(businessentityid = value))
+      override def territoryid = IdField[SalesterritoryId, SalesterritoryhistoryRow](_path, "territoryid", None, Some("int4"), x => x.territoryid, (row, value) => row.copy(territoryid = value))
+      override def startdate = IdField[TypoLocalDateTime, SalesterritoryhistoryRow](_path, "startdate", Some("text"), Some("timestamp"), x => x.startdate, (row, value) => row.copy(startdate = value))
+      override def enddate = OptField[TypoLocalDateTime, SalesterritoryhistoryRow](_path, "enddate", Some("text"), Some("timestamp"), x => x.enddate, (row, value) => row.copy(enddate = value))
+      override def rowguid = Field[TypoUUID, SalesterritoryhistoryRow](_path, "rowguid", None, Some("uuid"), x => x.rowguid, (row, value) => row.copy(rowguid = value))
+      override def modifieddate = Field[TypoLocalDateTime, SalesterritoryhistoryRow](_path, "modifieddate", Some("text"), Some("timestamp"), x => x.modifieddate, (row, value) => row.copy(modifieddate = value))
     }
   
-    override val columns: List[FieldLikeNoHkt[?, Row]] =
-      List[FieldLikeNoHkt[?, Row]](fields.businessentityid, fields.territoryid, fields.startdate, fields.enddate, fields.rowguid, fields.modifieddate)
+    override lazy val columns: List[FieldLikeNoHkt[?, SalesterritoryhistoryRow]] =
+      List[FieldLikeNoHkt[?, SalesterritoryhistoryRow]](fields.businessentityid, fields.territoryid, fields.startdate, fields.enddate, fields.rowguid, fields.modifieddate)
   
-    override def copy[NewRow](prefix: Option[String], extract: NewRow => SalesterritoryhistoryRow, merge: (NewRow, SalesterritoryhistoryRow) => NewRow): Impl[NewRow] =
-      new Impl(prefix, extract, merge)
+    override def copy(path: List[Path]): Impl =
+      new Impl(path)
   }
   
 }

--- a/typo-tester-anorm/generated-and-checked-in/adventureworks/sales/salesterritoryhistory/SalesterritoryhistoryRepoMock.scala
+++ b/typo-tester-anorm/generated-and-checked-in/adventureworks/sales/salesterritoryhistory/SalesterritoryhistoryRepoMock.scala
@@ -22,7 +22,7 @@ import typo.dsl.UpdateParams
 class SalesterritoryhistoryRepoMock(toRow: Function1[SalesterritoryhistoryRowUnsaved, SalesterritoryhistoryRow],
                                     map: scala.collection.mutable.Map[SalesterritoryhistoryId, SalesterritoryhistoryRow] = scala.collection.mutable.Map.empty) extends SalesterritoryhistoryRepo {
   override def delete: DeleteBuilder[SalesterritoryhistoryFields, SalesterritoryhistoryRow] = {
-    DeleteBuilderMock(DeleteParams.empty, SalesterritoryhistoryFields.structure.fields, map)
+    DeleteBuilderMock(DeleteParams.empty, SalesterritoryhistoryFields.structure, map)
   }
   override def deleteById(compositeId: SalesterritoryhistoryId)(implicit c: Connection): Boolean = {
     map.remove(compositeId).isDefined
@@ -72,7 +72,7 @@ class SalesterritoryhistoryRepoMock(toRow: Function1[SalesterritoryhistoryRowUns
     compositeIds.view.flatMap(id => byId.get(id).map(x => (id, x))).toMap
   }
   override def update: UpdateBuilder[SalesterritoryhistoryFields, SalesterritoryhistoryRow] = {
-    UpdateBuilderMock(UpdateParams.empty, SalesterritoryhistoryFields.structure.fields, map)
+    UpdateBuilderMock(UpdateParams.empty, SalesterritoryhistoryFields.structure, map)
   }
   override def update(row: SalesterritoryhistoryRow)(implicit c: Connection): Boolean = {
     map.get(row.compositeId) match {

--- a/typo-tester-anorm/generated-and-checked-in/adventureworks/sales/shoppingcartitem/ShoppingcartitemFields.scala
+++ b/typo-tester-anorm/generated-and-checked-in/adventureworks/sales/shoppingcartitem/ShoppingcartitemFields.scala
@@ -9,41 +9,42 @@ package shoppingcartitem
 
 import adventureworks.customtypes.TypoLocalDateTime
 import adventureworks.production.product.ProductId
+import typo.dsl.Path
 import typo.dsl.SqlExpr.Field
 import typo.dsl.SqlExpr.FieldLikeNoHkt
 import typo.dsl.SqlExpr.IdField
 import typo.dsl.Structure.Relation
 
-trait ShoppingcartitemFields[Row] {
-  val shoppingcartitemid: IdField[ShoppingcartitemId, Row]
-  val shoppingcartid: Field[/* max 50 chars */ String, Row]
-  val quantity: Field[Int, Row]
-  val productid: Field[ProductId, Row]
-  val datecreated: Field[TypoLocalDateTime, Row]
-  val modifieddate: Field[TypoLocalDateTime, Row]
+trait ShoppingcartitemFields {
+  def shoppingcartitemid: IdField[ShoppingcartitemId, ShoppingcartitemRow]
+  def shoppingcartid: Field[/* max 50 chars */ String, ShoppingcartitemRow]
+  def quantity: Field[Int, ShoppingcartitemRow]
+  def productid: Field[ProductId, ShoppingcartitemRow]
+  def datecreated: Field[TypoLocalDateTime, ShoppingcartitemRow]
+  def modifieddate: Field[TypoLocalDateTime, ShoppingcartitemRow]
 }
 
 object ShoppingcartitemFields {
-  val structure: Relation[ShoppingcartitemFields, ShoppingcartitemRow, ShoppingcartitemRow] = 
-    new Impl(None, identity, (_, x) => x)
+  lazy val structure: Relation[ShoppingcartitemFields, ShoppingcartitemRow] =
+    new Impl(Nil)
     
-  private final class Impl[Row](val prefix: Option[String], val extract: Row => ShoppingcartitemRow, val merge: (Row, ShoppingcartitemRow) => Row)
-    extends Relation[ShoppingcartitemFields, ShoppingcartitemRow, Row] { 
+  private final class Impl(val _path: List[Path])
+    extends Relation[ShoppingcartitemFields, ShoppingcartitemRow] {
   
-    override val fields: ShoppingcartitemFields[Row] = new ShoppingcartitemFields[Row] {
-      override val shoppingcartitemid = new IdField[ShoppingcartitemId, Row](prefix, "shoppingcartitemid", None, Some("int4"))(x => extract(x).shoppingcartitemid, (row, value) => merge(row, extract(row).copy(shoppingcartitemid = value)))
-      override val shoppingcartid = new Field[/* max 50 chars */ String, Row](prefix, "shoppingcartid", None, None)(x => extract(x).shoppingcartid, (row, value) => merge(row, extract(row).copy(shoppingcartid = value)))
-      override val quantity = new Field[Int, Row](prefix, "quantity", None, Some("int4"))(x => extract(x).quantity, (row, value) => merge(row, extract(row).copy(quantity = value)))
-      override val productid = new Field[ProductId, Row](prefix, "productid", None, Some("int4"))(x => extract(x).productid, (row, value) => merge(row, extract(row).copy(productid = value)))
-      override val datecreated = new Field[TypoLocalDateTime, Row](prefix, "datecreated", Some("text"), Some("timestamp"))(x => extract(x).datecreated, (row, value) => merge(row, extract(row).copy(datecreated = value)))
-      override val modifieddate = new Field[TypoLocalDateTime, Row](prefix, "modifieddate", Some("text"), Some("timestamp"))(x => extract(x).modifieddate, (row, value) => merge(row, extract(row).copy(modifieddate = value)))
+    override lazy val fields: ShoppingcartitemFields = new ShoppingcartitemFields {
+      override def shoppingcartitemid = IdField[ShoppingcartitemId, ShoppingcartitemRow](_path, "shoppingcartitemid", None, Some("int4"), x => x.shoppingcartitemid, (row, value) => row.copy(shoppingcartitemid = value))
+      override def shoppingcartid = Field[/* max 50 chars */ String, ShoppingcartitemRow](_path, "shoppingcartid", None, None, x => x.shoppingcartid, (row, value) => row.copy(shoppingcartid = value))
+      override def quantity = Field[Int, ShoppingcartitemRow](_path, "quantity", None, Some("int4"), x => x.quantity, (row, value) => row.copy(quantity = value))
+      override def productid = Field[ProductId, ShoppingcartitemRow](_path, "productid", None, Some("int4"), x => x.productid, (row, value) => row.copy(productid = value))
+      override def datecreated = Field[TypoLocalDateTime, ShoppingcartitemRow](_path, "datecreated", Some("text"), Some("timestamp"), x => x.datecreated, (row, value) => row.copy(datecreated = value))
+      override def modifieddate = Field[TypoLocalDateTime, ShoppingcartitemRow](_path, "modifieddate", Some("text"), Some("timestamp"), x => x.modifieddate, (row, value) => row.copy(modifieddate = value))
     }
   
-    override val columns: List[FieldLikeNoHkt[?, Row]] =
-      List[FieldLikeNoHkt[?, Row]](fields.shoppingcartitemid, fields.shoppingcartid, fields.quantity, fields.productid, fields.datecreated, fields.modifieddate)
+    override lazy val columns: List[FieldLikeNoHkt[?, ShoppingcartitemRow]] =
+      List[FieldLikeNoHkt[?, ShoppingcartitemRow]](fields.shoppingcartitemid, fields.shoppingcartid, fields.quantity, fields.productid, fields.datecreated, fields.modifieddate)
   
-    override def copy[NewRow](prefix: Option[String], extract: NewRow => ShoppingcartitemRow, merge: (NewRow, ShoppingcartitemRow) => NewRow): Impl[NewRow] =
-      new Impl(prefix, extract, merge)
+    override def copy(path: List[Path]): Impl =
+      new Impl(path)
   }
   
 }

--- a/typo-tester-anorm/generated-and-checked-in/adventureworks/sales/shoppingcartitem/ShoppingcartitemRepoMock.scala
+++ b/typo-tester-anorm/generated-and-checked-in/adventureworks/sales/shoppingcartitem/ShoppingcartitemRepoMock.scala
@@ -22,7 +22,7 @@ import typo.dsl.UpdateParams
 class ShoppingcartitemRepoMock(toRow: Function1[ShoppingcartitemRowUnsaved, ShoppingcartitemRow],
                                map: scala.collection.mutable.Map[ShoppingcartitemId, ShoppingcartitemRow] = scala.collection.mutable.Map.empty) extends ShoppingcartitemRepo {
   override def delete: DeleteBuilder[ShoppingcartitemFields, ShoppingcartitemRow] = {
-    DeleteBuilderMock(DeleteParams.empty, ShoppingcartitemFields.structure.fields, map)
+    DeleteBuilderMock(DeleteParams.empty, ShoppingcartitemFields.structure, map)
   }
   override def deleteById(shoppingcartitemid: ShoppingcartitemId)(implicit c: Connection): Boolean = {
     map.remove(shoppingcartitemid).isDefined
@@ -72,7 +72,7 @@ class ShoppingcartitemRepoMock(toRow: Function1[ShoppingcartitemRowUnsaved, Shop
     shoppingcartitemids.view.flatMap(id => byId.get(id).map(x => (id, x))).toMap
   }
   override def update: UpdateBuilder[ShoppingcartitemFields, ShoppingcartitemRow] = {
-    UpdateBuilderMock(UpdateParams.empty, ShoppingcartitemFields.structure.fields, map)
+    UpdateBuilderMock(UpdateParams.empty, ShoppingcartitemFields.structure, map)
   }
   override def update(row: ShoppingcartitemRow)(implicit c: Connection): Boolean = {
     map.get(row.shoppingcartitemid) match {

--- a/typo-tester-anorm/generated-and-checked-in/adventureworks/sales/specialoffer/SpecialofferFields.scala
+++ b/typo-tester-anorm/generated-and-checked-in/adventureworks/sales/specialoffer/SpecialofferFields.scala
@@ -9,52 +9,53 @@ package specialoffer
 
 import adventureworks.customtypes.TypoLocalDateTime
 import adventureworks.customtypes.TypoUUID
+import typo.dsl.Path
 import typo.dsl.SqlExpr.Field
 import typo.dsl.SqlExpr.FieldLikeNoHkt
 import typo.dsl.SqlExpr.IdField
 import typo.dsl.SqlExpr.OptField
 import typo.dsl.Structure.Relation
 
-trait SpecialofferFields[Row] {
-  val specialofferid: IdField[SpecialofferId, Row]
-  val description: Field[/* max 255 chars */ String, Row]
-  val discountpct: Field[BigDecimal, Row]
-  val `type`: Field[/* max 50 chars */ String, Row]
-  val category: Field[/* max 50 chars */ String, Row]
-  val startdate: Field[TypoLocalDateTime, Row]
-  val enddate: Field[TypoLocalDateTime, Row]
-  val minqty: Field[Int, Row]
-  val maxqty: OptField[Int, Row]
-  val rowguid: Field[TypoUUID, Row]
-  val modifieddate: Field[TypoLocalDateTime, Row]
+trait SpecialofferFields {
+  def specialofferid: IdField[SpecialofferId, SpecialofferRow]
+  def description: Field[/* max 255 chars */ String, SpecialofferRow]
+  def discountpct: Field[BigDecimal, SpecialofferRow]
+  def `type`: Field[/* max 50 chars */ String, SpecialofferRow]
+  def category: Field[/* max 50 chars */ String, SpecialofferRow]
+  def startdate: Field[TypoLocalDateTime, SpecialofferRow]
+  def enddate: Field[TypoLocalDateTime, SpecialofferRow]
+  def minqty: Field[Int, SpecialofferRow]
+  def maxqty: OptField[Int, SpecialofferRow]
+  def rowguid: Field[TypoUUID, SpecialofferRow]
+  def modifieddate: Field[TypoLocalDateTime, SpecialofferRow]
 }
 
 object SpecialofferFields {
-  val structure: Relation[SpecialofferFields, SpecialofferRow, SpecialofferRow] = 
-    new Impl(None, identity, (_, x) => x)
+  lazy val structure: Relation[SpecialofferFields, SpecialofferRow] =
+    new Impl(Nil)
     
-  private final class Impl[Row](val prefix: Option[String], val extract: Row => SpecialofferRow, val merge: (Row, SpecialofferRow) => Row)
-    extends Relation[SpecialofferFields, SpecialofferRow, Row] { 
+  private final class Impl(val _path: List[Path])
+    extends Relation[SpecialofferFields, SpecialofferRow] {
   
-    override val fields: SpecialofferFields[Row] = new SpecialofferFields[Row] {
-      override val specialofferid = new IdField[SpecialofferId, Row](prefix, "specialofferid", None, Some("int4"))(x => extract(x).specialofferid, (row, value) => merge(row, extract(row).copy(specialofferid = value)))
-      override val description = new Field[/* max 255 chars */ String, Row](prefix, "description", None, None)(x => extract(x).description, (row, value) => merge(row, extract(row).copy(description = value)))
-      override val discountpct = new Field[BigDecimal, Row](prefix, "discountpct", None, Some("numeric"))(x => extract(x).discountpct, (row, value) => merge(row, extract(row).copy(discountpct = value)))
-      override val `type` = new Field[/* max 50 chars */ String, Row](prefix, "type", None, None)(x => extract(x).`type`, (row, value) => merge(row, extract(row).copy(`type` = value)))
-      override val category = new Field[/* max 50 chars */ String, Row](prefix, "category", None, None)(x => extract(x).category, (row, value) => merge(row, extract(row).copy(category = value)))
-      override val startdate = new Field[TypoLocalDateTime, Row](prefix, "startdate", Some("text"), Some("timestamp"))(x => extract(x).startdate, (row, value) => merge(row, extract(row).copy(startdate = value)))
-      override val enddate = new Field[TypoLocalDateTime, Row](prefix, "enddate", Some("text"), Some("timestamp"))(x => extract(x).enddate, (row, value) => merge(row, extract(row).copy(enddate = value)))
-      override val minqty = new Field[Int, Row](prefix, "minqty", None, Some("int4"))(x => extract(x).minqty, (row, value) => merge(row, extract(row).copy(minqty = value)))
-      override val maxqty = new OptField[Int, Row](prefix, "maxqty", None, Some("int4"))(x => extract(x).maxqty, (row, value) => merge(row, extract(row).copy(maxqty = value)))
-      override val rowguid = new Field[TypoUUID, Row](prefix, "rowguid", None, Some("uuid"))(x => extract(x).rowguid, (row, value) => merge(row, extract(row).copy(rowguid = value)))
-      override val modifieddate = new Field[TypoLocalDateTime, Row](prefix, "modifieddate", Some("text"), Some("timestamp"))(x => extract(x).modifieddate, (row, value) => merge(row, extract(row).copy(modifieddate = value)))
+    override lazy val fields: SpecialofferFields = new SpecialofferFields {
+      override def specialofferid = IdField[SpecialofferId, SpecialofferRow](_path, "specialofferid", None, Some("int4"), x => x.specialofferid, (row, value) => row.copy(specialofferid = value))
+      override def description = Field[/* max 255 chars */ String, SpecialofferRow](_path, "description", None, None, x => x.description, (row, value) => row.copy(description = value))
+      override def discountpct = Field[BigDecimal, SpecialofferRow](_path, "discountpct", None, Some("numeric"), x => x.discountpct, (row, value) => row.copy(discountpct = value))
+      override def `type` = Field[/* max 50 chars */ String, SpecialofferRow](_path, "type", None, None, x => x.`type`, (row, value) => row.copy(`type` = value))
+      override def category = Field[/* max 50 chars */ String, SpecialofferRow](_path, "category", None, None, x => x.category, (row, value) => row.copy(category = value))
+      override def startdate = Field[TypoLocalDateTime, SpecialofferRow](_path, "startdate", Some("text"), Some("timestamp"), x => x.startdate, (row, value) => row.copy(startdate = value))
+      override def enddate = Field[TypoLocalDateTime, SpecialofferRow](_path, "enddate", Some("text"), Some("timestamp"), x => x.enddate, (row, value) => row.copy(enddate = value))
+      override def minqty = Field[Int, SpecialofferRow](_path, "minqty", None, Some("int4"), x => x.minqty, (row, value) => row.copy(minqty = value))
+      override def maxqty = OptField[Int, SpecialofferRow](_path, "maxqty", None, Some("int4"), x => x.maxqty, (row, value) => row.copy(maxqty = value))
+      override def rowguid = Field[TypoUUID, SpecialofferRow](_path, "rowguid", None, Some("uuid"), x => x.rowguid, (row, value) => row.copy(rowguid = value))
+      override def modifieddate = Field[TypoLocalDateTime, SpecialofferRow](_path, "modifieddate", Some("text"), Some("timestamp"), x => x.modifieddate, (row, value) => row.copy(modifieddate = value))
     }
   
-    override val columns: List[FieldLikeNoHkt[?, Row]] =
-      List[FieldLikeNoHkt[?, Row]](fields.specialofferid, fields.description, fields.discountpct, fields.`type`, fields.category, fields.startdate, fields.enddate, fields.minqty, fields.maxqty, fields.rowguid, fields.modifieddate)
+    override lazy val columns: List[FieldLikeNoHkt[?, SpecialofferRow]] =
+      List[FieldLikeNoHkt[?, SpecialofferRow]](fields.specialofferid, fields.description, fields.discountpct, fields.`type`, fields.category, fields.startdate, fields.enddate, fields.minqty, fields.maxqty, fields.rowguid, fields.modifieddate)
   
-    override def copy[NewRow](prefix: Option[String], extract: NewRow => SpecialofferRow, merge: (NewRow, SpecialofferRow) => NewRow): Impl[NewRow] =
-      new Impl(prefix, extract, merge)
+    override def copy(path: List[Path]): Impl =
+      new Impl(path)
   }
   
 }

--- a/typo-tester-anorm/generated-and-checked-in/adventureworks/sales/specialoffer/SpecialofferRepoMock.scala
+++ b/typo-tester-anorm/generated-and-checked-in/adventureworks/sales/specialoffer/SpecialofferRepoMock.scala
@@ -22,7 +22,7 @@ import typo.dsl.UpdateParams
 class SpecialofferRepoMock(toRow: Function1[SpecialofferRowUnsaved, SpecialofferRow],
                            map: scala.collection.mutable.Map[SpecialofferId, SpecialofferRow] = scala.collection.mutable.Map.empty) extends SpecialofferRepo {
   override def delete: DeleteBuilder[SpecialofferFields, SpecialofferRow] = {
-    DeleteBuilderMock(DeleteParams.empty, SpecialofferFields.structure.fields, map)
+    DeleteBuilderMock(DeleteParams.empty, SpecialofferFields.structure, map)
   }
   override def deleteById(specialofferid: SpecialofferId)(implicit c: Connection): Boolean = {
     map.remove(specialofferid).isDefined
@@ -72,7 +72,7 @@ class SpecialofferRepoMock(toRow: Function1[SpecialofferRowUnsaved, Specialoffer
     specialofferids.view.flatMap(id => byId.get(id).map(x => (id, x))).toMap
   }
   override def update: UpdateBuilder[SpecialofferFields, SpecialofferRow] = {
-    UpdateBuilderMock(UpdateParams.empty, SpecialofferFields.structure.fields, map)
+    UpdateBuilderMock(UpdateParams.empty, SpecialofferFields.structure, map)
   }
   override def update(row: SpecialofferRow)(implicit c: Connection): Boolean = {
     map.get(row.specialofferid) match {

--- a/typo-tester-anorm/generated-and-checked-in/adventureworks/sales/specialofferproduct/SpecialofferproductFields.scala
+++ b/typo-tester-anorm/generated-and-checked-in/adventureworks/sales/specialofferproduct/SpecialofferproductFields.scala
@@ -11,37 +11,38 @@ import adventureworks.customtypes.TypoLocalDateTime
 import adventureworks.customtypes.TypoUUID
 import adventureworks.production.product.ProductId
 import adventureworks.sales.specialoffer.SpecialofferId
+import typo.dsl.Path
 import typo.dsl.SqlExpr.Field
 import typo.dsl.SqlExpr.FieldLikeNoHkt
 import typo.dsl.SqlExpr.IdField
 import typo.dsl.Structure.Relation
 
-trait SpecialofferproductFields[Row] {
-  val specialofferid: IdField[SpecialofferId, Row]
-  val productid: IdField[ProductId, Row]
-  val rowguid: Field[TypoUUID, Row]
-  val modifieddate: Field[TypoLocalDateTime, Row]
+trait SpecialofferproductFields {
+  def specialofferid: IdField[SpecialofferId, SpecialofferproductRow]
+  def productid: IdField[ProductId, SpecialofferproductRow]
+  def rowguid: Field[TypoUUID, SpecialofferproductRow]
+  def modifieddate: Field[TypoLocalDateTime, SpecialofferproductRow]
 }
 
 object SpecialofferproductFields {
-  val structure: Relation[SpecialofferproductFields, SpecialofferproductRow, SpecialofferproductRow] = 
-    new Impl(None, identity, (_, x) => x)
+  lazy val structure: Relation[SpecialofferproductFields, SpecialofferproductRow] =
+    new Impl(Nil)
     
-  private final class Impl[Row](val prefix: Option[String], val extract: Row => SpecialofferproductRow, val merge: (Row, SpecialofferproductRow) => Row)
-    extends Relation[SpecialofferproductFields, SpecialofferproductRow, Row] { 
+  private final class Impl(val _path: List[Path])
+    extends Relation[SpecialofferproductFields, SpecialofferproductRow] {
   
-    override val fields: SpecialofferproductFields[Row] = new SpecialofferproductFields[Row] {
-      override val specialofferid = new IdField[SpecialofferId, Row](prefix, "specialofferid", None, Some("int4"))(x => extract(x).specialofferid, (row, value) => merge(row, extract(row).copy(specialofferid = value)))
-      override val productid = new IdField[ProductId, Row](prefix, "productid", None, Some("int4"))(x => extract(x).productid, (row, value) => merge(row, extract(row).copy(productid = value)))
-      override val rowguid = new Field[TypoUUID, Row](prefix, "rowguid", None, Some("uuid"))(x => extract(x).rowguid, (row, value) => merge(row, extract(row).copy(rowguid = value)))
-      override val modifieddate = new Field[TypoLocalDateTime, Row](prefix, "modifieddate", Some("text"), Some("timestamp"))(x => extract(x).modifieddate, (row, value) => merge(row, extract(row).copy(modifieddate = value)))
+    override lazy val fields: SpecialofferproductFields = new SpecialofferproductFields {
+      override def specialofferid = IdField[SpecialofferId, SpecialofferproductRow](_path, "specialofferid", None, Some("int4"), x => x.specialofferid, (row, value) => row.copy(specialofferid = value))
+      override def productid = IdField[ProductId, SpecialofferproductRow](_path, "productid", None, Some("int4"), x => x.productid, (row, value) => row.copy(productid = value))
+      override def rowguid = Field[TypoUUID, SpecialofferproductRow](_path, "rowguid", None, Some("uuid"), x => x.rowguid, (row, value) => row.copy(rowguid = value))
+      override def modifieddate = Field[TypoLocalDateTime, SpecialofferproductRow](_path, "modifieddate", Some("text"), Some("timestamp"), x => x.modifieddate, (row, value) => row.copy(modifieddate = value))
     }
   
-    override val columns: List[FieldLikeNoHkt[?, Row]] =
-      List[FieldLikeNoHkt[?, Row]](fields.specialofferid, fields.productid, fields.rowguid, fields.modifieddate)
+    override lazy val columns: List[FieldLikeNoHkt[?, SpecialofferproductRow]] =
+      List[FieldLikeNoHkt[?, SpecialofferproductRow]](fields.specialofferid, fields.productid, fields.rowguid, fields.modifieddate)
   
-    override def copy[NewRow](prefix: Option[String], extract: NewRow => SpecialofferproductRow, merge: (NewRow, SpecialofferproductRow) => NewRow): Impl[NewRow] =
-      new Impl(prefix, extract, merge)
+    override def copy(path: List[Path]): Impl =
+      new Impl(path)
   }
   
 }

--- a/typo-tester-anorm/generated-and-checked-in/adventureworks/sales/specialofferproduct/SpecialofferproductRepoMock.scala
+++ b/typo-tester-anorm/generated-and-checked-in/adventureworks/sales/specialofferproduct/SpecialofferproductRepoMock.scala
@@ -22,7 +22,7 @@ import typo.dsl.UpdateParams
 class SpecialofferproductRepoMock(toRow: Function1[SpecialofferproductRowUnsaved, SpecialofferproductRow],
                                   map: scala.collection.mutable.Map[SpecialofferproductId, SpecialofferproductRow] = scala.collection.mutable.Map.empty) extends SpecialofferproductRepo {
   override def delete: DeleteBuilder[SpecialofferproductFields, SpecialofferproductRow] = {
-    DeleteBuilderMock(DeleteParams.empty, SpecialofferproductFields.structure.fields, map)
+    DeleteBuilderMock(DeleteParams.empty, SpecialofferproductFields.structure, map)
   }
   override def deleteById(compositeId: SpecialofferproductId)(implicit c: Connection): Boolean = {
     map.remove(compositeId).isDefined
@@ -72,7 +72,7 @@ class SpecialofferproductRepoMock(toRow: Function1[SpecialofferproductRowUnsaved
     compositeIds.view.flatMap(id => byId.get(id).map(x => (id, x))).toMap
   }
   override def update: UpdateBuilder[SpecialofferproductFields, SpecialofferproductRow] = {
-    UpdateBuilderMock(UpdateParams.empty, SpecialofferproductFields.structure.fields, map)
+    UpdateBuilderMock(UpdateParams.empty, SpecialofferproductFields.structure, map)
   }
   override def update(row: SpecialofferproductRow)(implicit c: Connection): Boolean = {
     map.get(row.compositeId) match {

--- a/typo-tester-anorm/generated-and-checked-in/adventureworks/sales/store/StoreRepoMock.scala
+++ b/typo-tester-anorm/generated-and-checked-in/adventureworks/sales/store/StoreRepoMock.scala
@@ -23,7 +23,7 @@ import typo.dsl.UpdateParams
 class StoreRepoMock(toRow: Function1[StoreRowUnsaved, StoreRow],
                     map: scala.collection.mutable.Map[BusinessentityId, StoreRow] = scala.collection.mutable.Map.empty) extends StoreRepo {
   override def delete: DeleteBuilder[StoreFields, StoreRow] = {
-    DeleteBuilderMock(DeleteParams.empty, StoreFields.structure.fields, map)
+    DeleteBuilderMock(DeleteParams.empty, StoreFields.structure, map)
   }
   override def deleteById(businessentityid: BusinessentityId)(implicit c: Connection): Boolean = {
     map.remove(businessentityid).isDefined
@@ -73,7 +73,7 @@ class StoreRepoMock(toRow: Function1[StoreRowUnsaved, StoreRow],
     businessentityids.view.flatMap(id => byId.get(id).map(x => (id, x))).toMap
   }
   override def update: UpdateBuilder[StoreFields, StoreRow] = {
-    UpdateBuilderMock(UpdateParams.empty, StoreFields.structure.fields, map)
+    UpdateBuilderMock(UpdateParams.empty, StoreFields.structure, map)
   }
   override def update(row: StoreRow)(implicit c: Connection): Boolean = {
     map.get(row.businessentityid) match {

--- a/typo-tester-anorm/generated-and-checked-in/adventureworks/sales/vindividualcustomer/VindividualcustomerViewFields.scala
+++ b/typo-tester-anorm/generated-and-checked-in/adventureworks/sales/vindividualcustomer/VindividualcustomerViewFields.scala
@@ -12,65 +12,66 @@ import adventureworks.person.businessentity.BusinessentityId
 import adventureworks.public.Name
 import adventureworks.public.Phone
 import adventureworks.userdefined.FirstName
+import typo.dsl.Path
 import typo.dsl.SqlExpr.Field
 import typo.dsl.SqlExpr.FieldLikeNoHkt
 import typo.dsl.SqlExpr.OptField
 import typo.dsl.Structure.Relation
 
-trait VindividualcustomerViewFields[Row] {
-  val businessentityid: Field[BusinessentityId, Row]
-  val title: OptField[/* max 8 chars */ String, Row]
-  val firstname: Field[/* user-picked */ FirstName, Row]
-  val middlename: OptField[Name, Row]
-  val lastname: Field[Name, Row]
-  val suffix: OptField[/* max 10 chars */ String, Row]
-  val phonenumber: OptField[Phone, Row]
-  val phonenumbertype: OptField[Name, Row]
-  val emailaddress: OptField[/* max 50 chars */ String, Row]
-  val emailpromotion: Field[Int, Row]
-  val addresstype: Field[Name, Row]
-  val addressline1: Field[/* max 60 chars */ String, Row]
-  val addressline2: OptField[/* max 60 chars */ String, Row]
-  val city: Field[/* max 30 chars */ String, Row]
-  val stateprovincename: Field[Name, Row]
-  val postalcode: Field[/* max 15 chars */ String, Row]
-  val countryregionname: Field[Name, Row]
-  val demographics: OptField[TypoXml, Row]
+trait VindividualcustomerViewFields {
+  def businessentityid: Field[BusinessentityId, VindividualcustomerViewRow]
+  def title: OptField[/* max 8 chars */ String, VindividualcustomerViewRow]
+  def firstname: Field[/* user-picked */ FirstName, VindividualcustomerViewRow]
+  def middlename: OptField[Name, VindividualcustomerViewRow]
+  def lastname: Field[Name, VindividualcustomerViewRow]
+  def suffix: OptField[/* max 10 chars */ String, VindividualcustomerViewRow]
+  def phonenumber: OptField[Phone, VindividualcustomerViewRow]
+  def phonenumbertype: OptField[Name, VindividualcustomerViewRow]
+  def emailaddress: OptField[/* max 50 chars */ String, VindividualcustomerViewRow]
+  def emailpromotion: Field[Int, VindividualcustomerViewRow]
+  def addresstype: Field[Name, VindividualcustomerViewRow]
+  def addressline1: Field[/* max 60 chars */ String, VindividualcustomerViewRow]
+  def addressline2: OptField[/* max 60 chars */ String, VindividualcustomerViewRow]
+  def city: Field[/* max 30 chars */ String, VindividualcustomerViewRow]
+  def stateprovincename: Field[Name, VindividualcustomerViewRow]
+  def postalcode: Field[/* max 15 chars */ String, VindividualcustomerViewRow]
+  def countryregionname: Field[Name, VindividualcustomerViewRow]
+  def demographics: OptField[TypoXml, VindividualcustomerViewRow]
 }
 
 object VindividualcustomerViewFields {
-  val structure: Relation[VindividualcustomerViewFields, VindividualcustomerViewRow, VindividualcustomerViewRow] = 
-    new Impl(None, identity, (_, x) => x)
+  lazy val structure: Relation[VindividualcustomerViewFields, VindividualcustomerViewRow] =
+    new Impl(Nil)
     
-  private final class Impl[Row](val prefix: Option[String], val extract: Row => VindividualcustomerViewRow, val merge: (Row, VindividualcustomerViewRow) => Row)
-    extends Relation[VindividualcustomerViewFields, VindividualcustomerViewRow, Row] { 
+  private final class Impl(val _path: List[Path])
+    extends Relation[VindividualcustomerViewFields, VindividualcustomerViewRow] {
   
-    override val fields: VindividualcustomerViewFields[Row] = new VindividualcustomerViewFields[Row] {
-      override val businessentityid = new Field[BusinessentityId, Row](prefix, "businessentityid", None, None)(x => extract(x).businessentityid, (row, value) => merge(row, extract(row).copy(businessentityid = value)))
-      override val title = new OptField[/* max 8 chars */ String, Row](prefix, "title", None, None)(x => extract(x).title, (row, value) => merge(row, extract(row).copy(title = value)))
-      override val firstname = new Field[/* user-picked */ FirstName, Row](prefix, "firstname", None, None)(x => extract(x).firstname, (row, value) => merge(row, extract(row).copy(firstname = value)))
-      override val middlename = new OptField[Name, Row](prefix, "middlename", None, None)(x => extract(x).middlename, (row, value) => merge(row, extract(row).copy(middlename = value)))
-      override val lastname = new Field[Name, Row](prefix, "lastname", None, None)(x => extract(x).lastname, (row, value) => merge(row, extract(row).copy(lastname = value)))
-      override val suffix = new OptField[/* max 10 chars */ String, Row](prefix, "suffix", None, None)(x => extract(x).suffix, (row, value) => merge(row, extract(row).copy(suffix = value)))
-      override val phonenumber = new OptField[Phone, Row](prefix, "phonenumber", None, None)(x => extract(x).phonenumber, (row, value) => merge(row, extract(row).copy(phonenumber = value)))
-      override val phonenumbertype = new OptField[Name, Row](prefix, "phonenumbertype", None, None)(x => extract(x).phonenumbertype, (row, value) => merge(row, extract(row).copy(phonenumbertype = value)))
-      override val emailaddress = new OptField[/* max 50 chars */ String, Row](prefix, "emailaddress", None, None)(x => extract(x).emailaddress, (row, value) => merge(row, extract(row).copy(emailaddress = value)))
-      override val emailpromotion = new Field[Int, Row](prefix, "emailpromotion", None, None)(x => extract(x).emailpromotion, (row, value) => merge(row, extract(row).copy(emailpromotion = value)))
-      override val addresstype = new Field[Name, Row](prefix, "addresstype", None, None)(x => extract(x).addresstype, (row, value) => merge(row, extract(row).copy(addresstype = value)))
-      override val addressline1 = new Field[/* max 60 chars */ String, Row](prefix, "addressline1", None, None)(x => extract(x).addressline1, (row, value) => merge(row, extract(row).copy(addressline1 = value)))
-      override val addressline2 = new OptField[/* max 60 chars */ String, Row](prefix, "addressline2", None, None)(x => extract(x).addressline2, (row, value) => merge(row, extract(row).copy(addressline2 = value)))
-      override val city = new Field[/* max 30 chars */ String, Row](prefix, "city", None, None)(x => extract(x).city, (row, value) => merge(row, extract(row).copy(city = value)))
-      override val stateprovincename = new Field[Name, Row](prefix, "stateprovincename", None, None)(x => extract(x).stateprovincename, (row, value) => merge(row, extract(row).copy(stateprovincename = value)))
-      override val postalcode = new Field[/* max 15 chars */ String, Row](prefix, "postalcode", None, None)(x => extract(x).postalcode, (row, value) => merge(row, extract(row).copy(postalcode = value)))
-      override val countryregionname = new Field[Name, Row](prefix, "countryregionname", None, None)(x => extract(x).countryregionname, (row, value) => merge(row, extract(row).copy(countryregionname = value)))
-      override val demographics = new OptField[TypoXml, Row](prefix, "demographics", None, None)(x => extract(x).demographics, (row, value) => merge(row, extract(row).copy(demographics = value)))
+    override lazy val fields: VindividualcustomerViewFields = new VindividualcustomerViewFields {
+      override def businessentityid = Field[BusinessentityId, VindividualcustomerViewRow](_path, "businessentityid", None, None, x => x.businessentityid, (row, value) => row.copy(businessentityid = value))
+      override def title = OptField[/* max 8 chars */ String, VindividualcustomerViewRow](_path, "title", None, None, x => x.title, (row, value) => row.copy(title = value))
+      override def firstname = Field[/* user-picked */ FirstName, VindividualcustomerViewRow](_path, "firstname", None, None, x => x.firstname, (row, value) => row.copy(firstname = value))
+      override def middlename = OptField[Name, VindividualcustomerViewRow](_path, "middlename", None, None, x => x.middlename, (row, value) => row.copy(middlename = value))
+      override def lastname = Field[Name, VindividualcustomerViewRow](_path, "lastname", None, None, x => x.lastname, (row, value) => row.copy(lastname = value))
+      override def suffix = OptField[/* max 10 chars */ String, VindividualcustomerViewRow](_path, "suffix", None, None, x => x.suffix, (row, value) => row.copy(suffix = value))
+      override def phonenumber = OptField[Phone, VindividualcustomerViewRow](_path, "phonenumber", None, None, x => x.phonenumber, (row, value) => row.copy(phonenumber = value))
+      override def phonenumbertype = OptField[Name, VindividualcustomerViewRow](_path, "phonenumbertype", None, None, x => x.phonenumbertype, (row, value) => row.copy(phonenumbertype = value))
+      override def emailaddress = OptField[/* max 50 chars */ String, VindividualcustomerViewRow](_path, "emailaddress", None, None, x => x.emailaddress, (row, value) => row.copy(emailaddress = value))
+      override def emailpromotion = Field[Int, VindividualcustomerViewRow](_path, "emailpromotion", None, None, x => x.emailpromotion, (row, value) => row.copy(emailpromotion = value))
+      override def addresstype = Field[Name, VindividualcustomerViewRow](_path, "addresstype", None, None, x => x.addresstype, (row, value) => row.copy(addresstype = value))
+      override def addressline1 = Field[/* max 60 chars */ String, VindividualcustomerViewRow](_path, "addressline1", None, None, x => x.addressline1, (row, value) => row.copy(addressline1 = value))
+      override def addressline2 = OptField[/* max 60 chars */ String, VindividualcustomerViewRow](_path, "addressline2", None, None, x => x.addressline2, (row, value) => row.copy(addressline2 = value))
+      override def city = Field[/* max 30 chars */ String, VindividualcustomerViewRow](_path, "city", None, None, x => x.city, (row, value) => row.copy(city = value))
+      override def stateprovincename = Field[Name, VindividualcustomerViewRow](_path, "stateprovincename", None, None, x => x.stateprovincename, (row, value) => row.copy(stateprovincename = value))
+      override def postalcode = Field[/* max 15 chars */ String, VindividualcustomerViewRow](_path, "postalcode", None, None, x => x.postalcode, (row, value) => row.copy(postalcode = value))
+      override def countryregionname = Field[Name, VindividualcustomerViewRow](_path, "countryregionname", None, None, x => x.countryregionname, (row, value) => row.copy(countryregionname = value))
+      override def demographics = OptField[TypoXml, VindividualcustomerViewRow](_path, "demographics", None, None, x => x.demographics, (row, value) => row.copy(demographics = value))
     }
   
-    override val columns: List[FieldLikeNoHkt[?, Row]] =
-      List[FieldLikeNoHkt[?, Row]](fields.businessentityid, fields.title, fields.firstname, fields.middlename, fields.lastname, fields.suffix, fields.phonenumber, fields.phonenumbertype, fields.emailaddress, fields.emailpromotion, fields.addresstype, fields.addressline1, fields.addressline2, fields.city, fields.stateprovincename, fields.postalcode, fields.countryregionname, fields.demographics)
+    override lazy val columns: List[FieldLikeNoHkt[?, VindividualcustomerViewRow]] =
+      List[FieldLikeNoHkt[?, VindividualcustomerViewRow]](fields.businessentityid, fields.title, fields.firstname, fields.middlename, fields.lastname, fields.suffix, fields.phonenumber, fields.phonenumbertype, fields.emailaddress, fields.emailpromotion, fields.addresstype, fields.addressline1, fields.addressline2, fields.city, fields.stateprovincename, fields.postalcode, fields.countryregionname, fields.demographics)
   
-    override def copy[NewRow](prefix: Option[String], extract: NewRow => VindividualcustomerViewRow, merge: (NewRow, VindividualcustomerViewRow) => NewRow): Impl[NewRow] =
-      new Impl(prefix, extract, merge)
+    override def copy(path: List[Path]): Impl =
+      new Impl(path)
   }
   
 }

--- a/typo-tester-anorm/generated-and-checked-in/adventureworks/sales/vpersondemographics/VpersondemographicsViewFields.scala
+++ b/typo-tester-anorm/generated-and-checked-in/adventureworks/sales/vpersondemographics/VpersondemographicsViewFields.scala
@@ -10,55 +10,56 @@ package vpersondemographics
 import adventureworks.customtypes.TypoLocalDate
 import adventureworks.customtypes.TypoMoney
 import adventureworks.person.businessentity.BusinessentityId
+import typo.dsl.Path
 import typo.dsl.SqlExpr.Field
 import typo.dsl.SqlExpr.FieldLikeNoHkt
 import typo.dsl.SqlExpr.OptField
 import typo.dsl.Structure.Relation
 
-trait VpersondemographicsViewFields[Row] {
-  val businessentityid: Field[BusinessentityId, Row]
-  val totalpurchaseytd: OptField[TypoMoney, Row]
-  val datefirstpurchase: OptField[TypoLocalDate, Row]
-  val birthdate: OptField[TypoLocalDate, Row]
-  val maritalstatus: OptField[/* max 1 chars */ String, Row]
-  val yearlyincome: OptField[/* max 30 chars */ String, Row]
-  val gender: OptField[/* max 1 chars */ String, Row]
-  val totalchildren: OptField[Int, Row]
-  val numberchildrenathome: OptField[Int, Row]
-  val education: OptField[/* max 30 chars */ String, Row]
-  val occupation: OptField[/* max 30 chars */ String, Row]
-  val homeownerflag: OptField[Boolean, Row]
-  val numbercarsowned: OptField[Int, Row]
+trait VpersondemographicsViewFields {
+  def businessentityid: Field[BusinessentityId, VpersondemographicsViewRow]
+  def totalpurchaseytd: OptField[TypoMoney, VpersondemographicsViewRow]
+  def datefirstpurchase: OptField[TypoLocalDate, VpersondemographicsViewRow]
+  def birthdate: OptField[TypoLocalDate, VpersondemographicsViewRow]
+  def maritalstatus: OptField[/* max 1 chars */ String, VpersondemographicsViewRow]
+  def yearlyincome: OptField[/* max 30 chars */ String, VpersondemographicsViewRow]
+  def gender: OptField[/* max 1 chars */ String, VpersondemographicsViewRow]
+  def totalchildren: OptField[Int, VpersondemographicsViewRow]
+  def numberchildrenathome: OptField[Int, VpersondemographicsViewRow]
+  def education: OptField[/* max 30 chars */ String, VpersondemographicsViewRow]
+  def occupation: OptField[/* max 30 chars */ String, VpersondemographicsViewRow]
+  def homeownerflag: OptField[Boolean, VpersondemographicsViewRow]
+  def numbercarsowned: OptField[Int, VpersondemographicsViewRow]
 }
 
 object VpersondemographicsViewFields {
-  val structure: Relation[VpersondemographicsViewFields, VpersondemographicsViewRow, VpersondemographicsViewRow] = 
-    new Impl(None, identity, (_, x) => x)
+  lazy val structure: Relation[VpersondemographicsViewFields, VpersondemographicsViewRow] =
+    new Impl(Nil)
     
-  private final class Impl[Row](val prefix: Option[String], val extract: Row => VpersondemographicsViewRow, val merge: (Row, VpersondemographicsViewRow) => Row)
-    extends Relation[VpersondemographicsViewFields, VpersondemographicsViewRow, Row] { 
+  private final class Impl(val _path: List[Path])
+    extends Relation[VpersondemographicsViewFields, VpersondemographicsViewRow] {
   
-    override val fields: VpersondemographicsViewFields[Row] = new VpersondemographicsViewFields[Row] {
-      override val businessentityid = new Field[BusinessentityId, Row](prefix, "businessentityid", None, None)(x => extract(x).businessentityid, (row, value) => merge(row, extract(row).copy(businessentityid = value)))
-      override val totalpurchaseytd = new OptField[TypoMoney, Row](prefix, "totalpurchaseytd", Some("numeric"), None)(x => extract(x).totalpurchaseytd, (row, value) => merge(row, extract(row).copy(totalpurchaseytd = value)))
-      override val datefirstpurchase = new OptField[TypoLocalDate, Row](prefix, "datefirstpurchase", Some("text"), None)(x => extract(x).datefirstpurchase, (row, value) => merge(row, extract(row).copy(datefirstpurchase = value)))
-      override val birthdate = new OptField[TypoLocalDate, Row](prefix, "birthdate", Some("text"), None)(x => extract(x).birthdate, (row, value) => merge(row, extract(row).copy(birthdate = value)))
-      override val maritalstatus = new OptField[/* max 1 chars */ String, Row](prefix, "maritalstatus", None, None)(x => extract(x).maritalstatus, (row, value) => merge(row, extract(row).copy(maritalstatus = value)))
-      override val yearlyincome = new OptField[/* max 30 chars */ String, Row](prefix, "yearlyincome", None, None)(x => extract(x).yearlyincome, (row, value) => merge(row, extract(row).copy(yearlyincome = value)))
-      override val gender = new OptField[/* max 1 chars */ String, Row](prefix, "gender", None, None)(x => extract(x).gender, (row, value) => merge(row, extract(row).copy(gender = value)))
-      override val totalchildren = new OptField[Int, Row](prefix, "totalchildren", None, None)(x => extract(x).totalchildren, (row, value) => merge(row, extract(row).copy(totalchildren = value)))
-      override val numberchildrenathome = new OptField[Int, Row](prefix, "numberchildrenathome", None, None)(x => extract(x).numberchildrenathome, (row, value) => merge(row, extract(row).copy(numberchildrenathome = value)))
-      override val education = new OptField[/* max 30 chars */ String, Row](prefix, "education", None, None)(x => extract(x).education, (row, value) => merge(row, extract(row).copy(education = value)))
-      override val occupation = new OptField[/* max 30 chars */ String, Row](prefix, "occupation", None, None)(x => extract(x).occupation, (row, value) => merge(row, extract(row).copy(occupation = value)))
-      override val homeownerflag = new OptField[Boolean, Row](prefix, "homeownerflag", None, None)(x => extract(x).homeownerflag, (row, value) => merge(row, extract(row).copy(homeownerflag = value)))
-      override val numbercarsowned = new OptField[Int, Row](prefix, "numbercarsowned", None, None)(x => extract(x).numbercarsowned, (row, value) => merge(row, extract(row).copy(numbercarsowned = value)))
+    override lazy val fields: VpersondemographicsViewFields = new VpersondemographicsViewFields {
+      override def businessentityid = Field[BusinessentityId, VpersondemographicsViewRow](_path, "businessentityid", None, None, x => x.businessentityid, (row, value) => row.copy(businessentityid = value))
+      override def totalpurchaseytd = OptField[TypoMoney, VpersondemographicsViewRow](_path, "totalpurchaseytd", Some("numeric"), None, x => x.totalpurchaseytd, (row, value) => row.copy(totalpurchaseytd = value))
+      override def datefirstpurchase = OptField[TypoLocalDate, VpersondemographicsViewRow](_path, "datefirstpurchase", Some("text"), None, x => x.datefirstpurchase, (row, value) => row.copy(datefirstpurchase = value))
+      override def birthdate = OptField[TypoLocalDate, VpersondemographicsViewRow](_path, "birthdate", Some("text"), None, x => x.birthdate, (row, value) => row.copy(birthdate = value))
+      override def maritalstatus = OptField[/* max 1 chars */ String, VpersondemographicsViewRow](_path, "maritalstatus", None, None, x => x.maritalstatus, (row, value) => row.copy(maritalstatus = value))
+      override def yearlyincome = OptField[/* max 30 chars */ String, VpersondemographicsViewRow](_path, "yearlyincome", None, None, x => x.yearlyincome, (row, value) => row.copy(yearlyincome = value))
+      override def gender = OptField[/* max 1 chars */ String, VpersondemographicsViewRow](_path, "gender", None, None, x => x.gender, (row, value) => row.copy(gender = value))
+      override def totalchildren = OptField[Int, VpersondemographicsViewRow](_path, "totalchildren", None, None, x => x.totalchildren, (row, value) => row.copy(totalchildren = value))
+      override def numberchildrenathome = OptField[Int, VpersondemographicsViewRow](_path, "numberchildrenathome", None, None, x => x.numberchildrenathome, (row, value) => row.copy(numberchildrenathome = value))
+      override def education = OptField[/* max 30 chars */ String, VpersondemographicsViewRow](_path, "education", None, None, x => x.education, (row, value) => row.copy(education = value))
+      override def occupation = OptField[/* max 30 chars */ String, VpersondemographicsViewRow](_path, "occupation", None, None, x => x.occupation, (row, value) => row.copy(occupation = value))
+      override def homeownerflag = OptField[Boolean, VpersondemographicsViewRow](_path, "homeownerflag", None, None, x => x.homeownerflag, (row, value) => row.copy(homeownerflag = value))
+      override def numbercarsowned = OptField[Int, VpersondemographicsViewRow](_path, "numbercarsowned", None, None, x => x.numbercarsowned, (row, value) => row.copy(numbercarsowned = value))
     }
   
-    override val columns: List[FieldLikeNoHkt[?, Row]] =
-      List[FieldLikeNoHkt[?, Row]](fields.businessentityid, fields.totalpurchaseytd, fields.datefirstpurchase, fields.birthdate, fields.maritalstatus, fields.yearlyincome, fields.gender, fields.totalchildren, fields.numberchildrenathome, fields.education, fields.occupation, fields.homeownerflag, fields.numbercarsowned)
+    override lazy val columns: List[FieldLikeNoHkt[?, VpersondemographicsViewRow]] =
+      List[FieldLikeNoHkt[?, VpersondemographicsViewRow]](fields.businessentityid, fields.totalpurchaseytd, fields.datefirstpurchase, fields.birthdate, fields.maritalstatus, fields.yearlyincome, fields.gender, fields.totalchildren, fields.numberchildrenathome, fields.education, fields.occupation, fields.homeownerflag, fields.numbercarsowned)
   
-    override def copy[NewRow](prefix: Option[String], extract: NewRow => VpersondemographicsViewRow, merge: (NewRow, VpersondemographicsViewRow) => NewRow): Impl[NewRow] =
-      new Impl(prefix, extract, merge)
+    override def copy(path: List[Path]): Impl =
+      new Impl(path)
   }
   
 }

--- a/typo-tester-anorm/generated-and-checked-in/adventureworks/sales/vsalesperson/VsalespersonViewFields.scala
+++ b/typo-tester-anorm/generated-and-checked-in/adventureworks/sales/vsalesperson/VsalespersonViewFields.scala
@@ -11,73 +11,74 @@ import adventureworks.person.businessentity.BusinessentityId
 import adventureworks.public.Name
 import adventureworks.public.Phone
 import adventureworks.userdefined.FirstName
+import typo.dsl.Path
 import typo.dsl.SqlExpr.Field
 import typo.dsl.SqlExpr.FieldLikeNoHkt
 import typo.dsl.SqlExpr.OptField
 import typo.dsl.Structure.Relation
 
-trait VsalespersonViewFields[Row] {
-  val businessentityid: Field[BusinessentityId, Row]
-  val title: OptField[/* max 8 chars */ String, Row]
-  val firstname: Field[/* user-picked */ FirstName, Row]
-  val middlename: OptField[Name, Row]
-  val lastname: Field[Name, Row]
-  val suffix: OptField[/* max 10 chars */ String, Row]
-  val jobtitle: Field[/* max 50 chars */ String, Row]
-  val phonenumber: OptField[Phone, Row]
-  val phonenumbertype: OptField[Name, Row]
-  val emailaddress: OptField[/* max 50 chars */ String, Row]
-  val emailpromotion: Field[Int, Row]
-  val addressline1: Field[/* max 60 chars */ String, Row]
-  val addressline2: OptField[/* max 60 chars */ String, Row]
-  val city: Field[/* max 30 chars */ String, Row]
-  val stateprovincename: Field[Name, Row]
-  val postalcode: Field[/* max 15 chars */ String, Row]
-  val countryregionname: Field[Name, Row]
-  val territoryname: OptField[Name, Row]
-  val territorygroup: OptField[/* max 50 chars */ String, Row]
-  val salesquota: OptField[BigDecimal, Row]
-  val salesytd: Field[BigDecimal, Row]
-  val saleslastyear: Field[BigDecimal, Row]
+trait VsalespersonViewFields {
+  def businessentityid: Field[BusinessentityId, VsalespersonViewRow]
+  def title: OptField[/* max 8 chars */ String, VsalespersonViewRow]
+  def firstname: Field[/* user-picked */ FirstName, VsalespersonViewRow]
+  def middlename: OptField[Name, VsalespersonViewRow]
+  def lastname: Field[Name, VsalespersonViewRow]
+  def suffix: OptField[/* max 10 chars */ String, VsalespersonViewRow]
+  def jobtitle: Field[/* max 50 chars */ String, VsalespersonViewRow]
+  def phonenumber: OptField[Phone, VsalespersonViewRow]
+  def phonenumbertype: OptField[Name, VsalespersonViewRow]
+  def emailaddress: OptField[/* max 50 chars */ String, VsalespersonViewRow]
+  def emailpromotion: Field[Int, VsalespersonViewRow]
+  def addressline1: Field[/* max 60 chars */ String, VsalespersonViewRow]
+  def addressline2: OptField[/* max 60 chars */ String, VsalespersonViewRow]
+  def city: Field[/* max 30 chars */ String, VsalespersonViewRow]
+  def stateprovincename: Field[Name, VsalespersonViewRow]
+  def postalcode: Field[/* max 15 chars */ String, VsalespersonViewRow]
+  def countryregionname: Field[Name, VsalespersonViewRow]
+  def territoryname: OptField[Name, VsalespersonViewRow]
+  def territorygroup: OptField[/* max 50 chars */ String, VsalespersonViewRow]
+  def salesquota: OptField[BigDecimal, VsalespersonViewRow]
+  def salesytd: Field[BigDecimal, VsalespersonViewRow]
+  def saleslastyear: Field[BigDecimal, VsalespersonViewRow]
 }
 
 object VsalespersonViewFields {
-  val structure: Relation[VsalespersonViewFields, VsalespersonViewRow, VsalespersonViewRow] = 
-    new Impl(None, identity, (_, x) => x)
+  lazy val structure: Relation[VsalespersonViewFields, VsalespersonViewRow] =
+    new Impl(Nil)
     
-  private final class Impl[Row](val prefix: Option[String], val extract: Row => VsalespersonViewRow, val merge: (Row, VsalespersonViewRow) => Row)
-    extends Relation[VsalespersonViewFields, VsalespersonViewRow, Row] { 
+  private final class Impl(val _path: List[Path])
+    extends Relation[VsalespersonViewFields, VsalespersonViewRow] {
   
-    override val fields: VsalespersonViewFields[Row] = new VsalespersonViewFields[Row] {
-      override val businessentityid = new Field[BusinessentityId, Row](prefix, "businessentityid", None, None)(x => extract(x).businessentityid, (row, value) => merge(row, extract(row).copy(businessentityid = value)))
-      override val title = new OptField[/* max 8 chars */ String, Row](prefix, "title", None, None)(x => extract(x).title, (row, value) => merge(row, extract(row).copy(title = value)))
-      override val firstname = new Field[/* user-picked */ FirstName, Row](prefix, "firstname", None, None)(x => extract(x).firstname, (row, value) => merge(row, extract(row).copy(firstname = value)))
-      override val middlename = new OptField[Name, Row](prefix, "middlename", None, None)(x => extract(x).middlename, (row, value) => merge(row, extract(row).copy(middlename = value)))
-      override val lastname = new Field[Name, Row](prefix, "lastname", None, None)(x => extract(x).lastname, (row, value) => merge(row, extract(row).copy(lastname = value)))
-      override val suffix = new OptField[/* max 10 chars */ String, Row](prefix, "suffix", None, None)(x => extract(x).suffix, (row, value) => merge(row, extract(row).copy(suffix = value)))
-      override val jobtitle = new Field[/* max 50 chars */ String, Row](prefix, "jobtitle", None, None)(x => extract(x).jobtitle, (row, value) => merge(row, extract(row).copy(jobtitle = value)))
-      override val phonenumber = new OptField[Phone, Row](prefix, "phonenumber", None, None)(x => extract(x).phonenumber, (row, value) => merge(row, extract(row).copy(phonenumber = value)))
-      override val phonenumbertype = new OptField[Name, Row](prefix, "phonenumbertype", None, None)(x => extract(x).phonenumbertype, (row, value) => merge(row, extract(row).copy(phonenumbertype = value)))
-      override val emailaddress = new OptField[/* max 50 chars */ String, Row](prefix, "emailaddress", None, None)(x => extract(x).emailaddress, (row, value) => merge(row, extract(row).copy(emailaddress = value)))
-      override val emailpromotion = new Field[Int, Row](prefix, "emailpromotion", None, None)(x => extract(x).emailpromotion, (row, value) => merge(row, extract(row).copy(emailpromotion = value)))
-      override val addressline1 = new Field[/* max 60 chars */ String, Row](prefix, "addressline1", None, None)(x => extract(x).addressline1, (row, value) => merge(row, extract(row).copy(addressline1 = value)))
-      override val addressline2 = new OptField[/* max 60 chars */ String, Row](prefix, "addressline2", None, None)(x => extract(x).addressline2, (row, value) => merge(row, extract(row).copy(addressline2 = value)))
-      override val city = new Field[/* max 30 chars */ String, Row](prefix, "city", None, None)(x => extract(x).city, (row, value) => merge(row, extract(row).copy(city = value)))
-      override val stateprovincename = new Field[Name, Row](prefix, "stateprovincename", None, None)(x => extract(x).stateprovincename, (row, value) => merge(row, extract(row).copy(stateprovincename = value)))
-      override val postalcode = new Field[/* max 15 chars */ String, Row](prefix, "postalcode", None, None)(x => extract(x).postalcode, (row, value) => merge(row, extract(row).copy(postalcode = value)))
-      override val countryregionname = new Field[Name, Row](prefix, "countryregionname", None, None)(x => extract(x).countryregionname, (row, value) => merge(row, extract(row).copy(countryregionname = value)))
-      override val territoryname = new OptField[Name, Row](prefix, "territoryname", None, None)(x => extract(x).territoryname, (row, value) => merge(row, extract(row).copy(territoryname = value)))
-      override val territorygroup = new OptField[/* max 50 chars */ String, Row](prefix, "territorygroup", None, None)(x => extract(x).territorygroup, (row, value) => merge(row, extract(row).copy(territorygroup = value)))
-      override val salesquota = new OptField[BigDecimal, Row](prefix, "salesquota", None, None)(x => extract(x).salesquota, (row, value) => merge(row, extract(row).copy(salesquota = value)))
-      override val salesytd = new Field[BigDecimal, Row](prefix, "salesytd", None, None)(x => extract(x).salesytd, (row, value) => merge(row, extract(row).copy(salesytd = value)))
-      override val saleslastyear = new Field[BigDecimal, Row](prefix, "saleslastyear", None, None)(x => extract(x).saleslastyear, (row, value) => merge(row, extract(row).copy(saleslastyear = value)))
+    override lazy val fields: VsalespersonViewFields = new VsalespersonViewFields {
+      override def businessentityid = Field[BusinessentityId, VsalespersonViewRow](_path, "businessentityid", None, None, x => x.businessentityid, (row, value) => row.copy(businessentityid = value))
+      override def title = OptField[/* max 8 chars */ String, VsalespersonViewRow](_path, "title", None, None, x => x.title, (row, value) => row.copy(title = value))
+      override def firstname = Field[/* user-picked */ FirstName, VsalespersonViewRow](_path, "firstname", None, None, x => x.firstname, (row, value) => row.copy(firstname = value))
+      override def middlename = OptField[Name, VsalespersonViewRow](_path, "middlename", None, None, x => x.middlename, (row, value) => row.copy(middlename = value))
+      override def lastname = Field[Name, VsalespersonViewRow](_path, "lastname", None, None, x => x.lastname, (row, value) => row.copy(lastname = value))
+      override def suffix = OptField[/* max 10 chars */ String, VsalespersonViewRow](_path, "suffix", None, None, x => x.suffix, (row, value) => row.copy(suffix = value))
+      override def jobtitle = Field[/* max 50 chars */ String, VsalespersonViewRow](_path, "jobtitle", None, None, x => x.jobtitle, (row, value) => row.copy(jobtitle = value))
+      override def phonenumber = OptField[Phone, VsalespersonViewRow](_path, "phonenumber", None, None, x => x.phonenumber, (row, value) => row.copy(phonenumber = value))
+      override def phonenumbertype = OptField[Name, VsalespersonViewRow](_path, "phonenumbertype", None, None, x => x.phonenumbertype, (row, value) => row.copy(phonenumbertype = value))
+      override def emailaddress = OptField[/* max 50 chars */ String, VsalespersonViewRow](_path, "emailaddress", None, None, x => x.emailaddress, (row, value) => row.copy(emailaddress = value))
+      override def emailpromotion = Field[Int, VsalespersonViewRow](_path, "emailpromotion", None, None, x => x.emailpromotion, (row, value) => row.copy(emailpromotion = value))
+      override def addressline1 = Field[/* max 60 chars */ String, VsalespersonViewRow](_path, "addressline1", None, None, x => x.addressline1, (row, value) => row.copy(addressline1 = value))
+      override def addressline2 = OptField[/* max 60 chars */ String, VsalespersonViewRow](_path, "addressline2", None, None, x => x.addressline2, (row, value) => row.copy(addressline2 = value))
+      override def city = Field[/* max 30 chars */ String, VsalespersonViewRow](_path, "city", None, None, x => x.city, (row, value) => row.copy(city = value))
+      override def stateprovincename = Field[Name, VsalespersonViewRow](_path, "stateprovincename", None, None, x => x.stateprovincename, (row, value) => row.copy(stateprovincename = value))
+      override def postalcode = Field[/* max 15 chars */ String, VsalespersonViewRow](_path, "postalcode", None, None, x => x.postalcode, (row, value) => row.copy(postalcode = value))
+      override def countryregionname = Field[Name, VsalespersonViewRow](_path, "countryregionname", None, None, x => x.countryregionname, (row, value) => row.copy(countryregionname = value))
+      override def territoryname = OptField[Name, VsalespersonViewRow](_path, "territoryname", None, None, x => x.territoryname, (row, value) => row.copy(territoryname = value))
+      override def territorygroup = OptField[/* max 50 chars */ String, VsalespersonViewRow](_path, "territorygroup", None, None, x => x.territorygroup, (row, value) => row.copy(territorygroup = value))
+      override def salesquota = OptField[BigDecimal, VsalespersonViewRow](_path, "salesquota", None, None, x => x.salesquota, (row, value) => row.copy(salesquota = value))
+      override def salesytd = Field[BigDecimal, VsalespersonViewRow](_path, "salesytd", None, None, x => x.salesytd, (row, value) => row.copy(salesytd = value))
+      override def saleslastyear = Field[BigDecimal, VsalespersonViewRow](_path, "saleslastyear", None, None, x => x.saleslastyear, (row, value) => row.copy(saleslastyear = value))
     }
   
-    override val columns: List[FieldLikeNoHkt[?, Row]] =
-      List[FieldLikeNoHkt[?, Row]](fields.businessentityid, fields.title, fields.firstname, fields.middlename, fields.lastname, fields.suffix, fields.jobtitle, fields.phonenumber, fields.phonenumbertype, fields.emailaddress, fields.emailpromotion, fields.addressline1, fields.addressline2, fields.city, fields.stateprovincename, fields.postalcode, fields.countryregionname, fields.territoryname, fields.territorygroup, fields.salesquota, fields.salesytd, fields.saleslastyear)
+    override lazy val columns: List[FieldLikeNoHkt[?, VsalespersonViewRow]] =
+      List[FieldLikeNoHkt[?, VsalespersonViewRow]](fields.businessentityid, fields.title, fields.firstname, fields.middlename, fields.lastname, fields.suffix, fields.jobtitle, fields.phonenumber, fields.phonenumbertype, fields.emailaddress, fields.emailpromotion, fields.addressline1, fields.addressline2, fields.city, fields.stateprovincename, fields.postalcode, fields.countryregionname, fields.territoryname, fields.territorygroup, fields.salesquota, fields.salesytd, fields.saleslastyear)
   
-    override def copy[NewRow](prefix: Option[String], extract: NewRow => VsalespersonViewRow, merge: (NewRow, VsalespersonViewRow) => NewRow): Impl[NewRow] =
-      new Impl(prefix, extract, merge)
+    override def copy(path: List[Path]): Impl =
+      new Impl(path)
   }
   
 }

--- a/typo-tester-anorm/generated-and-checked-in/adventureworks/sales/vsalespersonsalesbyfiscalyears/VsalespersonsalesbyfiscalyearsViewFields.scala
+++ b/typo-tester-anorm/generated-and-checked-in/adventureworks/sales/vsalespersonsalesbyfiscalyears/VsalespersonsalesbyfiscalyearsViewFields.scala
@@ -7,42 +7,43 @@ package adventureworks
 package sales
 package vsalespersonsalesbyfiscalyears
 
+import typo.dsl.Path
 import typo.dsl.SqlExpr.FieldLikeNoHkt
 import typo.dsl.SqlExpr.OptField
 import typo.dsl.Structure.Relation
 
-trait VsalespersonsalesbyfiscalyearsViewFields[Row] {
-  val SalesPersonID: OptField[Int, Row]
-  val FullName: OptField[String, Row]
-  val JobTitle: OptField[String, Row]
-  val SalesTerritory: OptField[String, Row]
-  val `2012`: OptField[BigDecimal, Row]
-  val `2013`: OptField[BigDecimal, Row]
-  val `2014`: OptField[BigDecimal, Row]
+trait VsalespersonsalesbyfiscalyearsViewFields {
+  def SalesPersonID: OptField[Int, VsalespersonsalesbyfiscalyearsViewRow]
+  def FullName: OptField[String, VsalespersonsalesbyfiscalyearsViewRow]
+  def JobTitle: OptField[String, VsalespersonsalesbyfiscalyearsViewRow]
+  def SalesTerritory: OptField[String, VsalespersonsalesbyfiscalyearsViewRow]
+  def `2012`: OptField[BigDecimal, VsalespersonsalesbyfiscalyearsViewRow]
+  def `2013`: OptField[BigDecimal, VsalespersonsalesbyfiscalyearsViewRow]
+  def `2014`: OptField[BigDecimal, VsalespersonsalesbyfiscalyearsViewRow]
 }
 
 object VsalespersonsalesbyfiscalyearsViewFields {
-  val structure: Relation[VsalespersonsalesbyfiscalyearsViewFields, VsalespersonsalesbyfiscalyearsViewRow, VsalespersonsalesbyfiscalyearsViewRow] = 
-    new Impl(None, identity, (_, x) => x)
+  lazy val structure: Relation[VsalespersonsalesbyfiscalyearsViewFields, VsalespersonsalesbyfiscalyearsViewRow] =
+    new Impl(Nil)
     
-  private final class Impl[Row](val prefix: Option[String], val extract: Row => VsalespersonsalesbyfiscalyearsViewRow, val merge: (Row, VsalespersonsalesbyfiscalyearsViewRow) => Row)
-    extends Relation[VsalespersonsalesbyfiscalyearsViewFields, VsalespersonsalesbyfiscalyearsViewRow, Row] { 
+  private final class Impl(val _path: List[Path])
+    extends Relation[VsalespersonsalesbyfiscalyearsViewFields, VsalespersonsalesbyfiscalyearsViewRow] {
   
-    override val fields: VsalespersonsalesbyfiscalyearsViewFields[Row] = new VsalespersonsalesbyfiscalyearsViewFields[Row] {
-      override val SalesPersonID = new OptField[Int, Row](prefix, "SalesPersonID", None, None)(x => extract(x).SalesPersonID, (row, value) => merge(row, extract(row).copy(SalesPersonID = value)))
-      override val FullName = new OptField[String, Row](prefix, "FullName", None, None)(x => extract(x).FullName, (row, value) => merge(row, extract(row).copy(FullName = value)))
-      override val JobTitle = new OptField[String, Row](prefix, "JobTitle", None, None)(x => extract(x).JobTitle, (row, value) => merge(row, extract(row).copy(JobTitle = value)))
-      override val SalesTerritory = new OptField[String, Row](prefix, "SalesTerritory", None, None)(x => extract(x).SalesTerritory, (row, value) => merge(row, extract(row).copy(SalesTerritory = value)))
-      override val `2012` = new OptField[BigDecimal, Row](prefix, "2012", None, None)(x => extract(x).`2012`, (row, value) => merge(row, extract(row).copy(`2012` = value)))
-      override val `2013` = new OptField[BigDecimal, Row](prefix, "2013", None, None)(x => extract(x).`2013`, (row, value) => merge(row, extract(row).copy(`2013` = value)))
-      override val `2014` = new OptField[BigDecimal, Row](prefix, "2014", None, None)(x => extract(x).`2014`, (row, value) => merge(row, extract(row).copy(`2014` = value)))
+    override lazy val fields: VsalespersonsalesbyfiscalyearsViewFields = new VsalespersonsalesbyfiscalyearsViewFields {
+      override def SalesPersonID = OptField[Int, VsalespersonsalesbyfiscalyearsViewRow](_path, "SalesPersonID", None, None, x => x.SalesPersonID, (row, value) => row.copy(SalesPersonID = value))
+      override def FullName = OptField[String, VsalespersonsalesbyfiscalyearsViewRow](_path, "FullName", None, None, x => x.FullName, (row, value) => row.copy(FullName = value))
+      override def JobTitle = OptField[String, VsalespersonsalesbyfiscalyearsViewRow](_path, "JobTitle", None, None, x => x.JobTitle, (row, value) => row.copy(JobTitle = value))
+      override def SalesTerritory = OptField[String, VsalespersonsalesbyfiscalyearsViewRow](_path, "SalesTerritory", None, None, x => x.SalesTerritory, (row, value) => row.copy(SalesTerritory = value))
+      override def `2012` = OptField[BigDecimal, VsalespersonsalesbyfiscalyearsViewRow](_path, "2012", None, None, x => x.`2012`, (row, value) => row.copy(`2012` = value))
+      override def `2013` = OptField[BigDecimal, VsalespersonsalesbyfiscalyearsViewRow](_path, "2013", None, None, x => x.`2013`, (row, value) => row.copy(`2013` = value))
+      override def `2014` = OptField[BigDecimal, VsalespersonsalesbyfiscalyearsViewRow](_path, "2014", None, None, x => x.`2014`, (row, value) => row.copy(`2014` = value))
     }
   
-    override val columns: List[FieldLikeNoHkt[?, Row]] =
-      List[FieldLikeNoHkt[?, Row]](fields.SalesPersonID, fields.FullName, fields.JobTitle, fields.SalesTerritory, fields.`2012`, fields.`2013`, fields.`2014`)
+    override lazy val columns: List[FieldLikeNoHkt[?, VsalespersonsalesbyfiscalyearsViewRow]] =
+      List[FieldLikeNoHkt[?, VsalespersonsalesbyfiscalyearsViewRow]](fields.SalesPersonID, fields.FullName, fields.JobTitle, fields.SalesTerritory, fields.`2012`, fields.`2013`, fields.`2014`)
   
-    override def copy[NewRow](prefix: Option[String], extract: NewRow => VsalespersonsalesbyfiscalyearsViewRow, merge: (NewRow, VsalespersonsalesbyfiscalyearsViewRow) => NewRow): Impl[NewRow] =
-      new Impl(prefix, extract, merge)
+    override def copy(path: List[Path]): Impl =
+      new Impl(path)
   }
   
 }

--- a/typo-tester-anorm/generated-and-checked-in/adventureworks/sales/vsalespersonsalesbyfiscalyearsdata/VsalespersonsalesbyfiscalyearsdataViewFields.scala
+++ b/typo-tester-anorm/generated-and-checked-in/adventureworks/sales/vsalespersonsalesbyfiscalyearsdata/VsalespersonsalesbyfiscalyearsdataViewFields.scala
@@ -9,41 +9,42 @@ package vsalespersonsalesbyfiscalyearsdata
 
 import adventureworks.person.businessentity.BusinessentityId
 import adventureworks.public.Name
+import typo.dsl.Path
 import typo.dsl.SqlExpr.Field
 import typo.dsl.SqlExpr.FieldLikeNoHkt
 import typo.dsl.SqlExpr.OptField
 import typo.dsl.Structure.Relation
 
-trait VsalespersonsalesbyfiscalyearsdataViewFields[Row] {
-  val salespersonid: OptField[BusinessentityId, Row]
-  val fullname: OptField[String, Row]
-  val jobtitle: Field[/* max 50 chars */ String, Row]
-  val salesterritory: Field[Name, Row]
-  val salestotal: OptField[BigDecimal, Row]
-  val fiscalyear: OptField[BigDecimal, Row]
+trait VsalespersonsalesbyfiscalyearsdataViewFields {
+  def salespersonid: OptField[BusinessentityId, VsalespersonsalesbyfiscalyearsdataViewRow]
+  def fullname: OptField[String, VsalespersonsalesbyfiscalyearsdataViewRow]
+  def jobtitle: Field[/* max 50 chars */ String, VsalespersonsalesbyfiscalyearsdataViewRow]
+  def salesterritory: Field[Name, VsalespersonsalesbyfiscalyearsdataViewRow]
+  def salestotal: OptField[BigDecimal, VsalespersonsalesbyfiscalyearsdataViewRow]
+  def fiscalyear: OptField[BigDecimal, VsalespersonsalesbyfiscalyearsdataViewRow]
 }
 
 object VsalespersonsalesbyfiscalyearsdataViewFields {
-  val structure: Relation[VsalespersonsalesbyfiscalyearsdataViewFields, VsalespersonsalesbyfiscalyearsdataViewRow, VsalespersonsalesbyfiscalyearsdataViewRow] = 
-    new Impl(None, identity, (_, x) => x)
+  lazy val structure: Relation[VsalespersonsalesbyfiscalyearsdataViewFields, VsalespersonsalesbyfiscalyearsdataViewRow] =
+    new Impl(Nil)
     
-  private final class Impl[Row](val prefix: Option[String], val extract: Row => VsalespersonsalesbyfiscalyearsdataViewRow, val merge: (Row, VsalespersonsalesbyfiscalyearsdataViewRow) => Row)
-    extends Relation[VsalespersonsalesbyfiscalyearsdataViewFields, VsalespersonsalesbyfiscalyearsdataViewRow, Row] { 
+  private final class Impl(val _path: List[Path])
+    extends Relation[VsalespersonsalesbyfiscalyearsdataViewFields, VsalespersonsalesbyfiscalyearsdataViewRow] {
   
-    override val fields: VsalespersonsalesbyfiscalyearsdataViewFields[Row] = new VsalespersonsalesbyfiscalyearsdataViewFields[Row] {
-      override val salespersonid = new OptField[BusinessentityId, Row](prefix, "salespersonid", None, None)(x => extract(x).salespersonid, (row, value) => merge(row, extract(row).copy(salespersonid = value)))
-      override val fullname = new OptField[String, Row](prefix, "fullname", None, None)(x => extract(x).fullname, (row, value) => merge(row, extract(row).copy(fullname = value)))
-      override val jobtitle = new Field[/* max 50 chars */ String, Row](prefix, "jobtitle", None, None)(x => extract(x).jobtitle, (row, value) => merge(row, extract(row).copy(jobtitle = value)))
-      override val salesterritory = new Field[Name, Row](prefix, "salesterritory", None, None)(x => extract(x).salesterritory, (row, value) => merge(row, extract(row).copy(salesterritory = value)))
-      override val salestotal = new OptField[BigDecimal, Row](prefix, "salestotal", None, None)(x => extract(x).salestotal, (row, value) => merge(row, extract(row).copy(salestotal = value)))
-      override val fiscalyear = new OptField[BigDecimal, Row](prefix, "fiscalyear", None, None)(x => extract(x).fiscalyear, (row, value) => merge(row, extract(row).copy(fiscalyear = value)))
+    override lazy val fields: VsalespersonsalesbyfiscalyearsdataViewFields = new VsalespersonsalesbyfiscalyearsdataViewFields {
+      override def salespersonid = OptField[BusinessentityId, VsalespersonsalesbyfiscalyearsdataViewRow](_path, "salespersonid", None, None, x => x.salespersonid, (row, value) => row.copy(salespersonid = value))
+      override def fullname = OptField[String, VsalespersonsalesbyfiscalyearsdataViewRow](_path, "fullname", None, None, x => x.fullname, (row, value) => row.copy(fullname = value))
+      override def jobtitle = Field[/* max 50 chars */ String, VsalespersonsalesbyfiscalyearsdataViewRow](_path, "jobtitle", None, None, x => x.jobtitle, (row, value) => row.copy(jobtitle = value))
+      override def salesterritory = Field[Name, VsalespersonsalesbyfiscalyearsdataViewRow](_path, "salesterritory", None, None, x => x.salesterritory, (row, value) => row.copy(salesterritory = value))
+      override def salestotal = OptField[BigDecimal, VsalespersonsalesbyfiscalyearsdataViewRow](_path, "salestotal", None, None, x => x.salestotal, (row, value) => row.copy(salestotal = value))
+      override def fiscalyear = OptField[BigDecimal, VsalespersonsalesbyfiscalyearsdataViewRow](_path, "fiscalyear", None, None, x => x.fiscalyear, (row, value) => row.copy(fiscalyear = value))
     }
   
-    override val columns: List[FieldLikeNoHkt[?, Row]] =
-      List[FieldLikeNoHkt[?, Row]](fields.salespersonid, fields.fullname, fields.jobtitle, fields.salesterritory, fields.salestotal, fields.fiscalyear)
+    override lazy val columns: List[FieldLikeNoHkt[?, VsalespersonsalesbyfiscalyearsdataViewRow]] =
+      List[FieldLikeNoHkt[?, VsalespersonsalesbyfiscalyearsdataViewRow]](fields.salespersonid, fields.fullname, fields.jobtitle, fields.salesterritory, fields.salestotal, fields.fiscalyear)
   
-    override def copy[NewRow](prefix: Option[String], extract: NewRow => VsalespersonsalesbyfiscalyearsdataViewRow, merge: (NewRow, VsalespersonsalesbyfiscalyearsdataViewRow) => NewRow): Impl[NewRow] =
-      new Impl(prefix, extract, merge)
+    override def copy(path: List[Path]): Impl =
+      new Impl(path)
   }
   
 }

--- a/typo-tester-anorm/generated-and-checked-in/adventureworks/sales/vstorewithaddresses/VstorewithaddressesViewFields.scala
+++ b/typo-tester-anorm/generated-and-checked-in/adventureworks/sales/vstorewithaddresses/VstorewithaddressesViewFields.scala
@@ -9,47 +9,48 @@ package vstorewithaddresses
 
 import adventureworks.person.businessentity.BusinessentityId
 import adventureworks.public.Name
+import typo.dsl.Path
 import typo.dsl.SqlExpr.Field
 import typo.dsl.SqlExpr.FieldLikeNoHkt
 import typo.dsl.SqlExpr.OptField
 import typo.dsl.Structure.Relation
 
-trait VstorewithaddressesViewFields[Row] {
-  val businessentityid: Field[BusinessentityId, Row]
-  val name: Field[Name, Row]
-  val addresstype: Field[Name, Row]
-  val addressline1: Field[/* max 60 chars */ String, Row]
-  val addressline2: OptField[/* max 60 chars */ String, Row]
-  val city: Field[/* max 30 chars */ String, Row]
-  val stateprovincename: Field[Name, Row]
-  val postalcode: Field[/* max 15 chars */ String, Row]
-  val countryregionname: Field[Name, Row]
+trait VstorewithaddressesViewFields {
+  def businessentityid: Field[BusinessentityId, VstorewithaddressesViewRow]
+  def name: Field[Name, VstorewithaddressesViewRow]
+  def addresstype: Field[Name, VstorewithaddressesViewRow]
+  def addressline1: Field[/* max 60 chars */ String, VstorewithaddressesViewRow]
+  def addressline2: OptField[/* max 60 chars */ String, VstorewithaddressesViewRow]
+  def city: Field[/* max 30 chars */ String, VstorewithaddressesViewRow]
+  def stateprovincename: Field[Name, VstorewithaddressesViewRow]
+  def postalcode: Field[/* max 15 chars */ String, VstorewithaddressesViewRow]
+  def countryregionname: Field[Name, VstorewithaddressesViewRow]
 }
 
 object VstorewithaddressesViewFields {
-  val structure: Relation[VstorewithaddressesViewFields, VstorewithaddressesViewRow, VstorewithaddressesViewRow] = 
-    new Impl(None, identity, (_, x) => x)
+  lazy val structure: Relation[VstorewithaddressesViewFields, VstorewithaddressesViewRow] =
+    new Impl(Nil)
     
-  private final class Impl[Row](val prefix: Option[String], val extract: Row => VstorewithaddressesViewRow, val merge: (Row, VstorewithaddressesViewRow) => Row)
-    extends Relation[VstorewithaddressesViewFields, VstorewithaddressesViewRow, Row] { 
+  private final class Impl(val _path: List[Path])
+    extends Relation[VstorewithaddressesViewFields, VstorewithaddressesViewRow] {
   
-    override val fields: VstorewithaddressesViewFields[Row] = new VstorewithaddressesViewFields[Row] {
-      override val businessentityid = new Field[BusinessentityId, Row](prefix, "businessentityid", None, None)(x => extract(x).businessentityid, (row, value) => merge(row, extract(row).copy(businessentityid = value)))
-      override val name = new Field[Name, Row](prefix, "name", None, None)(x => extract(x).name, (row, value) => merge(row, extract(row).copy(name = value)))
-      override val addresstype = new Field[Name, Row](prefix, "addresstype", None, None)(x => extract(x).addresstype, (row, value) => merge(row, extract(row).copy(addresstype = value)))
-      override val addressline1 = new Field[/* max 60 chars */ String, Row](prefix, "addressline1", None, None)(x => extract(x).addressline1, (row, value) => merge(row, extract(row).copy(addressline1 = value)))
-      override val addressline2 = new OptField[/* max 60 chars */ String, Row](prefix, "addressline2", None, None)(x => extract(x).addressline2, (row, value) => merge(row, extract(row).copy(addressline2 = value)))
-      override val city = new Field[/* max 30 chars */ String, Row](prefix, "city", None, None)(x => extract(x).city, (row, value) => merge(row, extract(row).copy(city = value)))
-      override val stateprovincename = new Field[Name, Row](prefix, "stateprovincename", None, None)(x => extract(x).stateprovincename, (row, value) => merge(row, extract(row).copy(stateprovincename = value)))
-      override val postalcode = new Field[/* max 15 chars */ String, Row](prefix, "postalcode", None, None)(x => extract(x).postalcode, (row, value) => merge(row, extract(row).copy(postalcode = value)))
-      override val countryregionname = new Field[Name, Row](prefix, "countryregionname", None, None)(x => extract(x).countryregionname, (row, value) => merge(row, extract(row).copy(countryregionname = value)))
+    override lazy val fields: VstorewithaddressesViewFields = new VstorewithaddressesViewFields {
+      override def businessentityid = Field[BusinessentityId, VstorewithaddressesViewRow](_path, "businessentityid", None, None, x => x.businessentityid, (row, value) => row.copy(businessentityid = value))
+      override def name = Field[Name, VstorewithaddressesViewRow](_path, "name", None, None, x => x.name, (row, value) => row.copy(name = value))
+      override def addresstype = Field[Name, VstorewithaddressesViewRow](_path, "addresstype", None, None, x => x.addresstype, (row, value) => row.copy(addresstype = value))
+      override def addressline1 = Field[/* max 60 chars */ String, VstorewithaddressesViewRow](_path, "addressline1", None, None, x => x.addressline1, (row, value) => row.copy(addressline1 = value))
+      override def addressline2 = OptField[/* max 60 chars */ String, VstorewithaddressesViewRow](_path, "addressline2", None, None, x => x.addressline2, (row, value) => row.copy(addressline2 = value))
+      override def city = Field[/* max 30 chars */ String, VstorewithaddressesViewRow](_path, "city", None, None, x => x.city, (row, value) => row.copy(city = value))
+      override def stateprovincename = Field[Name, VstorewithaddressesViewRow](_path, "stateprovincename", None, None, x => x.stateprovincename, (row, value) => row.copy(stateprovincename = value))
+      override def postalcode = Field[/* max 15 chars */ String, VstorewithaddressesViewRow](_path, "postalcode", None, None, x => x.postalcode, (row, value) => row.copy(postalcode = value))
+      override def countryregionname = Field[Name, VstorewithaddressesViewRow](_path, "countryregionname", None, None, x => x.countryregionname, (row, value) => row.copy(countryregionname = value))
     }
   
-    override val columns: List[FieldLikeNoHkt[?, Row]] =
-      List[FieldLikeNoHkt[?, Row]](fields.businessentityid, fields.name, fields.addresstype, fields.addressline1, fields.addressline2, fields.city, fields.stateprovincename, fields.postalcode, fields.countryregionname)
+    override lazy val columns: List[FieldLikeNoHkt[?, VstorewithaddressesViewRow]] =
+      List[FieldLikeNoHkt[?, VstorewithaddressesViewRow]](fields.businessentityid, fields.name, fields.addresstype, fields.addressline1, fields.addressline2, fields.city, fields.stateprovincename, fields.postalcode, fields.countryregionname)
   
-    override def copy[NewRow](prefix: Option[String], extract: NewRow => VstorewithaddressesViewRow, merge: (NewRow, VstorewithaddressesViewRow) => NewRow): Impl[NewRow] =
-      new Impl(prefix, extract, merge)
+    override def copy(path: List[Path]): Impl =
+      new Impl(path)
   }
   
 }

--- a/typo-tester-anorm/generated-and-checked-in/adventureworks/sales/vstorewithcontacts/VstorewithcontactsViewFields.scala
+++ b/typo-tester-anorm/generated-and-checked-in/adventureworks/sales/vstorewithcontacts/VstorewithcontactsViewFields.scala
@@ -11,53 +11,54 @@ import adventureworks.person.businessentity.BusinessentityId
 import adventureworks.public.Name
 import adventureworks.public.Phone
 import adventureworks.userdefined.FirstName
+import typo.dsl.Path
 import typo.dsl.SqlExpr.Field
 import typo.dsl.SqlExpr.FieldLikeNoHkt
 import typo.dsl.SqlExpr.OptField
 import typo.dsl.Structure.Relation
 
-trait VstorewithcontactsViewFields[Row] {
-  val businessentityid: Field[BusinessentityId, Row]
-  val name: Field[Name, Row]
-  val contacttype: Field[Name, Row]
-  val title: OptField[/* max 8 chars */ String, Row]
-  val firstname: Field[/* user-picked */ FirstName, Row]
-  val middlename: OptField[Name, Row]
-  val lastname: Field[Name, Row]
-  val suffix: OptField[/* max 10 chars */ String, Row]
-  val phonenumber: OptField[Phone, Row]
-  val phonenumbertype: OptField[Name, Row]
-  val emailaddress: OptField[/* max 50 chars */ String, Row]
-  val emailpromotion: Field[Int, Row]
+trait VstorewithcontactsViewFields {
+  def businessentityid: Field[BusinessentityId, VstorewithcontactsViewRow]
+  def name: Field[Name, VstorewithcontactsViewRow]
+  def contacttype: Field[Name, VstorewithcontactsViewRow]
+  def title: OptField[/* max 8 chars */ String, VstorewithcontactsViewRow]
+  def firstname: Field[/* user-picked */ FirstName, VstorewithcontactsViewRow]
+  def middlename: OptField[Name, VstorewithcontactsViewRow]
+  def lastname: Field[Name, VstorewithcontactsViewRow]
+  def suffix: OptField[/* max 10 chars */ String, VstorewithcontactsViewRow]
+  def phonenumber: OptField[Phone, VstorewithcontactsViewRow]
+  def phonenumbertype: OptField[Name, VstorewithcontactsViewRow]
+  def emailaddress: OptField[/* max 50 chars */ String, VstorewithcontactsViewRow]
+  def emailpromotion: Field[Int, VstorewithcontactsViewRow]
 }
 
 object VstorewithcontactsViewFields {
-  val structure: Relation[VstorewithcontactsViewFields, VstorewithcontactsViewRow, VstorewithcontactsViewRow] = 
-    new Impl(None, identity, (_, x) => x)
+  lazy val structure: Relation[VstorewithcontactsViewFields, VstorewithcontactsViewRow] =
+    new Impl(Nil)
     
-  private final class Impl[Row](val prefix: Option[String], val extract: Row => VstorewithcontactsViewRow, val merge: (Row, VstorewithcontactsViewRow) => Row)
-    extends Relation[VstorewithcontactsViewFields, VstorewithcontactsViewRow, Row] { 
+  private final class Impl(val _path: List[Path])
+    extends Relation[VstorewithcontactsViewFields, VstorewithcontactsViewRow] {
   
-    override val fields: VstorewithcontactsViewFields[Row] = new VstorewithcontactsViewFields[Row] {
-      override val businessentityid = new Field[BusinessentityId, Row](prefix, "businessentityid", None, None)(x => extract(x).businessentityid, (row, value) => merge(row, extract(row).copy(businessentityid = value)))
-      override val name = new Field[Name, Row](prefix, "name", None, None)(x => extract(x).name, (row, value) => merge(row, extract(row).copy(name = value)))
-      override val contacttype = new Field[Name, Row](prefix, "contacttype", None, None)(x => extract(x).contacttype, (row, value) => merge(row, extract(row).copy(contacttype = value)))
-      override val title = new OptField[/* max 8 chars */ String, Row](prefix, "title", None, None)(x => extract(x).title, (row, value) => merge(row, extract(row).copy(title = value)))
-      override val firstname = new Field[/* user-picked */ FirstName, Row](prefix, "firstname", None, None)(x => extract(x).firstname, (row, value) => merge(row, extract(row).copy(firstname = value)))
-      override val middlename = new OptField[Name, Row](prefix, "middlename", None, None)(x => extract(x).middlename, (row, value) => merge(row, extract(row).copy(middlename = value)))
-      override val lastname = new Field[Name, Row](prefix, "lastname", None, None)(x => extract(x).lastname, (row, value) => merge(row, extract(row).copy(lastname = value)))
-      override val suffix = new OptField[/* max 10 chars */ String, Row](prefix, "suffix", None, None)(x => extract(x).suffix, (row, value) => merge(row, extract(row).copy(suffix = value)))
-      override val phonenumber = new OptField[Phone, Row](prefix, "phonenumber", None, None)(x => extract(x).phonenumber, (row, value) => merge(row, extract(row).copy(phonenumber = value)))
-      override val phonenumbertype = new OptField[Name, Row](prefix, "phonenumbertype", None, None)(x => extract(x).phonenumbertype, (row, value) => merge(row, extract(row).copy(phonenumbertype = value)))
-      override val emailaddress = new OptField[/* max 50 chars */ String, Row](prefix, "emailaddress", None, None)(x => extract(x).emailaddress, (row, value) => merge(row, extract(row).copy(emailaddress = value)))
-      override val emailpromotion = new Field[Int, Row](prefix, "emailpromotion", None, None)(x => extract(x).emailpromotion, (row, value) => merge(row, extract(row).copy(emailpromotion = value)))
+    override lazy val fields: VstorewithcontactsViewFields = new VstorewithcontactsViewFields {
+      override def businessentityid = Field[BusinessentityId, VstorewithcontactsViewRow](_path, "businessentityid", None, None, x => x.businessentityid, (row, value) => row.copy(businessentityid = value))
+      override def name = Field[Name, VstorewithcontactsViewRow](_path, "name", None, None, x => x.name, (row, value) => row.copy(name = value))
+      override def contacttype = Field[Name, VstorewithcontactsViewRow](_path, "contacttype", None, None, x => x.contacttype, (row, value) => row.copy(contacttype = value))
+      override def title = OptField[/* max 8 chars */ String, VstorewithcontactsViewRow](_path, "title", None, None, x => x.title, (row, value) => row.copy(title = value))
+      override def firstname = Field[/* user-picked */ FirstName, VstorewithcontactsViewRow](_path, "firstname", None, None, x => x.firstname, (row, value) => row.copy(firstname = value))
+      override def middlename = OptField[Name, VstorewithcontactsViewRow](_path, "middlename", None, None, x => x.middlename, (row, value) => row.copy(middlename = value))
+      override def lastname = Field[Name, VstorewithcontactsViewRow](_path, "lastname", None, None, x => x.lastname, (row, value) => row.copy(lastname = value))
+      override def suffix = OptField[/* max 10 chars */ String, VstorewithcontactsViewRow](_path, "suffix", None, None, x => x.suffix, (row, value) => row.copy(suffix = value))
+      override def phonenumber = OptField[Phone, VstorewithcontactsViewRow](_path, "phonenumber", None, None, x => x.phonenumber, (row, value) => row.copy(phonenumber = value))
+      override def phonenumbertype = OptField[Name, VstorewithcontactsViewRow](_path, "phonenumbertype", None, None, x => x.phonenumbertype, (row, value) => row.copy(phonenumbertype = value))
+      override def emailaddress = OptField[/* max 50 chars */ String, VstorewithcontactsViewRow](_path, "emailaddress", None, None, x => x.emailaddress, (row, value) => row.copy(emailaddress = value))
+      override def emailpromotion = Field[Int, VstorewithcontactsViewRow](_path, "emailpromotion", None, None, x => x.emailpromotion, (row, value) => row.copy(emailpromotion = value))
     }
   
-    override val columns: List[FieldLikeNoHkt[?, Row]] =
-      List[FieldLikeNoHkt[?, Row]](fields.businessentityid, fields.name, fields.contacttype, fields.title, fields.firstname, fields.middlename, fields.lastname, fields.suffix, fields.phonenumber, fields.phonenumbertype, fields.emailaddress, fields.emailpromotion)
+    override lazy val columns: List[FieldLikeNoHkt[?, VstorewithcontactsViewRow]] =
+      List[FieldLikeNoHkt[?, VstorewithcontactsViewRow]](fields.businessentityid, fields.name, fields.contacttype, fields.title, fields.firstname, fields.middlename, fields.lastname, fields.suffix, fields.phonenumber, fields.phonenumbertype, fields.emailaddress, fields.emailpromotion)
   
-    override def copy[NewRow](prefix: Option[String], extract: NewRow => VstorewithcontactsViewRow, merge: (NewRow, VstorewithcontactsViewRow) => NewRow): Impl[NewRow] =
-      new Impl(prefix, extract, merge)
+    override def copy(path: List[Path]): Impl =
+      new Impl(path)
   }
   
 }

--- a/typo-tester-anorm/generated-and-checked-in/adventureworks/sales/vstorewithdemographics/VstorewithdemographicsViewFields.scala
+++ b/typo-tester-anorm/generated-and-checked-in/adventureworks/sales/vstorewithdemographics/VstorewithdemographicsViewFields.scala
@@ -10,53 +10,54 @@ package vstorewithdemographics
 import adventureworks.customtypes.TypoMoney
 import adventureworks.person.businessentity.BusinessentityId
 import adventureworks.public.Name
+import typo.dsl.Path
 import typo.dsl.SqlExpr.Field
 import typo.dsl.SqlExpr.FieldLikeNoHkt
 import typo.dsl.SqlExpr.OptField
 import typo.dsl.Structure.Relation
 
-trait VstorewithdemographicsViewFields[Row] {
-  val businessentityid: Field[BusinessentityId, Row]
-  val name: Field[Name, Row]
-  val AnnualSales: OptField[TypoMoney, Row]
-  val AnnualRevenue: OptField[TypoMoney, Row]
-  val BankName: OptField[/* max 50 chars */ String, Row]
-  val BusinessType: OptField[/* max 5 chars */ String, Row]
-  val YearOpened: OptField[Int, Row]
-  val Specialty: OptField[/* max 50 chars */ String, Row]
-  val SquareFeet: OptField[Int, Row]
-  val Brands: OptField[/* max 30 chars */ String, Row]
-  val Internet: OptField[/* max 30 chars */ String, Row]
-  val NumberEmployees: OptField[Int, Row]
+trait VstorewithdemographicsViewFields {
+  def businessentityid: Field[BusinessentityId, VstorewithdemographicsViewRow]
+  def name: Field[Name, VstorewithdemographicsViewRow]
+  def AnnualSales: OptField[TypoMoney, VstorewithdemographicsViewRow]
+  def AnnualRevenue: OptField[TypoMoney, VstorewithdemographicsViewRow]
+  def BankName: OptField[/* max 50 chars */ String, VstorewithdemographicsViewRow]
+  def BusinessType: OptField[/* max 5 chars */ String, VstorewithdemographicsViewRow]
+  def YearOpened: OptField[Int, VstorewithdemographicsViewRow]
+  def Specialty: OptField[/* max 50 chars */ String, VstorewithdemographicsViewRow]
+  def SquareFeet: OptField[Int, VstorewithdemographicsViewRow]
+  def Brands: OptField[/* max 30 chars */ String, VstorewithdemographicsViewRow]
+  def Internet: OptField[/* max 30 chars */ String, VstorewithdemographicsViewRow]
+  def NumberEmployees: OptField[Int, VstorewithdemographicsViewRow]
 }
 
 object VstorewithdemographicsViewFields {
-  val structure: Relation[VstorewithdemographicsViewFields, VstorewithdemographicsViewRow, VstorewithdemographicsViewRow] = 
-    new Impl(None, identity, (_, x) => x)
+  lazy val structure: Relation[VstorewithdemographicsViewFields, VstorewithdemographicsViewRow] =
+    new Impl(Nil)
     
-  private final class Impl[Row](val prefix: Option[String], val extract: Row => VstorewithdemographicsViewRow, val merge: (Row, VstorewithdemographicsViewRow) => Row)
-    extends Relation[VstorewithdemographicsViewFields, VstorewithdemographicsViewRow, Row] { 
+  private final class Impl(val _path: List[Path])
+    extends Relation[VstorewithdemographicsViewFields, VstorewithdemographicsViewRow] {
   
-    override val fields: VstorewithdemographicsViewFields[Row] = new VstorewithdemographicsViewFields[Row] {
-      override val businessentityid = new Field[BusinessentityId, Row](prefix, "businessentityid", None, None)(x => extract(x).businessentityid, (row, value) => merge(row, extract(row).copy(businessentityid = value)))
-      override val name = new Field[Name, Row](prefix, "name", None, None)(x => extract(x).name, (row, value) => merge(row, extract(row).copy(name = value)))
-      override val AnnualSales = new OptField[TypoMoney, Row](prefix, "AnnualSales", Some("numeric"), None)(x => extract(x).AnnualSales, (row, value) => merge(row, extract(row).copy(AnnualSales = value)))
-      override val AnnualRevenue = new OptField[TypoMoney, Row](prefix, "AnnualRevenue", Some("numeric"), None)(x => extract(x).AnnualRevenue, (row, value) => merge(row, extract(row).copy(AnnualRevenue = value)))
-      override val BankName = new OptField[/* max 50 chars */ String, Row](prefix, "BankName", None, None)(x => extract(x).BankName, (row, value) => merge(row, extract(row).copy(BankName = value)))
-      override val BusinessType = new OptField[/* max 5 chars */ String, Row](prefix, "BusinessType", None, None)(x => extract(x).BusinessType, (row, value) => merge(row, extract(row).copy(BusinessType = value)))
-      override val YearOpened = new OptField[Int, Row](prefix, "YearOpened", None, None)(x => extract(x).YearOpened, (row, value) => merge(row, extract(row).copy(YearOpened = value)))
-      override val Specialty = new OptField[/* max 50 chars */ String, Row](prefix, "Specialty", None, None)(x => extract(x).Specialty, (row, value) => merge(row, extract(row).copy(Specialty = value)))
-      override val SquareFeet = new OptField[Int, Row](prefix, "SquareFeet", None, None)(x => extract(x).SquareFeet, (row, value) => merge(row, extract(row).copy(SquareFeet = value)))
-      override val Brands = new OptField[/* max 30 chars */ String, Row](prefix, "Brands", None, None)(x => extract(x).Brands, (row, value) => merge(row, extract(row).copy(Brands = value)))
-      override val Internet = new OptField[/* max 30 chars */ String, Row](prefix, "Internet", None, None)(x => extract(x).Internet, (row, value) => merge(row, extract(row).copy(Internet = value)))
-      override val NumberEmployees = new OptField[Int, Row](prefix, "NumberEmployees", None, None)(x => extract(x).NumberEmployees, (row, value) => merge(row, extract(row).copy(NumberEmployees = value)))
+    override lazy val fields: VstorewithdemographicsViewFields = new VstorewithdemographicsViewFields {
+      override def businessentityid = Field[BusinessentityId, VstorewithdemographicsViewRow](_path, "businessentityid", None, None, x => x.businessentityid, (row, value) => row.copy(businessentityid = value))
+      override def name = Field[Name, VstorewithdemographicsViewRow](_path, "name", None, None, x => x.name, (row, value) => row.copy(name = value))
+      override def AnnualSales = OptField[TypoMoney, VstorewithdemographicsViewRow](_path, "AnnualSales", Some("numeric"), None, x => x.AnnualSales, (row, value) => row.copy(AnnualSales = value))
+      override def AnnualRevenue = OptField[TypoMoney, VstorewithdemographicsViewRow](_path, "AnnualRevenue", Some("numeric"), None, x => x.AnnualRevenue, (row, value) => row.copy(AnnualRevenue = value))
+      override def BankName = OptField[/* max 50 chars */ String, VstorewithdemographicsViewRow](_path, "BankName", None, None, x => x.BankName, (row, value) => row.copy(BankName = value))
+      override def BusinessType = OptField[/* max 5 chars */ String, VstorewithdemographicsViewRow](_path, "BusinessType", None, None, x => x.BusinessType, (row, value) => row.copy(BusinessType = value))
+      override def YearOpened = OptField[Int, VstorewithdemographicsViewRow](_path, "YearOpened", None, None, x => x.YearOpened, (row, value) => row.copy(YearOpened = value))
+      override def Specialty = OptField[/* max 50 chars */ String, VstorewithdemographicsViewRow](_path, "Specialty", None, None, x => x.Specialty, (row, value) => row.copy(Specialty = value))
+      override def SquareFeet = OptField[Int, VstorewithdemographicsViewRow](_path, "SquareFeet", None, None, x => x.SquareFeet, (row, value) => row.copy(SquareFeet = value))
+      override def Brands = OptField[/* max 30 chars */ String, VstorewithdemographicsViewRow](_path, "Brands", None, None, x => x.Brands, (row, value) => row.copy(Brands = value))
+      override def Internet = OptField[/* max 30 chars */ String, VstorewithdemographicsViewRow](_path, "Internet", None, None, x => x.Internet, (row, value) => row.copy(Internet = value))
+      override def NumberEmployees = OptField[Int, VstorewithdemographicsViewRow](_path, "NumberEmployees", None, None, x => x.NumberEmployees, (row, value) => row.copy(NumberEmployees = value))
     }
   
-    override val columns: List[FieldLikeNoHkt[?, Row]] =
-      List[FieldLikeNoHkt[?, Row]](fields.businessentityid, fields.name, fields.AnnualSales, fields.AnnualRevenue, fields.BankName, fields.BusinessType, fields.YearOpened, fields.Specialty, fields.SquareFeet, fields.Brands, fields.Internet, fields.NumberEmployees)
+    override lazy val columns: List[FieldLikeNoHkt[?, VstorewithdemographicsViewRow]] =
+      List[FieldLikeNoHkt[?, VstorewithdemographicsViewRow]](fields.businessentityid, fields.name, fields.AnnualSales, fields.AnnualRevenue, fields.BankName, fields.BusinessType, fields.YearOpened, fields.Specialty, fields.SquareFeet, fields.Brands, fields.Internet, fields.NumberEmployees)
   
-    override def copy[NewRow](prefix: Option[String], extract: NewRow => VstorewithdemographicsViewRow, merge: (NewRow, VstorewithdemographicsViewRow) => NewRow): Impl[NewRow] =
-      new Impl(prefix, extract, merge)
+    override def copy(path: List[Path]): Impl =
+      new Impl(path)
   }
   
 }

--- a/typo-tester-anorm/src/scala/adventureworks/PaginationQueryCirce.scala
+++ b/typo-tester-anorm/src/scala/adventureworks/PaginationQueryCirce.scala
@@ -6,11 +6,11 @@ import typo.dsl.{SelectBuilder, SortOrder, SqlExpr}
 
 import java.sql.Connection
 
-class PaginationQueryCirce[Fields[_], Row](underlying: PaginationQuery[Fields, Row, JsValue]) {
-  def andOn[T, N[_]](v: Fields[Row] => SortOrder[T, N, Row])(implicit
+class PaginationQueryCirce[Fields, Row](underlying: PaginationQuery[Fields, Row, JsValue]) {
+  def andOn[T, N[_]](v: Fields => SortOrder[T, N])(implicit
       e: Writes[N[T]],
       d: Reads[N[T]],
-      asConst: SqlExpr.Const.As[T, N, Row]
+      asConst: SqlExpr.Const.As[T, N]
   ): PaginationQueryCirce[Fields, Row] =
     new PaginationQueryCirce(underlying.andOn(v)(PaginationQueryCirce.abstractCodec)(asConst))
 
@@ -33,11 +33,11 @@ object PaginationQueryCirce {
   implicit val clientCursorDecoder: Reads[ClientCursor[JsValue]] =
     implicitly[Reads[Map[String, JsValue]]].map(parts => ClientCursor(parts.map { case (k, v) => (SortOrderRepr(k), v) }))
 
-  implicit class PaginationQuerySyntax[Fields[_], Row](private val query: SelectBuilder[Fields, Row]) extends AnyVal {
-    def seekPaginationOn[T, N[_]](v: Fields[Row] => SortOrder[T, N, Row])(implicit
+  implicit class PaginationQuerySyntax[Fields, Row](private val query: SelectBuilder[Fields, Row]) extends AnyVal {
+    def seekPaginationOn[T, N[_]](v: Fields => SortOrder[T, N])(implicit
         e: Writes[N[T]],
         d: Reads[N[T]],
-        asConst: SqlExpr.Const.As[T, N, Row]
+        asConst: SqlExpr.Const.As[T, N]
     ): PaginationQueryCirce[Fields, Row] =
       new PaginationQueryCirce(new PaginationQuery(query, Nil).andOn(v)(PaginationQueryCirce.abstractCodec))
   }

--- a/typo-tester-anorm/src/scala/adventureworks/PaginationTest.scala
+++ b/typo-tester-anorm/src/scala/adventureworks/PaginationTest.scala
@@ -40,7 +40,7 @@ class PaginationTest extends AnyFunSuite with TypeCheckedTripleEquals {
     def patch(c: ClientCursor[JsValue]): ClientCursor[JsValue] =
       businessentityRepo match {
         case _: BusinessentityRepoMock =>
-          c.copy(parts = c.parts.map { case (k, v) => (SortOrderRepr(k.expr.replace("businessentity2.", "")), v) })
+          c.copy(parts = c.parts.map { case (k, v) => (SortOrderRepr(k.expr.replace("businessentity0.", "")), v) })
         case _ => c
       }
 
@@ -74,8 +74,8 @@ class PaginationTest extends AnyFunSuite with TypeCheckedTripleEquals {
           patch(
             ClientCursor(
               Map(
-                SortOrderRepr("businessentity2.modifieddate") -> JsString("2020-12-29T00:00:00"),
-                SortOrderRepr("(businessentity2.businessentityid - {param1}::INTEGER):2") -> JsNumber(BigDecimal(1))
+                SortOrderRepr("businessentity0.modifieddate") -> JsString("2020-12-29T00:00:00"),
+                SortOrderRepr("(businessentity0.businessentityid - {param1}::INTEGER):2") -> JsNumber(BigDecimal(1))
               )
             )
           )
@@ -90,8 +90,8 @@ class PaginationTest extends AnyFunSuite with TypeCheckedTripleEquals {
           patch(
             ClientCursor(
               Map(
-                SortOrderRepr("businessentity2.modifieddate") -> JsString("2020-12-25T00:00:00"),
-                SortOrderRepr("(businessentity2.businessentityid - {param1}::INTEGER):2") -> JsNumber(BigDecimal(15))
+                SortOrderRepr("businessentity0.modifieddate") -> JsString("2020-12-25T00:00:00"),
+                SortOrderRepr("(businessentity0.businessentityid - {param1}::INTEGER):2") -> JsNumber(BigDecimal(15))
               )
             )
           )

--- a/typo-tester-anorm/src/scala/adventureworks/production/product/SeekTest.scala
+++ b/typo-tester-anorm/src/scala/adventureworks/production/product/SeekTest.scala
@@ -13,8 +13,8 @@ class SeekTest extends AnyFunSuite with TypeCheckedTripleEquals {
       .seek(_.weight.asc)(Some(BigDecimal(22.2)))
       .seek(_.listprice.asc)(BigDecimal(33.3))
     assertResult(query.sql.get.toString)(
-      s"""Fragment(List(NamedParameter(param1,ParameterValue(Name(foo))), NamedParameter(param2,ParameterValue(Some(22.2))), NamedParameter(param3,ParameterValue(33.3))),select "productid","name","productnumber","makeflag","finishedgoodsflag","color","safetystocklevel","reorderpoint","standardcost","listprice","size","sizeunitmeasurecode","weightunitmeasurecode","weight","daystomanufacture","productline","class","style","productsubcategoryid","productmodelid","sellstartdate"::text,"sellenddate"::text,"discontinueddate"::text,"rowguid","modifieddate"::text from production.product
-         | where ((name,weight,listprice) > ({param1}::VARCHAR,{param2}::DECIMAL,{param3}::DECIMAL)) order by name ASC , weight ASC , listprice ASC${" "}
+      s"""Fragment(List(NamedParameter(param1,ParameterValue(Name(foo))), NamedParameter(param2,ParameterValue(Some(22.2))), NamedParameter(param3,ParameterValue(33.3))),select "productid","name","productnumber","makeflag","finishedgoodsflag","color","safetystocklevel","reorderpoint","standardcost","listprice","size","sizeunitmeasurecode","weightunitmeasurecode","weight","daystomanufacture","productline","class","style","productsubcategoryid","productmodelid","sellstartdate"::text,"sellenddate"::text,"discontinueddate"::text,"rowguid","modifieddate"::text from production.product product0
+         | where ((product0.name,product0.weight,product0.listprice) > ({param1}::VARCHAR,{param2}::DECIMAL,{param3}::DECIMAL)) order by product0.name ASC , product0.weight ASC , product0.listprice ASC${" "}
          |)""".stripMargin
     )
   }
@@ -25,8 +25,8 @@ class SeekTest extends AnyFunSuite with TypeCheckedTripleEquals {
       .seek(_.weight.desc)(Some(BigDecimal(22.2)))
       .seek(_.listprice.desc)(BigDecimal(33.3))
     assertResult(query.sql.get.toString)(
-      s"""Fragment(List(NamedParameter(param1,ParameterValue(Name(foo))), NamedParameter(param2,ParameterValue(Some(22.2))), NamedParameter(param3,ParameterValue(33.3))),select "productid","name","productnumber","makeflag","finishedgoodsflag","color","safetystocklevel","reorderpoint","standardcost","listprice","size","sizeunitmeasurecode","weightunitmeasurecode","weight","daystomanufacture","productline","class","style","productsubcategoryid","productmodelid","sellstartdate"::text,"sellenddate"::text,"discontinueddate"::text,"rowguid","modifieddate"::text from production.product
-         | where ((name,weight,listprice) < ({param1}::VARCHAR,{param2}::DECIMAL,{param3}::DECIMAL)) order by name DESC , weight DESC , listprice DESC${" "}
+      s"""Fragment(List(NamedParameter(param1,ParameterValue(Name(foo))), NamedParameter(param2,ParameterValue(Some(22.2))), NamedParameter(param3,ParameterValue(33.3))),select "productid","name","productnumber","makeflag","finishedgoodsflag","color","safetystocklevel","reorderpoint","standardcost","listprice","size","sizeunitmeasurecode","weightunitmeasurecode","weight","daystomanufacture","productline","class","style","productsubcategoryid","productmodelid","sellstartdate"::text,"sellenddate"::text,"discontinueddate"::text,"rowguid","modifieddate"::text from production.product product0
+         | where ((product0.name,product0.weight,product0.listprice) < ({param1}::VARCHAR,{param2}::DECIMAL,{param3}::DECIMAL)) order by product0.name DESC , product0.weight DESC , product0.listprice DESC${" "}
          |)""".stripMargin
     )
   }
@@ -37,8 +37,8 @@ class SeekTest extends AnyFunSuite with TypeCheckedTripleEquals {
       .seek(_.weight.desc)(Some(BigDecimal(22.2)))
       .seek(_.listprice.desc)(BigDecimal(33.3))
     assertResult(query.sql.get.toString)(
-      s"""Fragment(List(NamedParameter(param1,ParameterValue(Name(foo))), NamedParameter(param2,ParameterValue(Name(foo))), NamedParameter(param3,ParameterValue(Some(22.2))), NamedParameter(param4,ParameterValue(Name(foo))), NamedParameter(param5,ParameterValue(Some(22.2))), NamedParameter(param6,ParameterValue(33.3))),select "productid","name","productnumber","makeflag","finishedgoodsflag","color","safetystocklevel","reorderpoint","standardcost","listprice","size","sizeunitmeasurecode","weightunitmeasurecode","weight","daystomanufacture","productline","class","style","productsubcategoryid","productmodelid","sellstartdate"::text,"sellenddate"::text,"discontinueddate"::text,"rowguid","modifieddate"::text from production.product
-         | where (((name > {param1}::VARCHAR) OR ((name = {param2}::VARCHAR) AND (weight < {param3}::DECIMAL))) OR (((name = {param4}::VARCHAR) AND (weight = {param5}::DECIMAL)) AND (listprice < {param6}::DECIMAL))) order by name ASC , weight DESC , listprice DESC${" "}
+      s"""Fragment(List(NamedParameter(param1,ParameterValue(Name(foo))), NamedParameter(param2,ParameterValue(Name(foo))), NamedParameter(param3,ParameterValue(Some(22.2))), NamedParameter(param4,ParameterValue(Name(foo))), NamedParameter(param5,ParameterValue(Some(22.2))), NamedParameter(param6,ParameterValue(33.3))),select "productid","name","productnumber","makeflag","finishedgoodsflag","color","safetystocklevel","reorderpoint","standardcost","listprice","size","sizeunitmeasurecode","weightunitmeasurecode","weight","daystomanufacture","productline","class","style","productsubcategoryid","productmodelid","sellstartdate"::text,"sellenddate"::text,"discontinueddate"::text,"rowguid","modifieddate"::text from production.product product0
+         | where (((product0.name > {param1}::VARCHAR) OR ((product0.name = {param2}::VARCHAR) AND (product0.weight < {param3}::DECIMAL))) OR (((product0.name = {param4}::VARCHAR) AND (product0.weight = {param5}::DECIMAL)) AND (product0.listprice < {param6}::DECIMAL))) order by product0.name ASC , product0.weight DESC , product0.listprice DESC 
          |)""".stripMargin
     )
   }

--- a/typo-tester-doobie/generated-and-checked-in/adventureworks/customtypes/TypoShort.scala
+++ b/typo-tester-doobie/generated-and-checked-in/adventureworks/customtypes/TypoShort.scala
@@ -12,7 +12,6 @@ import doobie.util.Get
 import doobie.util.Put
 import io.circe.Decoder
 import io.circe.Encoder
-import scala.math.Numeric
 import typo.dsl.Bijection
 
 /** Short primitive */

--- a/typo-tester-doobie/generated-and-checked-in/adventureworks/hr/d/DViewFields.scala
+++ b/typo-tester-doobie/generated-and-checked-in/adventureworks/hr/d/DViewFields.scala
@@ -10,38 +10,39 @@ package d
 import adventureworks.customtypes.TypoLocalDateTime
 import adventureworks.humanresources.department.DepartmentId
 import adventureworks.public.Name
+import typo.dsl.Path
 import typo.dsl.SqlExpr.Field
 import typo.dsl.SqlExpr.FieldLikeNoHkt
 import typo.dsl.Structure.Relation
 
-trait DViewFields[Row] {
-  val id: Field[DepartmentId, Row]
-  val departmentid: Field[DepartmentId, Row]
-  val name: Field[Name, Row]
-  val groupname: Field[Name, Row]
-  val modifieddate: Field[TypoLocalDateTime, Row]
+trait DViewFields {
+  def id: Field[DepartmentId, DViewRow]
+  def departmentid: Field[DepartmentId, DViewRow]
+  def name: Field[Name, DViewRow]
+  def groupname: Field[Name, DViewRow]
+  def modifieddate: Field[TypoLocalDateTime, DViewRow]
 }
 
 object DViewFields {
-  val structure: Relation[DViewFields, DViewRow, DViewRow] = 
-    new Impl(None, identity, (_, x) => x)
+  lazy val structure: Relation[DViewFields, DViewRow] =
+    new Impl(Nil)
     
-  private final class Impl[Row](val prefix: Option[String], val extract: Row => DViewRow, val merge: (Row, DViewRow) => Row)
-    extends Relation[DViewFields, DViewRow, Row] { 
+  private final class Impl(val _path: List[Path])
+    extends Relation[DViewFields, DViewRow] {
   
-    override val fields: DViewFields[Row] = new DViewFields[Row] {
-      override val id = new Field[DepartmentId, Row](prefix, "id", None, None)(x => extract(x).id, (row, value) => merge(row, extract(row).copy(id = value)))
-      override val departmentid = new Field[DepartmentId, Row](prefix, "departmentid", None, None)(x => extract(x).departmentid, (row, value) => merge(row, extract(row).copy(departmentid = value)))
-      override val name = new Field[Name, Row](prefix, "name", None, None)(x => extract(x).name, (row, value) => merge(row, extract(row).copy(name = value)))
-      override val groupname = new Field[Name, Row](prefix, "groupname", None, None)(x => extract(x).groupname, (row, value) => merge(row, extract(row).copy(groupname = value)))
-      override val modifieddate = new Field[TypoLocalDateTime, Row](prefix, "modifieddate", Some("text"), None)(x => extract(x).modifieddate, (row, value) => merge(row, extract(row).copy(modifieddate = value)))
+    override lazy val fields: DViewFields = new DViewFields {
+      override def id = Field[DepartmentId, DViewRow](_path, "id", None, None, x => x.id, (row, value) => row.copy(id = value))
+      override def departmentid = Field[DepartmentId, DViewRow](_path, "departmentid", None, None, x => x.departmentid, (row, value) => row.copy(departmentid = value))
+      override def name = Field[Name, DViewRow](_path, "name", None, None, x => x.name, (row, value) => row.copy(name = value))
+      override def groupname = Field[Name, DViewRow](_path, "groupname", None, None, x => x.groupname, (row, value) => row.copy(groupname = value))
+      override def modifieddate = Field[TypoLocalDateTime, DViewRow](_path, "modifieddate", Some("text"), None, x => x.modifieddate, (row, value) => row.copy(modifieddate = value))
     }
   
-    override val columns: List[FieldLikeNoHkt[?, Row]] =
-      List[FieldLikeNoHkt[?, Row]](fields.id, fields.departmentid, fields.name, fields.groupname, fields.modifieddate)
+    override lazy val columns: List[FieldLikeNoHkt[?, DViewRow]] =
+      List[FieldLikeNoHkt[?, DViewRow]](fields.id, fields.departmentid, fields.name, fields.groupname, fields.modifieddate)
   
-    override def copy[NewRow](prefix: Option[String], extract: NewRow => DViewRow, merge: (NewRow, DViewRow) => NewRow): Impl[NewRow] =
-      new Impl(prefix, extract, merge)
+    override def copy(path: List[Path]): Impl =
+      new Impl(path)
   }
   
 }

--- a/typo-tester-doobie/generated-and-checked-in/adventureworks/hr/e/EViewFields.scala
+++ b/typo-tester-doobie/generated-and-checked-in/adventureworks/hr/e/EViewFields.scala
@@ -13,61 +13,62 @@ import adventureworks.customtypes.TypoShort
 import adventureworks.customtypes.TypoUUID
 import adventureworks.person.businessentity.BusinessentityId
 import adventureworks.public.Flag
+import typo.dsl.Path
 import typo.dsl.SqlExpr.Field
 import typo.dsl.SqlExpr.FieldLikeNoHkt
 import typo.dsl.SqlExpr.OptField
 import typo.dsl.Structure.Relation
 
-trait EViewFields[Row] {
-  val id: Field[BusinessentityId, Row]
-  val businessentityid: Field[BusinessentityId, Row]
-  val nationalidnumber: Field[/* max 15 chars */ String, Row]
-  val loginid: Field[/* max 256 chars */ String, Row]
-  val jobtitle: Field[/* max 50 chars */ String, Row]
-  val birthdate: Field[TypoLocalDate, Row]
-  val maritalstatus: Field[/* bpchar, max 1 chars */ String, Row]
-  val gender: Field[/* bpchar, max 1 chars */ String, Row]
-  val hiredate: Field[TypoLocalDate, Row]
-  val salariedflag: Field[Flag, Row]
-  val vacationhours: Field[TypoShort, Row]
-  val sickleavehours: Field[TypoShort, Row]
-  val currentflag: Field[Flag, Row]
-  val rowguid: Field[TypoUUID, Row]
-  val modifieddate: Field[TypoLocalDateTime, Row]
-  val organizationnode: OptField[String, Row]
+trait EViewFields {
+  def id: Field[BusinessentityId, EViewRow]
+  def businessentityid: Field[BusinessentityId, EViewRow]
+  def nationalidnumber: Field[/* max 15 chars */ String, EViewRow]
+  def loginid: Field[/* max 256 chars */ String, EViewRow]
+  def jobtitle: Field[/* max 50 chars */ String, EViewRow]
+  def birthdate: Field[TypoLocalDate, EViewRow]
+  def maritalstatus: Field[/* bpchar, max 1 chars */ String, EViewRow]
+  def gender: Field[/* bpchar, max 1 chars */ String, EViewRow]
+  def hiredate: Field[TypoLocalDate, EViewRow]
+  def salariedflag: Field[Flag, EViewRow]
+  def vacationhours: Field[TypoShort, EViewRow]
+  def sickleavehours: Field[TypoShort, EViewRow]
+  def currentflag: Field[Flag, EViewRow]
+  def rowguid: Field[TypoUUID, EViewRow]
+  def modifieddate: Field[TypoLocalDateTime, EViewRow]
+  def organizationnode: OptField[String, EViewRow]
 }
 
 object EViewFields {
-  val structure: Relation[EViewFields, EViewRow, EViewRow] = 
-    new Impl(None, identity, (_, x) => x)
+  lazy val structure: Relation[EViewFields, EViewRow] =
+    new Impl(Nil)
     
-  private final class Impl[Row](val prefix: Option[String], val extract: Row => EViewRow, val merge: (Row, EViewRow) => Row)
-    extends Relation[EViewFields, EViewRow, Row] { 
+  private final class Impl(val _path: List[Path])
+    extends Relation[EViewFields, EViewRow] {
   
-    override val fields: EViewFields[Row] = new EViewFields[Row] {
-      override val id = new Field[BusinessentityId, Row](prefix, "id", None, None)(x => extract(x).id, (row, value) => merge(row, extract(row).copy(id = value)))
-      override val businessentityid = new Field[BusinessentityId, Row](prefix, "businessentityid", None, None)(x => extract(x).businessentityid, (row, value) => merge(row, extract(row).copy(businessentityid = value)))
-      override val nationalidnumber = new Field[/* max 15 chars */ String, Row](prefix, "nationalidnumber", None, None)(x => extract(x).nationalidnumber, (row, value) => merge(row, extract(row).copy(nationalidnumber = value)))
-      override val loginid = new Field[/* max 256 chars */ String, Row](prefix, "loginid", None, None)(x => extract(x).loginid, (row, value) => merge(row, extract(row).copy(loginid = value)))
-      override val jobtitle = new Field[/* max 50 chars */ String, Row](prefix, "jobtitle", None, None)(x => extract(x).jobtitle, (row, value) => merge(row, extract(row).copy(jobtitle = value)))
-      override val birthdate = new Field[TypoLocalDate, Row](prefix, "birthdate", Some("text"), None)(x => extract(x).birthdate, (row, value) => merge(row, extract(row).copy(birthdate = value)))
-      override val maritalstatus = new Field[/* bpchar, max 1 chars */ String, Row](prefix, "maritalstatus", None, None)(x => extract(x).maritalstatus, (row, value) => merge(row, extract(row).copy(maritalstatus = value)))
-      override val gender = new Field[/* bpchar, max 1 chars */ String, Row](prefix, "gender", None, None)(x => extract(x).gender, (row, value) => merge(row, extract(row).copy(gender = value)))
-      override val hiredate = new Field[TypoLocalDate, Row](prefix, "hiredate", Some("text"), None)(x => extract(x).hiredate, (row, value) => merge(row, extract(row).copy(hiredate = value)))
-      override val salariedflag = new Field[Flag, Row](prefix, "salariedflag", None, None)(x => extract(x).salariedflag, (row, value) => merge(row, extract(row).copy(salariedflag = value)))
-      override val vacationhours = new Field[TypoShort, Row](prefix, "vacationhours", None, None)(x => extract(x).vacationhours, (row, value) => merge(row, extract(row).copy(vacationhours = value)))
-      override val sickleavehours = new Field[TypoShort, Row](prefix, "sickleavehours", None, None)(x => extract(x).sickleavehours, (row, value) => merge(row, extract(row).copy(sickleavehours = value)))
-      override val currentflag = new Field[Flag, Row](prefix, "currentflag", None, None)(x => extract(x).currentflag, (row, value) => merge(row, extract(row).copy(currentflag = value)))
-      override val rowguid = new Field[TypoUUID, Row](prefix, "rowguid", None, None)(x => extract(x).rowguid, (row, value) => merge(row, extract(row).copy(rowguid = value)))
-      override val modifieddate = new Field[TypoLocalDateTime, Row](prefix, "modifieddate", Some("text"), None)(x => extract(x).modifieddate, (row, value) => merge(row, extract(row).copy(modifieddate = value)))
-      override val organizationnode = new OptField[String, Row](prefix, "organizationnode", None, None)(x => extract(x).organizationnode, (row, value) => merge(row, extract(row).copy(organizationnode = value)))
+    override lazy val fields: EViewFields = new EViewFields {
+      override def id = Field[BusinessentityId, EViewRow](_path, "id", None, None, x => x.id, (row, value) => row.copy(id = value))
+      override def businessentityid = Field[BusinessentityId, EViewRow](_path, "businessentityid", None, None, x => x.businessentityid, (row, value) => row.copy(businessentityid = value))
+      override def nationalidnumber = Field[/* max 15 chars */ String, EViewRow](_path, "nationalidnumber", None, None, x => x.nationalidnumber, (row, value) => row.copy(nationalidnumber = value))
+      override def loginid = Field[/* max 256 chars */ String, EViewRow](_path, "loginid", None, None, x => x.loginid, (row, value) => row.copy(loginid = value))
+      override def jobtitle = Field[/* max 50 chars */ String, EViewRow](_path, "jobtitle", None, None, x => x.jobtitle, (row, value) => row.copy(jobtitle = value))
+      override def birthdate = Field[TypoLocalDate, EViewRow](_path, "birthdate", Some("text"), None, x => x.birthdate, (row, value) => row.copy(birthdate = value))
+      override def maritalstatus = Field[/* bpchar, max 1 chars */ String, EViewRow](_path, "maritalstatus", None, None, x => x.maritalstatus, (row, value) => row.copy(maritalstatus = value))
+      override def gender = Field[/* bpchar, max 1 chars */ String, EViewRow](_path, "gender", None, None, x => x.gender, (row, value) => row.copy(gender = value))
+      override def hiredate = Field[TypoLocalDate, EViewRow](_path, "hiredate", Some("text"), None, x => x.hiredate, (row, value) => row.copy(hiredate = value))
+      override def salariedflag = Field[Flag, EViewRow](_path, "salariedflag", None, None, x => x.salariedflag, (row, value) => row.copy(salariedflag = value))
+      override def vacationhours = Field[TypoShort, EViewRow](_path, "vacationhours", None, None, x => x.vacationhours, (row, value) => row.copy(vacationhours = value))
+      override def sickleavehours = Field[TypoShort, EViewRow](_path, "sickleavehours", None, None, x => x.sickleavehours, (row, value) => row.copy(sickleavehours = value))
+      override def currentflag = Field[Flag, EViewRow](_path, "currentflag", None, None, x => x.currentflag, (row, value) => row.copy(currentflag = value))
+      override def rowguid = Field[TypoUUID, EViewRow](_path, "rowguid", None, None, x => x.rowguid, (row, value) => row.copy(rowguid = value))
+      override def modifieddate = Field[TypoLocalDateTime, EViewRow](_path, "modifieddate", Some("text"), None, x => x.modifieddate, (row, value) => row.copy(modifieddate = value))
+      override def organizationnode = OptField[String, EViewRow](_path, "organizationnode", None, None, x => x.organizationnode, (row, value) => row.copy(organizationnode = value))
     }
   
-    override val columns: List[FieldLikeNoHkt[?, Row]] =
-      List[FieldLikeNoHkt[?, Row]](fields.id, fields.businessentityid, fields.nationalidnumber, fields.loginid, fields.jobtitle, fields.birthdate, fields.maritalstatus, fields.gender, fields.hiredate, fields.salariedflag, fields.vacationhours, fields.sickleavehours, fields.currentflag, fields.rowguid, fields.modifieddate, fields.organizationnode)
+    override lazy val columns: List[FieldLikeNoHkt[?, EViewRow]] =
+      List[FieldLikeNoHkt[?, EViewRow]](fields.id, fields.businessentityid, fields.nationalidnumber, fields.loginid, fields.jobtitle, fields.birthdate, fields.maritalstatus, fields.gender, fields.hiredate, fields.salariedflag, fields.vacationhours, fields.sickleavehours, fields.currentflag, fields.rowguid, fields.modifieddate, fields.organizationnode)
   
-    override def copy[NewRow](prefix: Option[String], extract: NewRow => EViewRow, merge: (NewRow, EViewRow) => NewRow): Impl[NewRow] =
-      new Impl(prefix, extract, merge)
+    override def copy(path: List[Path]): Impl =
+      new Impl(path)
   }
   
 }

--- a/typo-tester-doobie/generated-and-checked-in/adventureworks/hr/edh/EdhViewFields.scala
+++ b/typo-tester-doobie/generated-and-checked-in/adventureworks/hr/edh/EdhViewFields.scala
@@ -12,43 +12,44 @@ import adventureworks.customtypes.TypoLocalDateTime
 import adventureworks.humanresources.department.DepartmentId
 import adventureworks.humanresources.shift.ShiftId
 import adventureworks.person.businessentity.BusinessentityId
+import typo.dsl.Path
 import typo.dsl.SqlExpr.Field
 import typo.dsl.SqlExpr.FieldLikeNoHkt
 import typo.dsl.SqlExpr.OptField
 import typo.dsl.Structure.Relation
 
-trait EdhViewFields[Row] {
-  val id: Field[BusinessentityId, Row]
-  val businessentityid: Field[BusinessentityId, Row]
-  val departmentid: Field[DepartmentId, Row]
-  val shiftid: Field[ShiftId, Row]
-  val startdate: Field[TypoLocalDate, Row]
-  val enddate: OptField[TypoLocalDate, Row]
-  val modifieddate: Field[TypoLocalDateTime, Row]
+trait EdhViewFields {
+  def id: Field[BusinessentityId, EdhViewRow]
+  def businessentityid: Field[BusinessentityId, EdhViewRow]
+  def departmentid: Field[DepartmentId, EdhViewRow]
+  def shiftid: Field[ShiftId, EdhViewRow]
+  def startdate: Field[TypoLocalDate, EdhViewRow]
+  def enddate: OptField[TypoLocalDate, EdhViewRow]
+  def modifieddate: Field[TypoLocalDateTime, EdhViewRow]
 }
 
 object EdhViewFields {
-  val structure: Relation[EdhViewFields, EdhViewRow, EdhViewRow] = 
-    new Impl(None, identity, (_, x) => x)
+  lazy val structure: Relation[EdhViewFields, EdhViewRow] =
+    new Impl(Nil)
     
-  private final class Impl[Row](val prefix: Option[String], val extract: Row => EdhViewRow, val merge: (Row, EdhViewRow) => Row)
-    extends Relation[EdhViewFields, EdhViewRow, Row] { 
+  private final class Impl(val _path: List[Path])
+    extends Relation[EdhViewFields, EdhViewRow] {
   
-    override val fields: EdhViewFields[Row] = new EdhViewFields[Row] {
-      override val id = new Field[BusinessentityId, Row](prefix, "id", None, None)(x => extract(x).id, (row, value) => merge(row, extract(row).copy(id = value)))
-      override val businessentityid = new Field[BusinessentityId, Row](prefix, "businessentityid", None, None)(x => extract(x).businessentityid, (row, value) => merge(row, extract(row).copy(businessentityid = value)))
-      override val departmentid = new Field[DepartmentId, Row](prefix, "departmentid", None, None)(x => extract(x).departmentid, (row, value) => merge(row, extract(row).copy(departmentid = value)))
-      override val shiftid = new Field[ShiftId, Row](prefix, "shiftid", None, None)(x => extract(x).shiftid, (row, value) => merge(row, extract(row).copy(shiftid = value)))
-      override val startdate = new Field[TypoLocalDate, Row](prefix, "startdate", Some("text"), None)(x => extract(x).startdate, (row, value) => merge(row, extract(row).copy(startdate = value)))
-      override val enddate = new OptField[TypoLocalDate, Row](prefix, "enddate", Some("text"), None)(x => extract(x).enddate, (row, value) => merge(row, extract(row).copy(enddate = value)))
-      override val modifieddate = new Field[TypoLocalDateTime, Row](prefix, "modifieddate", Some("text"), None)(x => extract(x).modifieddate, (row, value) => merge(row, extract(row).copy(modifieddate = value)))
+    override lazy val fields: EdhViewFields = new EdhViewFields {
+      override def id = Field[BusinessentityId, EdhViewRow](_path, "id", None, None, x => x.id, (row, value) => row.copy(id = value))
+      override def businessentityid = Field[BusinessentityId, EdhViewRow](_path, "businessentityid", None, None, x => x.businessentityid, (row, value) => row.copy(businessentityid = value))
+      override def departmentid = Field[DepartmentId, EdhViewRow](_path, "departmentid", None, None, x => x.departmentid, (row, value) => row.copy(departmentid = value))
+      override def shiftid = Field[ShiftId, EdhViewRow](_path, "shiftid", None, None, x => x.shiftid, (row, value) => row.copy(shiftid = value))
+      override def startdate = Field[TypoLocalDate, EdhViewRow](_path, "startdate", Some("text"), None, x => x.startdate, (row, value) => row.copy(startdate = value))
+      override def enddate = OptField[TypoLocalDate, EdhViewRow](_path, "enddate", Some("text"), None, x => x.enddate, (row, value) => row.copy(enddate = value))
+      override def modifieddate = Field[TypoLocalDateTime, EdhViewRow](_path, "modifieddate", Some("text"), None, x => x.modifieddate, (row, value) => row.copy(modifieddate = value))
     }
   
-    override val columns: List[FieldLikeNoHkt[?, Row]] =
-      List[FieldLikeNoHkt[?, Row]](fields.id, fields.businessentityid, fields.departmentid, fields.shiftid, fields.startdate, fields.enddate, fields.modifieddate)
+    override lazy val columns: List[FieldLikeNoHkt[?, EdhViewRow]] =
+      List[FieldLikeNoHkt[?, EdhViewRow]](fields.id, fields.businessentityid, fields.departmentid, fields.shiftid, fields.startdate, fields.enddate, fields.modifieddate)
   
-    override def copy[NewRow](prefix: Option[String], extract: NewRow => EdhViewRow, merge: (NewRow, EdhViewRow) => NewRow): Impl[NewRow] =
-      new Impl(prefix, extract, merge)
+    override def copy(path: List[Path]): Impl =
+      new Impl(path)
   }
   
 }

--- a/typo-tester-doobie/generated-and-checked-in/adventureworks/hr/eph/EphViewFields.scala
+++ b/typo-tester-doobie/generated-and-checked-in/adventureworks/hr/eph/EphViewFields.scala
@@ -10,40 +10,41 @@ package eph
 import adventureworks.customtypes.TypoLocalDateTime
 import adventureworks.customtypes.TypoShort
 import adventureworks.person.businessentity.BusinessentityId
+import typo.dsl.Path
 import typo.dsl.SqlExpr.Field
 import typo.dsl.SqlExpr.FieldLikeNoHkt
 import typo.dsl.Structure.Relation
 
-trait EphViewFields[Row] {
-  val id: Field[BusinessentityId, Row]
-  val businessentityid: Field[BusinessentityId, Row]
-  val ratechangedate: Field[TypoLocalDateTime, Row]
-  val rate: Field[BigDecimal, Row]
-  val payfrequency: Field[TypoShort, Row]
-  val modifieddate: Field[TypoLocalDateTime, Row]
+trait EphViewFields {
+  def id: Field[BusinessentityId, EphViewRow]
+  def businessentityid: Field[BusinessentityId, EphViewRow]
+  def ratechangedate: Field[TypoLocalDateTime, EphViewRow]
+  def rate: Field[BigDecimal, EphViewRow]
+  def payfrequency: Field[TypoShort, EphViewRow]
+  def modifieddate: Field[TypoLocalDateTime, EphViewRow]
 }
 
 object EphViewFields {
-  val structure: Relation[EphViewFields, EphViewRow, EphViewRow] = 
-    new Impl(None, identity, (_, x) => x)
+  lazy val structure: Relation[EphViewFields, EphViewRow] =
+    new Impl(Nil)
     
-  private final class Impl[Row](val prefix: Option[String], val extract: Row => EphViewRow, val merge: (Row, EphViewRow) => Row)
-    extends Relation[EphViewFields, EphViewRow, Row] { 
+  private final class Impl(val _path: List[Path])
+    extends Relation[EphViewFields, EphViewRow] {
   
-    override val fields: EphViewFields[Row] = new EphViewFields[Row] {
-      override val id = new Field[BusinessentityId, Row](prefix, "id", None, None)(x => extract(x).id, (row, value) => merge(row, extract(row).copy(id = value)))
-      override val businessentityid = new Field[BusinessentityId, Row](prefix, "businessentityid", None, None)(x => extract(x).businessentityid, (row, value) => merge(row, extract(row).copy(businessentityid = value)))
-      override val ratechangedate = new Field[TypoLocalDateTime, Row](prefix, "ratechangedate", Some("text"), None)(x => extract(x).ratechangedate, (row, value) => merge(row, extract(row).copy(ratechangedate = value)))
-      override val rate = new Field[BigDecimal, Row](prefix, "rate", None, None)(x => extract(x).rate, (row, value) => merge(row, extract(row).copy(rate = value)))
-      override val payfrequency = new Field[TypoShort, Row](prefix, "payfrequency", None, None)(x => extract(x).payfrequency, (row, value) => merge(row, extract(row).copy(payfrequency = value)))
-      override val modifieddate = new Field[TypoLocalDateTime, Row](prefix, "modifieddate", Some("text"), None)(x => extract(x).modifieddate, (row, value) => merge(row, extract(row).copy(modifieddate = value)))
+    override lazy val fields: EphViewFields = new EphViewFields {
+      override def id = Field[BusinessentityId, EphViewRow](_path, "id", None, None, x => x.id, (row, value) => row.copy(id = value))
+      override def businessentityid = Field[BusinessentityId, EphViewRow](_path, "businessentityid", None, None, x => x.businessentityid, (row, value) => row.copy(businessentityid = value))
+      override def ratechangedate = Field[TypoLocalDateTime, EphViewRow](_path, "ratechangedate", Some("text"), None, x => x.ratechangedate, (row, value) => row.copy(ratechangedate = value))
+      override def rate = Field[BigDecimal, EphViewRow](_path, "rate", None, None, x => x.rate, (row, value) => row.copy(rate = value))
+      override def payfrequency = Field[TypoShort, EphViewRow](_path, "payfrequency", None, None, x => x.payfrequency, (row, value) => row.copy(payfrequency = value))
+      override def modifieddate = Field[TypoLocalDateTime, EphViewRow](_path, "modifieddate", Some("text"), None, x => x.modifieddate, (row, value) => row.copy(modifieddate = value))
     }
   
-    override val columns: List[FieldLikeNoHkt[?, Row]] =
-      List[FieldLikeNoHkt[?, Row]](fields.id, fields.businessentityid, fields.ratechangedate, fields.rate, fields.payfrequency, fields.modifieddate)
+    override lazy val columns: List[FieldLikeNoHkt[?, EphViewRow]] =
+      List[FieldLikeNoHkt[?, EphViewRow]](fields.id, fields.businessentityid, fields.ratechangedate, fields.rate, fields.payfrequency, fields.modifieddate)
   
-    override def copy[NewRow](prefix: Option[String], extract: NewRow => EphViewRow, merge: (NewRow, EphViewRow) => NewRow): Impl[NewRow] =
-      new Impl(prefix, extract, merge)
+    override def copy(path: List[Path]): Impl =
+      new Impl(path)
   }
   
 }

--- a/typo-tester-doobie/generated-and-checked-in/adventureworks/hr/jc/JcViewFields.scala
+++ b/typo-tester-doobie/generated-and-checked-in/adventureworks/hr/jc/JcViewFields.scala
@@ -11,39 +11,40 @@ import adventureworks.customtypes.TypoLocalDateTime
 import adventureworks.customtypes.TypoXml
 import adventureworks.humanresources.jobcandidate.JobcandidateId
 import adventureworks.person.businessentity.BusinessentityId
+import typo.dsl.Path
 import typo.dsl.SqlExpr.Field
 import typo.dsl.SqlExpr.FieldLikeNoHkt
 import typo.dsl.SqlExpr.OptField
 import typo.dsl.Structure.Relation
 
-trait JcViewFields[Row] {
-  val id: Field[JobcandidateId, Row]
-  val jobcandidateid: Field[JobcandidateId, Row]
-  val businessentityid: OptField[BusinessentityId, Row]
-  val resume: OptField[TypoXml, Row]
-  val modifieddate: Field[TypoLocalDateTime, Row]
+trait JcViewFields {
+  def id: Field[JobcandidateId, JcViewRow]
+  def jobcandidateid: Field[JobcandidateId, JcViewRow]
+  def businessentityid: OptField[BusinessentityId, JcViewRow]
+  def resume: OptField[TypoXml, JcViewRow]
+  def modifieddate: Field[TypoLocalDateTime, JcViewRow]
 }
 
 object JcViewFields {
-  val structure: Relation[JcViewFields, JcViewRow, JcViewRow] = 
-    new Impl(None, identity, (_, x) => x)
+  lazy val structure: Relation[JcViewFields, JcViewRow] =
+    new Impl(Nil)
     
-  private final class Impl[Row](val prefix: Option[String], val extract: Row => JcViewRow, val merge: (Row, JcViewRow) => Row)
-    extends Relation[JcViewFields, JcViewRow, Row] { 
+  private final class Impl(val _path: List[Path])
+    extends Relation[JcViewFields, JcViewRow] {
   
-    override val fields: JcViewFields[Row] = new JcViewFields[Row] {
-      override val id = new Field[JobcandidateId, Row](prefix, "id", None, None)(x => extract(x).id, (row, value) => merge(row, extract(row).copy(id = value)))
-      override val jobcandidateid = new Field[JobcandidateId, Row](prefix, "jobcandidateid", None, None)(x => extract(x).jobcandidateid, (row, value) => merge(row, extract(row).copy(jobcandidateid = value)))
-      override val businessentityid = new OptField[BusinessentityId, Row](prefix, "businessentityid", None, None)(x => extract(x).businessentityid, (row, value) => merge(row, extract(row).copy(businessentityid = value)))
-      override val resume = new OptField[TypoXml, Row](prefix, "resume", None, None)(x => extract(x).resume, (row, value) => merge(row, extract(row).copy(resume = value)))
-      override val modifieddate = new Field[TypoLocalDateTime, Row](prefix, "modifieddate", Some("text"), None)(x => extract(x).modifieddate, (row, value) => merge(row, extract(row).copy(modifieddate = value)))
+    override lazy val fields: JcViewFields = new JcViewFields {
+      override def id = Field[JobcandidateId, JcViewRow](_path, "id", None, None, x => x.id, (row, value) => row.copy(id = value))
+      override def jobcandidateid = Field[JobcandidateId, JcViewRow](_path, "jobcandidateid", None, None, x => x.jobcandidateid, (row, value) => row.copy(jobcandidateid = value))
+      override def businessentityid = OptField[BusinessentityId, JcViewRow](_path, "businessentityid", None, None, x => x.businessentityid, (row, value) => row.copy(businessentityid = value))
+      override def resume = OptField[TypoXml, JcViewRow](_path, "resume", None, None, x => x.resume, (row, value) => row.copy(resume = value))
+      override def modifieddate = Field[TypoLocalDateTime, JcViewRow](_path, "modifieddate", Some("text"), None, x => x.modifieddate, (row, value) => row.copy(modifieddate = value))
     }
   
-    override val columns: List[FieldLikeNoHkt[?, Row]] =
-      List[FieldLikeNoHkt[?, Row]](fields.id, fields.jobcandidateid, fields.businessentityid, fields.resume, fields.modifieddate)
+    override lazy val columns: List[FieldLikeNoHkt[?, JcViewRow]] =
+      List[FieldLikeNoHkt[?, JcViewRow]](fields.id, fields.jobcandidateid, fields.businessentityid, fields.resume, fields.modifieddate)
   
-    override def copy[NewRow](prefix: Option[String], extract: NewRow => JcViewRow, merge: (NewRow, JcViewRow) => NewRow): Impl[NewRow] =
-      new Impl(prefix, extract, merge)
+    override def copy(path: List[Path]): Impl =
+      new Impl(path)
   }
   
 }

--- a/typo-tester-doobie/generated-and-checked-in/adventureworks/hr/s/SViewFields.scala
+++ b/typo-tester-doobie/generated-and-checked-in/adventureworks/hr/s/SViewFields.scala
@@ -11,40 +11,41 @@ import adventureworks.customtypes.TypoLocalDateTime
 import adventureworks.customtypes.TypoLocalTime
 import adventureworks.humanresources.shift.ShiftId
 import adventureworks.public.Name
+import typo.dsl.Path
 import typo.dsl.SqlExpr.Field
 import typo.dsl.SqlExpr.FieldLikeNoHkt
 import typo.dsl.Structure.Relation
 
-trait SViewFields[Row] {
-  val id: Field[ShiftId, Row]
-  val shiftid: Field[ShiftId, Row]
-  val name: Field[Name, Row]
-  val starttime: Field[TypoLocalTime, Row]
-  val endtime: Field[TypoLocalTime, Row]
-  val modifieddate: Field[TypoLocalDateTime, Row]
+trait SViewFields {
+  def id: Field[ShiftId, SViewRow]
+  def shiftid: Field[ShiftId, SViewRow]
+  def name: Field[Name, SViewRow]
+  def starttime: Field[TypoLocalTime, SViewRow]
+  def endtime: Field[TypoLocalTime, SViewRow]
+  def modifieddate: Field[TypoLocalDateTime, SViewRow]
 }
 
 object SViewFields {
-  val structure: Relation[SViewFields, SViewRow, SViewRow] = 
-    new Impl(None, identity, (_, x) => x)
+  lazy val structure: Relation[SViewFields, SViewRow] =
+    new Impl(Nil)
     
-  private final class Impl[Row](val prefix: Option[String], val extract: Row => SViewRow, val merge: (Row, SViewRow) => Row)
-    extends Relation[SViewFields, SViewRow, Row] { 
+  private final class Impl(val _path: List[Path])
+    extends Relation[SViewFields, SViewRow] {
   
-    override val fields: SViewFields[Row] = new SViewFields[Row] {
-      override val id = new Field[ShiftId, Row](prefix, "id", None, None)(x => extract(x).id, (row, value) => merge(row, extract(row).copy(id = value)))
-      override val shiftid = new Field[ShiftId, Row](prefix, "shiftid", None, None)(x => extract(x).shiftid, (row, value) => merge(row, extract(row).copy(shiftid = value)))
-      override val name = new Field[Name, Row](prefix, "name", None, None)(x => extract(x).name, (row, value) => merge(row, extract(row).copy(name = value)))
-      override val starttime = new Field[TypoLocalTime, Row](prefix, "starttime", Some("text"), None)(x => extract(x).starttime, (row, value) => merge(row, extract(row).copy(starttime = value)))
-      override val endtime = new Field[TypoLocalTime, Row](prefix, "endtime", Some("text"), None)(x => extract(x).endtime, (row, value) => merge(row, extract(row).copy(endtime = value)))
-      override val modifieddate = new Field[TypoLocalDateTime, Row](prefix, "modifieddate", Some("text"), None)(x => extract(x).modifieddate, (row, value) => merge(row, extract(row).copy(modifieddate = value)))
+    override lazy val fields: SViewFields = new SViewFields {
+      override def id = Field[ShiftId, SViewRow](_path, "id", None, None, x => x.id, (row, value) => row.copy(id = value))
+      override def shiftid = Field[ShiftId, SViewRow](_path, "shiftid", None, None, x => x.shiftid, (row, value) => row.copy(shiftid = value))
+      override def name = Field[Name, SViewRow](_path, "name", None, None, x => x.name, (row, value) => row.copy(name = value))
+      override def starttime = Field[TypoLocalTime, SViewRow](_path, "starttime", Some("text"), None, x => x.starttime, (row, value) => row.copy(starttime = value))
+      override def endtime = Field[TypoLocalTime, SViewRow](_path, "endtime", Some("text"), None, x => x.endtime, (row, value) => row.copy(endtime = value))
+      override def modifieddate = Field[TypoLocalDateTime, SViewRow](_path, "modifieddate", Some("text"), None, x => x.modifieddate, (row, value) => row.copy(modifieddate = value))
     }
   
-    override val columns: List[FieldLikeNoHkt[?, Row]] =
-      List[FieldLikeNoHkt[?, Row]](fields.id, fields.shiftid, fields.name, fields.starttime, fields.endtime, fields.modifieddate)
+    override lazy val columns: List[FieldLikeNoHkt[?, SViewRow]] =
+      List[FieldLikeNoHkt[?, SViewRow]](fields.id, fields.shiftid, fields.name, fields.starttime, fields.endtime, fields.modifieddate)
   
-    override def copy[NewRow](prefix: Option[String], extract: NewRow => SViewRow, merge: (NewRow, SViewRow) => NewRow): Impl[NewRow] =
-      new Impl(prefix, extract, merge)
+    override def copy(path: List[Path]): Impl =
+      new Impl(path)
   }
   
 }

--- a/typo-tester-doobie/generated-and-checked-in/adventureworks/humanresources/department/DepartmentFields.scala
+++ b/typo-tester-doobie/generated-and-checked-in/adventureworks/humanresources/department/DepartmentFields.scala
@@ -9,37 +9,38 @@ package department
 
 import adventureworks.customtypes.TypoLocalDateTime
 import adventureworks.public.Name
+import typo.dsl.Path
 import typo.dsl.SqlExpr.Field
 import typo.dsl.SqlExpr.FieldLikeNoHkt
 import typo.dsl.SqlExpr.IdField
 import typo.dsl.Structure.Relation
 
-trait DepartmentFields[Row] {
-  val departmentid: IdField[DepartmentId, Row]
-  val name: Field[Name, Row]
-  val groupname: Field[Name, Row]
-  val modifieddate: Field[TypoLocalDateTime, Row]
+trait DepartmentFields {
+  def departmentid: IdField[DepartmentId, DepartmentRow]
+  def name: Field[Name, DepartmentRow]
+  def groupname: Field[Name, DepartmentRow]
+  def modifieddate: Field[TypoLocalDateTime, DepartmentRow]
 }
 
 object DepartmentFields {
-  val structure: Relation[DepartmentFields, DepartmentRow, DepartmentRow] = 
-    new Impl(None, identity, (_, x) => x)
+  lazy val structure: Relation[DepartmentFields, DepartmentRow] =
+    new Impl(Nil)
     
-  private final class Impl[Row](val prefix: Option[String], val extract: Row => DepartmentRow, val merge: (Row, DepartmentRow) => Row)
-    extends Relation[DepartmentFields, DepartmentRow, Row] { 
+  private final class Impl(val _path: List[Path])
+    extends Relation[DepartmentFields, DepartmentRow] {
   
-    override val fields: DepartmentFields[Row] = new DepartmentFields[Row] {
-      override val departmentid = new IdField[DepartmentId, Row](prefix, "departmentid", None, Some("int4"))(x => extract(x).departmentid, (row, value) => merge(row, extract(row).copy(departmentid = value)))
-      override val name = new Field[Name, Row](prefix, "name", None, Some("varchar"))(x => extract(x).name, (row, value) => merge(row, extract(row).copy(name = value)))
-      override val groupname = new Field[Name, Row](prefix, "groupname", None, Some("varchar"))(x => extract(x).groupname, (row, value) => merge(row, extract(row).copy(groupname = value)))
-      override val modifieddate = new Field[TypoLocalDateTime, Row](prefix, "modifieddate", Some("text"), Some("timestamp"))(x => extract(x).modifieddate, (row, value) => merge(row, extract(row).copy(modifieddate = value)))
+    override lazy val fields: DepartmentFields = new DepartmentFields {
+      override def departmentid = IdField[DepartmentId, DepartmentRow](_path, "departmentid", None, Some("int4"), x => x.departmentid, (row, value) => row.copy(departmentid = value))
+      override def name = Field[Name, DepartmentRow](_path, "name", None, Some("varchar"), x => x.name, (row, value) => row.copy(name = value))
+      override def groupname = Field[Name, DepartmentRow](_path, "groupname", None, Some("varchar"), x => x.groupname, (row, value) => row.copy(groupname = value))
+      override def modifieddate = Field[TypoLocalDateTime, DepartmentRow](_path, "modifieddate", Some("text"), Some("timestamp"), x => x.modifieddate, (row, value) => row.copy(modifieddate = value))
     }
   
-    override val columns: List[FieldLikeNoHkt[?, Row]] =
-      List[FieldLikeNoHkt[?, Row]](fields.departmentid, fields.name, fields.groupname, fields.modifieddate)
+    override lazy val columns: List[FieldLikeNoHkt[?, DepartmentRow]] =
+      List[FieldLikeNoHkt[?, DepartmentRow]](fields.departmentid, fields.name, fields.groupname, fields.modifieddate)
   
-    override def copy[NewRow](prefix: Option[String], extract: NewRow => DepartmentRow, merge: (NewRow, DepartmentRow) => NewRow): Impl[NewRow] =
-      new Impl(prefix, extract, merge)
+    override def copy(path: List[Path]): Impl =
+      new Impl(path)
   }
   
 }

--- a/typo-tester-doobie/generated-and-checked-in/adventureworks/humanresources/department/DepartmentRepoMock.scala
+++ b/typo-tester-doobie/generated-and-checked-in/adventureworks/humanresources/department/DepartmentRepoMock.scala
@@ -24,7 +24,7 @@ import typo.dsl.UpdateParams
 class DepartmentRepoMock(toRow: Function1[DepartmentRowUnsaved, DepartmentRow],
                          map: scala.collection.mutable.Map[DepartmentId, DepartmentRow] = scala.collection.mutable.Map.empty) extends DepartmentRepo {
   override def delete: DeleteBuilder[DepartmentFields, DepartmentRow] = {
-    DeleteBuilderMock(DeleteParams.empty, DepartmentFields.structure.fields, map)
+    DeleteBuilderMock(DeleteParams.empty, DepartmentFields.structure, map)
   }
   override def deleteById(departmentid: DepartmentId): ConnectionIO[Boolean] = {
     delay(map.remove(departmentid).isDefined)
@@ -86,7 +86,7 @@ class DepartmentRepoMock(toRow: Function1[DepartmentRowUnsaved, DepartmentRow],
     }
   }
   override def update: UpdateBuilder[DepartmentFields, DepartmentRow] = {
-    UpdateBuilderMock(UpdateParams.empty, DepartmentFields.structure.fields, map)
+    UpdateBuilderMock(UpdateParams.empty, DepartmentFields.structure, map)
   }
   override def update(row: DepartmentRow): ConnectionIO[Boolean] = {
     delay {

--- a/typo-tester-doobie/generated-and-checked-in/adventureworks/humanresources/employee/EmployeeFields.scala
+++ b/typo-tester-doobie/generated-and-checked-in/adventureworks/humanresources/employee/EmployeeFields.scala
@@ -13,60 +13,61 @@ import adventureworks.customtypes.TypoShort
 import adventureworks.customtypes.TypoUUID
 import adventureworks.person.businessentity.BusinessentityId
 import adventureworks.public.Flag
+import typo.dsl.Path
 import typo.dsl.SqlExpr.Field
 import typo.dsl.SqlExpr.FieldLikeNoHkt
 import typo.dsl.SqlExpr.IdField
 import typo.dsl.SqlExpr.OptField
 import typo.dsl.Structure.Relation
 
-trait EmployeeFields[Row] {
-  val businessentityid: IdField[BusinessentityId, Row]
-  val nationalidnumber: Field[/* max 15 chars */ String, Row]
-  val loginid: Field[/* max 256 chars */ String, Row]
-  val jobtitle: Field[/* max 50 chars */ String, Row]
-  val birthdate: Field[TypoLocalDate, Row]
-  val maritalstatus: Field[/* bpchar, max 1 chars */ String, Row]
-  val gender: Field[/* bpchar, max 1 chars */ String, Row]
-  val hiredate: Field[TypoLocalDate, Row]
-  val salariedflag: Field[Flag, Row]
-  val vacationhours: Field[TypoShort, Row]
-  val sickleavehours: Field[TypoShort, Row]
-  val currentflag: Field[Flag, Row]
-  val rowguid: Field[TypoUUID, Row]
-  val modifieddate: Field[TypoLocalDateTime, Row]
-  val organizationnode: OptField[String, Row]
+trait EmployeeFields {
+  def businessentityid: IdField[BusinessentityId, EmployeeRow]
+  def nationalidnumber: Field[/* max 15 chars */ String, EmployeeRow]
+  def loginid: Field[/* max 256 chars */ String, EmployeeRow]
+  def jobtitle: Field[/* max 50 chars */ String, EmployeeRow]
+  def birthdate: Field[TypoLocalDate, EmployeeRow]
+  def maritalstatus: Field[/* bpchar, max 1 chars */ String, EmployeeRow]
+  def gender: Field[/* bpchar, max 1 chars */ String, EmployeeRow]
+  def hiredate: Field[TypoLocalDate, EmployeeRow]
+  def salariedflag: Field[Flag, EmployeeRow]
+  def vacationhours: Field[TypoShort, EmployeeRow]
+  def sickleavehours: Field[TypoShort, EmployeeRow]
+  def currentflag: Field[Flag, EmployeeRow]
+  def rowguid: Field[TypoUUID, EmployeeRow]
+  def modifieddate: Field[TypoLocalDateTime, EmployeeRow]
+  def organizationnode: OptField[String, EmployeeRow]
 }
 
 object EmployeeFields {
-  val structure: Relation[EmployeeFields, EmployeeRow, EmployeeRow] = 
-    new Impl(None, identity, (_, x) => x)
+  lazy val structure: Relation[EmployeeFields, EmployeeRow] =
+    new Impl(Nil)
     
-  private final class Impl[Row](val prefix: Option[String], val extract: Row => EmployeeRow, val merge: (Row, EmployeeRow) => Row)
-    extends Relation[EmployeeFields, EmployeeRow, Row] { 
+  private final class Impl(val _path: List[Path])
+    extends Relation[EmployeeFields, EmployeeRow] {
   
-    override val fields: EmployeeFields[Row] = new EmployeeFields[Row] {
-      override val businessentityid = new IdField[BusinessentityId, Row](prefix, "businessentityid", None, Some("int4"))(x => extract(x).businessentityid, (row, value) => merge(row, extract(row).copy(businessentityid = value)))
-      override val nationalidnumber = new Field[/* max 15 chars */ String, Row](prefix, "nationalidnumber", None, None)(x => extract(x).nationalidnumber, (row, value) => merge(row, extract(row).copy(nationalidnumber = value)))
-      override val loginid = new Field[/* max 256 chars */ String, Row](prefix, "loginid", None, None)(x => extract(x).loginid, (row, value) => merge(row, extract(row).copy(loginid = value)))
-      override val jobtitle = new Field[/* max 50 chars */ String, Row](prefix, "jobtitle", None, None)(x => extract(x).jobtitle, (row, value) => merge(row, extract(row).copy(jobtitle = value)))
-      override val birthdate = new Field[TypoLocalDate, Row](prefix, "birthdate", Some("text"), Some("date"))(x => extract(x).birthdate, (row, value) => merge(row, extract(row).copy(birthdate = value)))
-      override val maritalstatus = new Field[/* bpchar, max 1 chars */ String, Row](prefix, "maritalstatus", None, Some("bpchar"))(x => extract(x).maritalstatus, (row, value) => merge(row, extract(row).copy(maritalstatus = value)))
-      override val gender = new Field[/* bpchar, max 1 chars */ String, Row](prefix, "gender", None, Some("bpchar"))(x => extract(x).gender, (row, value) => merge(row, extract(row).copy(gender = value)))
-      override val hiredate = new Field[TypoLocalDate, Row](prefix, "hiredate", Some("text"), Some("date"))(x => extract(x).hiredate, (row, value) => merge(row, extract(row).copy(hiredate = value)))
-      override val salariedflag = new Field[Flag, Row](prefix, "salariedflag", None, Some("bool"))(x => extract(x).salariedflag, (row, value) => merge(row, extract(row).copy(salariedflag = value)))
-      override val vacationhours = new Field[TypoShort, Row](prefix, "vacationhours", None, Some("int2"))(x => extract(x).vacationhours, (row, value) => merge(row, extract(row).copy(vacationhours = value)))
-      override val sickleavehours = new Field[TypoShort, Row](prefix, "sickleavehours", None, Some("int2"))(x => extract(x).sickleavehours, (row, value) => merge(row, extract(row).copy(sickleavehours = value)))
-      override val currentflag = new Field[Flag, Row](prefix, "currentflag", None, Some("bool"))(x => extract(x).currentflag, (row, value) => merge(row, extract(row).copy(currentflag = value)))
-      override val rowguid = new Field[TypoUUID, Row](prefix, "rowguid", None, Some("uuid"))(x => extract(x).rowguid, (row, value) => merge(row, extract(row).copy(rowguid = value)))
-      override val modifieddate = new Field[TypoLocalDateTime, Row](prefix, "modifieddate", Some("text"), Some("timestamp"))(x => extract(x).modifieddate, (row, value) => merge(row, extract(row).copy(modifieddate = value)))
-      override val organizationnode = new OptField[String, Row](prefix, "organizationnode", None, None)(x => extract(x).organizationnode, (row, value) => merge(row, extract(row).copy(organizationnode = value)))
+    override lazy val fields: EmployeeFields = new EmployeeFields {
+      override def businessentityid = IdField[BusinessentityId, EmployeeRow](_path, "businessentityid", None, Some("int4"), x => x.businessentityid, (row, value) => row.copy(businessentityid = value))
+      override def nationalidnumber = Field[/* max 15 chars */ String, EmployeeRow](_path, "nationalidnumber", None, None, x => x.nationalidnumber, (row, value) => row.copy(nationalidnumber = value))
+      override def loginid = Field[/* max 256 chars */ String, EmployeeRow](_path, "loginid", None, None, x => x.loginid, (row, value) => row.copy(loginid = value))
+      override def jobtitle = Field[/* max 50 chars */ String, EmployeeRow](_path, "jobtitle", None, None, x => x.jobtitle, (row, value) => row.copy(jobtitle = value))
+      override def birthdate = Field[TypoLocalDate, EmployeeRow](_path, "birthdate", Some("text"), Some("date"), x => x.birthdate, (row, value) => row.copy(birthdate = value))
+      override def maritalstatus = Field[/* bpchar, max 1 chars */ String, EmployeeRow](_path, "maritalstatus", None, Some("bpchar"), x => x.maritalstatus, (row, value) => row.copy(maritalstatus = value))
+      override def gender = Field[/* bpchar, max 1 chars */ String, EmployeeRow](_path, "gender", None, Some("bpchar"), x => x.gender, (row, value) => row.copy(gender = value))
+      override def hiredate = Field[TypoLocalDate, EmployeeRow](_path, "hiredate", Some("text"), Some("date"), x => x.hiredate, (row, value) => row.copy(hiredate = value))
+      override def salariedflag = Field[Flag, EmployeeRow](_path, "salariedflag", None, Some("bool"), x => x.salariedflag, (row, value) => row.copy(salariedflag = value))
+      override def vacationhours = Field[TypoShort, EmployeeRow](_path, "vacationhours", None, Some("int2"), x => x.vacationhours, (row, value) => row.copy(vacationhours = value))
+      override def sickleavehours = Field[TypoShort, EmployeeRow](_path, "sickleavehours", None, Some("int2"), x => x.sickleavehours, (row, value) => row.copy(sickleavehours = value))
+      override def currentflag = Field[Flag, EmployeeRow](_path, "currentflag", None, Some("bool"), x => x.currentflag, (row, value) => row.copy(currentflag = value))
+      override def rowguid = Field[TypoUUID, EmployeeRow](_path, "rowguid", None, Some("uuid"), x => x.rowguid, (row, value) => row.copy(rowguid = value))
+      override def modifieddate = Field[TypoLocalDateTime, EmployeeRow](_path, "modifieddate", Some("text"), Some("timestamp"), x => x.modifieddate, (row, value) => row.copy(modifieddate = value))
+      override def organizationnode = OptField[String, EmployeeRow](_path, "organizationnode", None, None, x => x.organizationnode, (row, value) => row.copy(organizationnode = value))
     }
   
-    override val columns: List[FieldLikeNoHkt[?, Row]] =
-      List[FieldLikeNoHkt[?, Row]](fields.businessentityid, fields.nationalidnumber, fields.loginid, fields.jobtitle, fields.birthdate, fields.maritalstatus, fields.gender, fields.hiredate, fields.salariedflag, fields.vacationhours, fields.sickleavehours, fields.currentflag, fields.rowguid, fields.modifieddate, fields.organizationnode)
+    override lazy val columns: List[FieldLikeNoHkt[?, EmployeeRow]] =
+      List[FieldLikeNoHkt[?, EmployeeRow]](fields.businessentityid, fields.nationalidnumber, fields.loginid, fields.jobtitle, fields.birthdate, fields.maritalstatus, fields.gender, fields.hiredate, fields.salariedflag, fields.vacationhours, fields.sickleavehours, fields.currentflag, fields.rowguid, fields.modifieddate, fields.organizationnode)
   
-    override def copy[NewRow](prefix: Option[String], extract: NewRow => EmployeeRow, merge: (NewRow, EmployeeRow) => NewRow): Impl[NewRow] =
-      new Impl(prefix, extract, merge)
+    override def copy(path: List[Path]): Impl =
+      new Impl(path)
   }
   
 }

--- a/typo-tester-doobie/generated-and-checked-in/adventureworks/humanresources/employee/EmployeeRepoMock.scala
+++ b/typo-tester-doobie/generated-and-checked-in/adventureworks/humanresources/employee/EmployeeRepoMock.scala
@@ -25,7 +25,7 @@ import typo.dsl.UpdateParams
 class EmployeeRepoMock(toRow: Function1[EmployeeRowUnsaved, EmployeeRow],
                        map: scala.collection.mutable.Map[BusinessentityId, EmployeeRow] = scala.collection.mutable.Map.empty) extends EmployeeRepo {
   override def delete: DeleteBuilder[EmployeeFields, EmployeeRow] = {
-    DeleteBuilderMock(DeleteParams.empty, EmployeeFields.structure.fields, map)
+    DeleteBuilderMock(DeleteParams.empty, EmployeeFields.structure, map)
   }
   override def deleteById(businessentityid: BusinessentityId): ConnectionIO[Boolean] = {
     delay(map.remove(businessentityid).isDefined)
@@ -87,7 +87,7 @@ class EmployeeRepoMock(toRow: Function1[EmployeeRowUnsaved, EmployeeRow],
     }
   }
   override def update: UpdateBuilder[EmployeeFields, EmployeeRow] = {
-    UpdateBuilderMock(UpdateParams.empty, EmployeeFields.structure.fields, map)
+    UpdateBuilderMock(UpdateParams.empty, EmployeeFields.structure, map)
   }
   override def update(row: EmployeeRow): ConnectionIO[Boolean] = {
     delay {

--- a/typo-tester-doobie/generated-and-checked-in/adventureworks/humanresources/employeedepartmenthistory/EmployeedepartmenthistoryFields.scala
+++ b/typo-tester-doobie/generated-and-checked-in/adventureworks/humanresources/employeedepartmenthistory/EmployeedepartmenthistoryFields.scala
@@ -12,42 +12,43 @@ import adventureworks.customtypes.TypoLocalDateTime
 import adventureworks.humanresources.department.DepartmentId
 import adventureworks.humanresources.shift.ShiftId
 import adventureworks.person.businessentity.BusinessentityId
+import typo.dsl.Path
 import typo.dsl.SqlExpr.Field
 import typo.dsl.SqlExpr.FieldLikeNoHkt
 import typo.dsl.SqlExpr.IdField
 import typo.dsl.SqlExpr.OptField
 import typo.dsl.Structure.Relation
 
-trait EmployeedepartmenthistoryFields[Row] {
-  val businessentityid: IdField[BusinessentityId, Row]
-  val departmentid: IdField[DepartmentId, Row]
-  val shiftid: IdField[ShiftId, Row]
-  val startdate: IdField[TypoLocalDate, Row]
-  val enddate: OptField[TypoLocalDate, Row]
-  val modifieddate: Field[TypoLocalDateTime, Row]
+trait EmployeedepartmenthistoryFields {
+  def businessentityid: IdField[BusinessentityId, EmployeedepartmenthistoryRow]
+  def departmentid: IdField[DepartmentId, EmployeedepartmenthistoryRow]
+  def shiftid: IdField[ShiftId, EmployeedepartmenthistoryRow]
+  def startdate: IdField[TypoLocalDate, EmployeedepartmenthistoryRow]
+  def enddate: OptField[TypoLocalDate, EmployeedepartmenthistoryRow]
+  def modifieddate: Field[TypoLocalDateTime, EmployeedepartmenthistoryRow]
 }
 
 object EmployeedepartmenthistoryFields {
-  val structure: Relation[EmployeedepartmenthistoryFields, EmployeedepartmenthistoryRow, EmployeedepartmenthistoryRow] = 
-    new Impl(None, identity, (_, x) => x)
+  lazy val structure: Relation[EmployeedepartmenthistoryFields, EmployeedepartmenthistoryRow] =
+    new Impl(Nil)
     
-  private final class Impl[Row](val prefix: Option[String], val extract: Row => EmployeedepartmenthistoryRow, val merge: (Row, EmployeedepartmenthistoryRow) => Row)
-    extends Relation[EmployeedepartmenthistoryFields, EmployeedepartmenthistoryRow, Row] { 
+  private final class Impl(val _path: List[Path])
+    extends Relation[EmployeedepartmenthistoryFields, EmployeedepartmenthistoryRow] {
   
-    override val fields: EmployeedepartmenthistoryFields[Row] = new EmployeedepartmenthistoryFields[Row] {
-      override val businessentityid = new IdField[BusinessentityId, Row](prefix, "businessentityid", None, Some("int4"))(x => extract(x).businessentityid, (row, value) => merge(row, extract(row).copy(businessentityid = value)))
-      override val departmentid = new IdField[DepartmentId, Row](prefix, "departmentid", None, Some("int2"))(x => extract(x).departmentid, (row, value) => merge(row, extract(row).copy(departmentid = value)))
-      override val shiftid = new IdField[ShiftId, Row](prefix, "shiftid", None, Some("int2"))(x => extract(x).shiftid, (row, value) => merge(row, extract(row).copy(shiftid = value)))
-      override val startdate = new IdField[TypoLocalDate, Row](prefix, "startdate", Some("text"), Some("date"))(x => extract(x).startdate, (row, value) => merge(row, extract(row).copy(startdate = value)))
-      override val enddate = new OptField[TypoLocalDate, Row](prefix, "enddate", Some("text"), Some("date"))(x => extract(x).enddate, (row, value) => merge(row, extract(row).copy(enddate = value)))
-      override val modifieddate = new Field[TypoLocalDateTime, Row](prefix, "modifieddate", Some("text"), Some("timestamp"))(x => extract(x).modifieddate, (row, value) => merge(row, extract(row).copy(modifieddate = value)))
+    override lazy val fields: EmployeedepartmenthistoryFields = new EmployeedepartmenthistoryFields {
+      override def businessentityid = IdField[BusinessentityId, EmployeedepartmenthistoryRow](_path, "businessentityid", None, Some("int4"), x => x.businessentityid, (row, value) => row.copy(businessentityid = value))
+      override def departmentid = IdField[DepartmentId, EmployeedepartmenthistoryRow](_path, "departmentid", None, Some("int2"), x => x.departmentid, (row, value) => row.copy(departmentid = value))
+      override def shiftid = IdField[ShiftId, EmployeedepartmenthistoryRow](_path, "shiftid", None, Some("int2"), x => x.shiftid, (row, value) => row.copy(shiftid = value))
+      override def startdate = IdField[TypoLocalDate, EmployeedepartmenthistoryRow](_path, "startdate", Some("text"), Some("date"), x => x.startdate, (row, value) => row.copy(startdate = value))
+      override def enddate = OptField[TypoLocalDate, EmployeedepartmenthistoryRow](_path, "enddate", Some("text"), Some("date"), x => x.enddate, (row, value) => row.copy(enddate = value))
+      override def modifieddate = Field[TypoLocalDateTime, EmployeedepartmenthistoryRow](_path, "modifieddate", Some("text"), Some("timestamp"), x => x.modifieddate, (row, value) => row.copy(modifieddate = value))
     }
   
-    override val columns: List[FieldLikeNoHkt[?, Row]] =
-      List[FieldLikeNoHkt[?, Row]](fields.businessentityid, fields.departmentid, fields.shiftid, fields.startdate, fields.enddate, fields.modifieddate)
+    override lazy val columns: List[FieldLikeNoHkt[?, EmployeedepartmenthistoryRow]] =
+      List[FieldLikeNoHkt[?, EmployeedepartmenthistoryRow]](fields.businessentityid, fields.departmentid, fields.shiftid, fields.startdate, fields.enddate, fields.modifieddate)
   
-    override def copy[NewRow](prefix: Option[String], extract: NewRow => EmployeedepartmenthistoryRow, merge: (NewRow, EmployeedepartmenthistoryRow) => NewRow): Impl[NewRow] =
-      new Impl(prefix, extract, merge)
+    override def copy(path: List[Path]): Impl =
+      new Impl(path)
   }
   
 }

--- a/typo-tester-doobie/generated-and-checked-in/adventureworks/humanresources/employeedepartmenthistory/EmployeedepartmenthistoryRepoMock.scala
+++ b/typo-tester-doobie/generated-and-checked-in/adventureworks/humanresources/employeedepartmenthistory/EmployeedepartmenthistoryRepoMock.scala
@@ -24,7 +24,7 @@ import typo.dsl.UpdateParams
 class EmployeedepartmenthistoryRepoMock(toRow: Function1[EmployeedepartmenthistoryRowUnsaved, EmployeedepartmenthistoryRow],
                                         map: scala.collection.mutable.Map[EmployeedepartmenthistoryId, EmployeedepartmenthistoryRow] = scala.collection.mutable.Map.empty) extends EmployeedepartmenthistoryRepo {
   override def delete: DeleteBuilder[EmployeedepartmenthistoryFields, EmployeedepartmenthistoryRow] = {
-    DeleteBuilderMock(DeleteParams.empty, EmployeedepartmenthistoryFields.structure.fields, map)
+    DeleteBuilderMock(DeleteParams.empty, EmployeedepartmenthistoryFields.structure, map)
   }
   override def deleteById(compositeId: EmployeedepartmenthistoryId): ConnectionIO[Boolean] = {
     delay(map.remove(compositeId).isDefined)
@@ -86,7 +86,7 @@ class EmployeedepartmenthistoryRepoMock(toRow: Function1[Employeedepartmenthisto
     }
   }
   override def update: UpdateBuilder[EmployeedepartmenthistoryFields, EmployeedepartmenthistoryRow] = {
-    UpdateBuilderMock(UpdateParams.empty, EmployeedepartmenthistoryFields.structure.fields, map)
+    UpdateBuilderMock(UpdateParams.empty, EmployeedepartmenthistoryFields.structure, map)
   }
   override def update(row: EmployeedepartmenthistoryRow): ConnectionIO[Boolean] = {
     delay {

--- a/typo-tester-doobie/generated-and-checked-in/adventureworks/humanresources/employeepayhistory/EmployeepayhistoryFields.scala
+++ b/typo-tester-doobie/generated-and-checked-in/adventureworks/humanresources/employeepayhistory/EmployeepayhistoryFields.scala
@@ -10,39 +10,40 @@ package employeepayhistory
 import adventureworks.customtypes.TypoLocalDateTime
 import adventureworks.customtypes.TypoShort
 import adventureworks.person.businessentity.BusinessentityId
+import typo.dsl.Path
 import typo.dsl.SqlExpr.Field
 import typo.dsl.SqlExpr.FieldLikeNoHkt
 import typo.dsl.SqlExpr.IdField
 import typo.dsl.Structure.Relation
 
-trait EmployeepayhistoryFields[Row] {
-  val businessentityid: IdField[BusinessentityId, Row]
-  val ratechangedate: IdField[TypoLocalDateTime, Row]
-  val rate: Field[BigDecimal, Row]
-  val payfrequency: Field[TypoShort, Row]
-  val modifieddate: Field[TypoLocalDateTime, Row]
+trait EmployeepayhistoryFields {
+  def businessentityid: IdField[BusinessentityId, EmployeepayhistoryRow]
+  def ratechangedate: IdField[TypoLocalDateTime, EmployeepayhistoryRow]
+  def rate: Field[BigDecimal, EmployeepayhistoryRow]
+  def payfrequency: Field[TypoShort, EmployeepayhistoryRow]
+  def modifieddate: Field[TypoLocalDateTime, EmployeepayhistoryRow]
 }
 
 object EmployeepayhistoryFields {
-  val structure: Relation[EmployeepayhistoryFields, EmployeepayhistoryRow, EmployeepayhistoryRow] = 
-    new Impl(None, identity, (_, x) => x)
+  lazy val structure: Relation[EmployeepayhistoryFields, EmployeepayhistoryRow] =
+    new Impl(Nil)
     
-  private final class Impl[Row](val prefix: Option[String], val extract: Row => EmployeepayhistoryRow, val merge: (Row, EmployeepayhistoryRow) => Row)
-    extends Relation[EmployeepayhistoryFields, EmployeepayhistoryRow, Row] { 
+  private final class Impl(val _path: List[Path])
+    extends Relation[EmployeepayhistoryFields, EmployeepayhistoryRow] {
   
-    override val fields: EmployeepayhistoryFields[Row] = new EmployeepayhistoryFields[Row] {
-      override val businessentityid = new IdField[BusinessentityId, Row](prefix, "businessentityid", None, Some("int4"))(x => extract(x).businessentityid, (row, value) => merge(row, extract(row).copy(businessentityid = value)))
-      override val ratechangedate = new IdField[TypoLocalDateTime, Row](prefix, "ratechangedate", Some("text"), Some("timestamp"))(x => extract(x).ratechangedate, (row, value) => merge(row, extract(row).copy(ratechangedate = value)))
-      override val rate = new Field[BigDecimal, Row](prefix, "rate", None, Some("numeric"))(x => extract(x).rate, (row, value) => merge(row, extract(row).copy(rate = value)))
-      override val payfrequency = new Field[TypoShort, Row](prefix, "payfrequency", None, Some("int2"))(x => extract(x).payfrequency, (row, value) => merge(row, extract(row).copy(payfrequency = value)))
-      override val modifieddate = new Field[TypoLocalDateTime, Row](prefix, "modifieddate", Some("text"), Some("timestamp"))(x => extract(x).modifieddate, (row, value) => merge(row, extract(row).copy(modifieddate = value)))
+    override lazy val fields: EmployeepayhistoryFields = new EmployeepayhistoryFields {
+      override def businessentityid = IdField[BusinessentityId, EmployeepayhistoryRow](_path, "businessentityid", None, Some("int4"), x => x.businessentityid, (row, value) => row.copy(businessentityid = value))
+      override def ratechangedate = IdField[TypoLocalDateTime, EmployeepayhistoryRow](_path, "ratechangedate", Some("text"), Some("timestamp"), x => x.ratechangedate, (row, value) => row.copy(ratechangedate = value))
+      override def rate = Field[BigDecimal, EmployeepayhistoryRow](_path, "rate", None, Some("numeric"), x => x.rate, (row, value) => row.copy(rate = value))
+      override def payfrequency = Field[TypoShort, EmployeepayhistoryRow](_path, "payfrequency", None, Some("int2"), x => x.payfrequency, (row, value) => row.copy(payfrequency = value))
+      override def modifieddate = Field[TypoLocalDateTime, EmployeepayhistoryRow](_path, "modifieddate", Some("text"), Some("timestamp"), x => x.modifieddate, (row, value) => row.copy(modifieddate = value))
     }
   
-    override val columns: List[FieldLikeNoHkt[?, Row]] =
-      List[FieldLikeNoHkt[?, Row]](fields.businessentityid, fields.ratechangedate, fields.rate, fields.payfrequency, fields.modifieddate)
+    override lazy val columns: List[FieldLikeNoHkt[?, EmployeepayhistoryRow]] =
+      List[FieldLikeNoHkt[?, EmployeepayhistoryRow]](fields.businessentityid, fields.ratechangedate, fields.rate, fields.payfrequency, fields.modifieddate)
   
-    override def copy[NewRow](prefix: Option[String], extract: NewRow => EmployeepayhistoryRow, merge: (NewRow, EmployeepayhistoryRow) => NewRow): Impl[NewRow] =
-      new Impl(prefix, extract, merge)
+    override def copy(path: List[Path]): Impl =
+      new Impl(path)
   }
   
 }

--- a/typo-tester-doobie/generated-and-checked-in/adventureworks/humanresources/employeepayhistory/EmployeepayhistoryRepoMock.scala
+++ b/typo-tester-doobie/generated-and-checked-in/adventureworks/humanresources/employeepayhistory/EmployeepayhistoryRepoMock.scala
@@ -24,7 +24,7 @@ import typo.dsl.UpdateParams
 class EmployeepayhistoryRepoMock(toRow: Function1[EmployeepayhistoryRowUnsaved, EmployeepayhistoryRow],
                                  map: scala.collection.mutable.Map[EmployeepayhistoryId, EmployeepayhistoryRow] = scala.collection.mutable.Map.empty) extends EmployeepayhistoryRepo {
   override def delete: DeleteBuilder[EmployeepayhistoryFields, EmployeepayhistoryRow] = {
-    DeleteBuilderMock(DeleteParams.empty, EmployeepayhistoryFields.structure.fields, map)
+    DeleteBuilderMock(DeleteParams.empty, EmployeepayhistoryFields.structure, map)
   }
   override def deleteById(compositeId: EmployeepayhistoryId): ConnectionIO[Boolean] = {
     delay(map.remove(compositeId).isDefined)
@@ -86,7 +86,7 @@ class EmployeepayhistoryRepoMock(toRow: Function1[EmployeepayhistoryRowUnsaved, 
     }
   }
   override def update: UpdateBuilder[EmployeepayhistoryFields, EmployeepayhistoryRow] = {
-    UpdateBuilderMock(UpdateParams.empty, EmployeepayhistoryFields.structure.fields, map)
+    UpdateBuilderMock(UpdateParams.empty, EmployeepayhistoryFields.structure, map)
   }
   override def update(row: EmployeepayhistoryRow): ConnectionIO[Boolean] = {
     delay {

--- a/typo-tester-doobie/generated-and-checked-in/adventureworks/humanresources/jobcandidate/JobcandidateFields.scala
+++ b/typo-tester-doobie/generated-and-checked-in/adventureworks/humanresources/jobcandidate/JobcandidateFields.scala
@@ -10,38 +10,39 @@ package jobcandidate
 import adventureworks.customtypes.TypoLocalDateTime
 import adventureworks.customtypes.TypoXml
 import adventureworks.person.businessentity.BusinessentityId
+import typo.dsl.Path
 import typo.dsl.SqlExpr.Field
 import typo.dsl.SqlExpr.FieldLikeNoHkt
 import typo.dsl.SqlExpr.IdField
 import typo.dsl.SqlExpr.OptField
 import typo.dsl.Structure.Relation
 
-trait JobcandidateFields[Row] {
-  val jobcandidateid: IdField[JobcandidateId, Row]
-  val businessentityid: OptField[BusinessentityId, Row]
-  val resume: OptField[TypoXml, Row]
-  val modifieddate: Field[TypoLocalDateTime, Row]
+trait JobcandidateFields {
+  def jobcandidateid: IdField[JobcandidateId, JobcandidateRow]
+  def businessentityid: OptField[BusinessentityId, JobcandidateRow]
+  def resume: OptField[TypoXml, JobcandidateRow]
+  def modifieddate: Field[TypoLocalDateTime, JobcandidateRow]
 }
 
 object JobcandidateFields {
-  val structure: Relation[JobcandidateFields, JobcandidateRow, JobcandidateRow] = 
-    new Impl(None, identity, (_, x) => x)
+  lazy val structure: Relation[JobcandidateFields, JobcandidateRow] =
+    new Impl(Nil)
     
-  private final class Impl[Row](val prefix: Option[String], val extract: Row => JobcandidateRow, val merge: (Row, JobcandidateRow) => Row)
-    extends Relation[JobcandidateFields, JobcandidateRow, Row] { 
+  private final class Impl(val _path: List[Path])
+    extends Relation[JobcandidateFields, JobcandidateRow] {
   
-    override val fields: JobcandidateFields[Row] = new JobcandidateFields[Row] {
-      override val jobcandidateid = new IdField[JobcandidateId, Row](prefix, "jobcandidateid", None, Some("int4"))(x => extract(x).jobcandidateid, (row, value) => merge(row, extract(row).copy(jobcandidateid = value)))
-      override val businessentityid = new OptField[BusinessentityId, Row](prefix, "businessentityid", None, Some("int4"))(x => extract(x).businessentityid, (row, value) => merge(row, extract(row).copy(businessentityid = value)))
-      override val resume = new OptField[TypoXml, Row](prefix, "resume", None, Some("xml"))(x => extract(x).resume, (row, value) => merge(row, extract(row).copy(resume = value)))
-      override val modifieddate = new Field[TypoLocalDateTime, Row](prefix, "modifieddate", Some("text"), Some("timestamp"))(x => extract(x).modifieddate, (row, value) => merge(row, extract(row).copy(modifieddate = value)))
+    override lazy val fields: JobcandidateFields = new JobcandidateFields {
+      override def jobcandidateid = IdField[JobcandidateId, JobcandidateRow](_path, "jobcandidateid", None, Some("int4"), x => x.jobcandidateid, (row, value) => row.copy(jobcandidateid = value))
+      override def businessentityid = OptField[BusinessentityId, JobcandidateRow](_path, "businessentityid", None, Some("int4"), x => x.businessentityid, (row, value) => row.copy(businessentityid = value))
+      override def resume = OptField[TypoXml, JobcandidateRow](_path, "resume", None, Some("xml"), x => x.resume, (row, value) => row.copy(resume = value))
+      override def modifieddate = Field[TypoLocalDateTime, JobcandidateRow](_path, "modifieddate", Some("text"), Some("timestamp"), x => x.modifieddate, (row, value) => row.copy(modifieddate = value))
     }
   
-    override val columns: List[FieldLikeNoHkt[?, Row]] =
-      List[FieldLikeNoHkt[?, Row]](fields.jobcandidateid, fields.businessentityid, fields.resume, fields.modifieddate)
+    override lazy val columns: List[FieldLikeNoHkt[?, JobcandidateRow]] =
+      List[FieldLikeNoHkt[?, JobcandidateRow]](fields.jobcandidateid, fields.businessentityid, fields.resume, fields.modifieddate)
   
-    override def copy[NewRow](prefix: Option[String], extract: NewRow => JobcandidateRow, merge: (NewRow, JobcandidateRow) => NewRow): Impl[NewRow] =
-      new Impl(prefix, extract, merge)
+    override def copy(path: List[Path]): Impl =
+      new Impl(path)
   }
   
 }

--- a/typo-tester-doobie/generated-and-checked-in/adventureworks/humanresources/jobcandidate/JobcandidateRepoMock.scala
+++ b/typo-tester-doobie/generated-and-checked-in/adventureworks/humanresources/jobcandidate/JobcandidateRepoMock.scala
@@ -24,7 +24,7 @@ import typo.dsl.UpdateParams
 class JobcandidateRepoMock(toRow: Function1[JobcandidateRowUnsaved, JobcandidateRow],
                            map: scala.collection.mutable.Map[JobcandidateId, JobcandidateRow] = scala.collection.mutable.Map.empty) extends JobcandidateRepo {
   override def delete: DeleteBuilder[JobcandidateFields, JobcandidateRow] = {
-    DeleteBuilderMock(DeleteParams.empty, JobcandidateFields.structure.fields, map)
+    DeleteBuilderMock(DeleteParams.empty, JobcandidateFields.structure, map)
   }
   override def deleteById(jobcandidateid: JobcandidateId): ConnectionIO[Boolean] = {
     delay(map.remove(jobcandidateid).isDefined)
@@ -86,7 +86,7 @@ class JobcandidateRepoMock(toRow: Function1[JobcandidateRowUnsaved, Jobcandidate
     }
   }
   override def update: UpdateBuilder[JobcandidateFields, JobcandidateRow] = {
-    UpdateBuilderMock(UpdateParams.empty, JobcandidateFields.structure.fields, map)
+    UpdateBuilderMock(UpdateParams.empty, JobcandidateFields.structure, map)
   }
   override def update(row: JobcandidateRow): ConnectionIO[Boolean] = {
     delay {

--- a/typo-tester-doobie/generated-and-checked-in/adventureworks/humanresources/shift/ShiftFields.scala
+++ b/typo-tester-doobie/generated-and-checked-in/adventureworks/humanresources/shift/ShiftFields.scala
@@ -10,39 +10,40 @@ package shift
 import adventureworks.customtypes.TypoLocalDateTime
 import adventureworks.customtypes.TypoLocalTime
 import adventureworks.public.Name
+import typo.dsl.Path
 import typo.dsl.SqlExpr.Field
 import typo.dsl.SqlExpr.FieldLikeNoHkt
 import typo.dsl.SqlExpr.IdField
 import typo.dsl.Structure.Relation
 
-trait ShiftFields[Row] {
-  val shiftid: IdField[ShiftId, Row]
-  val name: Field[Name, Row]
-  val starttime: Field[TypoLocalTime, Row]
-  val endtime: Field[TypoLocalTime, Row]
-  val modifieddate: Field[TypoLocalDateTime, Row]
+trait ShiftFields {
+  def shiftid: IdField[ShiftId, ShiftRow]
+  def name: Field[Name, ShiftRow]
+  def starttime: Field[TypoLocalTime, ShiftRow]
+  def endtime: Field[TypoLocalTime, ShiftRow]
+  def modifieddate: Field[TypoLocalDateTime, ShiftRow]
 }
 
 object ShiftFields {
-  val structure: Relation[ShiftFields, ShiftRow, ShiftRow] = 
-    new Impl(None, identity, (_, x) => x)
+  lazy val structure: Relation[ShiftFields, ShiftRow] =
+    new Impl(Nil)
     
-  private final class Impl[Row](val prefix: Option[String], val extract: Row => ShiftRow, val merge: (Row, ShiftRow) => Row)
-    extends Relation[ShiftFields, ShiftRow, Row] { 
+  private final class Impl(val _path: List[Path])
+    extends Relation[ShiftFields, ShiftRow] {
   
-    override val fields: ShiftFields[Row] = new ShiftFields[Row] {
-      override val shiftid = new IdField[ShiftId, Row](prefix, "shiftid", None, Some("int4"))(x => extract(x).shiftid, (row, value) => merge(row, extract(row).copy(shiftid = value)))
-      override val name = new Field[Name, Row](prefix, "name", None, Some("varchar"))(x => extract(x).name, (row, value) => merge(row, extract(row).copy(name = value)))
-      override val starttime = new Field[TypoLocalTime, Row](prefix, "starttime", Some("text"), Some("time"))(x => extract(x).starttime, (row, value) => merge(row, extract(row).copy(starttime = value)))
-      override val endtime = new Field[TypoLocalTime, Row](prefix, "endtime", Some("text"), Some("time"))(x => extract(x).endtime, (row, value) => merge(row, extract(row).copy(endtime = value)))
-      override val modifieddate = new Field[TypoLocalDateTime, Row](prefix, "modifieddate", Some("text"), Some("timestamp"))(x => extract(x).modifieddate, (row, value) => merge(row, extract(row).copy(modifieddate = value)))
+    override lazy val fields: ShiftFields = new ShiftFields {
+      override def shiftid = IdField[ShiftId, ShiftRow](_path, "shiftid", None, Some("int4"), x => x.shiftid, (row, value) => row.copy(shiftid = value))
+      override def name = Field[Name, ShiftRow](_path, "name", None, Some("varchar"), x => x.name, (row, value) => row.copy(name = value))
+      override def starttime = Field[TypoLocalTime, ShiftRow](_path, "starttime", Some("text"), Some("time"), x => x.starttime, (row, value) => row.copy(starttime = value))
+      override def endtime = Field[TypoLocalTime, ShiftRow](_path, "endtime", Some("text"), Some("time"), x => x.endtime, (row, value) => row.copy(endtime = value))
+      override def modifieddate = Field[TypoLocalDateTime, ShiftRow](_path, "modifieddate", Some("text"), Some("timestamp"), x => x.modifieddate, (row, value) => row.copy(modifieddate = value))
     }
   
-    override val columns: List[FieldLikeNoHkt[?, Row]] =
-      List[FieldLikeNoHkt[?, Row]](fields.shiftid, fields.name, fields.starttime, fields.endtime, fields.modifieddate)
+    override lazy val columns: List[FieldLikeNoHkt[?, ShiftRow]] =
+      List[FieldLikeNoHkt[?, ShiftRow]](fields.shiftid, fields.name, fields.starttime, fields.endtime, fields.modifieddate)
   
-    override def copy[NewRow](prefix: Option[String], extract: NewRow => ShiftRow, merge: (NewRow, ShiftRow) => NewRow): Impl[NewRow] =
-      new Impl(prefix, extract, merge)
+    override def copy(path: List[Path]): Impl =
+      new Impl(path)
   }
   
 }

--- a/typo-tester-doobie/generated-and-checked-in/adventureworks/humanresources/shift/ShiftRepoMock.scala
+++ b/typo-tester-doobie/generated-and-checked-in/adventureworks/humanresources/shift/ShiftRepoMock.scala
@@ -24,7 +24,7 @@ import typo.dsl.UpdateParams
 class ShiftRepoMock(toRow: Function1[ShiftRowUnsaved, ShiftRow],
                     map: scala.collection.mutable.Map[ShiftId, ShiftRow] = scala.collection.mutable.Map.empty) extends ShiftRepo {
   override def delete: DeleteBuilder[ShiftFields, ShiftRow] = {
-    DeleteBuilderMock(DeleteParams.empty, ShiftFields.structure.fields, map)
+    DeleteBuilderMock(DeleteParams.empty, ShiftFields.structure, map)
   }
   override def deleteById(shiftid: ShiftId): ConnectionIO[Boolean] = {
     delay(map.remove(shiftid).isDefined)
@@ -86,7 +86,7 @@ class ShiftRepoMock(toRow: Function1[ShiftRowUnsaved, ShiftRow],
     }
   }
   override def update: UpdateBuilder[ShiftFields, ShiftRow] = {
-    UpdateBuilderMock(UpdateParams.empty, ShiftFields.structure.fields, map)
+    UpdateBuilderMock(UpdateParams.empty, ShiftFields.structure, map)
   }
   override def update(row: ShiftRow): ConnectionIO[Boolean] = {
     delay {

--- a/typo-tester-doobie/generated-and-checked-in/adventureworks/humanresources/vemployee/VemployeeViewFields.scala
+++ b/typo-tester-doobie/generated-and-checked-in/adventureworks/humanresources/vemployee/VemployeeViewFields.scala
@@ -12,65 +12,66 @@ import adventureworks.person.businessentity.BusinessentityId
 import adventureworks.public.Name
 import adventureworks.public.Phone
 import adventureworks.userdefined.FirstName
+import typo.dsl.Path
 import typo.dsl.SqlExpr.Field
 import typo.dsl.SqlExpr.FieldLikeNoHkt
 import typo.dsl.SqlExpr.OptField
 import typo.dsl.Structure.Relation
 
-trait VemployeeViewFields[Row] {
-  val businessentityid: Field[BusinessentityId, Row]
-  val title: OptField[/* max 8 chars */ String, Row]
-  val firstname: Field[/* user-picked */ FirstName, Row]
-  val middlename: OptField[Name, Row]
-  val lastname: Field[Name, Row]
-  val suffix: OptField[/* max 10 chars */ String, Row]
-  val jobtitle: Field[/* max 50 chars */ String, Row]
-  val phonenumber: OptField[Phone, Row]
-  val phonenumbertype: OptField[Name, Row]
-  val emailaddress: OptField[/* max 50 chars */ String, Row]
-  val emailpromotion: Field[Int, Row]
-  val addressline1: Field[/* max 60 chars */ String, Row]
-  val addressline2: OptField[/* max 60 chars */ String, Row]
-  val city: Field[/* max 30 chars */ String, Row]
-  val stateprovincename: Field[Name, Row]
-  val postalcode: Field[/* max 15 chars */ String, Row]
-  val countryregionname: Field[Name, Row]
-  val additionalcontactinfo: OptField[TypoXml, Row]
+trait VemployeeViewFields {
+  def businessentityid: Field[BusinessentityId, VemployeeViewRow]
+  def title: OptField[/* max 8 chars */ String, VemployeeViewRow]
+  def firstname: Field[/* user-picked */ FirstName, VemployeeViewRow]
+  def middlename: OptField[Name, VemployeeViewRow]
+  def lastname: Field[Name, VemployeeViewRow]
+  def suffix: OptField[/* max 10 chars */ String, VemployeeViewRow]
+  def jobtitle: Field[/* max 50 chars */ String, VemployeeViewRow]
+  def phonenumber: OptField[Phone, VemployeeViewRow]
+  def phonenumbertype: OptField[Name, VemployeeViewRow]
+  def emailaddress: OptField[/* max 50 chars */ String, VemployeeViewRow]
+  def emailpromotion: Field[Int, VemployeeViewRow]
+  def addressline1: Field[/* max 60 chars */ String, VemployeeViewRow]
+  def addressline2: OptField[/* max 60 chars */ String, VemployeeViewRow]
+  def city: Field[/* max 30 chars */ String, VemployeeViewRow]
+  def stateprovincename: Field[Name, VemployeeViewRow]
+  def postalcode: Field[/* max 15 chars */ String, VemployeeViewRow]
+  def countryregionname: Field[Name, VemployeeViewRow]
+  def additionalcontactinfo: OptField[TypoXml, VemployeeViewRow]
 }
 
 object VemployeeViewFields {
-  val structure: Relation[VemployeeViewFields, VemployeeViewRow, VemployeeViewRow] = 
-    new Impl(None, identity, (_, x) => x)
+  lazy val structure: Relation[VemployeeViewFields, VemployeeViewRow] =
+    new Impl(Nil)
     
-  private final class Impl[Row](val prefix: Option[String], val extract: Row => VemployeeViewRow, val merge: (Row, VemployeeViewRow) => Row)
-    extends Relation[VemployeeViewFields, VemployeeViewRow, Row] { 
+  private final class Impl(val _path: List[Path])
+    extends Relation[VemployeeViewFields, VemployeeViewRow] {
   
-    override val fields: VemployeeViewFields[Row] = new VemployeeViewFields[Row] {
-      override val businessentityid = new Field[BusinessentityId, Row](prefix, "businessentityid", None, None)(x => extract(x).businessentityid, (row, value) => merge(row, extract(row).copy(businessentityid = value)))
-      override val title = new OptField[/* max 8 chars */ String, Row](prefix, "title", None, None)(x => extract(x).title, (row, value) => merge(row, extract(row).copy(title = value)))
-      override val firstname = new Field[/* user-picked */ FirstName, Row](prefix, "firstname", None, None)(x => extract(x).firstname, (row, value) => merge(row, extract(row).copy(firstname = value)))
-      override val middlename = new OptField[Name, Row](prefix, "middlename", None, None)(x => extract(x).middlename, (row, value) => merge(row, extract(row).copy(middlename = value)))
-      override val lastname = new Field[Name, Row](prefix, "lastname", None, None)(x => extract(x).lastname, (row, value) => merge(row, extract(row).copy(lastname = value)))
-      override val suffix = new OptField[/* max 10 chars */ String, Row](prefix, "suffix", None, None)(x => extract(x).suffix, (row, value) => merge(row, extract(row).copy(suffix = value)))
-      override val jobtitle = new Field[/* max 50 chars */ String, Row](prefix, "jobtitle", None, None)(x => extract(x).jobtitle, (row, value) => merge(row, extract(row).copy(jobtitle = value)))
-      override val phonenumber = new OptField[Phone, Row](prefix, "phonenumber", None, None)(x => extract(x).phonenumber, (row, value) => merge(row, extract(row).copy(phonenumber = value)))
-      override val phonenumbertype = new OptField[Name, Row](prefix, "phonenumbertype", None, None)(x => extract(x).phonenumbertype, (row, value) => merge(row, extract(row).copy(phonenumbertype = value)))
-      override val emailaddress = new OptField[/* max 50 chars */ String, Row](prefix, "emailaddress", None, None)(x => extract(x).emailaddress, (row, value) => merge(row, extract(row).copy(emailaddress = value)))
-      override val emailpromotion = new Field[Int, Row](prefix, "emailpromotion", None, None)(x => extract(x).emailpromotion, (row, value) => merge(row, extract(row).copy(emailpromotion = value)))
-      override val addressline1 = new Field[/* max 60 chars */ String, Row](prefix, "addressline1", None, None)(x => extract(x).addressline1, (row, value) => merge(row, extract(row).copy(addressline1 = value)))
-      override val addressline2 = new OptField[/* max 60 chars */ String, Row](prefix, "addressline2", None, None)(x => extract(x).addressline2, (row, value) => merge(row, extract(row).copy(addressline2 = value)))
-      override val city = new Field[/* max 30 chars */ String, Row](prefix, "city", None, None)(x => extract(x).city, (row, value) => merge(row, extract(row).copy(city = value)))
-      override val stateprovincename = new Field[Name, Row](prefix, "stateprovincename", None, None)(x => extract(x).stateprovincename, (row, value) => merge(row, extract(row).copy(stateprovincename = value)))
-      override val postalcode = new Field[/* max 15 chars */ String, Row](prefix, "postalcode", None, None)(x => extract(x).postalcode, (row, value) => merge(row, extract(row).copy(postalcode = value)))
-      override val countryregionname = new Field[Name, Row](prefix, "countryregionname", None, None)(x => extract(x).countryregionname, (row, value) => merge(row, extract(row).copy(countryregionname = value)))
-      override val additionalcontactinfo = new OptField[TypoXml, Row](prefix, "additionalcontactinfo", None, None)(x => extract(x).additionalcontactinfo, (row, value) => merge(row, extract(row).copy(additionalcontactinfo = value)))
+    override lazy val fields: VemployeeViewFields = new VemployeeViewFields {
+      override def businessentityid = Field[BusinessentityId, VemployeeViewRow](_path, "businessentityid", None, None, x => x.businessentityid, (row, value) => row.copy(businessentityid = value))
+      override def title = OptField[/* max 8 chars */ String, VemployeeViewRow](_path, "title", None, None, x => x.title, (row, value) => row.copy(title = value))
+      override def firstname = Field[/* user-picked */ FirstName, VemployeeViewRow](_path, "firstname", None, None, x => x.firstname, (row, value) => row.copy(firstname = value))
+      override def middlename = OptField[Name, VemployeeViewRow](_path, "middlename", None, None, x => x.middlename, (row, value) => row.copy(middlename = value))
+      override def lastname = Field[Name, VemployeeViewRow](_path, "lastname", None, None, x => x.lastname, (row, value) => row.copy(lastname = value))
+      override def suffix = OptField[/* max 10 chars */ String, VemployeeViewRow](_path, "suffix", None, None, x => x.suffix, (row, value) => row.copy(suffix = value))
+      override def jobtitle = Field[/* max 50 chars */ String, VemployeeViewRow](_path, "jobtitle", None, None, x => x.jobtitle, (row, value) => row.copy(jobtitle = value))
+      override def phonenumber = OptField[Phone, VemployeeViewRow](_path, "phonenumber", None, None, x => x.phonenumber, (row, value) => row.copy(phonenumber = value))
+      override def phonenumbertype = OptField[Name, VemployeeViewRow](_path, "phonenumbertype", None, None, x => x.phonenumbertype, (row, value) => row.copy(phonenumbertype = value))
+      override def emailaddress = OptField[/* max 50 chars */ String, VemployeeViewRow](_path, "emailaddress", None, None, x => x.emailaddress, (row, value) => row.copy(emailaddress = value))
+      override def emailpromotion = Field[Int, VemployeeViewRow](_path, "emailpromotion", None, None, x => x.emailpromotion, (row, value) => row.copy(emailpromotion = value))
+      override def addressline1 = Field[/* max 60 chars */ String, VemployeeViewRow](_path, "addressline1", None, None, x => x.addressline1, (row, value) => row.copy(addressline1 = value))
+      override def addressline2 = OptField[/* max 60 chars */ String, VemployeeViewRow](_path, "addressline2", None, None, x => x.addressline2, (row, value) => row.copy(addressline2 = value))
+      override def city = Field[/* max 30 chars */ String, VemployeeViewRow](_path, "city", None, None, x => x.city, (row, value) => row.copy(city = value))
+      override def stateprovincename = Field[Name, VemployeeViewRow](_path, "stateprovincename", None, None, x => x.stateprovincename, (row, value) => row.copy(stateprovincename = value))
+      override def postalcode = Field[/* max 15 chars */ String, VemployeeViewRow](_path, "postalcode", None, None, x => x.postalcode, (row, value) => row.copy(postalcode = value))
+      override def countryregionname = Field[Name, VemployeeViewRow](_path, "countryregionname", None, None, x => x.countryregionname, (row, value) => row.copy(countryregionname = value))
+      override def additionalcontactinfo = OptField[TypoXml, VemployeeViewRow](_path, "additionalcontactinfo", None, None, x => x.additionalcontactinfo, (row, value) => row.copy(additionalcontactinfo = value))
     }
   
-    override val columns: List[FieldLikeNoHkt[?, Row]] =
-      List[FieldLikeNoHkt[?, Row]](fields.businessentityid, fields.title, fields.firstname, fields.middlename, fields.lastname, fields.suffix, fields.jobtitle, fields.phonenumber, fields.phonenumbertype, fields.emailaddress, fields.emailpromotion, fields.addressline1, fields.addressline2, fields.city, fields.stateprovincename, fields.postalcode, fields.countryregionname, fields.additionalcontactinfo)
+    override lazy val columns: List[FieldLikeNoHkt[?, VemployeeViewRow]] =
+      List[FieldLikeNoHkt[?, VemployeeViewRow]](fields.businessentityid, fields.title, fields.firstname, fields.middlename, fields.lastname, fields.suffix, fields.jobtitle, fields.phonenumber, fields.phonenumbertype, fields.emailaddress, fields.emailpromotion, fields.addressline1, fields.addressline2, fields.city, fields.stateprovincename, fields.postalcode, fields.countryregionname, fields.additionalcontactinfo)
   
-    override def copy[NewRow](prefix: Option[String], extract: NewRow => VemployeeViewRow, merge: (NewRow, VemployeeViewRow) => NewRow): Impl[NewRow] =
-      new Impl(prefix, extract, merge)
+    override def copy(path: List[Path]): Impl =
+      new Impl(path)
   }
   
 }

--- a/typo-tester-doobie/generated-and-checked-in/adventureworks/humanresources/vemployeedepartment/VemployeedepartmentViewFields.scala
+++ b/typo-tester-doobie/generated-and-checked-in/adventureworks/humanresources/vemployeedepartment/VemployeedepartmentViewFields.scala
@@ -11,49 +11,50 @@ import adventureworks.customtypes.TypoLocalDate
 import adventureworks.person.businessentity.BusinessentityId
 import adventureworks.public.Name
 import adventureworks.userdefined.FirstName
+import typo.dsl.Path
 import typo.dsl.SqlExpr.Field
 import typo.dsl.SqlExpr.FieldLikeNoHkt
 import typo.dsl.SqlExpr.OptField
 import typo.dsl.Structure.Relation
 
-trait VemployeedepartmentViewFields[Row] {
-  val businessentityid: Field[BusinessentityId, Row]
-  val title: OptField[/* max 8 chars */ String, Row]
-  val firstname: Field[/* user-picked */ FirstName, Row]
-  val middlename: OptField[Name, Row]
-  val lastname: Field[Name, Row]
-  val suffix: OptField[/* max 10 chars */ String, Row]
-  val jobtitle: Field[/* max 50 chars */ String, Row]
-  val department: Field[Name, Row]
-  val groupname: Field[Name, Row]
-  val startdate: Field[TypoLocalDate, Row]
+trait VemployeedepartmentViewFields {
+  def businessentityid: Field[BusinessentityId, VemployeedepartmentViewRow]
+  def title: OptField[/* max 8 chars */ String, VemployeedepartmentViewRow]
+  def firstname: Field[/* user-picked */ FirstName, VemployeedepartmentViewRow]
+  def middlename: OptField[Name, VemployeedepartmentViewRow]
+  def lastname: Field[Name, VemployeedepartmentViewRow]
+  def suffix: OptField[/* max 10 chars */ String, VemployeedepartmentViewRow]
+  def jobtitle: Field[/* max 50 chars */ String, VemployeedepartmentViewRow]
+  def department: Field[Name, VemployeedepartmentViewRow]
+  def groupname: Field[Name, VemployeedepartmentViewRow]
+  def startdate: Field[TypoLocalDate, VemployeedepartmentViewRow]
 }
 
 object VemployeedepartmentViewFields {
-  val structure: Relation[VemployeedepartmentViewFields, VemployeedepartmentViewRow, VemployeedepartmentViewRow] = 
-    new Impl(None, identity, (_, x) => x)
+  lazy val structure: Relation[VemployeedepartmentViewFields, VemployeedepartmentViewRow] =
+    new Impl(Nil)
     
-  private final class Impl[Row](val prefix: Option[String], val extract: Row => VemployeedepartmentViewRow, val merge: (Row, VemployeedepartmentViewRow) => Row)
-    extends Relation[VemployeedepartmentViewFields, VemployeedepartmentViewRow, Row] { 
+  private final class Impl(val _path: List[Path])
+    extends Relation[VemployeedepartmentViewFields, VemployeedepartmentViewRow] {
   
-    override val fields: VemployeedepartmentViewFields[Row] = new VemployeedepartmentViewFields[Row] {
-      override val businessentityid = new Field[BusinessentityId, Row](prefix, "businessentityid", None, None)(x => extract(x).businessentityid, (row, value) => merge(row, extract(row).copy(businessentityid = value)))
-      override val title = new OptField[/* max 8 chars */ String, Row](prefix, "title", None, None)(x => extract(x).title, (row, value) => merge(row, extract(row).copy(title = value)))
-      override val firstname = new Field[/* user-picked */ FirstName, Row](prefix, "firstname", None, None)(x => extract(x).firstname, (row, value) => merge(row, extract(row).copy(firstname = value)))
-      override val middlename = new OptField[Name, Row](prefix, "middlename", None, None)(x => extract(x).middlename, (row, value) => merge(row, extract(row).copy(middlename = value)))
-      override val lastname = new Field[Name, Row](prefix, "lastname", None, None)(x => extract(x).lastname, (row, value) => merge(row, extract(row).copy(lastname = value)))
-      override val suffix = new OptField[/* max 10 chars */ String, Row](prefix, "suffix", None, None)(x => extract(x).suffix, (row, value) => merge(row, extract(row).copy(suffix = value)))
-      override val jobtitle = new Field[/* max 50 chars */ String, Row](prefix, "jobtitle", None, None)(x => extract(x).jobtitle, (row, value) => merge(row, extract(row).copy(jobtitle = value)))
-      override val department = new Field[Name, Row](prefix, "department", None, None)(x => extract(x).department, (row, value) => merge(row, extract(row).copy(department = value)))
-      override val groupname = new Field[Name, Row](prefix, "groupname", None, None)(x => extract(x).groupname, (row, value) => merge(row, extract(row).copy(groupname = value)))
-      override val startdate = new Field[TypoLocalDate, Row](prefix, "startdate", Some("text"), None)(x => extract(x).startdate, (row, value) => merge(row, extract(row).copy(startdate = value)))
+    override lazy val fields: VemployeedepartmentViewFields = new VemployeedepartmentViewFields {
+      override def businessentityid = Field[BusinessentityId, VemployeedepartmentViewRow](_path, "businessentityid", None, None, x => x.businessentityid, (row, value) => row.copy(businessentityid = value))
+      override def title = OptField[/* max 8 chars */ String, VemployeedepartmentViewRow](_path, "title", None, None, x => x.title, (row, value) => row.copy(title = value))
+      override def firstname = Field[/* user-picked */ FirstName, VemployeedepartmentViewRow](_path, "firstname", None, None, x => x.firstname, (row, value) => row.copy(firstname = value))
+      override def middlename = OptField[Name, VemployeedepartmentViewRow](_path, "middlename", None, None, x => x.middlename, (row, value) => row.copy(middlename = value))
+      override def lastname = Field[Name, VemployeedepartmentViewRow](_path, "lastname", None, None, x => x.lastname, (row, value) => row.copy(lastname = value))
+      override def suffix = OptField[/* max 10 chars */ String, VemployeedepartmentViewRow](_path, "suffix", None, None, x => x.suffix, (row, value) => row.copy(suffix = value))
+      override def jobtitle = Field[/* max 50 chars */ String, VemployeedepartmentViewRow](_path, "jobtitle", None, None, x => x.jobtitle, (row, value) => row.copy(jobtitle = value))
+      override def department = Field[Name, VemployeedepartmentViewRow](_path, "department", None, None, x => x.department, (row, value) => row.copy(department = value))
+      override def groupname = Field[Name, VemployeedepartmentViewRow](_path, "groupname", None, None, x => x.groupname, (row, value) => row.copy(groupname = value))
+      override def startdate = Field[TypoLocalDate, VemployeedepartmentViewRow](_path, "startdate", Some("text"), None, x => x.startdate, (row, value) => row.copy(startdate = value))
     }
   
-    override val columns: List[FieldLikeNoHkt[?, Row]] =
-      List[FieldLikeNoHkt[?, Row]](fields.businessentityid, fields.title, fields.firstname, fields.middlename, fields.lastname, fields.suffix, fields.jobtitle, fields.department, fields.groupname, fields.startdate)
+    override lazy val columns: List[FieldLikeNoHkt[?, VemployeedepartmentViewRow]] =
+      List[FieldLikeNoHkt[?, VemployeedepartmentViewRow]](fields.businessentityid, fields.title, fields.firstname, fields.middlename, fields.lastname, fields.suffix, fields.jobtitle, fields.department, fields.groupname, fields.startdate)
   
-    override def copy[NewRow](prefix: Option[String], extract: NewRow => VemployeedepartmentViewRow, merge: (NewRow, VemployeedepartmentViewRow) => NewRow): Impl[NewRow] =
-      new Impl(prefix, extract, merge)
+    override def copy(path: List[Path]): Impl =
+      new Impl(path)
   }
   
 }

--- a/typo-tester-doobie/generated-and-checked-in/adventureworks/humanresources/vemployeedepartmenthistory/VemployeedepartmenthistoryViewFields.scala
+++ b/typo-tester-doobie/generated-and-checked-in/adventureworks/humanresources/vemployeedepartmenthistory/VemployeedepartmenthistoryViewFields.scala
@@ -11,51 +11,52 @@ import adventureworks.customtypes.TypoLocalDate
 import adventureworks.person.businessentity.BusinessentityId
 import adventureworks.public.Name
 import adventureworks.userdefined.FirstName
+import typo.dsl.Path
 import typo.dsl.SqlExpr.Field
 import typo.dsl.SqlExpr.FieldLikeNoHkt
 import typo.dsl.SqlExpr.OptField
 import typo.dsl.Structure.Relation
 
-trait VemployeedepartmenthistoryViewFields[Row] {
-  val businessentityid: Field[BusinessentityId, Row]
-  val title: OptField[/* max 8 chars */ String, Row]
-  val firstname: Field[/* user-picked */ FirstName, Row]
-  val middlename: OptField[Name, Row]
-  val lastname: Field[Name, Row]
-  val suffix: OptField[/* max 10 chars */ String, Row]
-  val shift: Field[Name, Row]
-  val department: Field[Name, Row]
-  val groupname: Field[Name, Row]
-  val startdate: Field[TypoLocalDate, Row]
-  val enddate: OptField[TypoLocalDate, Row]
+trait VemployeedepartmenthistoryViewFields {
+  def businessentityid: Field[BusinessentityId, VemployeedepartmenthistoryViewRow]
+  def title: OptField[/* max 8 chars */ String, VemployeedepartmenthistoryViewRow]
+  def firstname: Field[/* user-picked */ FirstName, VemployeedepartmenthistoryViewRow]
+  def middlename: OptField[Name, VemployeedepartmenthistoryViewRow]
+  def lastname: Field[Name, VemployeedepartmenthistoryViewRow]
+  def suffix: OptField[/* max 10 chars */ String, VemployeedepartmenthistoryViewRow]
+  def shift: Field[Name, VemployeedepartmenthistoryViewRow]
+  def department: Field[Name, VemployeedepartmenthistoryViewRow]
+  def groupname: Field[Name, VemployeedepartmenthistoryViewRow]
+  def startdate: Field[TypoLocalDate, VemployeedepartmenthistoryViewRow]
+  def enddate: OptField[TypoLocalDate, VemployeedepartmenthistoryViewRow]
 }
 
 object VemployeedepartmenthistoryViewFields {
-  val structure: Relation[VemployeedepartmenthistoryViewFields, VemployeedepartmenthistoryViewRow, VemployeedepartmenthistoryViewRow] = 
-    new Impl(None, identity, (_, x) => x)
+  lazy val structure: Relation[VemployeedepartmenthistoryViewFields, VemployeedepartmenthistoryViewRow] =
+    new Impl(Nil)
     
-  private final class Impl[Row](val prefix: Option[String], val extract: Row => VemployeedepartmenthistoryViewRow, val merge: (Row, VemployeedepartmenthistoryViewRow) => Row)
-    extends Relation[VemployeedepartmenthistoryViewFields, VemployeedepartmenthistoryViewRow, Row] { 
+  private final class Impl(val _path: List[Path])
+    extends Relation[VemployeedepartmenthistoryViewFields, VemployeedepartmenthistoryViewRow] {
   
-    override val fields: VemployeedepartmenthistoryViewFields[Row] = new VemployeedepartmenthistoryViewFields[Row] {
-      override val businessentityid = new Field[BusinessentityId, Row](prefix, "businessentityid", None, None)(x => extract(x).businessentityid, (row, value) => merge(row, extract(row).copy(businessentityid = value)))
-      override val title = new OptField[/* max 8 chars */ String, Row](prefix, "title", None, None)(x => extract(x).title, (row, value) => merge(row, extract(row).copy(title = value)))
-      override val firstname = new Field[/* user-picked */ FirstName, Row](prefix, "firstname", None, None)(x => extract(x).firstname, (row, value) => merge(row, extract(row).copy(firstname = value)))
-      override val middlename = new OptField[Name, Row](prefix, "middlename", None, None)(x => extract(x).middlename, (row, value) => merge(row, extract(row).copy(middlename = value)))
-      override val lastname = new Field[Name, Row](prefix, "lastname", None, None)(x => extract(x).lastname, (row, value) => merge(row, extract(row).copy(lastname = value)))
-      override val suffix = new OptField[/* max 10 chars */ String, Row](prefix, "suffix", None, None)(x => extract(x).suffix, (row, value) => merge(row, extract(row).copy(suffix = value)))
-      override val shift = new Field[Name, Row](prefix, "shift", None, None)(x => extract(x).shift, (row, value) => merge(row, extract(row).copy(shift = value)))
-      override val department = new Field[Name, Row](prefix, "department", None, None)(x => extract(x).department, (row, value) => merge(row, extract(row).copy(department = value)))
-      override val groupname = new Field[Name, Row](prefix, "groupname", None, None)(x => extract(x).groupname, (row, value) => merge(row, extract(row).copy(groupname = value)))
-      override val startdate = new Field[TypoLocalDate, Row](prefix, "startdate", Some("text"), None)(x => extract(x).startdate, (row, value) => merge(row, extract(row).copy(startdate = value)))
-      override val enddate = new OptField[TypoLocalDate, Row](prefix, "enddate", Some("text"), None)(x => extract(x).enddate, (row, value) => merge(row, extract(row).copy(enddate = value)))
+    override lazy val fields: VemployeedepartmenthistoryViewFields = new VemployeedepartmenthistoryViewFields {
+      override def businessentityid = Field[BusinessentityId, VemployeedepartmenthistoryViewRow](_path, "businessentityid", None, None, x => x.businessentityid, (row, value) => row.copy(businessentityid = value))
+      override def title = OptField[/* max 8 chars */ String, VemployeedepartmenthistoryViewRow](_path, "title", None, None, x => x.title, (row, value) => row.copy(title = value))
+      override def firstname = Field[/* user-picked */ FirstName, VemployeedepartmenthistoryViewRow](_path, "firstname", None, None, x => x.firstname, (row, value) => row.copy(firstname = value))
+      override def middlename = OptField[Name, VemployeedepartmenthistoryViewRow](_path, "middlename", None, None, x => x.middlename, (row, value) => row.copy(middlename = value))
+      override def lastname = Field[Name, VemployeedepartmenthistoryViewRow](_path, "lastname", None, None, x => x.lastname, (row, value) => row.copy(lastname = value))
+      override def suffix = OptField[/* max 10 chars */ String, VemployeedepartmenthistoryViewRow](_path, "suffix", None, None, x => x.suffix, (row, value) => row.copy(suffix = value))
+      override def shift = Field[Name, VemployeedepartmenthistoryViewRow](_path, "shift", None, None, x => x.shift, (row, value) => row.copy(shift = value))
+      override def department = Field[Name, VemployeedepartmenthistoryViewRow](_path, "department", None, None, x => x.department, (row, value) => row.copy(department = value))
+      override def groupname = Field[Name, VemployeedepartmenthistoryViewRow](_path, "groupname", None, None, x => x.groupname, (row, value) => row.copy(groupname = value))
+      override def startdate = Field[TypoLocalDate, VemployeedepartmenthistoryViewRow](_path, "startdate", Some("text"), None, x => x.startdate, (row, value) => row.copy(startdate = value))
+      override def enddate = OptField[TypoLocalDate, VemployeedepartmenthistoryViewRow](_path, "enddate", Some("text"), None, x => x.enddate, (row, value) => row.copy(enddate = value))
     }
   
-    override val columns: List[FieldLikeNoHkt[?, Row]] =
-      List[FieldLikeNoHkt[?, Row]](fields.businessentityid, fields.title, fields.firstname, fields.middlename, fields.lastname, fields.suffix, fields.shift, fields.department, fields.groupname, fields.startdate, fields.enddate)
+    override lazy val columns: List[FieldLikeNoHkt[?, VemployeedepartmenthistoryViewRow]] =
+      List[FieldLikeNoHkt[?, VemployeedepartmenthistoryViewRow]](fields.businessentityid, fields.title, fields.firstname, fields.middlename, fields.lastname, fields.suffix, fields.shift, fields.department, fields.groupname, fields.startdate, fields.enddate)
   
-    override def copy[NewRow](prefix: Option[String], extract: NewRow => VemployeedepartmenthistoryViewRow, merge: (NewRow, VemployeedepartmenthistoryViewRow) => NewRow): Impl[NewRow] =
-      new Impl(prefix, extract, merge)
+    override def copy(path: List[Path]): Impl =
+      new Impl(path)
   }
   
 }

--- a/typo-tester-doobie/generated-and-checked-in/adventureworks/humanresources/vjobcandidate/VjobcandidateViewFields.scala
+++ b/typo-tester-doobie/generated-and-checked-in/adventureworks/humanresources/vjobcandidate/VjobcandidateViewFields.scala
@@ -10,61 +10,62 @@ package vjobcandidate
 import adventureworks.customtypes.TypoLocalDateTime
 import adventureworks.humanresources.jobcandidate.JobcandidateId
 import adventureworks.person.businessentity.BusinessentityId
+import typo.dsl.Path
 import typo.dsl.SqlExpr.Field
 import typo.dsl.SqlExpr.FieldLikeNoHkt
 import typo.dsl.SqlExpr.OptField
 import typo.dsl.Structure.Relation
 
-trait VjobcandidateViewFields[Row] {
-  val jobcandidateid: Field[JobcandidateId, Row]
-  val businessentityid: OptField[BusinessentityId, Row]
-  val NamePrefix: OptField[/* max 30 chars */ String, Row]
-  val NameFirst: OptField[/* max 30 chars */ String, Row]
-  val NameMiddle: OptField[/* max 30 chars */ String, Row]
-  val NameLast: OptField[/* max 30 chars */ String, Row]
-  val NameSuffix: OptField[/* max 30 chars */ String, Row]
-  val Skills: OptField[String, Row]
-  val AddrType: OptField[/* max 30 chars */ String, Row]
-  val AddrLocCountryRegion: OptField[/* max 100 chars */ String, Row]
-  val AddrLocState: OptField[/* max 100 chars */ String, Row]
-  val AddrLocCity: OptField[/* max 100 chars */ String, Row]
-  val AddrPostalCode: OptField[/* max 20 chars */ String, Row]
-  val EMail: OptField[String, Row]
-  val WebSite: OptField[String, Row]
-  val modifieddate: Field[TypoLocalDateTime, Row]
+trait VjobcandidateViewFields {
+  def jobcandidateid: Field[JobcandidateId, VjobcandidateViewRow]
+  def businessentityid: OptField[BusinessentityId, VjobcandidateViewRow]
+  def NamePrefix: OptField[/* max 30 chars */ String, VjobcandidateViewRow]
+  def NameFirst: OptField[/* max 30 chars */ String, VjobcandidateViewRow]
+  def NameMiddle: OptField[/* max 30 chars */ String, VjobcandidateViewRow]
+  def NameLast: OptField[/* max 30 chars */ String, VjobcandidateViewRow]
+  def NameSuffix: OptField[/* max 30 chars */ String, VjobcandidateViewRow]
+  def Skills: OptField[String, VjobcandidateViewRow]
+  def AddrType: OptField[/* max 30 chars */ String, VjobcandidateViewRow]
+  def AddrLocCountryRegion: OptField[/* max 100 chars */ String, VjobcandidateViewRow]
+  def AddrLocState: OptField[/* max 100 chars */ String, VjobcandidateViewRow]
+  def AddrLocCity: OptField[/* max 100 chars */ String, VjobcandidateViewRow]
+  def AddrPostalCode: OptField[/* max 20 chars */ String, VjobcandidateViewRow]
+  def EMail: OptField[String, VjobcandidateViewRow]
+  def WebSite: OptField[String, VjobcandidateViewRow]
+  def modifieddate: Field[TypoLocalDateTime, VjobcandidateViewRow]
 }
 
 object VjobcandidateViewFields {
-  val structure: Relation[VjobcandidateViewFields, VjobcandidateViewRow, VjobcandidateViewRow] = 
-    new Impl(None, identity, (_, x) => x)
+  lazy val structure: Relation[VjobcandidateViewFields, VjobcandidateViewRow] =
+    new Impl(Nil)
     
-  private final class Impl[Row](val prefix: Option[String], val extract: Row => VjobcandidateViewRow, val merge: (Row, VjobcandidateViewRow) => Row)
-    extends Relation[VjobcandidateViewFields, VjobcandidateViewRow, Row] { 
+  private final class Impl(val _path: List[Path])
+    extends Relation[VjobcandidateViewFields, VjobcandidateViewRow] {
   
-    override val fields: VjobcandidateViewFields[Row] = new VjobcandidateViewFields[Row] {
-      override val jobcandidateid = new Field[JobcandidateId, Row](prefix, "jobcandidateid", None, None)(x => extract(x).jobcandidateid, (row, value) => merge(row, extract(row).copy(jobcandidateid = value)))
-      override val businessentityid = new OptField[BusinessentityId, Row](prefix, "businessentityid", None, None)(x => extract(x).businessentityid, (row, value) => merge(row, extract(row).copy(businessentityid = value)))
-      override val NamePrefix = new OptField[/* max 30 chars */ String, Row](prefix, "Name.Prefix", None, None)(x => extract(x).NamePrefix, (row, value) => merge(row, extract(row).copy(NamePrefix = value)))
-      override val NameFirst = new OptField[/* max 30 chars */ String, Row](prefix, "Name.First", None, None)(x => extract(x).NameFirst, (row, value) => merge(row, extract(row).copy(NameFirst = value)))
-      override val NameMiddle = new OptField[/* max 30 chars */ String, Row](prefix, "Name.Middle", None, None)(x => extract(x).NameMiddle, (row, value) => merge(row, extract(row).copy(NameMiddle = value)))
-      override val NameLast = new OptField[/* max 30 chars */ String, Row](prefix, "Name.Last", None, None)(x => extract(x).NameLast, (row, value) => merge(row, extract(row).copy(NameLast = value)))
-      override val NameSuffix = new OptField[/* max 30 chars */ String, Row](prefix, "Name.Suffix", None, None)(x => extract(x).NameSuffix, (row, value) => merge(row, extract(row).copy(NameSuffix = value)))
-      override val Skills = new OptField[String, Row](prefix, "Skills", None, None)(x => extract(x).Skills, (row, value) => merge(row, extract(row).copy(Skills = value)))
-      override val AddrType = new OptField[/* max 30 chars */ String, Row](prefix, "Addr.Type", None, None)(x => extract(x).AddrType, (row, value) => merge(row, extract(row).copy(AddrType = value)))
-      override val AddrLocCountryRegion = new OptField[/* max 100 chars */ String, Row](prefix, "Addr.Loc.CountryRegion", None, None)(x => extract(x).AddrLocCountryRegion, (row, value) => merge(row, extract(row).copy(AddrLocCountryRegion = value)))
-      override val AddrLocState = new OptField[/* max 100 chars */ String, Row](prefix, "Addr.Loc.State", None, None)(x => extract(x).AddrLocState, (row, value) => merge(row, extract(row).copy(AddrLocState = value)))
-      override val AddrLocCity = new OptField[/* max 100 chars */ String, Row](prefix, "Addr.Loc.City", None, None)(x => extract(x).AddrLocCity, (row, value) => merge(row, extract(row).copy(AddrLocCity = value)))
-      override val AddrPostalCode = new OptField[/* max 20 chars */ String, Row](prefix, "Addr.PostalCode", None, None)(x => extract(x).AddrPostalCode, (row, value) => merge(row, extract(row).copy(AddrPostalCode = value)))
-      override val EMail = new OptField[String, Row](prefix, "EMail", None, None)(x => extract(x).EMail, (row, value) => merge(row, extract(row).copy(EMail = value)))
-      override val WebSite = new OptField[String, Row](prefix, "WebSite", None, None)(x => extract(x).WebSite, (row, value) => merge(row, extract(row).copy(WebSite = value)))
-      override val modifieddate = new Field[TypoLocalDateTime, Row](prefix, "modifieddate", Some("text"), None)(x => extract(x).modifieddate, (row, value) => merge(row, extract(row).copy(modifieddate = value)))
+    override lazy val fields: VjobcandidateViewFields = new VjobcandidateViewFields {
+      override def jobcandidateid = Field[JobcandidateId, VjobcandidateViewRow](_path, "jobcandidateid", None, None, x => x.jobcandidateid, (row, value) => row.copy(jobcandidateid = value))
+      override def businessentityid = OptField[BusinessentityId, VjobcandidateViewRow](_path, "businessentityid", None, None, x => x.businessentityid, (row, value) => row.copy(businessentityid = value))
+      override def NamePrefix = OptField[/* max 30 chars */ String, VjobcandidateViewRow](_path, "Name.Prefix", None, None, x => x.NamePrefix, (row, value) => row.copy(NamePrefix = value))
+      override def NameFirst = OptField[/* max 30 chars */ String, VjobcandidateViewRow](_path, "Name.First", None, None, x => x.NameFirst, (row, value) => row.copy(NameFirst = value))
+      override def NameMiddle = OptField[/* max 30 chars */ String, VjobcandidateViewRow](_path, "Name.Middle", None, None, x => x.NameMiddle, (row, value) => row.copy(NameMiddle = value))
+      override def NameLast = OptField[/* max 30 chars */ String, VjobcandidateViewRow](_path, "Name.Last", None, None, x => x.NameLast, (row, value) => row.copy(NameLast = value))
+      override def NameSuffix = OptField[/* max 30 chars */ String, VjobcandidateViewRow](_path, "Name.Suffix", None, None, x => x.NameSuffix, (row, value) => row.copy(NameSuffix = value))
+      override def Skills = OptField[String, VjobcandidateViewRow](_path, "Skills", None, None, x => x.Skills, (row, value) => row.copy(Skills = value))
+      override def AddrType = OptField[/* max 30 chars */ String, VjobcandidateViewRow](_path, "Addr.Type", None, None, x => x.AddrType, (row, value) => row.copy(AddrType = value))
+      override def AddrLocCountryRegion = OptField[/* max 100 chars */ String, VjobcandidateViewRow](_path, "Addr.Loc.CountryRegion", None, None, x => x.AddrLocCountryRegion, (row, value) => row.copy(AddrLocCountryRegion = value))
+      override def AddrLocState = OptField[/* max 100 chars */ String, VjobcandidateViewRow](_path, "Addr.Loc.State", None, None, x => x.AddrLocState, (row, value) => row.copy(AddrLocState = value))
+      override def AddrLocCity = OptField[/* max 100 chars */ String, VjobcandidateViewRow](_path, "Addr.Loc.City", None, None, x => x.AddrLocCity, (row, value) => row.copy(AddrLocCity = value))
+      override def AddrPostalCode = OptField[/* max 20 chars */ String, VjobcandidateViewRow](_path, "Addr.PostalCode", None, None, x => x.AddrPostalCode, (row, value) => row.copy(AddrPostalCode = value))
+      override def EMail = OptField[String, VjobcandidateViewRow](_path, "EMail", None, None, x => x.EMail, (row, value) => row.copy(EMail = value))
+      override def WebSite = OptField[String, VjobcandidateViewRow](_path, "WebSite", None, None, x => x.WebSite, (row, value) => row.copy(WebSite = value))
+      override def modifieddate = Field[TypoLocalDateTime, VjobcandidateViewRow](_path, "modifieddate", Some("text"), None, x => x.modifieddate, (row, value) => row.copy(modifieddate = value))
     }
   
-    override val columns: List[FieldLikeNoHkt[?, Row]] =
-      List[FieldLikeNoHkt[?, Row]](fields.jobcandidateid, fields.businessentityid, fields.NamePrefix, fields.NameFirst, fields.NameMiddle, fields.NameLast, fields.NameSuffix, fields.Skills, fields.AddrType, fields.AddrLocCountryRegion, fields.AddrLocState, fields.AddrLocCity, fields.AddrPostalCode, fields.EMail, fields.WebSite, fields.modifieddate)
+    override lazy val columns: List[FieldLikeNoHkt[?, VjobcandidateViewRow]] =
+      List[FieldLikeNoHkt[?, VjobcandidateViewRow]](fields.jobcandidateid, fields.businessentityid, fields.NamePrefix, fields.NameFirst, fields.NameMiddle, fields.NameLast, fields.NameSuffix, fields.Skills, fields.AddrType, fields.AddrLocCountryRegion, fields.AddrLocState, fields.AddrLocCity, fields.AddrPostalCode, fields.EMail, fields.WebSite, fields.modifieddate)
   
-    override def copy[NewRow](prefix: Option[String], extract: NewRow => VjobcandidateViewRow, merge: (NewRow, VjobcandidateViewRow) => NewRow): Impl[NewRow] =
-      new Impl(prefix, extract, merge)
+    override def copy(path: List[Path]): Impl =
+      new Impl(path)
   }
   
 }

--- a/typo-tester-doobie/generated-and-checked-in/adventureworks/humanresources/vjobcandidateeducation/VjobcandidateeducationViewFields.scala
+++ b/typo-tester-doobie/generated-and-checked-in/adventureworks/humanresources/vjobcandidateeducation/VjobcandidateeducationViewFields.scala
@@ -9,55 +9,56 @@ package vjobcandidateeducation
 
 import adventureworks.customtypes.TypoLocalDate
 import adventureworks.humanresources.jobcandidate.JobcandidateId
+import typo.dsl.Path
 import typo.dsl.SqlExpr.Field
 import typo.dsl.SqlExpr.FieldLikeNoHkt
 import typo.dsl.SqlExpr.OptField
 import typo.dsl.Structure.Relation
 
-trait VjobcandidateeducationViewFields[Row] {
-  val jobcandidateid: Field[JobcandidateId, Row]
-  val EduLevel: OptField[/* max 50 chars */ String, Row]
-  val EduStartDate: OptField[TypoLocalDate, Row]
-  val EduEndDate: OptField[TypoLocalDate, Row]
-  val EduDegree: OptField[/* max 50 chars */ String, Row]
-  val EduMajor: OptField[/* max 50 chars */ String, Row]
-  val EduMinor: OptField[/* max 50 chars */ String, Row]
-  val EduGPA: OptField[/* max 5 chars */ String, Row]
-  val EduGPAScale: OptField[/* max 5 chars */ String, Row]
-  val EduSchool: OptField[/* max 100 chars */ String, Row]
-  val EduLocCountryRegion: OptField[/* max 100 chars */ String, Row]
-  val EduLocState: OptField[/* max 100 chars */ String, Row]
-  val EduLocCity: OptField[/* max 100 chars */ String, Row]
+trait VjobcandidateeducationViewFields {
+  def jobcandidateid: Field[JobcandidateId, VjobcandidateeducationViewRow]
+  def EduLevel: OptField[/* max 50 chars */ String, VjobcandidateeducationViewRow]
+  def EduStartDate: OptField[TypoLocalDate, VjobcandidateeducationViewRow]
+  def EduEndDate: OptField[TypoLocalDate, VjobcandidateeducationViewRow]
+  def EduDegree: OptField[/* max 50 chars */ String, VjobcandidateeducationViewRow]
+  def EduMajor: OptField[/* max 50 chars */ String, VjobcandidateeducationViewRow]
+  def EduMinor: OptField[/* max 50 chars */ String, VjobcandidateeducationViewRow]
+  def EduGPA: OptField[/* max 5 chars */ String, VjobcandidateeducationViewRow]
+  def EduGPAScale: OptField[/* max 5 chars */ String, VjobcandidateeducationViewRow]
+  def EduSchool: OptField[/* max 100 chars */ String, VjobcandidateeducationViewRow]
+  def EduLocCountryRegion: OptField[/* max 100 chars */ String, VjobcandidateeducationViewRow]
+  def EduLocState: OptField[/* max 100 chars */ String, VjobcandidateeducationViewRow]
+  def EduLocCity: OptField[/* max 100 chars */ String, VjobcandidateeducationViewRow]
 }
 
 object VjobcandidateeducationViewFields {
-  val structure: Relation[VjobcandidateeducationViewFields, VjobcandidateeducationViewRow, VjobcandidateeducationViewRow] = 
-    new Impl(None, identity, (_, x) => x)
+  lazy val structure: Relation[VjobcandidateeducationViewFields, VjobcandidateeducationViewRow] =
+    new Impl(Nil)
     
-  private final class Impl[Row](val prefix: Option[String], val extract: Row => VjobcandidateeducationViewRow, val merge: (Row, VjobcandidateeducationViewRow) => Row)
-    extends Relation[VjobcandidateeducationViewFields, VjobcandidateeducationViewRow, Row] { 
+  private final class Impl(val _path: List[Path])
+    extends Relation[VjobcandidateeducationViewFields, VjobcandidateeducationViewRow] {
   
-    override val fields: VjobcandidateeducationViewFields[Row] = new VjobcandidateeducationViewFields[Row] {
-      override val jobcandidateid = new Field[JobcandidateId, Row](prefix, "jobcandidateid", None, None)(x => extract(x).jobcandidateid, (row, value) => merge(row, extract(row).copy(jobcandidateid = value)))
-      override val EduLevel = new OptField[/* max 50 chars */ String, Row](prefix, "Edu.Level", None, None)(x => extract(x).EduLevel, (row, value) => merge(row, extract(row).copy(EduLevel = value)))
-      override val EduStartDate = new OptField[TypoLocalDate, Row](prefix, "Edu.StartDate", Some("text"), None)(x => extract(x).EduStartDate, (row, value) => merge(row, extract(row).copy(EduStartDate = value)))
-      override val EduEndDate = new OptField[TypoLocalDate, Row](prefix, "Edu.EndDate", Some("text"), None)(x => extract(x).EduEndDate, (row, value) => merge(row, extract(row).copy(EduEndDate = value)))
-      override val EduDegree = new OptField[/* max 50 chars */ String, Row](prefix, "Edu.Degree", None, None)(x => extract(x).EduDegree, (row, value) => merge(row, extract(row).copy(EduDegree = value)))
-      override val EduMajor = new OptField[/* max 50 chars */ String, Row](prefix, "Edu.Major", None, None)(x => extract(x).EduMajor, (row, value) => merge(row, extract(row).copy(EduMajor = value)))
-      override val EduMinor = new OptField[/* max 50 chars */ String, Row](prefix, "Edu.Minor", None, None)(x => extract(x).EduMinor, (row, value) => merge(row, extract(row).copy(EduMinor = value)))
-      override val EduGPA = new OptField[/* max 5 chars */ String, Row](prefix, "Edu.GPA", None, None)(x => extract(x).EduGPA, (row, value) => merge(row, extract(row).copy(EduGPA = value)))
-      override val EduGPAScale = new OptField[/* max 5 chars */ String, Row](prefix, "Edu.GPAScale", None, None)(x => extract(x).EduGPAScale, (row, value) => merge(row, extract(row).copy(EduGPAScale = value)))
-      override val EduSchool = new OptField[/* max 100 chars */ String, Row](prefix, "Edu.School", None, None)(x => extract(x).EduSchool, (row, value) => merge(row, extract(row).copy(EduSchool = value)))
-      override val EduLocCountryRegion = new OptField[/* max 100 chars */ String, Row](prefix, "Edu.Loc.CountryRegion", None, None)(x => extract(x).EduLocCountryRegion, (row, value) => merge(row, extract(row).copy(EduLocCountryRegion = value)))
-      override val EduLocState = new OptField[/* max 100 chars */ String, Row](prefix, "Edu.Loc.State", None, None)(x => extract(x).EduLocState, (row, value) => merge(row, extract(row).copy(EduLocState = value)))
-      override val EduLocCity = new OptField[/* max 100 chars */ String, Row](prefix, "Edu.Loc.City", None, None)(x => extract(x).EduLocCity, (row, value) => merge(row, extract(row).copy(EduLocCity = value)))
+    override lazy val fields: VjobcandidateeducationViewFields = new VjobcandidateeducationViewFields {
+      override def jobcandidateid = Field[JobcandidateId, VjobcandidateeducationViewRow](_path, "jobcandidateid", None, None, x => x.jobcandidateid, (row, value) => row.copy(jobcandidateid = value))
+      override def EduLevel = OptField[/* max 50 chars */ String, VjobcandidateeducationViewRow](_path, "Edu.Level", None, None, x => x.EduLevel, (row, value) => row.copy(EduLevel = value))
+      override def EduStartDate = OptField[TypoLocalDate, VjobcandidateeducationViewRow](_path, "Edu.StartDate", Some("text"), None, x => x.EduStartDate, (row, value) => row.copy(EduStartDate = value))
+      override def EduEndDate = OptField[TypoLocalDate, VjobcandidateeducationViewRow](_path, "Edu.EndDate", Some("text"), None, x => x.EduEndDate, (row, value) => row.copy(EduEndDate = value))
+      override def EduDegree = OptField[/* max 50 chars */ String, VjobcandidateeducationViewRow](_path, "Edu.Degree", None, None, x => x.EduDegree, (row, value) => row.copy(EduDegree = value))
+      override def EduMajor = OptField[/* max 50 chars */ String, VjobcandidateeducationViewRow](_path, "Edu.Major", None, None, x => x.EduMajor, (row, value) => row.copy(EduMajor = value))
+      override def EduMinor = OptField[/* max 50 chars */ String, VjobcandidateeducationViewRow](_path, "Edu.Minor", None, None, x => x.EduMinor, (row, value) => row.copy(EduMinor = value))
+      override def EduGPA = OptField[/* max 5 chars */ String, VjobcandidateeducationViewRow](_path, "Edu.GPA", None, None, x => x.EduGPA, (row, value) => row.copy(EduGPA = value))
+      override def EduGPAScale = OptField[/* max 5 chars */ String, VjobcandidateeducationViewRow](_path, "Edu.GPAScale", None, None, x => x.EduGPAScale, (row, value) => row.copy(EduGPAScale = value))
+      override def EduSchool = OptField[/* max 100 chars */ String, VjobcandidateeducationViewRow](_path, "Edu.School", None, None, x => x.EduSchool, (row, value) => row.copy(EduSchool = value))
+      override def EduLocCountryRegion = OptField[/* max 100 chars */ String, VjobcandidateeducationViewRow](_path, "Edu.Loc.CountryRegion", None, None, x => x.EduLocCountryRegion, (row, value) => row.copy(EduLocCountryRegion = value))
+      override def EduLocState = OptField[/* max 100 chars */ String, VjobcandidateeducationViewRow](_path, "Edu.Loc.State", None, None, x => x.EduLocState, (row, value) => row.copy(EduLocState = value))
+      override def EduLocCity = OptField[/* max 100 chars */ String, VjobcandidateeducationViewRow](_path, "Edu.Loc.City", None, None, x => x.EduLocCity, (row, value) => row.copy(EduLocCity = value))
     }
   
-    override val columns: List[FieldLikeNoHkt[?, Row]] =
-      List[FieldLikeNoHkt[?, Row]](fields.jobcandidateid, fields.EduLevel, fields.EduStartDate, fields.EduEndDate, fields.EduDegree, fields.EduMajor, fields.EduMinor, fields.EduGPA, fields.EduGPAScale, fields.EduSchool, fields.EduLocCountryRegion, fields.EduLocState, fields.EduLocCity)
+    override lazy val columns: List[FieldLikeNoHkt[?, VjobcandidateeducationViewRow]] =
+      List[FieldLikeNoHkt[?, VjobcandidateeducationViewRow]](fields.jobcandidateid, fields.EduLevel, fields.EduStartDate, fields.EduEndDate, fields.EduDegree, fields.EduMajor, fields.EduMinor, fields.EduGPA, fields.EduGPAScale, fields.EduSchool, fields.EduLocCountryRegion, fields.EduLocState, fields.EduLocCity)
   
-    override def copy[NewRow](prefix: Option[String], extract: NewRow => VjobcandidateeducationViewRow, merge: (NewRow, VjobcandidateeducationViewRow) => NewRow): Impl[NewRow] =
-      new Impl(prefix, extract, merge)
+    override def copy(path: List[Path]): Impl =
+      new Impl(path)
   }
   
 }

--- a/typo-tester-doobie/generated-and-checked-in/adventureworks/humanresources/vjobcandidateemployment/VjobcandidateemploymentViewFields.scala
+++ b/typo-tester-doobie/generated-and-checked-in/adventureworks/humanresources/vjobcandidateemployment/VjobcandidateemploymentViewFields.scala
@@ -9,51 +9,52 @@ package vjobcandidateemployment
 
 import adventureworks.customtypes.TypoLocalDate
 import adventureworks.humanresources.jobcandidate.JobcandidateId
+import typo.dsl.Path
 import typo.dsl.SqlExpr.Field
 import typo.dsl.SqlExpr.FieldLikeNoHkt
 import typo.dsl.SqlExpr.OptField
 import typo.dsl.Structure.Relation
 
-trait VjobcandidateemploymentViewFields[Row] {
-  val jobcandidateid: Field[JobcandidateId, Row]
-  val EmpStartDate: OptField[TypoLocalDate, Row]
-  val EmpEndDate: OptField[TypoLocalDate, Row]
-  val EmpOrgName: OptField[/* max 100 chars */ String, Row]
-  val EmpJobTitle: OptField[/* max 100 chars */ String, Row]
-  val EmpResponsibility: OptField[String, Row]
-  val EmpFunctionCategory: OptField[String, Row]
-  val EmpIndustryCategory: OptField[String, Row]
-  val EmpLocCountryRegion: OptField[String, Row]
-  val EmpLocState: OptField[String, Row]
-  val EmpLocCity: OptField[String, Row]
+trait VjobcandidateemploymentViewFields {
+  def jobcandidateid: Field[JobcandidateId, VjobcandidateemploymentViewRow]
+  def EmpStartDate: OptField[TypoLocalDate, VjobcandidateemploymentViewRow]
+  def EmpEndDate: OptField[TypoLocalDate, VjobcandidateemploymentViewRow]
+  def EmpOrgName: OptField[/* max 100 chars */ String, VjobcandidateemploymentViewRow]
+  def EmpJobTitle: OptField[/* max 100 chars */ String, VjobcandidateemploymentViewRow]
+  def EmpResponsibility: OptField[String, VjobcandidateemploymentViewRow]
+  def EmpFunctionCategory: OptField[String, VjobcandidateemploymentViewRow]
+  def EmpIndustryCategory: OptField[String, VjobcandidateemploymentViewRow]
+  def EmpLocCountryRegion: OptField[String, VjobcandidateemploymentViewRow]
+  def EmpLocState: OptField[String, VjobcandidateemploymentViewRow]
+  def EmpLocCity: OptField[String, VjobcandidateemploymentViewRow]
 }
 
 object VjobcandidateemploymentViewFields {
-  val structure: Relation[VjobcandidateemploymentViewFields, VjobcandidateemploymentViewRow, VjobcandidateemploymentViewRow] = 
-    new Impl(None, identity, (_, x) => x)
+  lazy val structure: Relation[VjobcandidateemploymentViewFields, VjobcandidateemploymentViewRow] =
+    new Impl(Nil)
     
-  private final class Impl[Row](val prefix: Option[String], val extract: Row => VjobcandidateemploymentViewRow, val merge: (Row, VjobcandidateemploymentViewRow) => Row)
-    extends Relation[VjobcandidateemploymentViewFields, VjobcandidateemploymentViewRow, Row] { 
+  private final class Impl(val _path: List[Path])
+    extends Relation[VjobcandidateemploymentViewFields, VjobcandidateemploymentViewRow] {
   
-    override val fields: VjobcandidateemploymentViewFields[Row] = new VjobcandidateemploymentViewFields[Row] {
-      override val jobcandidateid = new Field[JobcandidateId, Row](prefix, "jobcandidateid", None, None)(x => extract(x).jobcandidateid, (row, value) => merge(row, extract(row).copy(jobcandidateid = value)))
-      override val EmpStartDate = new OptField[TypoLocalDate, Row](prefix, "Emp.StartDate", Some("text"), None)(x => extract(x).EmpStartDate, (row, value) => merge(row, extract(row).copy(EmpStartDate = value)))
-      override val EmpEndDate = new OptField[TypoLocalDate, Row](prefix, "Emp.EndDate", Some("text"), None)(x => extract(x).EmpEndDate, (row, value) => merge(row, extract(row).copy(EmpEndDate = value)))
-      override val EmpOrgName = new OptField[/* max 100 chars */ String, Row](prefix, "Emp.OrgName", None, None)(x => extract(x).EmpOrgName, (row, value) => merge(row, extract(row).copy(EmpOrgName = value)))
-      override val EmpJobTitle = new OptField[/* max 100 chars */ String, Row](prefix, "Emp.JobTitle", None, None)(x => extract(x).EmpJobTitle, (row, value) => merge(row, extract(row).copy(EmpJobTitle = value)))
-      override val EmpResponsibility = new OptField[String, Row](prefix, "Emp.Responsibility", None, None)(x => extract(x).EmpResponsibility, (row, value) => merge(row, extract(row).copy(EmpResponsibility = value)))
-      override val EmpFunctionCategory = new OptField[String, Row](prefix, "Emp.FunctionCategory", None, None)(x => extract(x).EmpFunctionCategory, (row, value) => merge(row, extract(row).copy(EmpFunctionCategory = value)))
-      override val EmpIndustryCategory = new OptField[String, Row](prefix, "Emp.IndustryCategory", None, None)(x => extract(x).EmpIndustryCategory, (row, value) => merge(row, extract(row).copy(EmpIndustryCategory = value)))
-      override val EmpLocCountryRegion = new OptField[String, Row](prefix, "Emp.Loc.CountryRegion", None, None)(x => extract(x).EmpLocCountryRegion, (row, value) => merge(row, extract(row).copy(EmpLocCountryRegion = value)))
-      override val EmpLocState = new OptField[String, Row](prefix, "Emp.Loc.State", None, None)(x => extract(x).EmpLocState, (row, value) => merge(row, extract(row).copy(EmpLocState = value)))
-      override val EmpLocCity = new OptField[String, Row](prefix, "Emp.Loc.City", None, None)(x => extract(x).EmpLocCity, (row, value) => merge(row, extract(row).copy(EmpLocCity = value)))
+    override lazy val fields: VjobcandidateemploymentViewFields = new VjobcandidateemploymentViewFields {
+      override def jobcandidateid = Field[JobcandidateId, VjobcandidateemploymentViewRow](_path, "jobcandidateid", None, None, x => x.jobcandidateid, (row, value) => row.copy(jobcandidateid = value))
+      override def EmpStartDate = OptField[TypoLocalDate, VjobcandidateemploymentViewRow](_path, "Emp.StartDate", Some("text"), None, x => x.EmpStartDate, (row, value) => row.copy(EmpStartDate = value))
+      override def EmpEndDate = OptField[TypoLocalDate, VjobcandidateemploymentViewRow](_path, "Emp.EndDate", Some("text"), None, x => x.EmpEndDate, (row, value) => row.copy(EmpEndDate = value))
+      override def EmpOrgName = OptField[/* max 100 chars */ String, VjobcandidateemploymentViewRow](_path, "Emp.OrgName", None, None, x => x.EmpOrgName, (row, value) => row.copy(EmpOrgName = value))
+      override def EmpJobTitle = OptField[/* max 100 chars */ String, VjobcandidateemploymentViewRow](_path, "Emp.JobTitle", None, None, x => x.EmpJobTitle, (row, value) => row.copy(EmpJobTitle = value))
+      override def EmpResponsibility = OptField[String, VjobcandidateemploymentViewRow](_path, "Emp.Responsibility", None, None, x => x.EmpResponsibility, (row, value) => row.copy(EmpResponsibility = value))
+      override def EmpFunctionCategory = OptField[String, VjobcandidateemploymentViewRow](_path, "Emp.FunctionCategory", None, None, x => x.EmpFunctionCategory, (row, value) => row.copy(EmpFunctionCategory = value))
+      override def EmpIndustryCategory = OptField[String, VjobcandidateemploymentViewRow](_path, "Emp.IndustryCategory", None, None, x => x.EmpIndustryCategory, (row, value) => row.copy(EmpIndustryCategory = value))
+      override def EmpLocCountryRegion = OptField[String, VjobcandidateemploymentViewRow](_path, "Emp.Loc.CountryRegion", None, None, x => x.EmpLocCountryRegion, (row, value) => row.copy(EmpLocCountryRegion = value))
+      override def EmpLocState = OptField[String, VjobcandidateemploymentViewRow](_path, "Emp.Loc.State", None, None, x => x.EmpLocState, (row, value) => row.copy(EmpLocState = value))
+      override def EmpLocCity = OptField[String, VjobcandidateemploymentViewRow](_path, "Emp.Loc.City", None, None, x => x.EmpLocCity, (row, value) => row.copy(EmpLocCity = value))
     }
   
-    override val columns: List[FieldLikeNoHkt[?, Row]] =
-      List[FieldLikeNoHkt[?, Row]](fields.jobcandidateid, fields.EmpStartDate, fields.EmpEndDate, fields.EmpOrgName, fields.EmpJobTitle, fields.EmpResponsibility, fields.EmpFunctionCategory, fields.EmpIndustryCategory, fields.EmpLocCountryRegion, fields.EmpLocState, fields.EmpLocCity)
+    override lazy val columns: List[FieldLikeNoHkt[?, VjobcandidateemploymentViewRow]] =
+      List[FieldLikeNoHkt[?, VjobcandidateemploymentViewRow]](fields.jobcandidateid, fields.EmpStartDate, fields.EmpEndDate, fields.EmpOrgName, fields.EmpJobTitle, fields.EmpResponsibility, fields.EmpFunctionCategory, fields.EmpIndustryCategory, fields.EmpLocCountryRegion, fields.EmpLocState, fields.EmpLocCity)
   
-    override def copy[NewRow](prefix: Option[String], extract: NewRow => VjobcandidateemploymentViewRow, merge: (NewRow, VjobcandidateemploymentViewRow) => NewRow): Impl[NewRow] =
-      new Impl(prefix, extract, merge)
+    override def copy(path: List[Path]): Impl =
+      new Impl(path)
   }
   
 }

--- a/typo-tester-doobie/generated-and-checked-in/adventureworks/pe/a/AViewFields.scala
+++ b/typo-tester-doobie/generated-and-checked-in/adventureworks/pe/a/AViewFields.scala
@@ -12,49 +12,50 @@ import adventureworks.customtypes.TypoLocalDateTime
 import adventureworks.customtypes.TypoUUID
 import adventureworks.person.address.AddressId
 import adventureworks.person.stateprovince.StateprovinceId
+import typo.dsl.Path
 import typo.dsl.SqlExpr.Field
 import typo.dsl.SqlExpr.FieldLikeNoHkt
 import typo.dsl.SqlExpr.OptField
 import typo.dsl.Structure.Relation
 
-trait AViewFields[Row] {
-  val id: Field[AddressId, Row]
-  val addressid: Field[AddressId, Row]
-  val addressline1: Field[/* max 60 chars */ String, Row]
-  val addressline2: OptField[/* max 60 chars */ String, Row]
-  val city: Field[/* max 30 chars */ String, Row]
-  val stateprovinceid: Field[StateprovinceId, Row]
-  val postalcode: Field[/* max 15 chars */ String, Row]
-  val spatiallocation: OptField[TypoBytea, Row]
-  val rowguid: Field[TypoUUID, Row]
-  val modifieddate: Field[TypoLocalDateTime, Row]
+trait AViewFields {
+  def id: Field[AddressId, AViewRow]
+  def addressid: Field[AddressId, AViewRow]
+  def addressline1: Field[/* max 60 chars */ String, AViewRow]
+  def addressline2: OptField[/* max 60 chars */ String, AViewRow]
+  def city: Field[/* max 30 chars */ String, AViewRow]
+  def stateprovinceid: Field[StateprovinceId, AViewRow]
+  def postalcode: Field[/* max 15 chars */ String, AViewRow]
+  def spatiallocation: OptField[TypoBytea, AViewRow]
+  def rowguid: Field[TypoUUID, AViewRow]
+  def modifieddate: Field[TypoLocalDateTime, AViewRow]
 }
 
 object AViewFields {
-  val structure: Relation[AViewFields, AViewRow, AViewRow] = 
-    new Impl(None, identity, (_, x) => x)
+  lazy val structure: Relation[AViewFields, AViewRow] =
+    new Impl(Nil)
     
-  private final class Impl[Row](val prefix: Option[String], val extract: Row => AViewRow, val merge: (Row, AViewRow) => Row)
-    extends Relation[AViewFields, AViewRow, Row] { 
+  private final class Impl(val _path: List[Path])
+    extends Relation[AViewFields, AViewRow] {
   
-    override val fields: AViewFields[Row] = new AViewFields[Row] {
-      override val id = new Field[AddressId, Row](prefix, "id", None, None)(x => extract(x).id, (row, value) => merge(row, extract(row).copy(id = value)))
-      override val addressid = new Field[AddressId, Row](prefix, "addressid", None, None)(x => extract(x).addressid, (row, value) => merge(row, extract(row).copy(addressid = value)))
-      override val addressline1 = new Field[/* max 60 chars */ String, Row](prefix, "addressline1", None, None)(x => extract(x).addressline1, (row, value) => merge(row, extract(row).copy(addressline1 = value)))
-      override val addressline2 = new OptField[/* max 60 chars */ String, Row](prefix, "addressline2", None, None)(x => extract(x).addressline2, (row, value) => merge(row, extract(row).copy(addressline2 = value)))
-      override val city = new Field[/* max 30 chars */ String, Row](prefix, "city", None, None)(x => extract(x).city, (row, value) => merge(row, extract(row).copy(city = value)))
-      override val stateprovinceid = new Field[StateprovinceId, Row](prefix, "stateprovinceid", None, None)(x => extract(x).stateprovinceid, (row, value) => merge(row, extract(row).copy(stateprovinceid = value)))
-      override val postalcode = new Field[/* max 15 chars */ String, Row](prefix, "postalcode", None, None)(x => extract(x).postalcode, (row, value) => merge(row, extract(row).copy(postalcode = value)))
-      override val spatiallocation = new OptField[TypoBytea, Row](prefix, "spatiallocation", None, None)(x => extract(x).spatiallocation, (row, value) => merge(row, extract(row).copy(spatiallocation = value)))
-      override val rowguid = new Field[TypoUUID, Row](prefix, "rowguid", None, None)(x => extract(x).rowguid, (row, value) => merge(row, extract(row).copy(rowguid = value)))
-      override val modifieddate = new Field[TypoLocalDateTime, Row](prefix, "modifieddate", Some("text"), None)(x => extract(x).modifieddate, (row, value) => merge(row, extract(row).copy(modifieddate = value)))
+    override lazy val fields: AViewFields = new AViewFields {
+      override def id = Field[AddressId, AViewRow](_path, "id", None, None, x => x.id, (row, value) => row.copy(id = value))
+      override def addressid = Field[AddressId, AViewRow](_path, "addressid", None, None, x => x.addressid, (row, value) => row.copy(addressid = value))
+      override def addressline1 = Field[/* max 60 chars */ String, AViewRow](_path, "addressline1", None, None, x => x.addressline1, (row, value) => row.copy(addressline1 = value))
+      override def addressline2 = OptField[/* max 60 chars */ String, AViewRow](_path, "addressline2", None, None, x => x.addressline2, (row, value) => row.copy(addressline2 = value))
+      override def city = Field[/* max 30 chars */ String, AViewRow](_path, "city", None, None, x => x.city, (row, value) => row.copy(city = value))
+      override def stateprovinceid = Field[StateprovinceId, AViewRow](_path, "stateprovinceid", None, None, x => x.stateprovinceid, (row, value) => row.copy(stateprovinceid = value))
+      override def postalcode = Field[/* max 15 chars */ String, AViewRow](_path, "postalcode", None, None, x => x.postalcode, (row, value) => row.copy(postalcode = value))
+      override def spatiallocation = OptField[TypoBytea, AViewRow](_path, "spatiallocation", None, None, x => x.spatiallocation, (row, value) => row.copy(spatiallocation = value))
+      override def rowguid = Field[TypoUUID, AViewRow](_path, "rowguid", None, None, x => x.rowguid, (row, value) => row.copy(rowguid = value))
+      override def modifieddate = Field[TypoLocalDateTime, AViewRow](_path, "modifieddate", Some("text"), None, x => x.modifieddate, (row, value) => row.copy(modifieddate = value))
     }
   
-    override val columns: List[FieldLikeNoHkt[?, Row]] =
-      List[FieldLikeNoHkt[?, Row]](fields.id, fields.addressid, fields.addressline1, fields.addressline2, fields.city, fields.stateprovinceid, fields.postalcode, fields.spatiallocation, fields.rowguid, fields.modifieddate)
+    override lazy val columns: List[FieldLikeNoHkt[?, AViewRow]] =
+      List[FieldLikeNoHkt[?, AViewRow]](fields.id, fields.addressid, fields.addressline1, fields.addressline2, fields.city, fields.stateprovinceid, fields.postalcode, fields.spatiallocation, fields.rowguid, fields.modifieddate)
   
-    override def copy[NewRow](prefix: Option[String], extract: NewRow => AViewRow, merge: (NewRow, AViewRow) => NewRow): Impl[NewRow] =
-      new Impl(prefix, extract, merge)
+    override def copy(path: List[Path]): Impl =
+      new Impl(path)
   }
   
 }

--- a/typo-tester-doobie/generated-and-checked-in/adventureworks/pe/at/AtViewFields.scala
+++ b/typo-tester-doobie/generated-and-checked-in/adventureworks/pe/at/AtViewFields.scala
@@ -11,38 +11,39 @@ import adventureworks.customtypes.TypoLocalDateTime
 import adventureworks.customtypes.TypoUUID
 import adventureworks.person.addresstype.AddresstypeId
 import adventureworks.public.Name
+import typo.dsl.Path
 import typo.dsl.SqlExpr.Field
 import typo.dsl.SqlExpr.FieldLikeNoHkt
 import typo.dsl.Structure.Relation
 
-trait AtViewFields[Row] {
-  val id: Field[AddresstypeId, Row]
-  val addresstypeid: Field[AddresstypeId, Row]
-  val name: Field[Name, Row]
-  val rowguid: Field[TypoUUID, Row]
-  val modifieddate: Field[TypoLocalDateTime, Row]
+trait AtViewFields {
+  def id: Field[AddresstypeId, AtViewRow]
+  def addresstypeid: Field[AddresstypeId, AtViewRow]
+  def name: Field[Name, AtViewRow]
+  def rowguid: Field[TypoUUID, AtViewRow]
+  def modifieddate: Field[TypoLocalDateTime, AtViewRow]
 }
 
 object AtViewFields {
-  val structure: Relation[AtViewFields, AtViewRow, AtViewRow] = 
-    new Impl(None, identity, (_, x) => x)
+  lazy val structure: Relation[AtViewFields, AtViewRow] =
+    new Impl(Nil)
     
-  private final class Impl[Row](val prefix: Option[String], val extract: Row => AtViewRow, val merge: (Row, AtViewRow) => Row)
-    extends Relation[AtViewFields, AtViewRow, Row] { 
+  private final class Impl(val _path: List[Path])
+    extends Relation[AtViewFields, AtViewRow] {
   
-    override val fields: AtViewFields[Row] = new AtViewFields[Row] {
-      override val id = new Field[AddresstypeId, Row](prefix, "id", None, None)(x => extract(x).id, (row, value) => merge(row, extract(row).copy(id = value)))
-      override val addresstypeid = new Field[AddresstypeId, Row](prefix, "addresstypeid", None, None)(x => extract(x).addresstypeid, (row, value) => merge(row, extract(row).copy(addresstypeid = value)))
-      override val name = new Field[Name, Row](prefix, "name", None, None)(x => extract(x).name, (row, value) => merge(row, extract(row).copy(name = value)))
-      override val rowguid = new Field[TypoUUID, Row](prefix, "rowguid", None, None)(x => extract(x).rowguid, (row, value) => merge(row, extract(row).copy(rowguid = value)))
-      override val modifieddate = new Field[TypoLocalDateTime, Row](prefix, "modifieddate", Some("text"), None)(x => extract(x).modifieddate, (row, value) => merge(row, extract(row).copy(modifieddate = value)))
+    override lazy val fields: AtViewFields = new AtViewFields {
+      override def id = Field[AddresstypeId, AtViewRow](_path, "id", None, None, x => x.id, (row, value) => row.copy(id = value))
+      override def addresstypeid = Field[AddresstypeId, AtViewRow](_path, "addresstypeid", None, None, x => x.addresstypeid, (row, value) => row.copy(addresstypeid = value))
+      override def name = Field[Name, AtViewRow](_path, "name", None, None, x => x.name, (row, value) => row.copy(name = value))
+      override def rowguid = Field[TypoUUID, AtViewRow](_path, "rowguid", None, None, x => x.rowguid, (row, value) => row.copy(rowguid = value))
+      override def modifieddate = Field[TypoLocalDateTime, AtViewRow](_path, "modifieddate", Some("text"), None, x => x.modifieddate, (row, value) => row.copy(modifieddate = value))
     }
   
-    override val columns: List[FieldLikeNoHkt[?, Row]] =
-      List[FieldLikeNoHkt[?, Row]](fields.id, fields.addresstypeid, fields.name, fields.rowguid, fields.modifieddate)
+    override lazy val columns: List[FieldLikeNoHkt[?, AtViewRow]] =
+      List[FieldLikeNoHkt[?, AtViewRow]](fields.id, fields.addresstypeid, fields.name, fields.rowguid, fields.modifieddate)
   
-    override def copy[NewRow](prefix: Option[String], extract: NewRow => AtViewRow, merge: (NewRow, AtViewRow) => NewRow): Impl[NewRow] =
-      new Impl(prefix, extract, merge)
+    override def copy(path: List[Path]): Impl =
+      new Impl(path)
   }
   
 }

--- a/typo-tester-doobie/generated-and-checked-in/adventureworks/pe/be/BeViewFields.scala
+++ b/typo-tester-doobie/generated-and-checked-in/adventureworks/pe/be/BeViewFields.scala
@@ -10,36 +10,37 @@ package be
 import adventureworks.customtypes.TypoLocalDateTime
 import adventureworks.customtypes.TypoUUID
 import adventureworks.person.businessentity.BusinessentityId
+import typo.dsl.Path
 import typo.dsl.SqlExpr.Field
 import typo.dsl.SqlExpr.FieldLikeNoHkt
 import typo.dsl.Structure.Relation
 
-trait BeViewFields[Row] {
-  val id: Field[BusinessentityId, Row]
-  val businessentityid: Field[BusinessentityId, Row]
-  val rowguid: Field[TypoUUID, Row]
-  val modifieddate: Field[TypoLocalDateTime, Row]
+trait BeViewFields {
+  def id: Field[BusinessentityId, BeViewRow]
+  def businessentityid: Field[BusinessentityId, BeViewRow]
+  def rowguid: Field[TypoUUID, BeViewRow]
+  def modifieddate: Field[TypoLocalDateTime, BeViewRow]
 }
 
 object BeViewFields {
-  val structure: Relation[BeViewFields, BeViewRow, BeViewRow] = 
-    new Impl(None, identity, (_, x) => x)
+  lazy val structure: Relation[BeViewFields, BeViewRow] =
+    new Impl(Nil)
     
-  private final class Impl[Row](val prefix: Option[String], val extract: Row => BeViewRow, val merge: (Row, BeViewRow) => Row)
-    extends Relation[BeViewFields, BeViewRow, Row] { 
+  private final class Impl(val _path: List[Path])
+    extends Relation[BeViewFields, BeViewRow] {
   
-    override val fields: BeViewFields[Row] = new BeViewFields[Row] {
-      override val id = new Field[BusinessentityId, Row](prefix, "id", None, None)(x => extract(x).id, (row, value) => merge(row, extract(row).copy(id = value)))
-      override val businessentityid = new Field[BusinessentityId, Row](prefix, "businessentityid", None, None)(x => extract(x).businessentityid, (row, value) => merge(row, extract(row).copy(businessentityid = value)))
-      override val rowguid = new Field[TypoUUID, Row](prefix, "rowguid", None, None)(x => extract(x).rowguid, (row, value) => merge(row, extract(row).copy(rowguid = value)))
-      override val modifieddate = new Field[TypoLocalDateTime, Row](prefix, "modifieddate", Some("text"), None)(x => extract(x).modifieddate, (row, value) => merge(row, extract(row).copy(modifieddate = value)))
+    override lazy val fields: BeViewFields = new BeViewFields {
+      override def id = Field[BusinessentityId, BeViewRow](_path, "id", None, None, x => x.id, (row, value) => row.copy(id = value))
+      override def businessentityid = Field[BusinessentityId, BeViewRow](_path, "businessentityid", None, None, x => x.businessentityid, (row, value) => row.copy(businessentityid = value))
+      override def rowguid = Field[TypoUUID, BeViewRow](_path, "rowguid", None, None, x => x.rowguid, (row, value) => row.copy(rowguid = value))
+      override def modifieddate = Field[TypoLocalDateTime, BeViewRow](_path, "modifieddate", Some("text"), None, x => x.modifieddate, (row, value) => row.copy(modifieddate = value))
     }
   
-    override val columns: List[FieldLikeNoHkt[?, Row]] =
-      List[FieldLikeNoHkt[?, Row]](fields.id, fields.businessentityid, fields.rowguid, fields.modifieddate)
+    override lazy val columns: List[FieldLikeNoHkt[?, BeViewRow]] =
+      List[FieldLikeNoHkt[?, BeViewRow]](fields.id, fields.businessentityid, fields.rowguid, fields.modifieddate)
   
-    override def copy[NewRow](prefix: Option[String], extract: NewRow => BeViewRow, merge: (NewRow, BeViewRow) => NewRow): Impl[NewRow] =
-      new Impl(prefix, extract, merge)
+    override def copy(path: List[Path]): Impl =
+      new Impl(path)
   }
   
 }

--- a/typo-tester-doobie/generated-and-checked-in/adventureworks/pe/bea/BeaViewFields.scala
+++ b/typo-tester-doobie/generated-and-checked-in/adventureworks/pe/bea/BeaViewFields.scala
@@ -12,40 +12,41 @@ import adventureworks.customtypes.TypoUUID
 import adventureworks.person.address.AddressId
 import adventureworks.person.addresstype.AddresstypeId
 import adventureworks.person.businessentity.BusinessentityId
+import typo.dsl.Path
 import typo.dsl.SqlExpr.Field
 import typo.dsl.SqlExpr.FieldLikeNoHkt
 import typo.dsl.Structure.Relation
 
-trait BeaViewFields[Row] {
-  val id: Field[BusinessentityId, Row]
-  val businessentityid: Field[BusinessentityId, Row]
-  val addressid: Field[AddressId, Row]
-  val addresstypeid: Field[AddresstypeId, Row]
-  val rowguid: Field[TypoUUID, Row]
-  val modifieddate: Field[TypoLocalDateTime, Row]
+trait BeaViewFields {
+  def id: Field[BusinessentityId, BeaViewRow]
+  def businessentityid: Field[BusinessentityId, BeaViewRow]
+  def addressid: Field[AddressId, BeaViewRow]
+  def addresstypeid: Field[AddresstypeId, BeaViewRow]
+  def rowguid: Field[TypoUUID, BeaViewRow]
+  def modifieddate: Field[TypoLocalDateTime, BeaViewRow]
 }
 
 object BeaViewFields {
-  val structure: Relation[BeaViewFields, BeaViewRow, BeaViewRow] = 
-    new Impl(None, identity, (_, x) => x)
+  lazy val structure: Relation[BeaViewFields, BeaViewRow] =
+    new Impl(Nil)
     
-  private final class Impl[Row](val prefix: Option[String], val extract: Row => BeaViewRow, val merge: (Row, BeaViewRow) => Row)
-    extends Relation[BeaViewFields, BeaViewRow, Row] { 
+  private final class Impl(val _path: List[Path])
+    extends Relation[BeaViewFields, BeaViewRow] {
   
-    override val fields: BeaViewFields[Row] = new BeaViewFields[Row] {
-      override val id = new Field[BusinessentityId, Row](prefix, "id", None, None)(x => extract(x).id, (row, value) => merge(row, extract(row).copy(id = value)))
-      override val businessentityid = new Field[BusinessentityId, Row](prefix, "businessentityid", None, None)(x => extract(x).businessentityid, (row, value) => merge(row, extract(row).copy(businessentityid = value)))
-      override val addressid = new Field[AddressId, Row](prefix, "addressid", None, None)(x => extract(x).addressid, (row, value) => merge(row, extract(row).copy(addressid = value)))
-      override val addresstypeid = new Field[AddresstypeId, Row](prefix, "addresstypeid", None, None)(x => extract(x).addresstypeid, (row, value) => merge(row, extract(row).copy(addresstypeid = value)))
-      override val rowguid = new Field[TypoUUID, Row](prefix, "rowguid", None, None)(x => extract(x).rowguid, (row, value) => merge(row, extract(row).copy(rowguid = value)))
-      override val modifieddate = new Field[TypoLocalDateTime, Row](prefix, "modifieddate", Some("text"), None)(x => extract(x).modifieddate, (row, value) => merge(row, extract(row).copy(modifieddate = value)))
+    override lazy val fields: BeaViewFields = new BeaViewFields {
+      override def id = Field[BusinessentityId, BeaViewRow](_path, "id", None, None, x => x.id, (row, value) => row.copy(id = value))
+      override def businessentityid = Field[BusinessentityId, BeaViewRow](_path, "businessentityid", None, None, x => x.businessentityid, (row, value) => row.copy(businessentityid = value))
+      override def addressid = Field[AddressId, BeaViewRow](_path, "addressid", None, None, x => x.addressid, (row, value) => row.copy(addressid = value))
+      override def addresstypeid = Field[AddresstypeId, BeaViewRow](_path, "addresstypeid", None, None, x => x.addresstypeid, (row, value) => row.copy(addresstypeid = value))
+      override def rowguid = Field[TypoUUID, BeaViewRow](_path, "rowguid", None, None, x => x.rowguid, (row, value) => row.copy(rowguid = value))
+      override def modifieddate = Field[TypoLocalDateTime, BeaViewRow](_path, "modifieddate", Some("text"), None, x => x.modifieddate, (row, value) => row.copy(modifieddate = value))
     }
   
-    override val columns: List[FieldLikeNoHkt[?, Row]] =
-      List[FieldLikeNoHkt[?, Row]](fields.id, fields.businessentityid, fields.addressid, fields.addresstypeid, fields.rowguid, fields.modifieddate)
+    override lazy val columns: List[FieldLikeNoHkt[?, BeaViewRow]] =
+      List[FieldLikeNoHkt[?, BeaViewRow]](fields.id, fields.businessentityid, fields.addressid, fields.addresstypeid, fields.rowguid, fields.modifieddate)
   
-    override def copy[NewRow](prefix: Option[String], extract: NewRow => BeaViewRow, merge: (NewRow, BeaViewRow) => NewRow): Impl[NewRow] =
-      new Impl(prefix, extract, merge)
+    override def copy(path: List[Path]): Impl =
+      new Impl(path)
   }
   
 }

--- a/typo-tester-doobie/generated-and-checked-in/adventureworks/pe/bec/BecViewFields.scala
+++ b/typo-tester-doobie/generated-and-checked-in/adventureworks/pe/bec/BecViewFields.scala
@@ -11,40 +11,41 @@ import adventureworks.customtypes.TypoLocalDateTime
 import adventureworks.customtypes.TypoUUID
 import adventureworks.person.businessentity.BusinessentityId
 import adventureworks.person.contacttype.ContacttypeId
+import typo.dsl.Path
 import typo.dsl.SqlExpr.Field
 import typo.dsl.SqlExpr.FieldLikeNoHkt
 import typo.dsl.Structure.Relation
 
-trait BecViewFields[Row] {
-  val id: Field[BusinessentityId, Row]
-  val businessentityid: Field[BusinessentityId, Row]
-  val personid: Field[BusinessentityId, Row]
-  val contacttypeid: Field[ContacttypeId, Row]
-  val rowguid: Field[TypoUUID, Row]
-  val modifieddate: Field[TypoLocalDateTime, Row]
+trait BecViewFields {
+  def id: Field[BusinessentityId, BecViewRow]
+  def businessentityid: Field[BusinessentityId, BecViewRow]
+  def personid: Field[BusinessentityId, BecViewRow]
+  def contacttypeid: Field[ContacttypeId, BecViewRow]
+  def rowguid: Field[TypoUUID, BecViewRow]
+  def modifieddate: Field[TypoLocalDateTime, BecViewRow]
 }
 
 object BecViewFields {
-  val structure: Relation[BecViewFields, BecViewRow, BecViewRow] = 
-    new Impl(None, identity, (_, x) => x)
+  lazy val structure: Relation[BecViewFields, BecViewRow] =
+    new Impl(Nil)
     
-  private final class Impl[Row](val prefix: Option[String], val extract: Row => BecViewRow, val merge: (Row, BecViewRow) => Row)
-    extends Relation[BecViewFields, BecViewRow, Row] { 
+  private final class Impl(val _path: List[Path])
+    extends Relation[BecViewFields, BecViewRow] {
   
-    override val fields: BecViewFields[Row] = new BecViewFields[Row] {
-      override val id = new Field[BusinessentityId, Row](prefix, "id", None, None)(x => extract(x).id, (row, value) => merge(row, extract(row).copy(id = value)))
-      override val businessentityid = new Field[BusinessentityId, Row](prefix, "businessentityid", None, None)(x => extract(x).businessentityid, (row, value) => merge(row, extract(row).copy(businessentityid = value)))
-      override val personid = new Field[BusinessentityId, Row](prefix, "personid", None, None)(x => extract(x).personid, (row, value) => merge(row, extract(row).copy(personid = value)))
-      override val contacttypeid = new Field[ContacttypeId, Row](prefix, "contacttypeid", None, None)(x => extract(x).contacttypeid, (row, value) => merge(row, extract(row).copy(contacttypeid = value)))
-      override val rowguid = new Field[TypoUUID, Row](prefix, "rowguid", None, None)(x => extract(x).rowguid, (row, value) => merge(row, extract(row).copy(rowguid = value)))
-      override val modifieddate = new Field[TypoLocalDateTime, Row](prefix, "modifieddate", Some("text"), None)(x => extract(x).modifieddate, (row, value) => merge(row, extract(row).copy(modifieddate = value)))
+    override lazy val fields: BecViewFields = new BecViewFields {
+      override def id = Field[BusinessentityId, BecViewRow](_path, "id", None, None, x => x.id, (row, value) => row.copy(id = value))
+      override def businessentityid = Field[BusinessentityId, BecViewRow](_path, "businessentityid", None, None, x => x.businessentityid, (row, value) => row.copy(businessentityid = value))
+      override def personid = Field[BusinessentityId, BecViewRow](_path, "personid", None, None, x => x.personid, (row, value) => row.copy(personid = value))
+      override def contacttypeid = Field[ContacttypeId, BecViewRow](_path, "contacttypeid", None, None, x => x.contacttypeid, (row, value) => row.copy(contacttypeid = value))
+      override def rowguid = Field[TypoUUID, BecViewRow](_path, "rowguid", None, None, x => x.rowguid, (row, value) => row.copy(rowguid = value))
+      override def modifieddate = Field[TypoLocalDateTime, BecViewRow](_path, "modifieddate", Some("text"), None, x => x.modifieddate, (row, value) => row.copy(modifieddate = value))
     }
   
-    override val columns: List[FieldLikeNoHkt[?, Row]] =
-      List[FieldLikeNoHkt[?, Row]](fields.id, fields.businessentityid, fields.personid, fields.contacttypeid, fields.rowguid, fields.modifieddate)
+    override lazy val columns: List[FieldLikeNoHkt[?, BecViewRow]] =
+      List[FieldLikeNoHkt[?, BecViewRow]](fields.id, fields.businessentityid, fields.personid, fields.contacttypeid, fields.rowguid, fields.modifieddate)
   
-    override def copy[NewRow](prefix: Option[String], extract: NewRow => BecViewRow, merge: (NewRow, BecViewRow) => NewRow): Impl[NewRow] =
-      new Impl(prefix, extract, merge)
+    override def copy(path: List[Path]): Impl =
+      new Impl(path)
   }
   
 }

--- a/typo-tester-doobie/generated-and-checked-in/adventureworks/pe/ct/CtViewFields.scala
+++ b/typo-tester-doobie/generated-and-checked-in/adventureworks/pe/ct/CtViewFields.scala
@@ -10,36 +10,37 @@ package ct
 import adventureworks.customtypes.TypoLocalDateTime
 import adventureworks.person.contacttype.ContacttypeId
 import adventureworks.public.Name
+import typo.dsl.Path
 import typo.dsl.SqlExpr.Field
 import typo.dsl.SqlExpr.FieldLikeNoHkt
 import typo.dsl.Structure.Relation
 
-trait CtViewFields[Row] {
-  val id: Field[ContacttypeId, Row]
-  val contacttypeid: Field[ContacttypeId, Row]
-  val name: Field[Name, Row]
-  val modifieddate: Field[TypoLocalDateTime, Row]
+trait CtViewFields {
+  def id: Field[ContacttypeId, CtViewRow]
+  def contacttypeid: Field[ContacttypeId, CtViewRow]
+  def name: Field[Name, CtViewRow]
+  def modifieddate: Field[TypoLocalDateTime, CtViewRow]
 }
 
 object CtViewFields {
-  val structure: Relation[CtViewFields, CtViewRow, CtViewRow] = 
-    new Impl(None, identity, (_, x) => x)
+  lazy val structure: Relation[CtViewFields, CtViewRow] =
+    new Impl(Nil)
     
-  private final class Impl[Row](val prefix: Option[String], val extract: Row => CtViewRow, val merge: (Row, CtViewRow) => Row)
-    extends Relation[CtViewFields, CtViewRow, Row] { 
+  private final class Impl(val _path: List[Path])
+    extends Relation[CtViewFields, CtViewRow] {
   
-    override val fields: CtViewFields[Row] = new CtViewFields[Row] {
-      override val id = new Field[ContacttypeId, Row](prefix, "id", None, None)(x => extract(x).id, (row, value) => merge(row, extract(row).copy(id = value)))
-      override val contacttypeid = new Field[ContacttypeId, Row](prefix, "contacttypeid", None, None)(x => extract(x).contacttypeid, (row, value) => merge(row, extract(row).copy(contacttypeid = value)))
-      override val name = new Field[Name, Row](prefix, "name", None, None)(x => extract(x).name, (row, value) => merge(row, extract(row).copy(name = value)))
-      override val modifieddate = new Field[TypoLocalDateTime, Row](prefix, "modifieddate", Some("text"), None)(x => extract(x).modifieddate, (row, value) => merge(row, extract(row).copy(modifieddate = value)))
+    override lazy val fields: CtViewFields = new CtViewFields {
+      override def id = Field[ContacttypeId, CtViewRow](_path, "id", None, None, x => x.id, (row, value) => row.copy(id = value))
+      override def contacttypeid = Field[ContacttypeId, CtViewRow](_path, "contacttypeid", None, None, x => x.contacttypeid, (row, value) => row.copy(contacttypeid = value))
+      override def name = Field[Name, CtViewRow](_path, "name", None, None, x => x.name, (row, value) => row.copy(name = value))
+      override def modifieddate = Field[TypoLocalDateTime, CtViewRow](_path, "modifieddate", Some("text"), None, x => x.modifieddate, (row, value) => row.copy(modifieddate = value))
     }
   
-    override val columns: List[FieldLikeNoHkt[?, Row]] =
-      List[FieldLikeNoHkt[?, Row]](fields.id, fields.contacttypeid, fields.name, fields.modifieddate)
+    override lazy val columns: List[FieldLikeNoHkt[?, CtViewRow]] =
+      List[FieldLikeNoHkt[?, CtViewRow]](fields.id, fields.contacttypeid, fields.name, fields.modifieddate)
   
-    override def copy[NewRow](prefix: Option[String], extract: NewRow => CtViewRow, merge: (NewRow, CtViewRow) => NewRow): Impl[NewRow] =
-      new Impl(prefix, extract, merge)
+    override def copy(path: List[Path]): Impl =
+      new Impl(path)
   }
   
 }

--- a/typo-tester-doobie/generated-and-checked-in/adventureworks/pe/e/EViewFields.scala
+++ b/typo-tester-doobie/generated-and-checked-in/adventureworks/pe/e/EViewFields.scala
@@ -10,41 +10,42 @@ package e
 import adventureworks.customtypes.TypoLocalDateTime
 import adventureworks.customtypes.TypoUUID
 import adventureworks.person.businessentity.BusinessentityId
+import typo.dsl.Path
 import typo.dsl.SqlExpr.Field
 import typo.dsl.SqlExpr.FieldLikeNoHkt
 import typo.dsl.SqlExpr.OptField
 import typo.dsl.Structure.Relation
 
-trait EViewFields[Row] {
-  val id: Field[Int, Row]
-  val businessentityid: Field[BusinessentityId, Row]
-  val emailaddressid: Field[Int, Row]
-  val emailaddress: OptField[/* max 50 chars */ String, Row]
-  val rowguid: Field[TypoUUID, Row]
-  val modifieddate: Field[TypoLocalDateTime, Row]
+trait EViewFields {
+  def id: Field[Int, EViewRow]
+  def businessentityid: Field[BusinessentityId, EViewRow]
+  def emailaddressid: Field[Int, EViewRow]
+  def emailaddress: OptField[/* max 50 chars */ String, EViewRow]
+  def rowguid: Field[TypoUUID, EViewRow]
+  def modifieddate: Field[TypoLocalDateTime, EViewRow]
 }
 
 object EViewFields {
-  val structure: Relation[EViewFields, EViewRow, EViewRow] = 
-    new Impl(None, identity, (_, x) => x)
+  lazy val structure: Relation[EViewFields, EViewRow] =
+    new Impl(Nil)
     
-  private final class Impl[Row](val prefix: Option[String], val extract: Row => EViewRow, val merge: (Row, EViewRow) => Row)
-    extends Relation[EViewFields, EViewRow, Row] { 
+  private final class Impl(val _path: List[Path])
+    extends Relation[EViewFields, EViewRow] {
   
-    override val fields: EViewFields[Row] = new EViewFields[Row] {
-      override val id = new Field[Int, Row](prefix, "id", None, None)(x => extract(x).id, (row, value) => merge(row, extract(row).copy(id = value)))
-      override val businessentityid = new Field[BusinessentityId, Row](prefix, "businessentityid", None, None)(x => extract(x).businessentityid, (row, value) => merge(row, extract(row).copy(businessentityid = value)))
-      override val emailaddressid = new Field[Int, Row](prefix, "emailaddressid", None, None)(x => extract(x).emailaddressid, (row, value) => merge(row, extract(row).copy(emailaddressid = value)))
-      override val emailaddress = new OptField[/* max 50 chars */ String, Row](prefix, "emailaddress", None, None)(x => extract(x).emailaddress, (row, value) => merge(row, extract(row).copy(emailaddress = value)))
-      override val rowguid = new Field[TypoUUID, Row](prefix, "rowguid", None, None)(x => extract(x).rowguid, (row, value) => merge(row, extract(row).copy(rowguid = value)))
-      override val modifieddate = new Field[TypoLocalDateTime, Row](prefix, "modifieddate", Some("text"), None)(x => extract(x).modifieddate, (row, value) => merge(row, extract(row).copy(modifieddate = value)))
+    override lazy val fields: EViewFields = new EViewFields {
+      override def id = Field[Int, EViewRow](_path, "id", None, None, x => x.id, (row, value) => row.copy(id = value))
+      override def businessentityid = Field[BusinessentityId, EViewRow](_path, "businessentityid", None, None, x => x.businessentityid, (row, value) => row.copy(businessentityid = value))
+      override def emailaddressid = Field[Int, EViewRow](_path, "emailaddressid", None, None, x => x.emailaddressid, (row, value) => row.copy(emailaddressid = value))
+      override def emailaddress = OptField[/* max 50 chars */ String, EViewRow](_path, "emailaddress", None, None, x => x.emailaddress, (row, value) => row.copy(emailaddress = value))
+      override def rowguid = Field[TypoUUID, EViewRow](_path, "rowguid", None, None, x => x.rowguid, (row, value) => row.copy(rowguid = value))
+      override def modifieddate = Field[TypoLocalDateTime, EViewRow](_path, "modifieddate", Some("text"), None, x => x.modifieddate, (row, value) => row.copy(modifieddate = value))
     }
   
-    override val columns: List[FieldLikeNoHkt[?, Row]] =
-      List[FieldLikeNoHkt[?, Row]](fields.id, fields.businessentityid, fields.emailaddressid, fields.emailaddress, fields.rowguid, fields.modifieddate)
+    override lazy val columns: List[FieldLikeNoHkt[?, EViewRow]] =
+      List[FieldLikeNoHkt[?, EViewRow]](fields.id, fields.businessentityid, fields.emailaddressid, fields.emailaddress, fields.rowguid, fields.modifieddate)
   
-    override def copy[NewRow](prefix: Option[String], extract: NewRow => EViewRow, merge: (NewRow, EViewRow) => NewRow): Impl[NewRow] =
-      new Impl(prefix, extract, merge)
+    override def copy(path: List[Path]): Impl =
+      new Impl(path)
   }
   
 }

--- a/typo-tester-doobie/generated-and-checked-in/adventureworks/pe/p/PViewFields.scala
+++ b/typo-tester-doobie/generated-and-checked-in/adventureworks/pe/p/PViewFields.scala
@@ -14,57 +14,58 @@ import adventureworks.person.businessentity.BusinessentityId
 import adventureworks.public.Name
 import adventureworks.public.NameStyle
 import adventureworks.userdefined.FirstName
+import typo.dsl.Path
 import typo.dsl.SqlExpr.Field
 import typo.dsl.SqlExpr.FieldLikeNoHkt
 import typo.dsl.SqlExpr.OptField
 import typo.dsl.Structure.Relation
 
-trait PViewFields[Row] {
-  val id: Field[BusinessentityId, Row]
-  val businessentityid: Field[BusinessentityId, Row]
-  val persontype: Field[/* bpchar, max 2 chars */ String, Row]
-  val namestyle: Field[NameStyle, Row]
-  val title: OptField[/* max 8 chars */ String, Row]
-  val firstname: Field[/* user-picked */ FirstName, Row]
-  val middlename: OptField[Name, Row]
-  val lastname: Field[Name, Row]
-  val suffix: OptField[/* max 10 chars */ String, Row]
-  val emailpromotion: Field[Int, Row]
-  val additionalcontactinfo: OptField[TypoXml, Row]
-  val demographics: OptField[TypoXml, Row]
-  val rowguid: Field[TypoUUID, Row]
-  val modifieddate: Field[TypoLocalDateTime, Row]
+trait PViewFields {
+  def id: Field[BusinessentityId, PViewRow]
+  def businessentityid: Field[BusinessentityId, PViewRow]
+  def persontype: Field[/* bpchar, max 2 chars */ String, PViewRow]
+  def namestyle: Field[NameStyle, PViewRow]
+  def title: OptField[/* max 8 chars */ String, PViewRow]
+  def firstname: Field[/* user-picked */ FirstName, PViewRow]
+  def middlename: OptField[Name, PViewRow]
+  def lastname: Field[Name, PViewRow]
+  def suffix: OptField[/* max 10 chars */ String, PViewRow]
+  def emailpromotion: Field[Int, PViewRow]
+  def additionalcontactinfo: OptField[TypoXml, PViewRow]
+  def demographics: OptField[TypoXml, PViewRow]
+  def rowguid: Field[TypoUUID, PViewRow]
+  def modifieddate: Field[TypoLocalDateTime, PViewRow]
 }
 
 object PViewFields {
-  val structure: Relation[PViewFields, PViewRow, PViewRow] = 
-    new Impl(None, identity, (_, x) => x)
+  lazy val structure: Relation[PViewFields, PViewRow] =
+    new Impl(Nil)
     
-  private final class Impl[Row](val prefix: Option[String], val extract: Row => PViewRow, val merge: (Row, PViewRow) => Row)
-    extends Relation[PViewFields, PViewRow, Row] { 
+  private final class Impl(val _path: List[Path])
+    extends Relation[PViewFields, PViewRow] {
   
-    override val fields: PViewFields[Row] = new PViewFields[Row] {
-      override val id = new Field[BusinessentityId, Row](prefix, "id", None, None)(x => extract(x).id, (row, value) => merge(row, extract(row).copy(id = value)))
-      override val businessentityid = new Field[BusinessentityId, Row](prefix, "businessentityid", None, None)(x => extract(x).businessentityid, (row, value) => merge(row, extract(row).copy(businessentityid = value)))
-      override val persontype = new Field[/* bpchar, max 2 chars */ String, Row](prefix, "persontype", None, None)(x => extract(x).persontype, (row, value) => merge(row, extract(row).copy(persontype = value)))
-      override val namestyle = new Field[NameStyle, Row](prefix, "namestyle", None, None)(x => extract(x).namestyle, (row, value) => merge(row, extract(row).copy(namestyle = value)))
-      override val title = new OptField[/* max 8 chars */ String, Row](prefix, "title", None, None)(x => extract(x).title, (row, value) => merge(row, extract(row).copy(title = value)))
-      override val firstname = new Field[/* user-picked */ FirstName, Row](prefix, "firstname", None, None)(x => extract(x).firstname, (row, value) => merge(row, extract(row).copy(firstname = value)))
-      override val middlename = new OptField[Name, Row](prefix, "middlename", None, None)(x => extract(x).middlename, (row, value) => merge(row, extract(row).copy(middlename = value)))
-      override val lastname = new Field[Name, Row](prefix, "lastname", None, None)(x => extract(x).lastname, (row, value) => merge(row, extract(row).copy(lastname = value)))
-      override val suffix = new OptField[/* max 10 chars */ String, Row](prefix, "suffix", None, None)(x => extract(x).suffix, (row, value) => merge(row, extract(row).copy(suffix = value)))
-      override val emailpromotion = new Field[Int, Row](prefix, "emailpromotion", None, None)(x => extract(x).emailpromotion, (row, value) => merge(row, extract(row).copy(emailpromotion = value)))
-      override val additionalcontactinfo = new OptField[TypoXml, Row](prefix, "additionalcontactinfo", None, None)(x => extract(x).additionalcontactinfo, (row, value) => merge(row, extract(row).copy(additionalcontactinfo = value)))
-      override val demographics = new OptField[TypoXml, Row](prefix, "demographics", None, None)(x => extract(x).demographics, (row, value) => merge(row, extract(row).copy(demographics = value)))
-      override val rowguid = new Field[TypoUUID, Row](prefix, "rowguid", None, None)(x => extract(x).rowguid, (row, value) => merge(row, extract(row).copy(rowguid = value)))
-      override val modifieddate = new Field[TypoLocalDateTime, Row](prefix, "modifieddate", Some("text"), None)(x => extract(x).modifieddate, (row, value) => merge(row, extract(row).copy(modifieddate = value)))
+    override lazy val fields: PViewFields = new PViewFields {
+      override def id = Field[BusinessentityId, PViewRow](_path, "id", None, None, x => x.id, (row, value) => row.copy(id = value))
+      override def businessentityid = Field[BusinessentityId, PViewRow](_path, "businessentityid", None, None, x => x.businessentityid, (row, value) => row.copy(businessentityid = value))
+      override def persontype = Field[/* bpchar, max 2 chars */ String, PViewRow](_path, "persontype", None, None, x => x.persontype, (row, value) => row.copy(persontype = value))
+      override def namestyle = Field[NameStyle, PViewRow](_path, "namestyle", None, None, x => x.namestyle, (row, value) => row.copy(namestyle = value))
+      override def title = OptField[/* max 8 chars */ String, PViewRow](_path, "title", None, None, x => x.title, (row, value) => row.copy(title = value))
+      override def firstname = Field[/* user-picked */ FirstName, PViewRow](_path, "firstname", None, None, x => x.firstname, (row, value) => row.copy(firstname = value))
+      override def middlename = OptField[Name, PViewRow](_path, "middlename", None, None, x => x.middlename, (row, value) => row.copy(middlename = value))
+      override def lastname = Field[Name, PViewRow](_path, "lastname", None, None, x => x.lastname, (row, value) => row.copy(lastname = value))
+      override def suffix = OptField[/* max 10 chars */ String, PViewRow](_path, "suffix", None, None, x => x.suffix, (row, value) => row.copy(suffix = value))
+      override def emailpromotion = Field[Int, PViewRow](_path, "emailpromotion", None, None, x => x.emailpromotion, (row, value) => row.copy(emailpromotion = value))
+      override def additionalcontactinfo = OptField[TypoXml, PViewRow](_path, "additionalcontactinfo", None, None, x => x.additionalcontactinfo, (row, value) => row.copy(additionalcontactinfo = value))
+      override def demographics = OptField[TypoXml, PViewRow](_path, "demographics", None, None, x => x.demographics, (row, value) => row.copy(demographics = value))
+      override def rowguid = Field[TypoUUID, PViewRow](_path, "rowguid", None, None, x => x.rowguid, (row, value) => row.copy(rowguid = value))
+      override def modifieddate = Field[TypoLocalDateTime, PViewRow](_path, "modifieddate", Some("text"), None, x => x.modifieddate, (row, value) => row.copy(modifieddate = value))
     }
   
-    override val columns: List[FieldLikeNoHkt[?, Row]] =
-      List[FieldLikeNoHkt[?, Row]](fields.id, fields.businessentityid, fields.persontype, fields.namestyle, fields.title, fields.firstname, fields.middlename, fields.lastname, fields.suffix, fields.emailpromotion, fields.additionalcontactinfo, fields.demographics, fields.rowguid, fields.modifieddate)
+    override lazy val columns: List[FieldLikeNoHkt[?, PViewRow]] =
+      List[FieldLikeNoHkt[?, PViewRow]](fields.id, fields.businessentityid, fields.persontype, fields.namestyle, fields.title, fields.firstname, fields.middlename, fields.lastname, fields.suffix, fields.emailpromotion, fields.additionalcontactinfo, fields.demographics, fields.rowguid, fields.modifieddate)
   
-    override def copy[NewRow](prefix: Option[String], extract: NewRow => PViewRow, merge: (NewRow, PViewRow) => NewRow): Impl[NewRow] =
-      new Impl(prefix, extract, merge)
+    override def copy(path: List[Path]): Impl =
+      new Impl(path)
   }
   
 }

--- a/typo-tester-doobie/generated-and-checked-in/adventureworks/pe/pa/PaViewFields.scala
+++ b/typo-tester-doobie/generated-and-checked-in/adventureworks/pe/pa/PaViewFields.scala
@@ -10,40 +10,41 @@ package pa
 import adventureworks.customtypes.TypoLocalDateTime
 import adventureworks.customtypes.TypoUUID
 import adventureworks.person.businessentity.BusinessentityId
+import typo.dsl.Path
 import typo.dsl.SqlExpr.Field
 import typo.dsl.SqlExpr.FieldLikeNoHkt
 import typo.dsl.Structure.Relation
 
-trait PaViewFields[Row] {
-  val id: Field[BusinessentityId, Row]
-  val businessentityid: Field[BusinessentityId, Row]
-  val passwordhash: Field[/* max 128 chars */ String, Row]
-  val passwordsalt: Field[/* max 10 chars */ String, Row]
-  val rowguid: Field[TypoUUID, Row]
-  val modifieddate: Field[TypoLocalDateTime, Row]
+trait PaViewFields {
+  def id: Field[BusinessentityId, PaViewRow]
+  def businessentityid: Field[BusinessentityId, PaViewRow]
+  def passwordhash: Field[/* max 128 chars */ String, PaViewRow]
+  def passwordsalt: Field[/* max 10 chars */ String, PaViewRow]
+  def rowguid: Field[TypoUUID, PaViewRow]
+  def modifieddate: Field[TypoLocalDateTime, PaViewRow]
 }
 
 object PaViewFields {
-  val structure: Relation[PaViewFields, PaViewRow, PaViewRow] = 
-    new Impl(None, identity, (_, x) => x)
+  lazy val structure: Relation[PaViewFields, PaViewRow] =
+    new Impl(Nil)
     
-  private final class Impl[Row](val prefix: Option[String], val extract: Row => PaViewRow, val merge: (Row, PaViewRow) => Row)
-    extends Relation[PaViewFields, PaViewRow, Row] { 
+  private final class Impl(val _path: List[Path])
+    extends Relation[PaViewFields, PaViewRow] {
   
-    override val fields: PaViewFields[Row] = new PaViewFields[Row] {
-      override val id = new Field[BusinessentityId, Row](prefix, "id", None, None)(x => extract(x).id, (row, value) => merge(row, extract(row).copy(id = value)))
-      override val businessentityid = new Field[BusinessentityId, Row](prefix, "businessentityid", None, None)(x => extract(x).businessentityid, (row, value) => merge(row, extract(row).copy(businessentityid = value)))
-      override val passwordhash = new Field[/* max 128 chars */ String, Row](prefix, "passwordhash", None, None)(x => extract(x).passwordhash, (row, value) => merge(row, extract(row).copy(passwordhash = value)))
-      override val passwordsalt = new Field[/* max 10 chars */ String, Row](prefix, "passwordsalt", None, None)(x => extract(x).passwordsalt, (row, value) => merge(row, extract(row).copy(passwordsalt = value)))
-      override val rowguid = new Field[TypoUUID, Row](prefix, "rowguid", None, None)(x => extract(x).rowguid, (row, value) => merge(row, extract(row).copy(rowguid = value)))
-      override val modifieddate = new Field[TypoLocalDateTime, Row](prefix, "modifieddate", Some("text"), None)(x => extract(x).modifieddate, (row, value) => merge(row, extract(row).copy(modifieddate = value)))
+    override lazy val fields: PaViewFields = new PaViewFields {
+      override def id = Field[BusinessentityId, PaViewRow](_path, "id", None, None, x => x.id, (row, value) => row.copy(id = value))
+      override def businessentityid = Field[BusinessentityId, PaViewRow](_path, "businessentityid", None, None, x => x.businessentityid, (row, value) => row.copy(businessentityid = value))
+      override def passwordhash = Field[/* max 128 chars */ String, PaViewRow](_path, "passwordhash", None, None, x => x.passwordhash, (row, value) => row.copy(passwordhash = value))
+      override def passwordsalt = Field[/* max 10 chars */ String, PaViewRow](_path, "passwordsalt", None, None, x => x.passwordsalt, (row, value) => row.copy(passwordsalt = value))
+      override def rowguid = Field[TypoUUID, PaViewRow](_path, "rowguid", None, None, x => x.rowguid, (row, value) => row.copy(rowguid = value))
+      override def modifieddate = Field[TypoLocalDateTime, PaViewRow](_path, "modifieddate", Some("text"), None, x => x.modifieddate, (row, value) => row.copy(modifieddate = value))
     }
   
-    override val columns: List[FieldLikeNoHkt[?, Row]] =
-      List[FieldLikeNoHkt[?, Row]](fields.id, fields.businessentityid, fields.passwordhash, fields.passwordsalt, fields.rowguid, fields.modifieddate)
+    override lazy val columns: List[FieldLikeNoHkt[?, PaViewRow]] =
+      List[FieldLikeNoHkt[?, PaViewRow]](fields.id, fields.businessentityid, fields.passwordhash, fields.passwordsalt, fields.rowguid, fields.modifieddate)
   
-    override def copy[NewRow](prefix: Option[String], extract: NewRow => PaViewRow, merge: (NewRow, PaViewRow) => NewRow): Impl[NewRow] =
-      new Impl(prefix, extract, merge)
+    override def copy(path: List[Path]): Impl =
+      new Impl(path)
   }
   
 }

--- a/typo-tester-doobie/generated-and-checked-in/adventureworks/pe/pnt/PntViewFields.scala
+++ b/typo-tester-doobie/generated-and-checked-in/adventureworks/pe/pnt/PntViewFields.scala
@@ -10,36 +10,37 @@ package pnt
 import adventureworks.customtypes.TypoLocalDateTime
 import adventureworks.person.phonenumbertype.PhonenumbertypeId
 import adventureworks.public.Name
+import typo.dsl.Path
 import typo.dsl.SqlExpr.Field
 import typo.dsl.SqlExpr.FieldLikeNoHkt
 import typo.dsl.Structure.Relation
 
-trait PntViewFields[Row] {
-  val id: Field[PhonenumbertypeId, Row]
-  val phonenumbertypeid: Field[PhonenumbertypeId, Row]
-  val name: Field[Name, Row]
-  val modifieddate: Field[TypoLocalDateTime, Row]
+trait PntViewFields {
+  def id: Field[PhonenumbertypeId, PntViewRow]
+  def phonenumbertypeid: Field[PhonenumbertypeId, PntViewRow]
+  def name: Field[Name, PntViewRow]
+  def modifieddate: Field[TypoLocalDateTime, PntViewRow]
 }
 
 object PntViewFields {
-  val structure: Relation[PntViewFields, PntViewRow, PntViewRow] = 
-    new Impl(None, identity, (_, x) => x)
+  lazy val structure: Relation[PntViewFields, PntViewRow] =
+    new Impl(Nil)
     
-  private final class Impl[Row](val prefix: Option[String], val extract: Row => PntViewRow, val merge: (Row, PntViewRow) => Row)
-    extends Relation[PntViewFields, PntViewRow, Row] { 
+  private final class Impl(val _path: List[Path])
+    extends Relation[PntViewFields, PntViewRow] {
   
-    override val fields: PntViewFields[Row] = new PntViewFields[Row] {
-      override val id = new Field[PhonenumbertypeId, Row](prefix, "id", None, None)(x => extract(x).id, (row, value) => merge(row, extract(row).copy(id = value)))
-      override val phonenumbertypeid = new Field[PhonenumbertypeId, Row](prefix, "phonenumbertypeid", None, None)(x => extract(x).phonenumbertypeid, (row, value) => merge(row, extract(row).copy(phonenumbertypeid = value)))
-      override val name = new Field[Name, Row](prefix, "name", None, None)(x => extract(x).name, (row, value) => merge(row, extract(row).copy(name = value)))
-      override val modifieddate = new Field[TypoLocalDateTime, Row](prefix, "modifieddate", Some("text"), None)(x => extract(x).modifieddate, (row, value) => merge(row, extract(row).copy(modifieddate = value)))
+    override lazy val fields: PntViewFields = new PntViewFields {
+      override def id = Field[PhonenumbertypeId, PntViewRow](_path, "id", None, None, x => x.id, (row, value) => row.copy(id = value))
+      override def phonenumbertypeid = Field[PhonenumbertypeId, PntViewRow](_path, "phonenumbertypeid", None, None, x => x.phonenumbertypeid, (row, value) => row.copy(phonenumbertypeid = value))
+      override def name = Field[Name, PntViewRow](_path, "name", None, None, x => x.name, (row, value) => row.copy(name = value))
+      override def modifieddate = Field[TypoLocalDateTime, PntViewRow](_path, "modifieddate", Some("text"), None, x => x.modifieddate, (row, value) => row.copy(modifieddate = value))
     }
   
-    override val columns: List[FieldLikeNoHkt[?, Row]] =
-      List[FieldLikeNoHkt[?, Row]](fields.id, fields.phonenumbertypeid, fields.name, fields.modifieddate)
+    override lazy val columns: List[FieldLikeNoHkt[?, PntViewRow]] =
+      List[FieldLikeNoHkt[?, PntViewRow]](fields.id, fields.phonenumbertypeid, fields.name, fields.modifieddate)
   
-    override def copy[NewRow](prefix: Option[String], extract: NewRow => PntViewRow, merge: (NewRow, PntViewRow) => NewRow): Impl[NewRow] =
-      new Impl(prefix, extract, merge)
+    override def copy(path: List[Path]): Impl =
+      new Impl(path)
   }
   
 }

--- a/typo-tester-doobie/generated-and-checked-in/adventureworks/pe/pp/PpViewFields.scala
+++ b/typo-tester-doobie/generated-and-checked-in/adventureworks/pe/pp/PpViewFields.scala
@@ -11,38 +11,39 @@ import adventureworks.customtypes.TypoLocalDateTime
 import adventureworks.person.businessentity.BusinessentityId
 import adventureworks.person.phonenumbertype.PhonenumbertypeId
 import adventureworks.public.Phone
+import typo.dsl.Path
 import typo.dsl.SqlExpr.Field
 import typo.dsl.SqlExpr.FieldLikeNoHkt
 import typo.dsl.Structure.Relation
 
-trait PpViewFields[Row] {
-  val id: Field[BusinessentityId, Row]
-  val businessentityid: Field[BusinessentityId, Row]
-  val phonenumber: Field[Phone, Row]
-  val phonenumbertypeid: Field[PhonenumbertypeId, Row]
-  val modifieddate: Field[TypoLocalDateTime, Row]
+trait PpViewFields {
+  def id: Field[BusinessentityId, PpViewRow]
+  def businessentityid: Field[BusinessentityId, PpViewRow]
+  def phonenumber: Field[Phone, PpViewRow]
+  def phonenumbertypeid: Field[PhonenumbertypeId, PpViewRow]
+  def modifieddate: Field[TypoLocalDateTime, PpViewRow]
 }
 
 object PpViewFields {
-  val structure: Relation[PpViewFields, PpViewRow, PpViewRow] = 
-    new Impl(None, identity, (_, x) => x)
+  lazy val structure: Relation[PpViewFields, PpViewRow] =
+    new Impl(Nil)
     
-  private final class Impl[Row](val prefix: Option[String], val extract: Row => PpViewRow, val merge: (Row, PpViewRow) => Row)
-    extends Relation[PpViewFields, PpViewRow, Row] { 
+  private final class Impl(val _path: List[Path])
+    extends Relation[PpViewFields, PpViewRow] {
   
-    override val fields: PpViewFields[Row] = new PpViewFields[Row] {
-      override val id = new Field[BusinessentityId, Row](prefix, "id", None, None)(x => extract(x).id, (row, value) => merge(row, extract(row).copy(id = value)))
-      override val businessentityid = new Field[BusinessentityId, Row](prefix, "businessentityid", None, None)(x => extract(x).businessentityid, (row, value) => merge(row, extract(row).copy(businessentityid = value)))
-      override val phonenumber = new Field[Phone, Row](prefix, "phonenumber", None, None)(x => extract(x).phonenumber, (row, value) => merge(row, extract(row).copy(phonenumber = value)))
-      override val phonenumbertypeid = new Field[PhonenumbertypeId, Row](prefix, "phonenumbertypeid", None, None)(x => extract(x).phonenumbertypeid, (row, value) => merge(row, extract(row).copy(phonenumbertypeid = value)))
-      override val modifieddate = new Field[TypoLocalDateTime, Row](prefix, "modifieddate", Some("text"), None)(x => extract(x).modifieddate, (row, value) => merge(row, extract(row).copy(modifieddate = value)))
+    override lazy val fields: PpViewFields = new PpViewFields {
+      override def id = Field[BusinessentityId, PpViewRow](_path, "id", None, None, x => x.id, (row, value) => row.copy(id = value))
+      override def businessentityid = Field[BusinessentityId, PpViewRow](_path, "businessentityid", None, None, x => x.businessentityid, (row, value) => row.copy(businessentityid = value))
+      override def phonenumber = Field[Phone, PpViewRow](_path, "phonenumber", None, None, x => x.phonenumber, (row, value) => row.copy(phonenumber = value))
+      override def phonenumbertypeid = Field[PhonenumbertypeId, PpViewRow](_path, "phonenumbertypeid", None, None, x => x.phonenumbertypeid, (row, value) => row.copy(phonenumbertypeid = value))
+      override def modifieddate = Field[TypoLocalDateTime, PpViewRow](_path, "modifieddate", Some("text"), None, x => x.modifieddate, (row, value) => row.copy(modifieddate = value))
     }
   
-    override val columns: List[FieldLikeNoHkt[?, Row]] =
-      List[FieldLikeNoHkt[?, Row]](fields.id, fields.businessentityid, fields.phonenumber, fields.phonenumbertypeid, fields.modifieddate)
+    override lazy val columns: List[FieldLikeNoHkt[?, PpViewRow]] =
+      List[FieldLikeNoHkt[?, PpViewRow]](fields.id, fields.businessentityid, fields.phonenumber, fields.phonenumbertypeid, fields.modifieddate)
   
-    override def copy[NewRow](prefix: Option[String], extract: NewRow => PpViewRow, merge: (NewRow, PpViewRow) => NewRow): Impl[NewRow] =
-      new Impl(prefix, extract, merge)
+    override def copy(path: List[Path]): Impl =
+      new Impl(path)
   }
   
 }

--- a/typo-tester-doobie/generated-and-checked-in/adventureworks/pe/sp/SpViewFields.scala
+++ b/typo-tester-doobie/generated-and-checked-in/adventureworks/pe/sp/SpViewFields.scala
@@ -14,46 +14,47 @@ import adventureworks.person.stateprovince.StateprovinceId
 import adventureworks.public.Flag
 import adventureworks.public.Name
 import adventureworks.sales.salesterritory.SalesterritoryId
+import typo.dsl.Path
 import typo.dsl.SqlExpr.Field
 import typo.dsl.SqlExpr.FieldLikeNoHkt
 import typo.dsl.Structure.Relation
 
-trait SpViewFields[Row] {
-  val id: Field[StateprovinceId, Row]
-  val stateprovinceid: Field[StateprovinceId, Row]
-  val stateprovincecode: Field[/* bpchar, max 3 chars */ String, Row]
-  val countryregioncode: Field[CountryregionId, Row]
-  val isonlystateprovinceflag: Field[Flag, Row]
-  val name: Field[Name, Row]
-  val territoryid: Field[SalesterritoryId, Row]
-  val rowguid: Field[TypoUUID, Row]
-  val modifieddate: Field[TypoLocalDateTime, Row]
+trait SpViewFields {
+  def id: Field[StateprovinceId, SpViewRow]
+  def stateprovinceid: Field[StateprovinceId, SpViewRow]
+  def stateprovincecode: Field[/* bpchar, max 3 chars */ String, SpViewRow]
+  def countryregioncode: Field[CountryregionId, SpViewRow]
+  def isonlystateprovinceflag: Field[Flag, SpViewRow]
+  def name: Field[Name, SpViewRow]
+  def territoryid: Field[SalesterritoryId, SpViewRow]
+  def rowguid: Field[TypoUUID, SpViewRow]
+  def modifieddate: Field[TypoLocalDateTime, SpViewRow]
 }
 
 object SpViewFields {
-  val structure: Relation[SpViewFields, SpViewRow, SpViewRow] = 
-    new Impl(None, identity, (_, x) => x)
+  lazy val structure: Relation[SpViewFields, SpViewRow] =
+    new Impl(Nil)
     
-  private final class Impl[Row](val prefix: Option[String], val extract: Row => SpViewRow, val merge: (Row, SpViewRow) => Row)
-    extends Relation[SpViewFields, SpViewRow, Row] { 
+  private final class Impl(val _path: List[Path])
+    extends Relation[SpViewFields, SpViewRow] {
   
-    override val fields: SpViewFields[Row] = new SpViewFields[Row] {
-      override val id = new Field[StateprovinceId, Row](prefix, "id", None, None)(x => extract(x).id, (row, value) => merge(row, extract(row).copy(id = value)))
-      override val stateprovinceid = new Field[StateprovinceId, Row](prefix, "stateprovinceid", None, None)(x => extract(x).stateprovinceid, (row, value) => merge(row, extract(row).copy(stateprovinceid = value)))
-      override val stateprovincecode = new Field[/* bpchar, max 3 chars */ String, Row](prefix, "stateprovincecode", None, None)(x => extract(x).stateprovincecode, (row, value) => merge(row, extract(row).copy(stateprovincecode = value)))
-      override val countryregioncode = new Field[CountryregionId, Row](prefix, "countryregioncode", None, None)(x => extract(x).countryregioncode, (row, value) => merge(row, extract(row).copy(countryregioncode = value)))
-      override val isonlystateprovinceflag = new Field[Flag, Row](prefix, "isonlystateprovinceflag", None, None)(x => extract(x).isonlystateprovinceflag, (row, value) => merge(row, extract(row).copy(isonlystateprovinceflag = value)))
-      override val name = new Field[Name, Row](prefix, "name", None, None)(x => extract(x).name, (row, value) => merge(row, extract(row).copy(name = value)))
-      override val territoryid = new Field[SalesterritoryId, Row](prefix, "territoryid", None, None)(x => extract(x).territoryid, (row, value) => merge(row, extract(row).copy(territoryid = value)))
-      override val rowguid = new Field[TypoUUID, Row](prefix, "rowguid", None, None)(x => extract(x).rowguid, (row, value) => merge(row, extract(row).copy(rowguid = value)))
-      override val modifieddate = new Field[TypoLocalDateTime, Row](prefix, "modifieddate", Some("text"), None)(x => extract(x).modifieddate, (row, value) => merge(row, extract(row).copy(modifieddate = value)))
+    override lazy val fields: SpViewFields = new SpViewFields {
+      override def id = Field[StateprovinceId, SpViewRow](_path, "id", None, None, x => x.id, (row, value) => row.copy(id = value))
+      override def stateprovinceid = Field[StateprovinceId, SpViewRow](_path, "stateprovinceid", None, None, x => x.stateprovinceid, (row, value) => row.copy(stateprovinceid = value))
+      override def stateprovincecode = Field[/* bpchar, max 3 chars */ String, SpViewRow](_path, "stateprovincecode", None, None, x => x.stateprovincecode, (row, value) => row.copy(stateprovincecode = value))
+      override def countryregioncode = Field[CountryregionId, SpViewRow](_path, "countryregioncode", None, None, x => x.countryregioncode, (row, value) => row.copy(countryregioncode = value))
+      override def isonlystateprovinceflag = Field[Flag, SpViewRow](_path, "isonlystateprovinceflag", None, None, x => x.isonlystateprovinceflag, (row, value) => row.copy(isonlystateprovinceflag = value))
+      override def name = Field[Name, SpViewRow](_path, "name", None, None, x => x.name, (row, value) => row.copy(name = value))
+      override def territoryid = Field[SalesterritoryId, SpViewRow](_path, "territoryid", None, None, x => x.territoryid, (row, value) => row.copy(territoryid = value))
+      override def rowguid = Field[TypoUUID, SpViewRow](_path, "rowguid", None, None, x => x.rowguid, (row, value) => row.copy(rowguid = value))
+      override def modifieddate = Field[TypoLocalDateTime, SpViewRow](_path, "modifieddate", Some("text"), None, x => x.modifieddate, (row, value) => row.copy(modifieddate = value))
     }
   
-    override val columns: List[FieldLikeNoHkt[?, Row]] =
-      List[FieldLikeNoHkt[?, Row]](fields.id, fields.stateprovinceid, fields.stateprovincecode, fields.countryregioncode, fields.isonlystateprovinceflag, fields.name, fields.territoryid, fields.rowguid, fields.modifieddate)
+    override lazy val columns: List[FieldLikeNoHkt[?, SpViewRow]] =
+      List[FieldLikeNoHkt[?, SpViewRow]](fields.id, fields.stateprovinceid, fields.stateprovincecode, fields.countryregioncode, fields.isonlystateprovinceflag, fields.name, fields.territoryid, fields.rowguid, fields.modifieddate)
   
-    override def copy[NewRow](prefix: Option[String], extract: NewRow => SpViewRow, merge: (NewRow, SpViewRow) => NewRow): Impl[NewRow] =
-      new Impl(prefix, extract, merge)
+    override def copy(path: List[Path]): Impl =
+      new Impl(path)
   }
   
 }

--- a/typo-tester-doobie/generated-and-checked-in/adventureworks/person/address/AddressFields.scala
+++ b/typo-tester-doobie/generated-and-checked-in/adventureworks/person/address/AddressFields.scala
@@ -11,48 +11,49 @@ import adventureworks.customtypes.TypoBytea
 import adventureworks.customtypes.TypoLocalDateTime
 import adventureworks.customtypes.TypoUUID
 import adventureworks.person.stateprovince.StateprovinceId
+import typo.dsl.Path
 import typo.dsl.SqlExpr.Field
 import typo.dsl.SqlExpr.FieldLikeNoHkt
 import typo.dsl.SqlExpr.IdField
 import typo.dsl.SqlExpr.OptField
 import typo.dsl.Structure.Relation
 
-trait AddressFields[Row] {
-  val addressid: IdField[AddressId, Row]
-  val addressline1: Field[/* max 60 chars */ String, Row]
-  val addressline2: OptField[/* max 60 chars */ String, Row]
-  val city: Field[/* max 30 chars */ String, Row]
-  val stateprovinceid: Field[StateprovinceId, Row]
-  val postalcode: Field[/* max 15 chars */ String, Row]
-  val spatiallocation: OptField[TypoBytea, Row]
-  val rowguid: Field[TypoUUID, Row]
-  val modifieddate: Field[TypoLocalDateTime, Row]
+trait AddressFields {
+  def addressid: IdField[AddressId, AddressRow]
+  def addressline1: Field[/* max 60 chars */ String, AddressRow]
+  def addressline2: OptField[/* max 60 chars */ String, AddressRow]
+  def city: Field[/* max 30 chars */ String, AddressRow]
+  def stateprovinceid: Field[StateprovinceId, AddressRow]
+  def postalcode: Field[/* max 15 chars */ String, AddressRow]
+  def spatiallocation: OptField[TypoBytea, AddressRow]
+  def rowguid: Field[TypoUUID, AddressRow]
+  def modifieddate: Field[TypoLocalDateTime, AddressRow]
 }
 
 object AddressFields {
-  val structure: Relation[AddressFields, AddressRow, AddressRow] = 
-    new Impl(None, identity, (_, x) => x)
+  lazy val structure: Relation[AddressFields, AddressRow] =
+    new Impl(Nil)
     
-  private final class Impl[Row](val prefix: Option[String], val extract: Row => AddressRow, val merge: (Row, AddressRow) => Row)
-    extends Relation[AddressFields, AddressRow, Row] { 
+  private final class Impl(val _path: List[Path])
+    extends Relation[AddressFields, AddressRow] {
   
-    override val fields: AddressFields[Row] = new AddressFields[Row] {
-      override val addressid = new IdField[AddressId, Row](prefix, "addressid", None, Some("int4"))(x => extract(x).addressid, (row, value) => merge(row, extract(row).copy(addressid = value)))
-      override val addressline1 = new Field[/* max 60 chars */ String, Row](prefix, "addressline1", None, None)(x => extract(x).addressline1, (row, value) => merge(row, extract(row).copy(addressline1 = value)))
-      override val addressline2 = new OptField[/* max 60 chars */ String, Row](prefix, "addressline2", None, None)(x => extract(x).addressline2, (row, value) => merge(row, extract(row).copy(addressline2 = value)))
-      override val city = new Field[/* max 30 chars */ String, Row](prefix, "city", None, None)(x => extract(x).city, (row, value) => merge(row, extract(row).copy(city = value)))
-      override val stateprovinceid = new Field[StateprovinceId, Row](prefix, "stateprovinceid", None, Some("int4"))(x => extract(x).stateprovinceid, (row, value) => merge(row, extract(row).copy(stateprovinceid = value)))
-      override val postalcode = new Field[/* max 15 chars */ String, Row](prefix, "postalcode", None, None)(x => extract(x).postalcode, (row, value) => merge(row, extract(row).copy(postalcode = value)))
-      override val spatiallocation = new OptField[TypoBytea, Row](prefix, "spatiallocation", None, Some("bytea"))(x => extract(x).spatiallocation, (row, value) => merge(row, extract(row).copy(spatiallocation = value)))
-      override val rowguid = new Field[TypoUUID, Row](prefix, "rowguid", None, Some("uuid"))(x => extract(x).rowguid, (row, value) => merge(row, extract(row).copy(rowguid = value)))
-      override val modifieddate = new Field[TypoLocalDateTime, Row](prefix, "modifieddate", Some("text"), Some("timestamp"))(x => extract(x).modifieddate, (row, value) => merge(row, extract(row).copy(modifieddate = value)))
+    override lazy val fields: AddressFields = new AddressFields {
+      override def addressid = IdField[AddressId, AddressRow](_path, "addressid", None, Some("int4"), x => x.addressid, (row, value) => row.copy(addressid = value))
+      override def addressline1 = Field[/* max 60 chars */ String, AddressRow](_path, "addressline1", None, None, x => x.addressline1, (row, value) => row.copy(addressline1 = value))
+      override def addressline2 = OptField[/* max 60 chars */ String, AddressRow](_path, "addressline2", None, None, x => x.addressline2, (row, value) => row.copy(addressline2 = value))
+      override def city = Field[/* max 30 chars */ String, AddressRow](_path, "city", None, None, x => x.city, (row, value) => row.copy(city = value))
+      override def stateprovinceid = Field[StateprovinceId, AddressRow](_path, "stateprovinceid", None, Some("int4"), x => x.stateprovinceid, (row, value) => row.copy(stateprovinceid = value))
+      override def postalcode = Field[/* max 15 chars */ String, AddressRow](_path, "postalcode", None, None, x => x.postalcode, (row, value) => row.copy(postalcode = value))
+      override def spatiallocation = OptField[TypoBytea, AddressRow](_path, "spatiallocation", None, Some("bytea"), x => x.spatiallocation, (row, value) => row.copy(spatiallocation = value))
+      override def rowguid = Field[TypoUUID, AddressRow](_path, "rowguid", None, Some("uuid"), x => x.rowguid, (row, value) => row.copy(rowguid = value))
+      override def modifieddate = Field[TypoLocalDateTime, AddressRow](_path, "modifieddate", Some("text"), Some("timestamp"), x => x.modifieddate, (row, value) => row.copy(modifieddate = value))
     }
   
-    override val columns: List[FieldLikeNoHkt[?, Row]] =
-      List[FieldLikeNoHkt[?, Row]](fields.addressid, fields.addressline1, fields.addressline2, fields.city, fields.stateprovinceid, fields.postalcode, fields.spatiallocation, fields.rowguid, fields.modifieddate)
+    override lazy val columns: List[FieldLikeNoHkt[?, AddressRow]] =
+      List[FieldLikeNoHkt[?, AddressRow]](fields.addressid, fields.addressline1, fields.addressline2, fields.city, fields.stateprovinceid, fields.postalcode, fields.spatiallocation, fields.rowguid, fields.modifieddate)
   
-    override def copy[NewRow](prefix: Option[String], extract: NewRow => AddressRow, merge: (NewRow, AddressRow) => NewRow): Impl[NewRow] =
-      new Impl(prefix, extract, merge)
+    override def copy(path: List[Path]): Impl =
+      new Impl(path)
   }
   
 }

--- a/typo-tester-doobie/generated-and-checked-in/adventureworks/person/address/AddressRepoMock.scala
+++ b/typo-tester-doobie/generated-and-checked-in/adventureworks/person/address/AddressRepoMock.scala
@@ -24,7 +24,7 @@ import typo.dsl.UpdateParams
 class AddressRepoMock(toRow: Function1[AddressRowUnsaved, AddressRow],
                       map: scala.collection.mutable.Map[AddressId, AddressRow] = scala.collection.mutable.Map.empty) extends AddressRepo {
   override def delete: DeleteBuilder[AddressFields, AddressRow] = {
-    DeleteBuilderMock(DeleteParams.empty, AddressFields.structure.fields, map)
+    DeleteBuilderMock(DeleteParams.empty, AddressFields.structure, map)
   }
   override def deleteById(addressid: AddressId): ConnectionIO[Boolean] = {
     delay(map.remove(addressid).isDefined)
@@ -86,7 +86,7 @@ class AddressRepoMock(toRow: Function1[AddressRowUnsaved, AddressRow],
     }
   }
   override def update: UpdateBuilder[AddressFields, AddressRow] = {
-    UpdateBuilderMock(UpdateParams.empty, AddressFields.structure.fields, map)
+    UpdateBuilderMock(UpdateParams.empty, AddressFields.structure, map)
   }
   override def update(row: AddressRow): ConnectionIO[Boolean] = {
     delay {

--- a/typo-tester-doobie/generated-and-checked-in/adventureworks/person/addresstype/AddresstypeFields.scala
+++ b/typo-tester-doobie/generated-and-checked-in/adventureworks/person/addresstype/AddresstypeFields.scala
@@ -10,37 +10,38 @@ package addresstype
 import adventureworks.customtypes.TypoLocalDateTime
 import adventureworks.customtypes.TypoUUID
 import adventureworks.public.Name
+import typo.dsl.Path
 import typo.dsl.SqlExpr.Field
 import typo.dsl.SqlExpr.FieldLikeNoHkt
 import typo.dsl.SqlExpr.IdField
 import typo.dsl.Structure.Relation
 
-trait AddresstypeFields[Row] {
-  val addresstypeid: IdField[AddresstypeId, Row]
-  val name: Field[Name, Row]
-  val rowguid: Field[TypoUUID, Row]
-  val modifieddate: Field[TypoLocalDateTime, Row]
+trait AddresstypeFields {
+  def addresstypeid: IdField[AddresstypeId, AddresstypeRow]
+  def name: Field[Name, AddresstypeRow]
+  def rowguid: Field[TypoUUID, AddresstypeRow]
+  def modifieddate: Field[TypoLocalDateTime, AddresstypeRow]
 }
 
 object AddresstypeFields {
-  val structure: Relation[AddresstypeFields, AddresstypeRow, AddresstypeRow] = 
-    new Impl(None, identity, (_, x) => x)
+  lazy val structure: Relation[AddresstypeFields, AddresstypeRow] =
+    new Impl(Nil)
     
-  private final class Impl[Row](val prefix: Option[String], val extract: Row => AddresstypeRow, val merge: (Row, AddresstypeRow) => Row)
-    extends Relation[AddresstypeFields, AddresstypeRow, Row] { 
+  private final class Impl(val _path: List[Path])
+    extends Relation[AddresstypeFields, AddresstypeRow] {
   
-    override val fields: AddresstypeFields[Row] = new AddresstypeFields[Row] {
-      override val addresstypeid = new IdField[AddresstypeId, Row](prefix, "addresstypeid", None, Some("int4"))(x => extract(x).addresstypeid, (row, value) => merge(row, extract(row).copy(addresstypeid = value)))
-      override val name = new Field[Name, Row](prefix, "name", None, Some("varchar"))(x => extract(x).name, (row, value) => merge(row, extract(row).copy(name = value)))
-      override val rowguid = new Field[TypoUUID, Row](prefix, "rowguid", None, Some("uuid"))(x => extract(x).rowguid, (row, value) => merge(row, extract(row).copy(rowguid = value)))
-      override val modifieddate = new Field[TypoLocalDateTime, Row](prefix, "modifieddate", Some("text"), Some("timestamp"))(x => extract(x).modifieddate, (row, value) => merge(row, extract(row).copy(modifieddate = value)))
+    override lazy val fields: AddresstypeFields = new AddresstypeFields {
+      override def addresstypeid = IdField[AddresstypeId, AddresstypeRow](_path, "addresstypeid", None, Some("int4"), x => x.addresstypeid, (row, value) => row.copy(addresstypeid = value))
+      override def name = Field[Name, AddresstypeRow](_path, "name", None, Some("varchar"), x => x.name, (row, value) => row.copy(name = value))
+      override def rowguid = Field[TypoUUID, AddresstypeRow](_path, "rowguid", None, Some("uuid"), x => x.rowguid, (row, value) => row.copy(rowguid = value))
+      override def modifieddate = Field[TypoLocalDateTime, AddresstypeRow](_path, "modifieddate", Some("text"), Some("timestamp"), x => x.modifieddate, (row, value) => row.copy(modifieddate = value))
     }
   
-    override val columns: List[FieldLikeNoHkt[?, Row]] =
-      List[FieldLikeNoHkt[?, Row]](fields.addresstypeid, fields.name, fields.rowguid, fields.modifieddate)
+    override lazy val columns: List[FieldLikeNoHkt[?, AddresstypeRow]] =
+      List[FieldLikeNoHkt[?, AddresstypeRow]](fields.addresstypeid, fields.name, fields.rowguid, fields.modifieddate)
   
-    override def copy[NewRow](prefix: Option[String], extract: NewRow => AddresstypeRow, merge: (NewRow, AddresstypeRow) => NewRow): Impl[NewRow] =
-      new Impl(prefix, extract, merge)
+    override def copy(path: List[Path]): Impl =
+      new Impl(path)
   }
   
 }

--- a/typo-tester-doobie/generated-and-checked-in/adventureworks/person/addresstype/AddresstypeRepoMock.scala
+++ b/typo-tester-doobie/generated-and-checked-in/adventureworks/person/addresstype/AddresstypeRepoMock.scala
@@ -24,7 +24,7 @@ import typo.dsl.UpdateParams
 class AddresstypeRepoMock(toRow: Function1[AddresstypeRowUnsaved, AddresstypeRow],
                           map: scala.collection.mutable.Map[AddresstypeId, AddresstypeRow] = scala.collection.mutable.Map.empty) extends AddresstypeRepo {
   override def delete: DeleteBuilder[AddresstypeFields, AddresstypeRow] = {
-    DeleteBuilderMock(DeleteParams.empty, AddresstypeFields.structure.fields, map)
+    DeleteBuilderMock(DeleteParams.empty, AddresstypeFields.structure, map)
   }
   override def deleteById(addresstypeid: AddresstypeId): ConnectionIO[Boolean] = {
     delay(map.remove(addresstypeid).isDefined)
@@ -86,7 +86,7 @@ class AddresstypeRepoMock(toRow: Function1[AddresstypeRowUnsaved, AddresstypeRow
     }
   }
   override def update: UpdateBuilder[AddresstypeFields, AddresstypeRow] = {
-    UpdateBuilderMock(UpdateParams.empty, AddresstypeFields.structure.fields, map)
+    UpdateBuilderMock(UpdateParams.empty, AddresstypeFields.structure, map)
   }
   override def update(row: AddresstypeRow): ConnectionIO[Boolean] = {
     delay {

--- a/typo-tester-doobie/generated-and-checked-in/adventureworks/person/businessentity/BusinessentityRepoMock.scala
+++ b/typo-tester-doobie/generated-and-checked-in/adventureworks/person/businessentity/BusinessentityRepoMock.scala
@@ -24,7 +24,7 @@ import typo.dsl.UpdateParams
 class BusinessentityRepoMock(toRow: Function1[BusinessentityRowUnsaved, BusinessentityRow],
                              map: scala.collection.mutable.Map[BusinessentityId, BusinessentityRow] = scala.collection.mutable.Map.empty) extends BusinessentityRepo {
   override def delete: DeleteBuilder[BusinessentityFields, BusinessentityRow] = {
-    DeleteBuilderMock(DeleteParams.empty, BusinessentityFields.structure.fields, map)
+    DeleteBuilderMock(DeleteParams.empty, BusinessentityFields.structure, map)
   }
   override def deleteById(businessentityid: BusinessentityId): ConnectionIO[Boolean] = {
     delay(map.remove(businessentityid).isDefined)
@@ -86,7 +86,7 @@ class BusinessentityRepoMock(toRow: Function1[BusinessentityRowUnsaved, Business
     }
   }
   override def update: UpdateBuilder[BusinessentityFields, BusinessentityRow] = {
-    UpdateBuilderMock(UpdateParams.empty, BusinessentityFields.structure.fields, map)
+    UpdateBuilderMock(UpdateParams.empty, BusinessentityFields.structure, map)
   }
   override def update(row: BusinessentityRow): ConnectionIO[Boolean] = {
     delay {

--- a/typo-tester-doobie/generated-and-checked-in/adventureworks/person/businessentityaddress/BusinessentityaddressFields.scala
+++ b/typo-tester-doobie/generated-and-checked-in/adventureworks/person/businessentityaddress/BusinessentityaddressFields.scala
@@ -12,39 +12,40 @@ import adventureworks.customtypes.TypoUUID
 import adventureworks.person.address.AddressId
 import adventureworks.person.addresstype.AddresstypeId
 import adventureworks.person.businessentity.BusinessentityId
+import typo.dsl.Path
 import typo.dsl.SqlExpr.Field
 import typo.dsl.SqlExpr.FieldLikeNoHkt
 import typo.dsl.SqlExpr.IdField
 import typo.dsl.Structure.Relation
 
-trait BusinessentityaddressFields[Row] {
-  val businessentityid: IdField[BusinessentityId, Row]
-  val addressid: IdField[AddressId, Row]
-  val addresstypeid: IdField[AddresstypeId, Row]
-  val rowguid: Field[TypoUUID, Row]
-  val modifieddate: Field[TypoLocalDateTime, Row]
+trait BusinessentityaddressFields {
+  def businessentityid: IdField[BusinessentityId, BusinessentityaddressRow]
+  def addressid: IdField[AddressId, BusinessentityaddressRow]
+  def addresstypeid: IdField[AddresstypeId, BusinessentityaddressRow]
+  def rowguid: Field[TypoUUID, BusinessentityaddressRow]
+  def modifieddate: Field[TypoLocalDateTime, BusinessentityaddressRow]
 }
 
 object BusinessentityaddressFields {
-  val structure: Relation[BusinessentityaddressFields, BusinessentityaddressRow, BusinessentityaddressRow] = 
-    new Impl(None, identity, (_, x) => x)
+  lazy val structure: Relation[BusinessentityaddressFields, BusinessentityaddressRow] =
+    new Impl(Nil)
     
-  private final class Impl[Row](val prefix: Option[String], val extract: Row => BusinessentityaddressRow, val merge: (Row, BusinessentityaddressRow) => Row)
-    extends Relation[BusinessentityaddressFields, BusinessentityaddressRow, Row] { 
+  private final class Impl(val _path: List[Path])
+    extends Relation[BusinessentityaddressFields, BusinessentityaddressRow] {
   
-    override val fields: BusinessentityaddressFields[Row] = new BusinessentityaddressFields[Row] {
-      override val businessentityid = new IdField[BusinessentityId, Row](prefix, "businessentityid", None, Some("int4"))(x => extract(x).businessentityid, (row, value) => merge(row, extract(row).copy(businessentityid = value)))
-      override val addressid = new IdField[AddressId, Row](prefix, "addressid", None, Some("int4"))(x => extract(x).addressid, (row, value) => merge(row, extract(row).copy(addressid = value)))
-      override val addresstypeid = new IdField[AddresstypeId, Row](prefix, "addresstypeid", None, Some("int4"))(x => extract(x).addresstypeid, (row, value) => merge(row, extract(row).copy(addresstypeid = value)))
-      override val rowguid = new Field[TypoUUID, Row](prefix, "rowguid", None, Some("uuid"))(x => extract(x).rowguid, (row, value) => merge(row, extract(row).copy(rowguid = value)))
-      override val modifieddate = new Field[TypoLocalDateTime, Row](prefix, "modifieddate", Some("text"), Some("timestamp"))(x => extract(x).modifieddate, (row, value) => merge(row, extract(row).copy(modifieddate = value)))
+    override lazy val fields: BusinessentityaddressFields = new BusinessentityaddressFields {
+      override def businessentityid = IdField[BusinessentityId, BusinessentityaddressRow](_path, "businessentityid", None, Some("int4"), x => x.businessentityid, (row, value) => row.copy(businessentityid = value))
+      override def addressid = IdField[AddressId, BusinessentityaddressRow](_path, "addressid", None, Some("int4"), x => x.addressid, (row, value) => row.copy(addressid = value))
+      override def addresstypeid = IdField[AddresstypeId, BusinessentityaddressRow](_path, "addresstypeid", None, Some("int4"), x => x.addresstypeid, (row, value) => row.copy(addresstypeid = value))
+      override def rowguid = Field[TypoUUID, BusinessentityaddressRow](_path, "rowguid", None, Some("uuid"), x => x.rowguid, (row, value) => row.copy(rowguid = value))
+      override def modifieddate = Field[TypoLocalDateTime, BusinessentityaddressRow](_path, "modifieddate", Some("text"), Some("timestamp"), x => x.modifieddate, (row, value) => row.copy(modifieddate = value))
     }
   
-    override val columns: List[FieldLikeNoHkt[?, Row]] =
-      List[FieldLikeNoHkt[?, Row]](fields.businessentityid, fields.addressid, fields.addresstypeid, fields.rowguid, fields.modifieddate)
+    override lazy val columns: List[FieldLikeNoHkt[?, BusinessentityaddressRow]] =
+      List[FieldLikeNoHkt[?, BusinessentityaddressRow]](fields.businessentityid, fields.addressid, fields.addresstypeid, fields.rowguid, fields.modifieddate)
   
-    override def copy[NewRow](prefix: Option[String], extract: NewRow => BusinessentityaddressRow, merge: (NewRow, BusinessentityaddressRow) => NewRow): Impl[NewRow] =
-      new Impl(prefix, extract, merge)
+    override def copy(path: List[Path]): Impl =
+      new Impl(path)
   }
   
 }

--- a/typo-tester-doobie/generated-and-checked-in/adventureworks/person/businessentityaddress/BusinessentityaddressRepoMock.scala
+++ b/typo-tester-doobie/generated-and-checked-in/adventureworks/person/businessentityaddress/BusinessentityaddressRepoMock.scala
@@ -24,7 +24,7 @@ import typo.dsl.UpdateParams
 class BusinessentityaddressRepoMock(toRow: Function1[BusinessentityaddressRowUnsaved, BusinessentityaddressRow],
                                     map: scala.collection.mutable.Map[BusinessentityaddressId, BusinessentityaddressRow] = scala.collection.mutable.Map.empty) extends BusinessentityaddressRepo {
   override def delete: DeleteBuilder[BusinessentityaddressFields, BusinessentityaddressRow] = {
-    DeleteBuilderMock(DeleteParams.empty, BusinessentityaddressFields.structure.fields, map)
+    DeleteBuilderMock(DeleteParams.empty, BusinessentityaddressFields.structure, map)
   }
   override def deleteById(compositeId: BusinessentityaddressId): ConnectionIO[Boolean] = {
     delay(map.remove(compositeId).isDefined)
@@ -86,7 +86,7 @@ class BusinessentityaddressRepoMock(toRow: Function1[BusinessentityaddressRowUns
     }
   }
   override def update: UpdateBuilder[BusinessentityaddressFields, BusinessentityaddressRow] = {
-    UpdateBuilderMock(UpdateParams.empty, BusinessentityaddressFields.structure.fields, map)
+    UpdateBuilderMock(UpdateParams.empty, BusinessentityaddressFields.structure, map)
   }
   override def update(row: BusinessentityaddressRow): ConnectionIO[Boolean] = {
     delay {

--- a/typo-tester-doobie/generated-and-checked-in/adventureworks/person/businessentitycontact/BusinessentitycontactFields.scala
+++ b/typo-tester-doobie/generated-and-checked-in/adventureworks/person/businessentitycontact/BusinessentitycontactFields.scala
@@ -11,39 +11,40 @@ import adventureworks.customtypes.TypoLocalDateTime
 import adventureworks.customtypes.TypoUUID
 import adventureworks.person.businessentity.BusinessentityId
 import adventureworks.person.contacttype.ContacttypeId
+import typo.dsl.Path
 import typo.dsl.SqlExpr.Field
 import typo.dsl.SqlExpr.FieldLikeNoHkt
 import typo.dsl.SqlExpr.IdField
 import typo.dsl.Structure.Relation
 
-trait BusinessentitycontactFields[Row] {
-  val businessentityid: IdField[BusinessentityId, Row]
-  val personid: IdField[BusinessentityId, Row]
-  val contacttypeid: IdField[ContacttypeId, Row]
-  val rowguid: Field[TypoUUID, Row]
-  val modifieddate: Field[TypoLocalDateTime, Row]
+trait BusinessentitycontactFields {
+  def businessentityid: IdField[BusinessentityId, BusinessentitycontactRow]
+  def personid: IdField[BusinessentityId, BusinessentitycontactRow]
+  def contacttypeid: IdField[ContacttypeId, BusinessentitycontactRow]
+  def rowguid: Field[TypoUUID, BusinessentitycontactRow]
+  def modifieddate: Field[TypoLocalDateTime, BusinessentitycontactRow]
 }
 
 object BusinessentitycontactFields {
-  val structure: Relation[BusinessentitycontactFields, BusinessentitycontactRow, BusinessentitycontactRow] = 
-    new Impl(None, identity, (_, x) => x)
+  lazy val structure: Relation[BusinessentitycontactFields, BusinessentitycontactRow] =
+    new Impl(Nil)
     
-  private final class Impl[Row](val prefix: Option[String], val extract: Row => BusinessentitycontactRow, val merge: (Row, BusinessentitycontactRow) => Row)
-    extends Relation[BusinessentitycontactFields, BusinessentitycontactRow, Row] { 
+  private final class Impl(val _path: List[Path])
+    extends Relation[BusinessentitycontactFields, BusinessentitycontactRow] {
   
-    override val fields: BusinessentitycontactFields[Row] = new BusinessentitycontactFields[Row] {
-      override val businessentityid = new IdField[BusinessentityId, Row](prefix, "businessentityid", None, Some("int4"))(x => extract(x).businessentityid, (row, value) => merge(row, extract(row).copy(businessentityid = value)))
-      override val personid = new IdField[BusinessentityId, Row](prefix, "personid", None, Some("int4"))(x => extract(x).personid, (row, value) => merge(row, extract(row).copy(personid = value)))
-      override val contacttypeid = new IdField[ContacttypeId, Row](prefix, "contacttypeid", None, Some("int4"))(x => extract(x).contacttypeid, (row, value) => merge(row, extract(row).copy(contacttypeid = value)))
-      override val rowguid = new Field[TypoUUID, Row](prefix, "rowguid", None, Some("uuid"))(x => extract(x).rowguid, (row, value) => merge(row, extract(row).copy(rowguid = value)))
-      override val modifieddate = new Field[TypoLocalDateTime, Row](prefix, "modifieddate", Some("text"), Some("timestamp"))(x => extract(x).modifieddate, (row, value) => merge(row, extract(row).copy(modifieddate = value)))
+    override lazy val fields: BusinessentitycontactFields = new BusinessentitycontactFields {
+      override def businessentityid = IdField[BusinessentityId, BusinessentitycontactRow](_path, "businessentityid", None, Some("int4"), x => x.businessentityid, (row, value) => row.copy(businessentityid = value))
+      override def personid = IdField[BusinessentityId, BusinessentitycontactRow](_path, "personid", None, Some("int4"), x => x.personid, (row, value) => row.copy(personid = value))
+      override def contacttypeid = IdField[ContacttypeId, BusinessentitycontactRow](_path, "contacttypeid", None, Some("int4"), x => x.contacttypeid, (row, value) => row.copy(contacttypeid = value))
+      override def rowguid = Field[TypoUUID, BusinessentitycontactRow](_path, "rowguid", None, Some("uuid"), x => x.rowguid, (row, value) => row.copy(rowguid = value))
+      override def modifieddate = Field[TypoLocalDateTime, BusinessentitycontactRow](_path, "modifieddate", Some("text"), Some("timestamp"), x => x.modifieddate, (row, value) => row.copy(modifieddate = value))
     }
   
-    override val columns: List[FieldLikeNoHkt[?, Row]] =
-      List[FieldLikeNoHkt[?, Row]](fields.businessentityid, fields.personid, fields.contacttypeid, fields.rowguid, fields.modifieddate)
+    override lazy val columns: List[FieldLikeNoHkt[?, BusinessentitycontactRow]] =
+      List[FieldLikeNoHkt[?, BusinessentitycontactRow]](fields.businessentityid, fields.personid, fields.contacttypeid, fields.rowguid, fields.modifieddate)
   
-    override def copy[NewRow](prefix: Option[String], extract: NewRow => BusinessentitycontactRow, merge: (NewRow, BusinessentitycontactRow) => NewRow): Impl[NewRow] =
-      new Impl(prefix, extract, merge)
+    override def copy(path: List[Path]): Impl =
+      new Impl(path)
   }
   
 }

--- a/typo-tester-doobie/generated-and-checked-in/adventureworks/person/businessentitycontact/BusinessentitycontactRepoMock.scala
+++ b/typo-tester-doobie/generated-and-checked-in/adventureworks/person/businessentitycontact/BusinessentitycontactRepoMock.scala
@@ -24,7 +24,7 @@ import typo.dsl.UpdateParams
 class BusinessentitycontactRepoMock(toRow: Function1[BusinessentitycontactRowUnsaved, BusinessentitycontactRow],
                                     map: scala.collection.mutable.Map[BusinessentitycontactId, BusinessentitycontactRow] = scala.collection.mutable.Map.empty) extends BusinessentitycontactRepo {
   override def delete: DeleteBuilder[BusinessentitycontactFields, BusinessentitycontactRow] = {
-    DeleteBuilderMock(DeleteParams.empty, BusinessentitycontactFields.structure.fields, map)
+    DeleteBuilderMock(DeleteParams.empty, BusinessentitycontactFields.structure, map)
   }
   override def deleteById(compositeId: BusinessentitycontactId): ConnectionIO[Boolean] = {
     delay(map.remove(compositeId).isDefined)
@@ -86,7 +86,7 @@ class BusinessentitycontactRepoMock(toRow: Function1[BusinessentitycontactRowUns
     }
   }
   override def update: UpdateBuilder[BusinessentitycontactFields, BusinessentitycontactRow] = {
-    UpdateBuilderMock(UpdateParams.empty, BusinessentitycontactFields.structure.fields, map)
+    UpdateBuilderMock(UpdateParams.empty, BusinessentitycontactFields.structure, map)
   }
   override def update(row: BusinessentitycontactRow): ConnectionIO[Boolean] = {
     delay {

--- a/typo-tester-doobie/generated-and-checked-in/adventureworks/person/contacttype/ContacttypeFields.scala
+++ b/typo-tester-doobie/generated-and-checked-in/adventureworks/person/contacttype/ContacttypeFields.scala
@@ -9,35 +9,36 @@ package contacttype
 
 import adventureworks.customtypes.TypoLocalDateTime
 import adventureworks.public.Name
+import typo.dsl.Path
 import typo.dsl.SqlExpr.Field
 import typo.dsl.SqlExpr.FieldLikeNoHkt
 import typo.dsl.SqlExpr.IdField
 import typo.dsl.Structure.Relation
 
-trait ContacttypeFields[Row] {
-  val contacttypeid: IdField[ContacttypeId, Row]
-  val name: Field[Name, Row]
-  val modifieddate: Field[TypoLocalDateTime, Row]
+trait ContacttypeFields {
+  def contacttypeid: IdField[ContacttypeId, ContacttypeRow]
+  def name: Field[Name, ContacttypeRow]
+  def modifieddate: Field[TypoLocalDateTime, ContacttypeRow]
 }
 
 object ContacttypeFields {
-  val structure: Relation[ContacttypeFields, ContacttypeRow, ContacttypeRow] = 
-    new Impl(None, identity, (_, x) => x)
+  lazy val structure: Relation[ContacttypeFields, ContacttypeRow] =
+    new Impl(Nil)
     
-  private final class Impl[Row](val prefix: Option[String], val extract: Row => ContacttypeRow, val merge: (Row, ContacttypeRow) => Row)
-    extends Relation[ContacttypeFields, ContacttypeRow, Row] { 
+  private final class Impl(val _path: List[Path])
+    extends Relation[ContacttypeFields, ContacttypeRow] {
   
-    override val fields: ContacttypeFields[Row] = new ContacttypeFields[Row] {
-      override val contacttypeid = new IdField[ContacttypeId, Row](prefix, "contacttypeid", None, Some("int4"))(x => extract(x).contacttypeid, (row, value) => merge(row, extract(row).copy(contacttypeid = value)))
-      override val name = new Field[Name, Row](prefix, "name", None, Some("varchar"))(x => extract(x).name, (row, value) => merge(row, extract(row).copy(name = value)))
-      override val modifieddate = new Field[TypoLocalDateTime, Row](prefix, "modifieddate", Some("text"), Some("timestamp"))(x => extract(x).modifieddate, (row, value) => merge(row, extract(row).copy(modifieddate = value)))
+    override lazy val fields: ContacttypeFields = new ContacttypeFields {
+      override def contacttypeid = IdField[ContacttypeId, ContacttypeRow](_path, "contacttypeid", None, Some("int4"), x => x.contacttypeid, (row, value) => row.copy(contacttypeid = value))
+      override def name = Field[Name, ContacttypeRow](_path, "name", None, Some("varchar"), x => x.name, (row, value) => row.copy(name = value))
+      override def modifieddate = Field[TypoLocalDateTime, ContacttypeRow](_path, "modifieddate", Some("text"), Some("timestamp"), x => x.modifieddate, (row, value) => row.copy(modifieddate = value))
     }
   
-    override val columns: List[FieldLikeNoHkt[?, Row]] =
-      List[FieldLikeNoHkt[?, Row]](fields.contacttypeid, fields.name, fields.modifieddate)
+    override lazy val columns: List[FieldLikeNoHkt[?, ContacttypeRow]] =
+      List[FieldLikeNoHkt[?, ContacttypeRow]](fields.contacttypeid, fields.name, fields.modifieddate)
   
-    override def copy[NewRow](prefix: Option[String], extract: NewRow => ContacttypeRow, merge: (NewRow, ContacttypeRow) => NewRow): Impl[NewRow] =
-      new Impl(prefix, extract, merge)
+    override def copy(path: List[Path]): Impl =
+      new Impl(path)
   }
   
 }

--- a/typo-tester-doobie/generated-and-checked-in/adventureworks/person/contacttype/ContacttypeRepoMock.scala
+++ b/typo-tester-doobie/generated-and-checked-in/adventureworks/person/contacttype/ContacttypeRepoMock.scala
@@ -24,7 +24,7 @@ import typo.dsl.UpdateParams
 class ContacttypeRepoMock(toRow: Function1[ContacttypeRowUnsaved, ContacttypeRow],
                           map: scala.collection.mutable.Map[ContacttypeId, ContacttypeRow] = scala.collection.mutable.Map.empty) extends ContacttypeRepo {
   override def delete: DeleteBuilder[ContacttypeFields, ContacttypeRow] = {
-    DeleteBuilderMock(DeleteParams.empty, ContacttypeFields.structure.fields, map)
+    DeleteBuilderMock(DeleteParams.empty, ContacttypeFields.structure, map)
   }
   override def deleteById(contacttypeid: ContacttypeId): ConnectionIO[Boolean] = {
     delay(map.remove(contacttypeid).isDefined)
@@ -86,7 +86,7 @@ class ContacttypeRepoMock(toRow: Function1[ContacttypeRowUnsaved, ContacttypeRow
     }
   }
   override def update: UpdateBuilder[ContacttypeFields, ContacttypeRow] = {
-    UpdateBuilderMock(UpdateParams.empty, ContacttypeFields.structure.fields, map)
+    UpdateBuilderMock(UpdateParams.empty, ContacttypeFields.structure, map)
   }
   override def update(row: ContacttypeRow): ConnectionIO[Boolean] = {
     delay {

--- a/typo-tester-doobie/generated-and-checked-in/adventureworks/person/countryregion/CountryregionFields.scala
+++ b/typo-tester-doobie/generated-and-checked-in/adventureworks/person/countryregion/CountryregionFields.scala
@@ -9,35 +9,36 @@ package countryregion
 
 import adventureworks.customtypes.TypoLocalDateTime
 import adventureworks.public.Name
+import typo.dsl.Path
 import typo.dsl.SqlExpr.Field
 import typo.dsl.SqlExpr.FieldLikeNoHkt
 import typo.dsl.SqlExpr.IdField
 import typo.dsl.Structure.Relation
 
-trait CountryregionFields[Row] {
-  val countryregioncode: IdField[CountryregionId, Row]
-  val name: Field[Name, Row]
-  val modifieddate: Field[TypoLocalDateTime, Row]
+trait CountryregionFields {
+  def countryregioncode: IdField[CountryregionId, CountryregionRow]
+  def name: Field[Name, CountryregionRow]
+  def modifieddate: Field[TypoLocalDateTime, CountryregionRow]
 }
 
 object CountryregionFields {
-  val structure: Relation[CountryregionFields, CountryregionRow, CountryregionRow] = 
-    new Impl(None, identity, (_, x) => x)
+  lazy val structure: Relation[CountryregionFields, CountryregionRow] =
+    new Impl(Nil)
     
-  private final class Impl[Row](val prefix: Option[String], val extract: Row => CountryregionRow, val merge: (Row, CountryregionRow) => Row)
-    extends Relation[CountryregionFields, CountryregionRow, Row] { 
+  private final class Impl(val _path: List[Path])
+    extends Relation[CountryregionFields, CountryregionRow] {
   
-    override val fields: CountryregionFields[Row] = new CountryregionFields[Row] {
-      override val countryregioncode = new IdField[CountryregionId, Row](prefix, "countryregioncode", None, None)(x => extract(x).countryregioncode, (row, value) => merge(row, extract(row).copy(countryregioncode = value)))
-      override val name = new Field[Name, Row](prefix, "name", None, Some("varchar"))(x => extract(x).name, (row, value) => merge(row, extract(row).copy(name = value)))
-      override val modifieddate = new Field[TypoLocalDateTime, Row](prefix, "modifieddate", Some("text"), Some("timestamp"))(x => extract(x).modifieddate, (row, value) => merge(row, extract(row).copy(modifieddate = value)))
+    override lazy val fields: CountryregionFields = new CountryregionFields {
+      override def countryregioncode = IdField[CountryregionId, CountryregionRow](_path, "countryregioncode", None, None, x => x.countryregioncode, (row, value) => row.copy(countryregioncode = value))
+      override def name = Field[Name, CountryregionRow](_path, "name", None, Some("varchar"), x => x.name, (row, value) => row.copy(name = value))
+      override def modifieddate = Field[TypoLocalDateTime, CountryregionRow](_path, "modifieddate", Some("text"), Some("timestamp"), x => x.modifieddate, (row, value) => row.copy(modifieddate = value))
     }
   
-    override val columns: List[FieldLikeNoHkt[?, Row]] =
-      List[FieldLikeNoHkt[?, Row]](fields.countryregioncode, fields.name, fields.modifieddate)
+    override lazy val columns: List[FieldLikeNoHkt[?, CountryregionRow]] =
+      List[FieldLikeNoHkt[?, CountryregionRow]](fields.countryregioncode, fields.name, fields.modifieddate)
   
-    override def copy[NewRow](prefix: Option[String], extract: NewRow => CountryregionRow, merge: (NewRow, CountryregionRow) => NewRow): Impl[NewRow] =
-      new Impl(prefix, extract, merge)
+    override def copy(path: List[Path]): Impl =
+      new Impl(path)
   }
   
 }

--- a/typo-tester-doobie/generated-and-checked-in/adventureworks/person/countryregion/CountryregionRepoMock.scala
+++ b/typo-tester-doobie/generated-and-checked-in/adventureworks/person/countryregion/CountryregionRepoMock.scala
@@ -24,7 +24,7 @@ import typo.dsl.UpdateParams
 class CountryregionRepoMock(toRow: Function1[CountryregionRowUnsaved, CountryregionRow],
                             map: scala.collection.mutable.Map[CountryregionId, CountryregionRow] = scala.collection.mutable.Map.empty) extends CountryregionRepo {
   override def delete: DeleteBuilder[CountryregionFields, CountryregionRow] = {
-    DeleteBuilderMock(DeleteParams.empty, CountryregionFields.structure.fields, map)
+    DeleteBuilderMock(DeleteParams.empty, CountryregionFields.structure, map)
   }
   override def deleteById(countryregioncode: CountryregionId): ConnectionIO[Boolean] = {
     delay(map.remove(countryregioncode).isDefined)
@@ -86,7 +86,7 @@ class CountryregionRepoMock(toRow: Function1[CountryregionRowUnsaved, Countryreg
     }
   }
   override def update: UpdateBuilder[CountryregionFields, CountryregionRow] = {
-    UpdateBuilderMock(UpdateParams.empty, CountryregionFields.structure.fields, map)
+    UpdateBuilderMock(UpdateParams.empty, CountryregionFields.structure, map)
   }
   override def update(row: CountryregionRow): ConnectionIO[Boolean] = {
     delay {

--- a/typo-tester-doobie/generated-and-checked-in/adventureworks/person/emailaddress/EmailaddressFields.scala
+++ b/typo-tester-doobie/generated-and-checked-in/adventureworks/person/emailaddress/EmailaddressFields.scala
@@ -10,40 +10,41 @@ package emailaddress
 import adventureworks.customtypes.TypoLocalDateTime
 import adventureworks.customtypes.TypoUUID
 import adventureworks.person.businessentity.BusinessentityId
+import typo.dsl.Path
 import typo.dsl.SqlExpr.Field
 import typo.dsl.SqlExpr.FieldLikeNoHkt
 import typo.dsl.SqlExpr.IdField
 import typo.dsl.SqlExpr.OptField
 import typo.dsl.Structure.Relation
 
-trait EmailaddressFields[Row] {
-  val businessentityid: IdField[BusinessentityId, Row]
-  val emailaddressid: IdField[Int, Row]
-  val emailaddress: OptField[/* max 50 chars */ String, Row]
-  val rowguid: Field[TypoUUID, Row]
-  val modifieddate: Field[TypoLocalDateTime, Row]
+trait EmailaddressFields {
+  def businessentityid: IdField[BusinessentityId, EmailaddressRow]
+  def emailaddressid: IdField[Int, EmailaddressRow]
+  def emailaddress: OptField[/* max 50 chars */ String, EmailaddressRow]
+  def rowguid: Field[TypoUUID, EmailaddressRow]
+  def modifieddate: Field[TypoLocalDateTime, EmailaddressRow]
 }
 
 object EmailaddressFields {
-  val structure: Relation[EmailaddressFields, EmailaddressRow, EmailaddressRow] = 
-    new Impl(None, identity, (_, x) => x)
+  lazy val structure: Relation[EmailaddressFields, EmailaddressRow] =
+    new Impl(Nil)
     
-  private final class Impl[Row](val prefix: Option[String], val extract: Row => EmailaddressRow, val merge: (Row, EmailaddressRow) => Row)
-    extends Relation[EmailaddressFields, EmailaddressRow, Row] { 
+  private final class Impl(val _path: List[Path])
+    extends Relation[EmailaddressFields, EmailaddressRow] {
   
-    override val fields: EmailaddressFields[Row] = new EmailaddressFields[Row] {
-      override val businessentityid = new IdField[BusinessentityId, Row](prefix, "businessentityid", None, Some("int4"))(x => extract(x).businessentityid, (row, value) => merge(row, extract(row).copy(businessentityid = value)))
-      override val emailaddressid = new IdField[Int, Row](prefix, "emailaddressid", None, Some("int4"))(x => extract(x).emailaddressid, (row, value) => merge(row, extract(row).copy(emailaddressid = value)))
-      override val emailaddress = new OptField[/* max 50 chars */ String, Row](prefix, "emailaddress", None, None)(x => extract(x).emailaddress, (row, value) => merge(row, extract(row).copy(emailaddress = value)))
-      override val rowguid = new Field[TypoUUID, Row](prefix, "rowguid", None, Some("uuid"))(x => extract(x).rowguid, (row, value) => merge(row, extract(row).copy(rowguid = value)))
-      override val modifieddate = new Field[TypoLocalDateTime, Row](prefix, "modifieddate", Some("text"), Some("timestamp"))(x => extract(x).modifieddate, (row, value) => merge(row, extract(row).copy(modifieddate = value)))
+    override lazy val fields: EmailaddressFields = new EmailaddressFields {
+      override def businessentityid = IdField[BusinessentityId, EmailaddressRow](_path, "businessentityid", None, Some("int4"), x => x.businessentityid, (row, value) => row.copy(businessentityid = value))
+      override def emailaddressid = IdField[Int, EmailaddressRow](_path, "emailaddressid", None, Some("int4"), x => x.emailaddressid, (row, value) => row.copy(emailaddressid = value))
+      override def emailaddress = OptField[/* max 50 chars */ String, EmailaddressRow](_path, "emailaddress", None, None, x => x.emailaddress, (row, value) => row.copy(emailaddress = value))
+      override def rowguid = Field[TypoUUID, EmailaddressRow](_path, "rowguid", None, Some("uuid"), x => x.rowguid, (row, value) => row.copy(rowguid = value))
+      override def modifieddate = Field[TypoLocalDateTime, EmailaddressRow](_path, "modifieddate", Some("text"), Some("timestamp"), x => x.modifieddate, (row, value) => row.copy(modifieddate = value))
     }
   
-    override val columns: List[FieldLikeNoHkt[?, Row]] =
-      List[FieldLikeNoHkt[?, Row]](fields.businessentityid, fields.emailaddressid, fields.emailaddress, fields.rowguid, fields.modifieddate)
+    override lazy val columns: List[FieldLikeNoHkt[?, EmailaddressRow]] =
+      List[FieldLikeNoHkt[?, EmailaddressRow]](fields.businessentityid, fields.emailaddressid, fields.emailaddress, fields.rowguid, fields.modifieddate)
   
-    override def copy[NewRow](prefix: Option[String], extract: NewRow => EmailaddressRow, merge: (NewRow, EmailaddressRow) => NewRow): Impl[NewRow] =
-      new Impl(prefix, extract, merge)
+    override def copy(path: List[Path]): Impl =
+      new Impl(path)
   }
   
 }

--- a/typo-tester-doobie/generated-and-checked-in/adventureworks/person/emailaddress/EmailaddressRepoMock.scala
+++ b/typo-tester-doobie/generated-and-checked-in/adventureworks/person/emailaddress/EmailaddressRepoMock.scala
@@ -24,7 +24,7 @@ import typo.dsl.UpdateParams
 class EmailaddressRepoMock(toRow: Function1[EmailaddressRowUnsaved, EmailaddressRow],
                            map: scala.collection.mutable.Map[EmailaddressId, EmailaddressRow] = scala.collection.mutable.Map.empty) extends EmailaddressRepo {
   override def delete: DeleteBuilder[EmailaddressFields, EmailaddressRow] = {
-    DeleteBuilderMock(DeleteParams.empty, EmailaddressFields.structure.fields, map)
+    DeleteBuilderMock(DeleteParams.empty, EmailaddressFields.structure, map)
   }
   override def deleteById(compositeId: EmailaddressId): ConnectionIO[Boolean] = {
     delay(map.remove(compositeId).isDefined)
@@ -86,7 +86,7 @@ class EmailaddressRepoMock(toRow: Function1[EmailaddressRowUnsaved, Emailaddress
     }
   }
   override def update: UpdateBuilder[EmailaddressFields, EmailaddressRow] = {
-    UpdateBuilderMock(UpdateParams.empty, EmailaddressFields.structure.fields, map)
+    UpdateBuilderMock(UpdateParams.empty, EmailaddressFields.structure, map)
   }
   override def update(row: EmailaddressRow): ConnectionIO[Boolean] = {
     delay {

--- a/typo-tester-doobie/generated-and-checked-in/adventureworks/person/password/PasswordFields.scala
+++ b/typo-tester-doobie/generated-and-checked-in/adventureworks/person/password/PasswordFields.scala
@@ -10,39 +10,40 @@ package password
 import adventureworks.customtypes.TypoLocalDateTime
 import adventureworks.customtypes.TypoUUID
 import adventureworks.person.businessentity.BusinessentityId
+import typo.dsl.Path
 import typo.dsl.SqlExpr.Field
 import typo.dsl.SqlExpr.FieldLikeNoHkt
 import typo.dsl.SqlExpr.IdField
 import typo.dsl.Structure.Relation
 
-trait PasswordFields[Row] {
-  val businessentityid: IdField[BusinessentityId, Row]
-  val passwordhash: Field[/* max 128 chars */ String, Row]
-  val passwordsalt: Field[/* max 10 chars */ String, Row]
-  val rowguid: Field[TypoUUID, Row]
-  val modifieddate: Field[TypoLocalDateTime, Row]
+trait PasswordFields {
+  def businessentityid: IdField[BusinessentityId, PasswordRow]
+  def passwordhash: Field[/* max 128 chars */ String, PasswordRow]
+  def passwordsalt: Field[/* max 10 chars */ String, PasswordRow]
+  def rowguid: Field[TypoUUID, PasswordRow]
+  def modifieddate: Field[TypoLocalDateTime, PasswordRow]
 }
 
 object PasswordFields {
-  val structure: Relation[PasswordFields, PasswordRow, PasswordRow] = 
-    new Impl(None, identity, (_, x) => x)
+  lazy val structure: Relation[PasswordFields, PasswordRow] =
+    new Impl(Nil)
     
-  private final class Impl[Row](val prefix: Option[String], val extract: Row => PasswordRow, val merge: (Row, PasswordRow) => Row)
-    extends Relation[PasswordFields, PasswordRow, Row] { 
+  private final class Impl(val _path: List[Path])
+    extends Relation[PasswordFields, PasswordRow] {
   
-    override val fields: PasswordFields[Row] = new PasswordFields[Row] {
-      override val businessentityid = new IdField[BusinessentityId, Row](prefix, "businessentityid", None, Some("int4"))(x => extract(x).businessentityid, (row, value) => merge(row, extract(row).copy(businessentityid = value)))
-      override val passwordhash = new Field[/* max 128 chars */ String, Row](prefix, "passwordhash", None, None)(x => extract(x).passwordhash, (row, value) => merge(row, extract(row).copy(passwordhash = value)))
-      override val passwordsalt = new Field[/* max 10 chars */ String, Row](prefix, "passwordsalt", None, None)(x => extract(x).passwordsalt, (row, value) => merge(row, extract(row).copy(passwordsalt = value)))
-      override val rowguid = new Field[TypoUUID, Row](prefix, "rowguid", None, Some("uuid"))(x => extract(x).rowguid, (row, value) => merge(row, extract(row).copy(rowguid = value)))
-      override val modifieddate = new Field[TypoLocalDateTime, Row](prefix, "modifieddate", Some("text"), Some("timestamp"))(x => extract(x).modifieddate, (row, value) => merge(row, extract(row).copy(modifieddate = value)))
+    override lazy val fields: PasswordFields = new PasswordFields {
+      override def businessentityid = IdField[BusinessentityId, PasswordRow](_path, "businessentityid", None, Some("int4"), x => x.businessentityid, (row, value) => row.copy(businessentityid = value))
+      override def passwordhash = Field[/* max 128 chars */ String, PasswordRow](_path, "passwordhash", None, None, x => x.passwordhash, (row, value) => row.copy(passwordhash = value))
+      override def passwordsalt = Field[/* max 10 chars */ String, PasswordRow](_path, "passwordsalt", None, None, x => x.passwordsalt, (row, value) => row.copy(passwordsalt = value))
+      override def rowguid = Field[TypoUUID, PasswordRow](_path, "rowguid", None, Some("uuid"), x => x.rowguid, (row, value) => row.copy(rowguid = value))
+      override def modifieddate = Field[TypoLocalDateTime, PasswordRow](_path, "modifieddate", Some("text"), Some("timestamp"), x => x.modifieddate, (row, value) => row.copy(modifieddate = value))
     }
   
-    override val columns: List[FieldLikeNoHkt[?, Row]] =
-      List[FieldLikeNoHkt[?, Row]](fields.businessentityid, fields.passwordhash, fields.passwordsalt, fields.rowguid, fields.modifieddate)
+    override lazy val columns: List[FieldLikeNoHkt[?, PasswordRow]] =
+      List[FieldLikeNoHkt[?, PasswordRow]](fields.businessentityid, fields.passwordhash, fields.passwordsalt, fields.rowguid, fields.modifieddate)
   
-    override def copy[NewRow](prefix: Option[String], extract: NewRow => PasswordRow, merge: (NewRow, PasswordRow) => NewRow): Impl[NewRow] =
-      new Impl(prefix, extract, merge)
+    override def copy(path: List[Path]): Impl =
+      new Impl(path)
   }
   
 }

--- a/typo-tester-doobie/generated-and-checked-in/adventureworks/person/password/PasswordRepoMock.scala
+++ b/typo-tester-doobie/generated-and-checked-in/adventureworks/person/password/PasswordRepoMock.scala
@@ -25,7 +25,7 @@ import typo.dsl.UpdateParams
 class PasswordRepoMock(toRow: Function1[PasswordRowUnsaved, PasswordRow],
                        map: scala.collection.mutable.Map[BusinessentityId, PasswordRow] = scala.collection.mutable.Map.empty) extends PasswordRepo {
   override def delete: DeleteBuilder[PasswordFields, PasswordRow] = {
-    DeleteBuilderMock(DeleteParams.empty, PasswordFields.structure.fields, map)
+    DeleteBuilderMock(DeleteParams.empty, PasswordFields.structure, map)
   }
   override def deleteById(businessentityid: BusinessentityId): ConnectionIO[Boolean] = {
     delay(map.remove(businessentityid).isDefined)
@@ -87,7 +87,7 @@ class PasswordRepoMock(toRow: Function1[PasswordRowUnsaved, PasswordRow],
     }
   }
   override def update: UpdateBuilder[PasswordFields, PasswordRow] = {
-    UpdateBuilderMock(UpdateParams.empty, PasswordFields.structure.fields, map)
+    UpdateBuilderMock(UpdateParams.empty, PasswordFields.structure, map)
   }
   override def update(row: PasswordRow): ConnectionIO[Boolean] = {
     delay {

--- a/typo-tester-doobie/generated-and-checked-in/adventureworks/person/person/PersonFields.scala
+++ b/typo-tester-doobie/generated-and-checked-in/adventureworks/person/person/PersonFields.scala
@@ -14,56 +14,57 @@ import adventureworks.person.businessentity.BusinessentityId
 import adventureworks.public.Name
 import adventureworks.public.NameStyle
 import adventureworks.userdefined.FirstName
+import typo.dsl.Path
 import typo.dsl.SqlExpr.Field
 import typo.dsl.SqlExpr.FieldLikeNoHkt
 import typo.dsl.SqlExpr.IdField
 import typo.dsl.SqlExpr.OptField
 import typo.dsl.Structure.Relation
 
-trait PersonFields[Row] {
-  val businessentityid: IdField[BusinessentityId, Row]
-  val persontype: Field[/* bpchar, max 2 chars */ String, Row]
-  val namestyle: Field[NameStyle, Row]
-  val title: OptField[/* max 8 chars */ String, Row]
-  val firstname: Field[/* user-picked */ FirstName, Row]
-  val middlename: OptField[Name, Row]
-  val lastname: Field[Name, Row]
-  val suffix: OptField[/* max 10 chars */ String, Row]
-  val emailpromotion: Field[Int, Row]
-  val additionalcontactinfo: OptField[TypoXml, Row]
-  val demographics: OptField[TypoXml, Row]
-  val rowguid: Field[TypoUUID, Row]
-  val modifieddate: Field[TypoLocalDateTime, Row]
+trait PersonFields {
+  def businessentityid: IdField[BusinessentityId, PersonRow]
+  def persontype: Field[/* bpchar, max 2 chars */ String, PersonRow]
+  def namestyle: Field[NameStyle, PersonRow]
+  def title: OptField[/* max 8 chars */ String, PersonRow]
+  def firstname: Field[/* user-picked */ FirstName, PersonRow]
+  def middlename: OptField[Name, PersonRow]
+  def lastname: Field[Name, PersonRow]
+  def suffix: OptField[/* max 10 chars */ String, PersonRow]
+  def emailpromotion: Field[Int, PersonRow]
+  def additionalcontactinfo: OptField[TypoXml, PersonRow]
+  def demographics: OptField[TypoXml, PersonRow]
+  def rowguid: Field[TypoUUID, PersonRow]
+  def modifieddate: Field[TypoLocalDateTime, PersonRow]
 }
 
 object PersonFields {
-  val structure: Relation[PersonFields, PersonRow, PersonRow] = 
-    new Impl(None, identity, (_, x) => x)
+  lazy val structure: Relation[PersonFields, PersonRow] =
+    new Impl(Nil)
     
-  private final class Impl[Row](val prefix: Option[String], val extract: Row => PersonRow, val merge: (Row, PersonRow) => Row)
-    extends Relation[PersonFields, PersonRow, Row] { 
+  private final class Impl(val _path: List[Path])
+    extends Relation[PersonFields, PersonRow] {
   
-    override val fields: PersonFields[Row] = new PersonFields[Row] {
-      override val businessentityid = new IdField[BusinessentityId, Row](prefix, "businessentityid", None, Some("int4"))(x => extract(x).businessentityid, (row, value) => merge(row, extract(row).copy(businessentityid = value)))
-      override val persontype = new Field[/* bpchar, max 2 chars */ String, Row](prefix, "persontype", None, Some("bpchar"))(x => extract(x).persontype, (row, value) => merge(row, extract(row).copy(persontype = value)))
-      override val namestyle = new Field[NameStyle, Row](prefix, "namestyle", None, Some("bool"))(x => extract(x).namestyle, (row, value) => merge(row, extract(row).copy(namestyle = value)))
-      override val title = new OptField[/* max 8 chars */ String, Row](prefix, "title", None, None)(x => extract(x).title, (row, value) => merge(row, extract(row).copy(title = value)))
-      override val firstname = new Field[/* user-picked */ FirstName, Row](prefix, "firstname", None, Some("varchar"))(x => extract(x).firstname, (row, value) => merge(row, extract(row).copy(firstname = value)))
-      override val middlename = new OptField[Name, Row](prefix, "middlename", None, Some("varchar"))(x => extract(x).middlename, (row, value) => merge(row, extract(row).copy(middlename = value)))
-      override val lastname = new Field[Name, Row](prefix, "lastname", None, Some("varchar"))(x => extract(x).lastname, (row, value) => merge(row, extract(row).copy(lastname = value)))
-      override val suffix = new OptField[/* max 10 chars */ String, Row](prefix, "suffix", None, None)(x => extract(x).suffix, (row, value) => merge(row, extract(row).copy(suffix = value)))
-      override val emailpromotion = new Field[Int, Row](prefix, "emailpromotion", None, Some("int4"))(x => extract(x).emailpromotion, (row, value) => merge(row, extract(row).copy(emailpromotion = value)))
-      override val additionalcontactinfo = new OptField[TypoXml, Row](prefix, "additionalcontactinfo", None, Some("xml"))(x => extract(x).additionalcontactinfo, (row, value) => merge(row, extract(row).copy(additionalcontactinfo = value)))
-      override val demographics = new OptField[TypoXml, Row](prefix, "demographics", None, Some("xml"))(x => extract(x).demographics, (row, value) => merge(row, extract(row).copy(demographics = value)))
-      override val rowguid = new Field[TypoUUID, Row](prefix, "rowguid", None, Some("uuid"))(x => extract(x).rowguid, (row, value) => merge(row, extract(row).copy(rowguid = value)))
-      override val modifieddate = new Field[TypoLocalDateTime, Row](prefix, "modifieddate", Some("text"), Some("timestamp"))(x => extract(x).modifieddate, (row, value) => merge(row, extract(row).copy(modifieddate = value)))
+    override lazy val fields: PersonFields = new PersonFields {
+      override def businessentityid = IdField[BusinessentityId, PersonRow](_path, "businessentityid", None, Some("int4"), x => x.businessentityid, (row, value) => row.copy(businessentityid = value))
+      override def persontype = Field[/* bpchar, max 2 chars */ String, PersonRow](_path, "persontype", None, Some("bpchar"), x => x.persontype, (row, value) => row.copy(persontype = value))
+      override def namestyle = Field[NameStyle, PersonRow](_path, "namestyle", None, Some("bool"), x => x.namestyle, (row, value) => row.copy(namestyle = value))
+      override def title = OptField[/* max 8 chars */ String, PersonRow](_path, "title", None, None, x => x.title, (row, value) => row.copy(title = value))
+      override def firstname = Field[/* user-picked */ FirstName, PersonRow](_path, "firstname", None, Some("varchar"), x => x.firstname, (row, value) => row.copy(firstname = value))
+      override def middlename = OptField[Name, PersonRow](_path, "middlename", None, Some("varchar"), x => x.middlename, (row, value) => row.copy(middlename = value))
+      override def lastname = Field[Name, PersonRow](_path, "lastname", None, Some("varchar"), x => x.lastname, (row, value) => row.copy(lastname = value))
+      override def suffix = OptField[/* max 10 chars */ String, PersonRow](_path, "suffix", None, None, x => x.suffix, (row, value) => row.copy(suffix = value))
+      override def emailpromotion = Field[Int, PersonRow](_path, "emailpromotion", None, Some("int4"), x => x.emailpromotion, (row, value) => row.copy(emailpromotion = value))
+      override def additionalcontactinfo = OptField[TypoXml, PersonRow](_path, "additionalcontactinfo", None, Some("xml"), x => x.additionalcontactinfo, (row, value) => row.copy(additionalcontactinfo = value))
+      override def demographics = OptField[TypoXml, PersonRow](_path, "demographics", None, Some("xml"), x => x.demographics, (row, value) => row.copy(demographics = value))
+      override def rowguid = Field[TypoUUID, PersonRow](_path, "rowguid", None, Some("uuid"), x => x.rowguid, (row, value) => row.copy(rowguid = value))
+      override def modifieddate = Field[TypoLocalDateTime, PersonRow](_path, "modifieddate", Some("text"), Some("timestamp"), x => x.modifieddate, (row, value) => row.copy(modifieddate = value))
     }
   
-    override val columns: List[FieldLikeNoHkt[?, Row]] =
-      List[FieldLikeNoHkt[?, Row]](fields.businessentityid, fields.persontype, fields.namestyle, fields.title, fields.firstname, fields.middlename, fields.lastname, fields.suffix, fields.emailpromotion, fields.additionalcontactinfo, fields.demographics, fields.rowguid, fields.modifieddate)
+    override lazy val columns: List[FieldLikeNoHkt[?, PersonRow]] =
+      List[FieldLikeNoHkt[?, PersonRow]](fields.businessentityid, fields.persontype, fields.namestyle, fields.title, fields.firstname, fields.middlename, fields.lastname, fields.suffix, fields.emailpromotion, fields.additionalcontactinfo, fields.demographics, fields.rowguid, fields.modifieddate)
   
-    override def copy[NewRow](prefix: Option[String], extract: NewRow => PersonRow, merge: (NewRow, PersonRow) => NewRow): Impl[NewRow] =
-      new Impl(prefix, extract, merge)
+    override def copy(path: List[Path]): Impl =
+      new Impl(path)
   }
   
 }

--- a/typo-tester-doobie/generated-and-checked-in/adventureworks/person/person/PersonRepoMock.scala
+++ b/typo-tester-doobie/generated-and-checked-in/adventureworks/person/person/PersonRepoMock.scala
@@ -25,7 +25,7 @@ import typo.dsl.UpdateParams
 class PersonRepoMock(toRow: Function1[PersonRowUnsaved, PersonRow],
                      map: scala.collection.mutable.Map[BusinessentityId, PersonRow] = scala.collection.mutable.Map.empty) extends PersonRepo {
   override def delete: DeleteBuilder[PersonFields, PersonRow] = {
-    DeleteBuilderMock(DeleteParams.empty, PersonFields.structure.fields, map)
+    DeleteBuilderMock(DeleteParams.empty, PersonFields.structure, map)
   }
   override def deleteById(businessentityid: BusinessentityId): ConnectionIO[Boolean] = {
     delay(map.remove(businessentityid).isDefined)
@@ -87,7 +87,7 @@ class PersonRepoMock(toRow: Function1[PersonRowUnsaved, PersonRow],
     }
   }
   override def update: UpdateBuilder[PersonFields, PersonRow] = {
-    UpdateBuilderMock(UpdateParams.empty, PersonFields.structure.fields, map)
+    UpdateBuilderMock(UpdateParams.empty, PersonFields.structure, map)
   }
   override def update(row: PersonRow): ConnectionIO[Boolean] = {
     delay {

--- a/typo-tester-doobie/generated-and-checked-in/adventureworks/person/personphone/PersonphoneFields.scala
+++ b/typo-tester-doobie/generated-and-checked-in/adventureworks/person/personphone/PersonphoneFields.scala
@@ -11,37 +11,38 @@ import adventureworks.customtypes.TypoLocalDateTime
 import adventureworks.person.businessentity.BusinessentityId
 import adventureworks.person.phonenumbertype.PhonenumbertypeId
 import adventureworks.public.Phone
+import typo.dsl.Path
 import typo.dsl.SqlExpr.Field
 import typo.dsl.SqlExpr.FieldLikeNoHkt
 import typo.dsl.SqlExpr.IdField
 import typo.dsl.Structure.Relation
 
-trait PersonphoneFields[Row] {
-  val businessentityid: IdField[BusinessentityId, Row]
-  val phonenumber: IdField[Phone, Row]
-  val phonenumbertypeid: IdField[PhonenumbertypeId, Row]
-  val modifieddate: Field[TypoLocalDateTime, Row]
+trait PersonphoneFields {
+  def businessentityid: IdField[BusinessentityId, PersonphoneRow]
+  def phonenumber: IdField[Phone, PersonphoneRow]
+  def phonenumbertypeid: IdField[PhonenumbertypeId, PersonphoneRow]
+  def modifieddate: Field[TypoLocalDateTime, PersonphoneRow]
 }
 
 object PersonphoneFields {
-  val structure: Relation[PersonphoneFields, PersonphoneRow, PersonphoneRow] = 
-    new Impl(None, identity, (_, x) => x)
+  lazy val structure: Relation[PersonphoneFields, PersonphoneRow] =
+    new Impl(Nil)
     
-  private final class Impl[Row](val prefix: Option[String], val extract: Row => PersonphoneRow, val merge: (Row, PersonphoneRow) => Row)
-    extends Relation[PersonphoneFields, PersonphoneRow, Row] { 
+  private final class Impl(val _path: List[Path])
+    extends Relation[PersonphoneFields, PersonphoneRow] {
   
-    override val fields: PersonphoneFields[Row] = new PersonphoneFields[Row] {
-      override val businessentityid = new IdField[BusinessentityId, Row](prefix, "businessentityid", None, Some("int4"))(x => extract(x).businessentityid, (row, value) => merge(row, extract(row).copy(businessentityid = value)))
-      override val phonenumber = new IdField[Phone, Row](prefix, "phonenumber", None, Some("varchar"))(x => extract(x).phonenumber, (row, value) => merge(row, extract(row).copy(phonenumber = value)))
-      override val phonenumbertypeid = new IdField[PhonenumbertypeId, Row](prefix, "phonenumbertypeid", None, Some("int4"))(x => extract(x).phonenumbertypeid, (row, value) => merge(row, extract(row).copy(phonenumbertypeid = value)))
-      override val modifieddate = new Field[TypoLocalDateTime, Row](prefix, "modifieddate", Some("text"), Some("timestamp"))(x => extract(x).modifieddate, (row, value) => merge(row, extract(row).copy(modifieddate = value)))
+    override lazy val fields: PersonphoneFields = new PersonphoneFields {
+      override def businessentityid = IdField[BusinessentityId, PersonphoneRow](_path, "businessentityid", None, Some("int4"), x => x.businessentityid, (row, value) => row.copy(businessentityid = value))
+      override def phonenumber = IdField[Phone, PersonphoneRow](_path, "phonenumber", None, Some("varchar"), x => x.phonenumber, (row, value) => row.copy(phonenumber = value))
+      override def phonenumbertypeid = IdField[PhonenumbertypeId, PersonphoneRow](_path, "phonenumbertypeid", None, Some("int4"), x => x.phonenumbertypeid, (row, value) => row.copy(phonenumbertypeid = value))
+      override def modifieddate = Field[TypoLocalDateTime, PersonphoneRow](_path, "modifieddate", Some("text"), Some("timestamp"), x => x.modifieddate, (row, value) => row.copy(modifieddate = value))
     }
   
-    override val columns: List[FieldLikeNoHkt[?, Row]] =
-      List[FieldLikeNoHkt[?, Row]](fields.businessentityid, fields.phonenumber, fields.phonenumbertypeid, fields.modifieddate)
+    override lazy val columns: List[FieldLikeNoHkt[?, PersonphoneRow]] =
+      List[FieldLikeNoHkt[?, PersonphoneRow]](fields.businessentityid, fields.phonenumber, fields.phonenumbertypeid, fields.modifieddate)
   
-    override def copy[NewRow](prefix: Option[String], extract: NewRow => PersonphoneRow, merge: (NewRow, PersonphoneRow) => NewRow): Impl[NewRow] =
-      new Impl(prefix, extract, merge)
+    override def copy(path: List[Path]): Impl =
+      new Impl(path)
   }
   
 }

--- a/typo-tester-doobie/generated-and-checked-in/adventureworks/person/personphone/PersonphoneRepoMock.scala
+++ b/typo-tester-doobie/generated-and-checked-in/adventureworks/person/personphone/PersonphoneRepoMock.scala
@@ -24,7 +24,7 @@ import typo.dsl.UpdateParams
 class PersonphoneRepoMock(toRow: Function1[PersonphoneRowUnsaved, PersonphoneRow],
                           map: scala.collection.mutable.Map[PersonphoneId, PersonphoneRow] = scala.collection.mutable.Map.empty) extends PersonphoneRepo {
   override def delete: DeleteBuilder[PersonphoneFields, PersonphoneRow] = {
-    DeleteBuilderMock(DeleteParams.empty, PersonphoneFields.structure.fields, map)
+    DeleteBuilderMock(DeleteParams.empty, PersonphoneFields.structure, map)
   }
   override def deleteById(compositeId: PersonphoneId): ConnectionIO[Boolean] = {
     delay(map.remove(compositeId).isDefined)
@@ -86,7 +86,7 @@ class PersonphoneRepoMock(toRow: Function1[PersonphoneRowUnsaved, PersonphoneRow
     }
   }
   override def update: UpdateBuilder[PersonphoneFields, PersonphoneRow] = {
-    UpdateBuilderMock(UpdateParams.empty, PersonphoneFields.structure.fields, map)
+    UpdateBuilderMock(UpdateParams.empty, PersonphoneFields.structure, map)
   }
   override def update(row: PersonphoneRow): ConnectionIO[Boolean] = {
     delay {

--- a/typo-tester-doobie/generated-and-checked-in/adventureworks/person/phonenumbertype/PhonenumbertypeFields.scala
+++ b/typo-tester-doobie/generated-and-checked-in/adventureworks/person/phonenumbertype/PhonenumbertypeFields.scala
@@ -9,35 +9,36 @@ package phonenumbertype
 
 import adventureworks.customtypes.TypoLocalDateTime
 import adventureworks.public.Name
+import typo.dsl.Path
 import typo.dsl.SqlExpr.Field
 import typo.dsl.SqlExpr.FieldLikeNoHkt
 import typo.dsl.SqlExpr.IdField
 import typo.dsl.Structure.Relation
 
-trait PhonenumbertypeFields[Row] {
-  val phonenumbertypeid: IdField[PhonenumbertypeId, Row]
-  val name: Field[Name, Row]
-  val modifieddate: Field[TypoLocalDateTime, Row]
+trait PhonenumbertypeFields {
+  def phonenumbertypeid: IdField[PhonenumbertypeId, PhonenumbertypeRow]
+  def name: Field[Name, PhonenumbertypeRow]
+  def modifieddate: Field[TypoLocalDateTime, PhonenumbertypeRow]
 }
 
 object PhonenumbertypeFields {
-  val structure: Relation[PhonenumbertypeFields, PhonenumbertypeRow, PhonenumbertypeRow] = 
-    new Impl(None, identity, (_, x) => x)
+  lazy val structure: Relation[PhonenumbertypeFields, PhonenumbertypeRow] =
+    new Impl(Nil)
     
-  private final class Impl[Row](val prefix: Option[String], val extract: Row => PhonenumbertypeRow, val merge: (Row, PhonenumbertypeRow) => Row)
-    extends Relation[PhonenumbertypeFields, PhonenumbertypeRow, Row] { 
+  private final class Impl(val _path: List[Path])
+    extends Relation[PhonenumbertypeFields, PhonenumbertypeRow] {
   
-    override val fields: PhonenumbertypeFields[Row] = new PhonenumbertypeFields[Row] {
-      override val phonenumbertypeid = new IdField[PhonenumbertypeId, Row](prefix, "phonenumbertypeid", None, Some("int4"))(x => extract(x).phonenumbertypeid, (row, value) => merge(row, extract(row).copy(phonenumbertypeid = value)))
-      override val name = new Field[Name, Row](prefix, "name", None, Some("varchar"))(x => extract(x).name, (row, value) => merge(row, extract(row).copy(name = value)))
-      override val modifieddate = new Field[TypoLocalDateTime, Row](prefix, "modifieddate", Some("text"), Some("timestamp"))(x => extract(x).modifieddate, (row, value) => merge(row, extract(row).copy(modifieddate = value)))
+    override lazy val fields: PhonenumbertypeFields = new PhonenumbertypeFields {
+      override def phonenumbertypeid = IdField[PhonenumbertypeId, PhonenumbertypeRow](_path, "phonenumbertypeid", None, Some("int4"), x => x.phonenumbertypeid, (row, value) => row.copy(phonenumbertypeid = value))
+      override def name = Field[Name, PhonenumbertypeRow](_path, "name", None, Some("varchar"), x => x.name, (row, value) => row.copy(name = value))
+      override def modifieddate = Field[TypoLocalDateTime, PhonenumbertypeRow](_path, "modifieddate", Some("text"), Some("timestamp"), x => x.modifieddate, (row, value) => row.copy(modifieddate = value))
     }
   
-    override val columns: List[FieldLikeNoHkt[?, Row]] =
-      List[FieldLikeNoHkt[?, Row]](fields.phonenumbertypeid, fields.name, fields.modifieddate)
+    override lazy val columns: List[FieldLikeNoHkt[?, PhonenumbertypeRow]] =
+      List[FieldLikeNoHkt[?, PhonenumbertypeRow]](fields.phonenumbertypeid, fields.name, fields.modifieddate)
   
-    override def copy[NewRow](prefix: Option[String], extract: NewRow => PhonenumbertypeRow, merge: (NewRow, PhonenumbertypeRow) => NewRow): Impl[NewRow] =
-      new Impl(prefix, extract, merge)
+    override def copy(path: List[Path]): Impl =
+      new Impl(path)
   }
   
 }

--- a/typo-tester-doobie/generated-and-checked-in/adventureworks/person/phonenumbertype/PhonenumbertypeRepoMock.scala
+++ b/typo-tester-doobie/generated-and-checked-in/adventureworks/person/phonenumbertype/PhonenumbertypeRepoMock.scala
@@ -24,7 +24,7 @@ import typo.dsl.UpdateParams
 class PhonenumbertypeRepoMock(toRow: Function1[PhonenumbertypeRowUnsaved, PhonenumbertypeRow],
                               map: scala.collection.mutable.Map[PhonenumbertypeId, PhonenumbertypeRow] = scala.collection.mutable.Map.empty) extends PhonenumbertypeRepo {
   override def delete: DeleteBuilder[PhonenumbertypeFields, PhonenumbertypeRow] = {
-    DeleteBuilderMock(DeleteParams.empty, PhonenumbertypeFields.structure.fields, map)
+    DeleteBuilderMock(DeleteParams.empty, PhonenumbertypeFields.structure, map)
   }
   override def deleteById(phonenumbertypeid: PhonenumbertypeId): ConnectionIO[Boolean] = {
     delay(map.remove(phonenumbertypeid).isDefined)
@@ -86,7 +86,7 @@ class PhonenumbertypeRepoMock(toRow: Function1[PhonenumbertypeRowUnsaved, Phonen
     }
   }
   override def update: UpdateBuilder[PhonenumbertypeFields, PhonenumbertypeRow] = {
-    UpdateBuilderMock(UpdateParams.empty, PhonenumbertypeFields.structure.fields, map)
+    UpdateBuilderMock(UpdateParams.empty, PhonenumbertypeFields.structure, map)
   }
   override def update(row: PhonenumbertypeRow): ConnectionIO[Boolean] = {
     delay {

--- a/typo-tester-doobie/generated-and-checked-in/adventureworks/person/stateprovince/StateprovinceFields.scala
+++ b/typo-tester-doobie/generated-and-checked-in/adventureworks/person/stateprovince/StateprovinceFields.scala
@@ -13,45 +13,46 @@ import adventureworks.person.countryregion.CountryregionId
 import adventureworks.public.Flag
 import adventureworks.public.Name
 import adventureworks.sales.salesterritory.SalesterritoryId
+import typo.dsl.Path
 import typo.dsl.SqlExpr.Field
 import typo.dsl.SqlExpr.FieldLikeNoHkt
 import typo.dsl.SqlExpr.IdField
 import typo.dsl.Structure.Relation
 
-trait StateprovinceFields[Row] {
-  val stateprovinceid: IdField[StateprovinceId, Row]
-  val stateprovincecode: Field[/* bpchar, max 3 chars */ String, Row]
-  val countryregioncode: Field[CountryregionId, Row]
-  val isonlystateprovinceflag: Field[Flag, Row]
-  val name: Field[Name, Row]
-  val territoryid: Field[SalesterritoryId, Row]
-  val rowguid: Field[TypoUUID, Row]
-  val modifieddate: Field[TypoLocalDateTime, Row]
+trait StateprovinceFields {
+  def stateprovinceid: IdField[StateprovinceId, StateprovinceRow]
+  def stateprovincecode: Field[/* bpchar, max 3 chars */ String, StateprovinceRow]
+  def countryregioncode: Field[CountryregionId, StateprovinceRow]
+  def isonlystateprovinceflag: Field[Flag, StateprovinceRow]
+  def name: Field[Name, StateprovinceRow]
+  def territoryid: Field[SalesterritoryId, StateprovinceRow]
+  def rowguid: Field[TypoUUID, StateprovinceRow]
+  def modifieddate: Field[TypoLocalDateTime, StateprovinceRow]
 }
 
 object StateprovinceFields {
-  val structure: Relation[StateprovinceFields, StateprovinceRow, StateprovinceRow] = 
-    new Impl(None, identity, (_, x) => x)
+  lazy val structure: Relation[StateprovinceFields, StateprovinceRow] =
+    new Impl(Nil)
     
-  private final class Impl[Row](val prefix: Option[String], val extract: Row => StateprovinceRow, val merge: (Row, StateprovinceRow) => Row)
-    extends Relation[StateprovinceFields, StateprovinceRow, Row] { 
+  private final class Impl(val _path: List[Path])
+    extends Relation[StateprovinceFields, StateprovinceRow] {
   
-    override val fields: StateprovinceFields[Row] = new StateprovinceFields[Row] {
-      override val stateprovinceid = new IdField[StateprovinceId, Row](prefix, "stateprovinceid", None, Some("int4"))(x => extract(x).stateprovinceid, (row, value) => merge(row, extract(row).copy(stateprovinceid = value)))
-      override val stateprovincecode = new Field[/* bpchar, max 3 chars */ String, Row](prefix, "stateprovincecode", None, Some("bpchar"))(x => extract(x).stateprovincecode, (row, value) => merge(row, extract(row).copy(stateprovincecode = value)))
-      override val countryregioncode = new Field[CountryregionId, Row](prefix, "countryregioncode", None, None)(x => extract(x).countryregioncode, (row, value) => merge(row, extract(row).copy(countryregioncode = value)))
-      override val isonlystateprovinceflag = new Field[Flag, Row](prefix, "isonlystateprovinceflag", None, Some("bool"))(x => extract(x).isonlystateprovinceflag, (row, value) => merge(row, extract(row).copy(isonlystateprovinceflag = value)))
-      override val name = new Field[Name, Row](prefix, "name", None, Some("varchar"))(x => extract(x).name, (row, value) => merge(row, extract(row).copy(name = value)))
-      override val territoryid = new Field[SalesterritoryId, Row](prefix, "territoryid", None, Some("int4"))(x => extract(x).territoryid, (row, value) => merge(row, extract(row).copy(territoryid = value)))
-      override val rowguid = new Field[TypoUUID, Row](prefix, "rowguid", None, Some("uuid"))(x => extract(x).rowguid, (row, value) => merge(row, extract(row).copy(rowguid = value)))
-      override val modifieddate = new Field[TypoLocalDateTime, Row](prefix, "modifieddate", Some("text"), Some("timestamp"))(x => extract(x).modifieddate, (row, value) => merge(row, extract(row).copy(modifieddate = value)))
+    override lazy val fields: StateprovinceFields = new StateprovinceFields {
+      override def stateprovinceid = IdField[StateprovinceId, StateprovinceRow](_path, "stateprovinceid", None, Some("int4"), x => x.stateprovinceid, (row, value) => row.copy(stateprovinceid = value))
+      override def stateprovincecode = Field[/* bpchar, max 3 chars */ String, StateprovinceRow](_path, "stateprovincecode", None, Some("bpchar"), x => x.stateprovincecode, (row, value) => row.copy(stateprovincecode = value))
+      override def countryregioncode = Field[CountryregionId, StateprovinceRow](_path, "countryregioncode", None, None, x => x.countryregioncode, (row, value) => row.copy(countryregioncode = value))
+      override def isonlystateprovinceflag = Field[Flag, StateprovinceRow](_path, "isonlystateprovinceflag", None, Some("bool"), x => x.isonlystateprovinceflag, (row, value) => row.copy(isonlystateprovinceflag = value))
+      override def name = Field[Name, StateprovinceRow](_path, "name", None, Some("varchar"), x => x.name, (row, value) => row.copy(name = value))
+      override def territoryid = Field[SalesterritoryId, StateprovinceRow](_path, "territoryid", None, Some("int4"), x => x.territoryid, (row, value) => row.copy(territoryid = value))
+      override def rowguid = Field[TypoUUID, StateprovinceRow](_path, "rowguid", None, Some("uuid"), x => x.rowguid, (row, value) => row.copy(rowguid = value))
+      override def modifieddate = Field[TypoLocalDateTime, StateprovinceRow](_path, "modifieddate", Some("text"), Some("timestamp"), x => x.modifieddate, (row, value) => row.copy(modifieddate = value))
     }
   
-    override val columns: List[FieldLikeNoHkt[?, Row]] =
-      List[FieldLikeNoHkt[?, Row]](fields.stateprovinceid, fields.stateprovincecode, fields.countryregioncode, fields.isonlystateprovinceflag, fields.name, fields.territoryid, fields.rowguid, fields.modifieddate)
+    override lazy val columns: List[FieldLikeNoHkt[?, StateprovinceRow]] =
+      List[FieldLikeNoHkt[?, StateprovinceRow]](fields.stateprovinceid, fields.stateprovincecode, fields.countryregioncode, fields.isonlystateprovinceflag, fields.name, fields.territoryid, fields.rowguid, fields.modifieddate)
   
-    override def copy[NewRow](prefix: Option[String], extract: NewRow => StateprovinceRow, merge: (NewRow, StateprovinceRow) => NewRow): Impl[NewRow] =
-      new Impl(prefix, extract, merge)
+    override def copy(path: List[Path]): Impl =
+      new Impl(path)
   }
   
 }

--- a/typo-tester-doobie/generated-and-checked-in/adventureworks/person/stateprovince/StateprovinceRepoMock.scala
+++ b/typo-tester-doobie/generated-and-checked-in/adventureworks/person/stateprovince/StateprovinceRepoMock.scala
@@ -24,7 +24,7 @@ import typo.dsl.UpdateParams
 class StateprovinceRepoMock(toRow: Function1[StateprovinceRowUnsaved, StateprovinceRow],
                             map: scala.collection.mutable.Map[StateprovinceId, StateprovinceRow] = scala.collection.mutable.Map.empty) extends StateprovinceRepo {
   override def delete: DeleteBuilder[StateprovinceFields, StateprovinceRow] = {
-    DeleteBuilderMock(DeleteParams.empty, StateprovinceFields.structure.fields, map)
+    DeleteBuilderMock(DeleteParams.empty, StateprovinceFields.structure, map)
   }
   override def deleteById(stateprovinceid: StateprovinceId): ConnectionIO[Boolean] = {
     delay(map.remove(stateprovinceid).isDefined)
@@ -86,7 +86,7 @@ class StateprovinceRepoMock(toRow: Function1[StateprovinceRowUnsaved, Stateprovi
     }
   }
   override def update: UpdateBuilder[StateprovinceFields, StateprovinceRow] = {
-    UpdateBuilderMock(UpdateParams.empty, StateprovinceFields.structure.fields, map)
+    UpdateBuilderMock(UpdateParams.empty, StateprovinceFields.structure, map)
   }
   override def update(row: StateprovinceRow): ConnectionIO[Boolean] = {
     delay {

--- a/typo-tester-doobie/generated-and-checked-in/adventureworks/person/vadditionalcontactinfo/VadditionalcontactinfoViewFields.scala
+++ b/typo-tester-doobie/generated-and-checked-in/adventureworks/person/vadditionalcontactinfo/VadditionalcontactinfoViewFields.scala
@@ -13,63 +13,64 @@ import adventureworks.customtypes.TypoXml
 import adventureworks.person.businessentity.BusinessentityId
 import adventureworks.public.Name
 import adventureworks.userdefined.FirstName
+import typo.dsl.Path
 import typo.dsl.SqlExpr.Field
 import typo.dsl.SqlExpr.FieldLikeNoHkt
 import typo.dsl.SqlExpr.OptField
 import typo.dsl.Structure.Relation
 
-trait VadditionalcontactinfoViewFields[Row] {
-  val businessentityid: Field[BusinessentityId, Row]
-  val firstname: Field[/* user-picked */ FirstName, Row]
-  val middlename: OptField[Name, Row]
-  val lastname: Field[Name, Row]
-  val telephonenumber: OptField[TypoXml, Row]
-  val telephonespecialinstructions: OptField[String, Row]
-  val street: OptField[TypoXml, Row]
-  val city: OptField[TypoXml, Row]
-  val stateprovince: OptField[TypoXml, Row]
-  val postalcode: OptField[TypoXml, Row]
-  val countryregion: OptField[TypoXml, Row]
-  val homeaddressspecialinstructions: OptField[TypoXml, Row]
-  val emailaddress: OptField[TypoXml, Row]
-  val emailspecialinstructions: OptField[String, Row]
-  val emailtelephonenumber: OptField[TypoXml, Row]
-  val rowguid: Field[TypoUUID, Row]
-  val modifieddate: Field[TypoLocalDateTime, Row]
+trait VadditionalcontactinfoViewFields {
+  def businessentityid: Field[BusinessentityId, VadditionalcontactinfoViewRow]
+  def firstname: Field[/* user-picked */ FirstName, VadditionalcontactinfoViewRow]
+  def middlename: OptField[Name, VadditionalcontactinfoViewRow]
+  def lastname: Field[Name, VadditionalcontactinfoViewRow]
+  def telephonenumber: OptField[TypoXml, VadditionalcontactinfoViewRow]
+  def telephonespecialinstructions: OptField[String, VadditionalcontactinfoViewRow]
+  def street: OptField[TypoXml, VadditionalcontactinfoViewRow]
+  def city: OptField[TypoXml, VadditionalcontactinfoViewRow]
+  def stateprovince: OptField[TypoXml, VadditionalcontactinfoViewRow]
+  def postalcode: OptField[TypoXml, VadditionalcontactinfoViewRow]
+  def countryregion: OptField[TypoXml, VadditionalcontactinfoViewRow]
+  def homeaddressspecialinstructions: OptField[TypoXml, VadditionalcontactinfoViewRow]
+  def emailaddress: OptField[TypoXml, VadditionalcontactinfoViewRow]
+  def emailspecialinstructions: OptField[String, VadditionalcontactinfoViewRow]
+  def emailtelephonenumber: OptField[TypoXml, VadditionalcontactinfoViewRow]
+  def rowguid: Field[TypoUUID, VadditionalcontactinfoViewRow]
+  def modifieddate: Field[TypoLocalDateTime, VadditionalcontactinfoViewRow]
 }
 
 object VadditionalcontactinfoViewFields {
-  val structure: Relation[VadditionalcontactinfoViewFields, VadditionalcontactinfoViewRow, VadditionalcontactinfoViewRow] = 
-    new Impl(None, identity, (_, x) => x)
+  lazy val structure: Relation[VadditionalcontactinfoViewFields, VadditionalcontactinfoViewRow] =
+    new Impl(Nil)
     
-  private final class Impl[Row](val prefix: Option[String], val extract: Row => VadditionalcontactinfoViewRow, val merge: (Row, VadditionalcontactinfoViewRow) => Row)
-    extends Relation[VadditionalcontactinfoViewFields, VadditionalcontactinfoViewRow, Row] { 
+  private final class Impl(val _path: List[Path])
+    extends Relation[VadditionalcontactinfoViewFields, VadditionalcontactinfoViewRow] {
   
-    override val fields: VadditionalcontactinfoViewFields[Row] = new VadditionalcontactinfoViewFields[Row] {
-      override val businessentityid = new Field[BusinessentityId, Row](prefix, "businessentityid", None, None)(x => extract(x).businessentityid, (row, value) => merge(row, extract(row).copy(businessentityid = value)))
-      override val firstname = new Field[/* user-picked */ FirstName, Row](prefix, "firstname", None, None)(x => extract(x).firstname, (row, value) => merge(row, extract(row).copy(firstname = value)))
-      override val middlename = new OptField[Name, Row](prefix, "middlename", None, None)(x => extract(x).middlename, (row, value) => merge(row, extract(row).copy(middlename = value)))
-      override val lastname = new Field[Name, Row](prefix, "lastname", None, None)(x => extract(x).lastname, (row, value) => merge(row, extract(row).copy(lastname = value)))
-      override val telephonenumber = new OptField[TypoXml, Row](prefix, "telephonenumber", None, None)(x => extract(x).telephonenumber, (row, value) => merge(row, extract(row).copy(telephonenumber = value)))
-      override val telephonespecialinstructions = new OptField[String, Row](prefix, "telephonespecialinstructions", None, None)(x => extract(x).telephonespecialinstructions, (row, value) => merge(row, extract(row).copy(telephonespecialinstructions = value)))
-      override val street = new OptField[TypoXml, Row](prefix, "street", None, None)(x => extract(x).street, (row, value) => merge(row, extract(row).copy(street = value)))
-      override val city = new OptField[TypoXml, Row](prefix, "city", None, None)(x => extract(x).city, (row, value) => merge(row, extract(row).copy(city = value)))
-      override val stateprovince = new OptField[TypoXml, Row](prefix, "stateprovince", None, None)(x => extract(x).stateprovince, (row, value) => merge(row, extract(row).copy(stateprovince = value)))
-      override val postalcode = new OptField[TypoXml, Row](prefix, "postalcode", None, None)(x => extract(x).postalcode, (row, value) => merge(row, extract(row).copy(postalcode = value)))
-      override val countryregion = new OptField[TypoXml, Row](prefix, "countryregion", None, None)(x => extract(x).countryregion, (row, value) => merge(row, extract(row).copy(countryregion = value)))
-      override val homeaddressspecialinstructions = new OptField[TypoXml, Row](prefix, "homeaddressspecialinstructions", None, None)(x => extract(x).homeaddressspecialinstructions, (row, value) => merge(row, extract(row).copy(homeaddressspecialinstructions = value)))
-      override val emailaddress = new OptField[TypoXml, Row](prefix, "emailaddress", None, None)(x => extract(x).emailaddress, (row, value) => merge(row, extract(row).copy(emailaddress = value)))
-      override val emailspecialinstructions = new OptField[String, Row](prefix, "emailspecialinstructions", None, None)(x => extract(x).emailspecialinstructions, (row, value) => merge(row, extract(row).copy(emailspecialinstructions = value)))
-      override val emailtelephonenumber = new OptField[TypoXml, Row](prefix, "emailtelephonenumber", None, None)(x => extract(x).emailtelephonenumber, (row, value) => merge(row, extract(row).copy(emailtelephonenumber = value)))
-      override val rowguid = new Field[TypoUUID, Row](prefix, "rowguid", None, None)(x => extract(x).rowguid, (row, value) => merge(row, extract(row).copy(rowguid = value)))
-      override val modifieddate = new Field[TypoLocalDateTime, Row](prefix, "modifieddate", Some("text"), None)(x => extract(x).modifieddate, (row, value) => merge(row, extract(row).copy(modifieddate = value)))
+    override lazy val fields: VadditionalcontactinfoViewFields = new VadditionalcontactinfoViewFields {
+      override def businessentityid = Field[BusinessentityId, VadditionalcontactinfoViewRow](_path, "businessentityid", None, None, x => x.businessentityid, (row, value) => row.copy(businessentityid = value))
+      override def firstname = Field[/* user-picked */ FirstName, VadditionalcontactinfoViewRow](_path, "firstname", None, None, x => x.firstname, (row, value) => row.copy(firstname = value))
+      override def middlename = OptField[Name, VadditionalcontactinfoViewRow](_path, "middlename", None, None, x => x.middlename, (row, value) => row.copy(middlename = value))
+      override def lastname = Field[Name, VadditionalcontactinfoViewRow](_path, "lastname", None, None, x => x.lastname, (row, value) => row.copy(lastname = value))
+      override def telephonenumber = OptField[TypoXml, VadditionalcontactinfoViewRow](_path, "telephonenumber", None, None, x => x.telephonenumber, (row, value) => row.copy(telephonenumber = value))
+      override def telephonespecialinstructions = OptField[String, VadditionalcontactinfoViewRow](_path, "telephonespecialinstructions", None, None, x => x.telephonespecialinstructions, (row, value) => row.copy(telephonespecialinstructions = value))
+      override def street = OptField[TypoXml, VadditionalcontactinfoViewRow](_path, "street", None, None, x => x.street, (row, value) => row.copy(street = value))
+      override def city = OptField[TypoXml, VadditionalcontactinfoViewRow](_path, "city", None, None, x => x.city, (row, value) => row.copy(city = value))
+      override def stateprovince = OptField[TypoXml, VadditionalcontactinfoViewRow](_path, "stateprovince", None, None, x => x.stateprovince, (row, value) => row.copy(stateprovince = value))
+      override def postalcode = OptField[TypoXml, VadditionalcontactinfoViewRow](_path, "postalcode", None, None, x => x.postalcode, (row, value) => row.copy(postalcode = value))
+      override def countryregion = OptField[TypoXml, VadditionalcontactinfoViewRow](_path, "countryregion", None, None, x => x.countryregion, (row, value) => row.copy(countryregion = value))
+      override def homeaddressspecialinstructions = OptField[TypoXml, VadditionalcontactinfoViewRow](_path, "homeaddressspecialinstructions", None, None, x => x.homeaddressspecialinstructions, (row, value) => row.copy(homeaddressspecialinstructions = value))
+      override def emailaddress = OptField[TypoXml, VadditionalcontactinfoViewRow](_path, "emailaddress", None, None, x => x.emailaddress, (row, value) => row.copy(emailaddress = value))
+      override def emailspecialinstructions = OptField[String, VadditionalcontactinfoViewRow](_path, "emailspecialinstructions", None, None, x => x.emailspecialinstructions, (row, value) => row.copy(emailspecialinstructions = value))
+      override def emailtelephonenumber = OptField[TypoXml, VadditionalcontactinfoViewRow](_path, "emailtelephonenumber", None, None, x => x.emailtelephonenumber, (row, value) => row.copy(emailtelephonenumber = value))
+      override def rowguid = Field[TypoUUID, VadditionalcontactinfoViewRow](_path, "rowguid", None, None, x => x.rowguid, (row, value) => row.copy(rowguid = value))
+      override def modifieddate = Field[TypoLocalDateTime, VadditionalcontactinfoViewRow](_path, "modifieddate", Some("text"), None, x => x.modifieddate, (row, value) => row.copy(modifieddate = value))
     }
   
-    override val columns: List[FieldLikeNoHkt[?, Row]] =
-      List[FieldLikeNoHkt[?, Row]](fields.businessentityid, fields.firstname, fields.middlename, fields.lastname, fields.telephonenumber, fields.telephonespecialinstructions, fields.street, fields.city, fields.stateprovince, fields.postalcode, fields.countryregion, fields.homeaddressspecialinstructions, fields.emailaddress, fields.emailspecialinstructions, fields.emailtelephonenumber, fields.rowguid, fields.modifieddate)
+    override lazy val columns: List[FieldLikeNoHkt[?, VadditionalcontactinfoViewRow]] =
+      List[FieldLikeNoHkt[?, VadditionalcontactinfoViewRow]](fields.businessentityid, fields.firstname, fields.middlename, fields.lastname, fields.telephonenumber, fields.telephonespecialinstructions, fields.street, fields.city, fields.stateprovince, fields.postalcode, fields.countryregion, fields.homeaddressspecialinstructions, fields.emailaddress, fields.emailspecialinstructions, fields.emailtelephonenumber, fields.rowguid, fields.modifieddate)
   
-    override def copy[NewRow](prefix: Option[String], extract: NewRow => VadditionalcontactinfoViewRow, merge: (NewRow, VadditionalcontactinfoViewRow) => NewRow): Impl[NewRow] =
-      new Impl(prefix, extract, merge)
+    override def copy(path: List[Path]): Impl =
+      new Impl(path)
   }
   
 }

--- a/typo-tester-doobie/generated-and-checked-in/adventureworks/person/vstateprovincecountryregion/VstateprovincecountryregionMVFields.scala
+++ b/typo-tester-doobie/generated-and-checked-in/adventureworks/person/vstateprovincecountryregion/VstateprovincecountryregionMVFields.scala
@@ -12,42 +12,43 @@ import adventureworks.person.stateprovince.StateprovinceId
 import adventureworks.public.Flag
 import adventureworks.public.Name
 import adventureworks.sales.salesterritory.SalesterritoryId
+import typo.dsl.Path
 import typo.dsl.SqlExpr.Field
 import typo.dsl.SqlExpr.FieldLikeNoHkt
 import typo.dsl.Structure.Relation
 
-trait VstateprovincecountryregionMVFields[Row] {
-  val stateprovinceid: Field[StateprovinceId, Row]
-  val stateprovincecode: Field[/* bpchar, max 3 chars */ String, Row]
-  val isonlystateprovinceflag: Field[Flag, Row]
-  val stateprovincename: Field[Name, Row]
-  val territoryid: Field[SalesterritoryId, Row]
-  val countryregioncode: Field[CountryregionId, Row]
-  val countryregionname: Field[Name, Row]
+trait VstateprovincecountryregionMVFields {
+  def stateprovinceid: Field[StateprovinceId, VstateprovincecountryregionMVRow]
+  def stateprovincecode: Field[/* bpchar, max 3 chars */ String, VstateprovincecountryregionMVRow]
+  def isonlystateprovinceflag: Field[Flag, VstateprovincecountryregionMVRow]
+  def stateprovincename: Field[Name, VstateprovincecountryregionMVRow]
+  def territoryid: Field[SalesterritoryId, VstateprovincecountryregionMVRow]
+  def countryregioncode: Field[CountryregionId, VstateprovincecountryregionMVRow]
+  def countryregionname: Field[Name, VstateprovincecountryregionMVRow]
 }
 
 object VstateprovincecountryregionMVFields {
-  val structure: Relation[VstateprovincecountryregionMVFields, VstateprovincecountryregionMVRow, VstateprovincecountryregionMVRow] = 
-    new Impl(None, identity, (_, x) => x)
+  lazy val structure: Relation[VstateprovincecountryregionMVFields, VstateprovincecountryregionMVRow] =
+    new Impl(Nil)
     
-  private final class Impl[Row](val prefix: Option[String], val extract: Row => VstateprovincecountryregionMVRow, val merge: (Row, VstateprovincecountryregionMVRow) => Row)
-    extends Relation[VstateprovincecountryregionMVFields, VstateprovincecountryregionMVRow, Row] { 
+  private final class Impl(val _path: List[Path])
+    extends Relation[VstateprovincecountryregionMVFields, VstateprovincecountryregionMVRow] {
   
-    override val fields: VstateprovincecountryregionMVFields[Row] = new VstateprovincecountryregionMVFields[Row] {
-      override val stateprovinceid = new Field[StateprovinceId, Row](prefix, "stateprovinceid", None, None)(x => extract(x).stateprovinceid, (row, value) => merge(row, extract(row).copy(stateprovinceid = value)))
-      override val stateprovincecode = new Field[/* bpchar, max 3 chars */ String, Row](prefix, "stateprovincecode", None, None)(x => extract(x).stateprovincecode, (row, value) => merge(row, extract(row).copy(stateprovincecode = value)))
-      override val isonlystateprovinceflag = new Field[Flag, Row](prefix, "isonlystateprovinceflag", None, None)(x => extract(x).isonlystateprovinceflag, (row, value) => merge(row, extract(row).copy(isonlystateprovinceflag = value)))
-      override val stateprovincename = new Field[Name, Row](prefix, "stateprovincename", None, None)(x => extract(x).stateprovincename, (row, value) => merge(row, extract(row).copy(stateprovincename = value)))
-      override val territoryid = new Field[SalesterritoryId, Row](prefix, "territoryid", None, None)(x => extract(x).territoryid, (row, value) => merge(row, extract(row).copy(territoryid = value)))
-      override val countryregioncode = new Field[CountryregionId, Row](prefix, "countryregioncode", None, None)(x => extract(x).countryregioncode, (row, value) => merge(row, extract(row).copy(countryregioncode = value)))
-      override val countryregionname = new Field[Name, Row](prefix, "countryregionname", None, None)(x => extract(x).countryregionname, (row, value) => merge(row, extract(row).copy(countryregionname = value)))
+    override lazy val fields: VstateprovincecountryregionMVFields = new VstateprovincecountryregionMVFields {
+      override def stateprovinceid = Field[StateprovinceId, VstateprovincecountryregionMVRow](_path, "stateprovinceid", None, None, x => x.stateprovinceid, (row, value) => row.copy(stateprovinceid = value))
+      override def stateprovincecode = Field[/* bpchar, max 3 chars */ String, VstateprovincecountryregionMVRow](_path, "stateprovincecode", None, None, x => x.stateprovincecode, (row, value) => row.copy(stateprovincecode = value))
+      override def isonlystateprovinceflag = Field[Flag, VstateprovincecountryregionMVRow](_path, "isonlystateprovinceflag", None, None, x => x.isonlystateprovinceflag, (row, value) => row.copy(isonlystateprovinceflag = value))
+      override def stateprovincename = Field[Name, VstateprovincecountryregionMVRow](_path, "stateprovincename", None, None, x => x.stateprovincename, (row, value) => row.copy(stateprovincename = value))
+      override def territoryid = Field[SalesterritoryId, VstateprovincecountryregionMVRow](_path, "territoryid", None, None, x => x.territoryid, (row, value) => row.copy(territoryid = value))
+      override def countryregioncode = Field[CountryregionId, VstateprovincecountryregionMVRow](_path, "countryregioncode", None, None, x => x.countryregioncode, (row, value) => row.copy(countryregioncode = value))
+      override def countryregionname = Field[Name, VstateprovincecountryregionMVRow](_path, "countryregionname", None, None, x => x.countryregionname, (row, value) => row.copy(countryregionname = value))
     }
   
-    override val columns: List[FieldLikeNoHkt[?, Row]] =
-      List[FieldLikeNoHkt[?, Row]](fields.stateprovinceid, fields.stateprovincecode, fields.isonlystateprovinceflag, fields.stateprovincename, fields.territoryid, fields.countryregioncode, fields.countryregionname)
+    override lazy val columns: List[FieldLikeNoHkt[?, VstateprovincecountryregionMVRow]] =
+      List[FieldLikeNoHkt[?, VstateprovincecountryregionMVRow]](fields.stateprovinceid, fields.stateprovincecode, fields.isonlystateprovinceflag, fields.stateprovincename, fields.territoryid, fields.countryregioncode, fields.countryregionname)
   
-    override def copy[NewRow](prefix: Option[String], extract: NewRow => VstateprovincecountryregionMVRow, merge: (NewRow, VstateprovincecountryregionMVRow) => NewRow): Impl[NewRow] =
-      new Impl(prefix, extract, merge)
+    override def copy(path: List[Path]): Impl =
+      new Impl(path)
   }
   
 }

--- a/typo-tester-doobie/generated-and-checked-in/adventureworks/pr/bom/BomViewFields.scala
+++ b/typo-tester-doobie/generated-and-checked-in/adventureworks/pr/bom/BomViewFields.scala
@@ -11,49 +11,50 @@ import adventureworks.customtypes.TypoLocalDateTime
 import adventureworks.customtypes.TypoShort
 import adventureworks.production.product.ProductId
 import adventureworks.production.unitmeasure.UnitmeasureId
+import typo.dsl.Path
 import typo.dsl.SqlExpr.Field
 import typo.dsl.SqlExpr.FieldLikeNoHkt
 import typo.dsl.SqlExpr.OptField
 import typo.dsl.Structure.Relation
 
-trait BomViewFields[Row] {
-  val id: Field[Int, Row]
-  val billofmaterialsid: Field[Int, Row]
-  val productassemblyid: OptField[ProductId, Row]
-  val componentid: Field[ProductId, Row]
-  val startdate: Field[TypoLocalDateTime, Row]
-  val enddate: OptField[TypoLocalDateTime, Row]
-  val unitmeasurecode: Field[UnitmeasureId, Row]
-  val bomlevel: Field[TypoShort, Row]
-  val perassemblyqty: Field[BigDecimal, Row]
-  val modifieddate: Field[TypoLocalDateTime, Row]
+trait BomViewFields {
+  def id: Field[Int, BomViewRow]
+  def billofmaterialsid: Field[Int, BomViewRow]
+  def productassemblyid: OptField[ProductId, BomViewRow]
+  def componentid: Field[ProductId, BomViewRow]
+  def startdate: Field[TypoLocalDateTime, BomViewRow]
+  def enddate: OptField[TypoLocalDateTime, BomViewRow]
+  def unitmeasurecode: Field[UnitmeasureId, BomViewRow]
+  def bomlevel: Field[TypoShort, BomViewRow]
+  def perassemblyqty: Field[BigDecimal, BomViewRow]
+  def modifieddate: Field[TypoLocalDateTime, BomViewRow]
 }
 
 object BomViewFields {
-  val structure: Relation[BomViewFields, BomViewRow, BomViewRow] = 
-    new Impl(None, identity, (_, x) => x)
+  lazy val structure: Relation[BomViewFields, BomViewRow] =
+    new Impl(Nil)
     
-  private final class Impl[Row](val prefix: Option[String], val extract: Row => BomViewRow, val merge: (Row, BomViewRow) => Row)
-    extends Relation[BomViewFields, BomViewRow, Row] { 
+  private final class Impl(val _path: List[Path])
+    extends Relation[BomViewFields, BomViewRow] {
   
-    override val fields: BomViewFields[Row] = new BomViewFields[Row] {
-      override val id = new Field[Int, Row](prefix, "id", None, None)(x => extract(x).id, (row, value) => merge(row, extract(row).copy(id = value)))
-      override val billofmaterialsid = new Field[Int, Row](prefix, "billofmaterialsid", None, None)(x => extract(x).billofmaterialsid, (row, value) => merge(row, extract(row).copy(billofmaterialsid = value)))
-      override val productassemblyid = new OptField[ProductId, Row](prefix, "productassemblyid", None, None)(x => extract(x).productassemblyid, (row, value) => merge(row, extract(row).copy(productassemblyid = value)))
-      override val componentid = new Field[ProductId, Row](prefix, "componentid", None, None)(x => extract(x).componentid, (row, value) => merge(row, extract(row).copy(componentid = value)))
-      override val startdate = new Field[TypoLocalDateTime, Row](prefix, "startdate", Some("text"), None)(x => extract(x).startdate, (row, value) => merge(row, extract(row).copy(startdate = value)))
-      override val enddate = new OptField[TypoLocalDateTime, Row](prefix, "enddate", Some("text"), None)(x => extract(x).enddate, (row, value) => merge(row, extract(row).copy(enddate = value)))
-      override val unitmeasurecode = new Field[UnitmeasureId, Row](prefix, "unitmeasurecode", None, None)(x => extract(x).unitmeasurecode, (row, value) => merge(row, extract(row).copy(unitmeasurecode = value)))
-      override val bomlevel = new Field[TypoShort, Row](prefix, "bomlevel", None, None)(x => extract(x).bomlevel, (row, value) => merge(row, extract(row).copy(bomlevel = value)))
-      override val perassemblyqty = new Field[BigDecimal, Row](prefix, "perassemblyqty", None, None)(x => extract(x).perassemblyqty, (row, value) => merge(row, extract(row).copy(perassemblyqty = value)))
-      override val modifieddate = new Field[TypoLocalDateTime, Row](prefix, "modifieddate", Some("text"), None)(x => extract(x).modifieddate, (row, value) => merge(row, extract(row).copy(modifieddate = value)))
+    override lazy val fields: BomViewFields = new BomViewFields {
+      override def id = Field[Int, BomViewRow](_path, "id", None, None, x => x.id, (row, value) => row.copy(id = value))
+      override def billofmaterialsid = Field[Int, BomViewRow](_path, "billofmaterialsid", None, None, x => x.billofmaterialsid, (row, value) => row.copy(billofmaterialsid = value))
+      override def productassemblyid = OptField[ProductId, BomViewRow](_path, "productassemblyid", None, None, x => x.productassemblyid, (row, value) => row.copy(productassemblyid = value))
+      override def componentid = Field[ProductId, BomViewRow](_path, "componentid", None, None, x => x.componentid, (row, value) => row.copy(componentid = value))
+      override def startdate = Field[TypoLocalDateTime, BomViewRow](_path, "startdate", Some("text"), None, x => x.startdate, (row, value) => row.copy(startdate = value))
+      override def enddate = OptField[TypoLocalDateTime, BomViewRow](_path, "enddate", Some("text"), None, x => x.enddate, (row, value) => row.copy(enddate = value))
+      override def unitmeasurecode = Field[UnitmeasureId, BomViewRow](_path, "unitmeasurecode", None, None, x => x.unitmeasurecode, (row, value) => row.copy(unitmeasurecode = value))
+      override def bomlevel = Field[TypoShort, BomViewRow](_path, "bomlevel", None, None, x => x.bomlevel, (row, value) => row.copy(bomlevel = value))
+      override def perassemblyqty = Field[BigDecimal, BomViewRow](_path, "perassemblyqty", None, None, x => x.perassemblyqty, (row, value) => row.copy(perassemblyqty = value))
+      override def modifieddate = Field[TypoLocalDateTime, BomViewRow](_path, "modifieddate", Some("text"), None, x => x.modifieddate, (row, value) => row.copy(modifieddate = value))
     }
   
-    override val columns: List[FieldLikeNoHkt[?, Row]] =
-      List[FieldLikeNoHkt[?, Row]](fields.id, fields.billofmaterialsid, fields.productassemblyid, fields.componentid, fields.startdate, fields.enddate, fields.unitmeasurecode, fields.bomlevel, fields.perassemblyqty, fields.modifieddate)
+    override lazy val columns: List[FieldLikeNoHkt[?, BomViewRow]] =
+      List[FieldLikeNoHkt[?, BomViewRow]](fields.id, fields.billofmaterialsid, fields.productassemblyid, fields.componentid, fields.startdate, fields.enddate, fields.unitmeasurecode, fields.bomlevel, fields.perassemblyqty, fields.modifieddate)
   
-    override def copy[NewRow](prefix: Option[String], extract: NewRow => BomViewRow, merge: (NewRow, BomViewRow) => NewRow): Impl[NewRow] =
-      new Impl(prefix, extract, merge)
+    override def copy(path: List[Path]): Impl =
+      new Impl(path)
   }
   
 }

--- a/typo-tester-doobie/generated-and-checked-in/adventureworks/pr/d/DViewFields.scala
+++ b/typo-tester-doobie/generated-and-checked-in/adventureworks/pr/d/DViewFields.scala
@@ -14,55 +14,56 @@ import adventureworks.customtypes.TypoUUID
 import adventureworks.person.businessentity.BusinessentityId
 import adventureworks.production.document.DocumentId
 import adventureworks.public.Flag
+import typo.dsl.Path
 import typo.dsl.SqlExpr.Field
 import typo.dsl.SqlExpr.FieldLikeNoHkt
 import typo.dsl.SqlExpr.OptField
 import typo.dsl.Structure.Relation
 
-trait DViewFields[Row] {
-  val title: Field[/* max 50 chars */ String, Row]
-  val owner: Field[BusinessentityId, Row]
-  val folderflag: Field[Flag, Row]
-  val filename: Field[/* max 400 chars */ String, Row]
-  val fileextension: OptField[/* max 8 chars */ String, Row]
-  val revision: Field[/* bpchar, max 5 chars */ String, Row]
-  val changenumber: Field[Int, Row]
-  val status: Field[TypoShort, Row]
-  val documentsummary: OptField[String, Row]
-  val document: OptField[TypoBytea, Row]
-  val rowguid: Field[TypoUUID, Row]
-  val modifieddate: Field[TypoLocalDateTime, Row]
-  val documentnode: Field[DocumentId, Row]
+trait DViewFields {
+  def title: Field[/* max 50 chars */ String, DViewRow]
+  def owner: Field[BusinessentityId, DViewRow]
+  def folderflag: Field[Flag, DViewRow]
+  def filename: Field[/* max 400 chars */ String, DViewRow]
+  def fileextension: OptField[/* max 8 chars */ String, DViewRow]
+  def revision: Field[/* bpchar, max 5 chars */ String, DViewRow]
+  def changenumber: Field[Int, DViewRow]
+  def status: Field[TypoShort, DViewRow]
+  def documentsummary: OptField[String, DViewRow]
+  def document: OptField[TypoBytea, DViewRow]
+  def rowguid: Field[TypoUUID, DViewRow]
+  def modifieddate: Field[TypoLocalDateTime, DViewRow]
+  def documentnode: Field[DocumentId, DViewRow]
 }
 
 object DViewFields {
-  val structure: Relation[DViewFields, DViewRow, DViewRow] = 
-    new Impl(None, identity, (_, x) => x)
+  lazy val structure: Relation[DViewFields, DViewRow] =
+    new Impl(Nil)
     
-  private final class Impl[Row](val prefix: Option[String], val extract: Row => DViewRow, val merge: (Row, DViewRow) => Row)
-    extends Relation[DViewFields, DViewRow, Row] { 
+  private final class Impl(val _path: List[Path])
+    extends Relation[DViewFields, DViewRow] {
   
-    override val fields: DViewFields[Row] = new DViewFields[Row] {
-      override val title = new Field[/* max 50 chars */ String, Row](prefix, "title", None, None)(x => extract(x).title, (row, value) => merge(row, extract(row).copy(title = value)))
-      override val owner = new Field[BusinessentityId, Row](prefix, "owner", None, None)(x => extract(x).owner, (row, value) => merge(row, extract(row).copy(owner = value)))
-      override val folderflag = new Field[Flag, Row](prefix, "folderflag", None, None)(x => extract(x).folderflag, (row, value) => merge(row, extract(row).copy(folderflag = value)))
-      override val filename = new Field[/* max 400 chars */ String, Row](prefix, "filename", None, None)(x => extract(x).filename, (row, value) => merge(row, extract(row).copy(filename = value)))
-      override val fileextension = new OptField[/* max 8 chars */ String, Row](prefix, "fileextension", None, None)(x => extract(x).fileextension, (row, value) => merge(row, extract(row).copy(fileextension = value)))
-      override val revision = new Field[/* bpchar, max 5 chars */ String, Row](prefix, "revision", None, None)(x => extract(x).revision, (row, value) => merge(row, extract(row).copy(revision = value)))
-      override val changenumber = new Field[Int, Row](prefix, "changenumber", None, None)(x => extract(x).changenumber, (row, value) => merge(row, extract(row).copy(changenumber = value)))
-      override val status = new Field[TypoShort, Row](prefix, "status", None, None)(x => extract(x).status, (row, value) => merge(row, extract(row).copy(status = value)))
-      override val documentsummary = new OptField[String, Row](prefix, "documentsummary", None, None)(x => extract(x).documentsummary, (row, value) => merge(row, extract(row).copy(documentsummary = value)))
-      override val document = new OptField[TypoBytea, Row](prefix, "document", None, None)(x => extract(x).document, (row, value) => merge(row, extract(row).copy(document = value)))
-      override val rowguid = new Field[TypoUUID, Row](prefix, "rowguid", None, None)(x => extract(x).rowguid, (row, value) => merge(row, extract(row).copy(rowguid = value)))
-      override val modifieddate = new Field[TypoLocalDateTime, Row](prefix, "modifieddate", Some("text"), None)(x => extract(x).modifieddate, (row, value) => merge(row, extract(row).copy(modifieddate = value)))
-      override val documentnode = new Field[DocumentId, Row](prefix, "documentnode", None, None)(x => extract(x).documentnode, (row, value) => merge(row, extract(row).copy(documentnode = value)))
+    override lazy val fields: DViewFields = new DViewFields {
+      override def title = Field[/* max 50 chars */ String, DViewRow](_path, "title", None, None, x => x.title, (row, value) => row.copy(title = value))
+      override def owner = Field[BusinessentityId, DViewRow](_path, "owner", None, None, x => x.owner, (row, value) => row.copy(owner = value))
+      override def folderflag = Field[Flag, DViewRow](_path, "folderflag", None, None, x => x.folderflag, (row, value) => row.copy(folderflag = value))
+      override def filename = Field[/* max 400 chars */ String, DViewRow](_path, "filename", None, None, x => x.filename, (row, value) => row.copy(filename = value))
+      override def fileextension = OptField[/* max 8 chars */ String, DViewRow](_path, "fileextension", None, None, x => x.fileextension, (row, value) => row.copy(fileextension = value))
+      override def revision = Field[/* bpchar, max 5 chars */ String, DViewRow](_path, "revision", None, None, x => x.revision, (row, value) => row.copy(revision = value))
+      override def changenumber = Field[Int, DViewRow](_path, "changenumber", None, None, x => x.changenumber, (row, value) => row.copy(changenumber = value))
+      override def status = Field[TypoShort, DViewRow](_path, "status", None, None, x => x.status, (row, value) => row.copy(status = value))
+      override def documentsummary = OptField[String, DViewRow](_path, "documentsummary", None, None, x => x.documentsummary, (row, value) => row.copy(documentsummary = value))
+      override def document = OptField[TypoBytea, DViewRow](_path, "document", None, None, x => x.document, (row, value) => row.copy(document = value))
+      override def rowguid = Field[TypoUUID, DViewRow](_path, "rowguid", None, None, x => x.rowguid, (row, value) => row.copy(rowguid = value))
+      override def modifieddate = Field[TypoLocalDateTime, DViewRow](_path, "modifieddate", Some("text"), None, x => x.modifieddate, (row, value) => row.copy(modifieddate = value))
+      override def documentnode = Field[DocumentId, DViewRow](_path, "documentnode", None, None, x => x.documentnode, (row, value) => row.copy(documentnode = value))
     }
   
-    override val columns: List[FieldLikeNoHkt[?, Row]] =
-      List[FieldLikeNoHkt[?, Row]](fields.title, fields.owner, fields.folderflag, fields.filename, fields.fileextension, fields.revision, fields.changenumber, fields.status, fields.documentsummary, fields.document, fields.rowguid, fields.modifieddate, fields.documentnode)
+    override lazy val columns: List[FieldLikeNoHkt[?, DViewRow]] =
+      List[FieldLikeNoHkt[?, DViewRow]](fields.title, fields.owner, fields.folderflag, fields.filename, fields.fileextension, fields.revision, fields.changenumber, fields.status, fields.documentsummary, fields.document, fields.rowguid, fields.modifieddate, fields.documentnode)
   
-    override def copy[NewRow](prefix: Option[String], extract: NewRow => DViewRow, merge: (NewRow, DViewRow) => NewRow): Impl[NewRow] =
-      new Impl(prefix, extract, merge)
+    override def copy(path: List[Path]): Impl =
+      new Impl(path)
   }
   
 }

--- a/typo-tester-doobie/generated-and-checked-in/adventureworks/pr/l/LViewFields.scala
+++ b/typo-tester-doobie/generated-and-checked-in/adventureworks/pr/l/LViewFields.scala
@@ -10,40 +10,41 @@ package l
 import adventureworks.customtypes.TypoLocalDateTime
 import adventureworks.production.location.LocationId
 import adventureworks.public.Name
+import typo.dsl.Path
 import typo.dsl.SqlExpr.Field
 import typo.dsl.SqlExpr.FieldLikeNoHkt
 import typo.dsl.Structure.Relation
 
-trait LViewFields[Row] {
-  val id: Field[LocationId, Row]
-  val locationid: Field[LocationId, Row]
-  val name: Field[Name, Row]
-  val costrate: Field[BigDecimal, Row]
-  val availability: Field[BigDecimal, Row]
-  val modifieddate: Field[TypoLocalDateTime, Row]
+trait LViewFields {
+  def id: Field[LocationId, LViewRow]
+  def locationid: Field[LocationId, LViewRow]
+  def name: Field[Name, LViewRow]
+  def costrate: Field[BigDecimal, LViewRow]
+  def availability: Field[BigDecimal, LViewRow]
+  def modifieddate: Field[TypoLocalDateTime, LViewRow]
 }
 
 object LViewFields {
-  val structure: Relation[LViewFields, LViewRow, LViewRow] = 
-    new Impl(None, identity, (_, x) => x)
+  lazy val structure: Relation[LViewFields, LViewRow] =
+    new Impl(Nil)
     
-  private final class Impl[Row](val prefix: Option[String], val extract: Row => LViewRow, val merge: (Row, LViewRow) => Row)
-    extends Relation[LViewFields, LViewRow, Row] { 
+  private final class Impl(val _path: List[Path])
+    extends Relation[LViewFields, LViewRow] {
   
-    override val fields: LViewFields[Row] = new LViewFields[Row] {
-      override val id = new Field[LocationId, Row](prefix, "id", None, None)(x => extract(x).id, (row, value) => merge(row, extract(row).copy(id = value)))
-      override val locationid = new Field[LocationId, Row](prefix, "locationid", None, None)(x => extract(x).locationid, (row, value) => merge(row, extract(row).copy(locationid = value)))
-      override val name = new Field[Name, Row](prefix, "name", None, None)(x => extract(x).name, (row, value) => merge(row, extract(row).copy(name = value)))
-      override val costrate = new Field[BigDecimal, Row](prefix, "costrate", None, None)(x => extract(x).costrate, (row, value) => merge(row, extract(row).copy(costrate = value)))
-      override val availability = new Field[BigDecimal, Row](prefix, "availability", None, None)(x => extract(x).availability, (row, value) => merge(row, extract(row).copy(availability = value)))
-      override val modifieddate = new Field[TypoLocalDateTime, Row](prefix, "modifieddate", Some("text"), None)(x => extract(x).modifieddate, (row, value) => merge(row, extract(row).copy(modifieddate = value)))
+    override lazy val fields: LViewFields = new LViewFields {
+      override def id = Field[LocationId, LViewRow](_path, "id", None, None, x => x.id, (row, value) => row.copy(id = value))
+      override def locationid = Field[LocationId, LViewRow](_path, "locationid", None, None, x => x.locationid, (row, value) => row.copy(locationid = value))
+      override def name = Field[Name, LViewRow](_path, "name", None, None, x => x.name, (row, value) => row.copy(name = value))
+      override def costrate = Field[BigDecimal, LViewRow](_path, "costrate", None, None, x => x.costrate, (row, value) => row.copy(costrate = value))
+      override def availability = Field[BigDecimal, LViewRow](_path, "availability", None, None, x => x.availability, (row, value) => row.copy(availability = value))
+      override def modifieddate = Field[TypoLocalDateTime, LViewRow](_path, "modifieddate", Some("text"), None, x => x.modifieddate, (row, value) => row.copy(modifieddate = value))
     }
   
-    override val columns: List[FieldLikeNoHkt[?, Row]] =
-      List[FieldLikeNoHkt[?, Row]](fields.id, fields.locationid, fields.name, fields.costrate, fields.availability, fields.modifieddate)
+    override lazy val columns: List[FieldLikeNoHkt[?, LViewRow]] =
+      List[FieldLikeNoHkt[?, LViewRow]](fields.id, fields.locationid, fields.name, fields.costrate, fields.availability, fields.modifieddate)
   
-    override def copy[NewRow](prefix: Option[String], extract: NewRow => LViewRow, merge: (NewRow, LViewRow) => NewRow): Impl[NewRow] =
-      new Impl(prefix, extract, merge)
+    override def copy(path: List[Path]): Impl =
+      new Impl(path)
   }
   
 }

--- a/typo-tester-doobie/generated-and-checked-in/adventureworks/pr/p/PViewFields.scala
+++ b/typo-tester-doobie/generated-and-checked-in/adventureworks/pr/p/PViewFields.scala
@@ -16,81 +16,82 @@ import adventureworks.production.productsubcategory.ProductsubcategoryId
 import adventureworks.production.unitmeasure.UnitmeasureId
 import adventureworks.public.Flag
 import adventureworks.public.Name
+import typo.dsl.Path
 import typo.dsl.SqlExpr.Field
 import typo.dsl.SqlExpr.FieldLikeNoHkt
 import typo.dsl.SqlExpr.OptField
 import typo.dsl.Structure.Relation
 
-trait PViewFields[Row] {
-  val id: Field[ProductId, Row]
-  val productid: Field[ProductId, Row]
-  val name: Field[Name, Row]
-  val productnumber: Field[/* max 25 chars */ String, Row]
-  val makeflag: Field[Flag, Row]
-  val finishedgoodsflag: Field[Flag, Row]
-  val color: OptField[/* max 15 chars */ String, Row]
-  val safetystocklevel: Field[TypoShort, Row]
-  val reorderpoint: Field[TypoShort, Row]
-  val standardcost: Field[BigDecimal, Row]
-  val listprice: Field[BigDecimal, Row]
-  val size: OptField[/* max 5 chars */ String, Row]
-  val sizeunitmeasurecode: OptField[UnitmeasureId, Row]
-  val weightunitmeasurecode: OptField[UnitmeasureId, Row]
-  val weight: OptField[BigDecimal, Row]
-  val daystomanufacture: Field[Int, Row]
-  val productline: OptField[/* bpchar, max 2 chars */ String, Row]
-  val `class`: OptField[/* bpchar, max 2 chars */ String, Row]
-  val style: OptField[/* bpchar, max 2 chars */ String, Row]
-  val productsubcategoryid: OptField[ProductsubcategoryId, Row]
-  val productmodelid: OptField[ProductmodelId, Row]
-  val sellstartdate: Field[TypoLocalDateTime, Row]
-  val sellenddate: OptField[TypoLocalDateTime, Row]
-  val discontinueddate: OptField[TypoLocalDateTime, Row]
-  val rowguid: Field[TypoUUID, Row]
-  val modifieddate: Field[TypoLocalDateTime, Row]
+trait PViewFields {
+  def id: Field[ProductId, PViewRow]
+  def productid: Field[ProductId, PViewRow]
+  def name: Field[Name, PViewRow]
+  def productnumber: Field[/* max 25 chars */ String, PViewRow]
+  def makeflag: Field[Flag, PViewRow]
+  def finishedgoodsflag: Field[Flag, PViewRow]
+  def color: OptField[/* max 15 chars */ String, PViewRow]
+  def safetystocklevel: Field[TypoShort, PViewRow]
+  def reorderpoint: Field[TypoShort, PViewRow]
+  def standardcost: Field[BigDecimal, PViewRow]
+  def listprice: Field[BigDecimal, PViewRow]
+  def size: OptField[/* max 5 chars */ String, PViewRow]
+  def sizeunitmeasurecode: OptField[UnitmeasureId, PViewRow]
+  def weightunitmeasurecode: OptField[UnitmeasureId, PViewRow]
+  def weight: OptField[BigDecimal, PViewRow]
+  def daystomanufacture: Field[Int, PViewRow]
+  def productline: OptField[/* bpchar, max 2 chars */ String, PViewRow]
+  def `class`: OptField[/* bpchar, max 2 chars */ String, PViewRow]
+  def style: OptField[/* bpchar, max 2 chars */ String, PViewRow]
+  def productsubcategoryid: OptField[ProductsubcategoryId, PViewRow]
+  def productmodelid: OptField[ProductmodelId, PViewRow]
+  def sellstartdate: Field[TypoLocalDateTime, PViewRow]
+  def sellenddate: OptField[TypoLocalDateTime, PViewRow]
+  def discontinueddate: OptField[TypoLocalDateTime, PViewRow]
+  def rowguid: Field[TypoUUID, PViewRow]
+  def modifieddate: Field[TypoLocalDateTime, PViewRow]
 }
 
 object PViewFields {
-  val structure: Relation[PViewFields, PViewRow, PViewRow] = 
-    new Impl(None, identity, (_, x) => x)
+  lazy val structure: Relation[PViewFields, PViewRow] =
+    new Impl(Nil)
     
-  private final class Impl[Row](val prefix: Option[String], val extract: Row => PViewRow, val merge: (Row, PViewRow) => Row)
-    extends Relation[PViewFields, PViewRow, Row] { 
+  private final class Impl(val _path: List[Path])
+    extends Relation[PViewFields, PViewRow] {
   
-    override val fields: PViewFields[Row] = new PViewFields[Row] {
-      override val id = new Field[ProductId, Row](prefix, "id", None, None)(x => extract(x).id, (row, value) => merge(row, extract(row).copy(id = value)))
-      override val productid = new Field[ProductId, Row](prefix, "productid", None, None)(x => extract(x).productid, (row, value) => merge(row, extract(row).copy(productid = value)))
-      override val name = new Field[Name, Row](prefix, "name", None, None)(x => extract(x).name, (row, value) => merge(row, extract(row).copy(name = value)))
-      override val productnumber = new Field[/* max 25 chars */ String, Row](prefix, "productnumber", None, None)(x => extract(x).productnumber, (row, value) => merge(row, extract(row).copy(productnumber = value)))
-      override val makeflag = new Field[Flag, Row](prefix, "makeflag", None, None)(x => extract(x).makeflag, (row, value) => merge(row, extract(row).copy(makeflag = value)))
-      override val finishedgoodsflag = new Field[Flag, Row](prefix, "finishedgoodsflag", None, None)(x => extract(x).finishedgoodsflag, (row, value) => merge(row, extract(row).copy(finishedgoodsflag = value)))
-      override val color = new OptField[/* max 15 chars */ String, Row](prefix, "color", None, None)(x => extract(x).color, (row, value) => merge(row, extract(row).copy(color = value)))
-      override val safetystocklevel = new Field[TypoShort, Row](prefix, "safetystocklevel", None, None)(x => extract(x).safetystocklevel, (row, value) => merge(row, extract(row).copy(safetystocklevel = value)))
-      override val reorderpoint = new Field[TypoShort, Row](prefix, "reorderpoint", None, None)(x => extract(x).reorderpoint, (row, value) => merge(row, extract(row).copy(reorderpoint = value)))
-      override val standardcost = new Field[BigDecimal, Row](prefix, "standardcost", None, None)(x => extract(x).standardcost, (row, value) => merge(row, extract(row).copy(standardcost = value)))
-      override val listprice = new Field[BigDecimal, Row](prefix, "listprice", None, None)(x => extract(x).listprice, (row, value) => merge(row, extract(row).copy(listprice = value)))
-      override val size = new OptField[/* max 5 chars */ String, Row](prefix, "size", None, None)(x => extract(x).size, (row, value) => merge(row, extract(row).copy(size = value)))
-      override val sizeunitmeasurecode = new OptField[UnitmeasureId, Row](prefix, "sizeunitmeasurecode", None, None)(x => extract(x).sizeunitmeasurecode, (row, value) => merge(row, extract(row).copy(sizeunitmeasurecode = value)))
-      override val weightunitmeasurecode = new OptField[UnitmeasureId, Row](prefix, "weightunitmeasurecode", None, None)(x => extract(x).weightunitmeasurecode, (row, value) => merge(row, extract(row).copy(weightunitmeasurecode = value)))
-      override val weight = new OptField[BigDecimal, Row](prefix, "weight", None, None)(x => extract(x).weight, (row, value) => merge(row, extract(row).copy(weight = value)))
-      override val daystomanufacture = new Field[Int, Row](prefix, "daystomanufacture", None, None)(x => extract(x).daystomanufacture, (row, value) => merge(row, extract(row).copy(daystomanufacture = value)))
-      override val productline = new OptField[/* bpchar, max 2 chars */ String, Row](prefix, "productline", None, None)(x => extract(x).productline, (row, value) => merge(row, extract(row).copy(productline = value)))
-      override val `class` = new OptField[/* bpchar, max 2 chars */ String, Row](prefix, "class", None, None)(x => extract(x).`class`, (row, value) => merge(row, extract(row).copy(`class` = value)))
-      override val style = new OptField[/* bpchar, max 2 chars */ String, Row](prefix, "style", None, None)(x => extract(x).style, (row, value) => merge(row, extract(row).copy(style = value)))
-      override val productsubcategoryid = new OptField[ProductsubcategoryId, Row](prefix, "productsubcategoryid", None, None)(x => extract(x).productsubcategoryid, (row, value) => merge(row, extract(row).copy(productsubcategoryid = value)))
-      override val productmodelid = new OptField[ProductmodelId, Row](prefix, "productmodelid", None, None)(x => extract(x).productmodelid, (row, value) => merge(row, extract(row).copy(productmodelid = value)))
-      override val sellstartdate = new Field[TypoLocalDateTime, Row](prefix, "sellstartdate", Some("text"), None)(x => extract(x).sellstartdate, (row, value) => merge(row, extract(row).copy(sellstartdate = value)))
-      override val sellenddate = new OptField[TypoLocalDateTime, Row](prefix, "sellenddate", Some("text"), None)(x => extract(x).sellenddate, (row, value) => merge(row, extract(row).copy(sellenddate = value)))
-      override val discontinueddate = new OptField[TypoLocalDateTime, Row](prefix, "discontinueddate", Some("text"), None)(x => extract(x).discontinueddate, (row, value) => merge(row, extract(row).copy(discontinueddate = value)))
-      override val rowguid = new Field[TypoUUID, Row](prefix, "rowguid", None, None)(x => extract(x).rowguid, (row, value) => merge(row, extract(row).copy(rowguid = value)))
-      override val modifieddate = new Field[TypoLocalDateTime, Row](prefix, "modifieddate", Some("text"), None)(x => extract(x).modifieddate, (row, value) => merge(row, extract(row).copy(modifieddate = value)))
+    override lazy val fields: PViewFields = new PViewFields {
+      override def id = Field[ProductId, PViewRow](_path, "id", None, None, x => x.id, (row, value) => row.copy(id = value))
+      override def productid = Field[ProductId, PViewRow](_path, "productid", None, None, x => x.productid, (row, value) => row.copy(productid = value))
+      override def name = Field[Name, PViewRow](_path, "name", None, None, x => x.name, (row, value) => row.copy(name = value))
+      override def productnumber = Field[/* max 25 chars */ String, PViewRow](_path, "productnumber", None, None, x => x.productnumber, (row, value) => row.copy(productnumber = value))
+      override def makeflag = Field[Flag, PViewRow](_path, "makeflag", None, None, x => x.makeflag, (row, value) => row.copy(makeflag = value))
+      override def finishedgoodsflag = Field[Flag, PViewRow](_path, "finishedgoodsflag", None, None, x => x.finishedgoodsflag, (row, value) => row.copy(finishedgoodsflag = value))
+      override def color = OptField[/* max 15 chars */ String, PViewRow](_path, "color", None, None, x => x.color, (row, value) => row.copy(color = value))
+      override def safetystocklevel = Field[TypoShort, PViewRow](_path, "safetystocklevel", None, None, x => x.safetystocklevel, (row, value) => row.copy(safetystocklevel = value))
+      override def reorderpoint = Field[TypoShort, PViewRow](_path, "reorderpoint", None, None, x => x.reorderpoint, (row, value) => row.copy(reorderpoint = value))
+      override def standardcost = Field[BigDecimal, PViewRow](_path, "standardcost", None, None, x => x.standardcost, (row, value) => row.copy(standardcost = value))
+      override def listprice = Field[BigDecimal, PViewRow](_path, "listprice", None, None, x => x.listprice, (row, value) => row.copy(listprice = value))
+      override def size = OptField[/* max 5 chars */ String, PViewRow](_path, "size", None, None, x => x.size, (row, value) => row.copy(size = value))
+      override def sizeunitmeasurecode = OptField[UnitmeasureId, PViewRow](_path, "sizeunitmeasurecode", None, None, x => x.sizeunitmeasurecode, (row, value) => row.copy(sizeunitmeasurecode = value))
+      override def weightunitmeasurecode = OptField[UnitmeasureId, PViewRow](_path, "weightunitmeasurecode", None, None, x => x.weightunitmeasurecode, (row, value) => row.copy(weightunitmeasurecode = value))
+      override def weight = OptField[BigDecimal, PViewRow](_path, "weight", None, None, x => x.weight, (row, value) => row.copy(weight = value))
+      override def daystomanufacture = Field[Int, PViewRow](_path, "daystomanufacture", None, None, x => x.daystomanufacture, (row, value) => row.copy(daystomanufacture = value))
+      override def productline = OptField[/* bpchar, max 2 chars */ String, PViewRow](_path, "productline", None, None, x => x.productline, (row, value) => row.copy(productline = value))
+      override def `class` = OptField[/* bpchar, max 2 chars */ String, PViewRow](_path, "class", None, None, x => x.`class`, (row, value) => row.copy(`class` = value))
+      override def style = OptField[/* bpchar, max 2 chars */ String, PViewRow](_path, "style", None, None, x => x.style, (row, value) => row.copy(style = value))
+      override def productsubcategoryid = OptField[ProductsubcategoryId, PViewRow](_path, "productsubcategoryid", None, None, x => x.productsubcategoryid, (row, value) => row.copy(productsubcategoryid = value))
+      override def productmodelid = OptField[ProductmodelId, PViewRow](_path, "productmodelid", None, None, x => x.productmodelid, (row, value) => row.copy(productmodelid = value))
+      override def sellstartdate = Field[TypoLocalDateTime, PViewRow](_path, "sellstartdate", Some("text"), None, x => x.sellstartdate, (row, value) => row.copy(sellstartdate = value))
+      override def sellenddate = OptField[TypoLocalDateTime, PViewRow](_path, "sellenddate", Some("text"), None, x => x.sellenddate, (row, value) => row.copy(sellenddate = value))
+      override def discontinueddate = OptField[TypoLocalDateTime, PViewRow](_path, "discontinueddate", Some("text"), None, x => x.discontinueddate, (row, value) => row.copy(discontinueddate = value))
+      override def rowguid = Field[TypoUUID, PViewRow](_path, "rowguid", None, None, x => x.rowguid, (row, value) => row.copy(rowguid = value))
+      override def modifieddate = Field[TypoLocalDateTime, PViewRow](_path, "modifieddate", Some("text"), None, x => x.modifieddate, (row, value) => row.copy(modifieddate = value))
     }
   
-    override val columns: List[FieldLikeNoHkt[?, Row]] =
-      List[FieldLikeNoHkt[?, Row]](fields.id, fields.productid, fields.name, fields.productnumber, fields.makeflag, fields.finishedgoodsflag, fields.color, fields.safetystocklevel, fields.reorderpoint, fields.standardcost, fields.listprice, fields.size, fields.sizeunitmeasurecode, fields.weightunitmeasurecode, fields.weight, fields.daystomanufacture, fields.productline, fields.`class`, fields.style, fields.productsubcategoryid, fields.productmodelid, fields.sellstartdate, fields.sellenddate, fields.discontinueddate, fields.rowguid, fields.modifieddate)
+    override lazy val columns: List[FieldLikeNoHkt[?, PViewRow]] =
+      List[FieldLikeNoHkt[?, PViewRow]](fields.id, fields.productid, fields.name, fields.productnumber, fields.makeflag, fields.finishedgoodsflag, fields.color, fields.safetystocklevel, fields.reorderpoint, fields.standardcost, fields.listprice, fields.size, fields.sizeunitmeasurecode, fields.weightunitmeasurecode, fields.weight, fields.daystomanufacture, fields.productline, fields.`class`, fields.style, fields.productsubcategoryid, fields.productmodelid, fields.sellstartdate, fields.sellenddate, fields.discontinueddate, fields.rowguid, fields.modifieddate)
   
-    override def copy[NewRow](prefix: Option[String], extract: NewRow => PViewRow, merge: (NewRow, PViewRow) => NewRow): Impl[NewRow] =
-      new Impl(prefix, extract, merge)
+    override def copy(path: List[Path]): Impl =
+      new Impl(path)
   }
   
 }

--- a/typo-tester-doobie/generated-and-checked-in/adventureworks/pr/pc/PcViewFields.scala
+++ b/typo-tester-doobie/generated-and-checked-in/adventureworks/pr/pc/PcViewFields.scala
@@ -11,38 +11,39 @@ import adventureworks.customtypes.TypoLocalDateTime
 import adventureworks.customtypes.TypoUUID
 import adventureworks.production.productcategory.ProductcategoryId
 import adventureworks.public.Name
+import typo.dsl.Path
 import typo.dsl.SqlExpr.Field
 import typo.dsl.SqlExpr.FieldLikeNoHkt
 import typo.dsl.Structure.Relation
 
-trait PcViewFields[Row] {
-  val id: Field[ProductcategoryId, Row]
-  val productcategoryid: Field[ProductcategoryId, Row]
-  val name: Field[Name, Row]
-  val rowguid: Field[TypoUUID, Row]
-  val modifieddate: Field[TypoLocalDateTime, Row]
+trait PcViewFields {
+  def id: Field[ProductcategoryId, PcViewRow]
+  def productcategoryid: Field[ProductcategoryId, PcViewRow]
+  def name: Field[Name, PcViewRow]
+  def rowguid: Field[TypoUUID, PcViewRow]
+  def modifieddate: Field[TypoLocalDateTime, PcViewRow]
 }
 
 object PcViewFields {
-  val structure: Relation[PcViewFields, PcViewRow, PcViewRow] = 
-    new Impl(None, identity, (_, x) => x)
+  lazy val structure: Relation[PcViewFields, PcViewRow] =
+    new Impl(Nil)
     
-  private final class Impl[Row](val prefix: Option[String], val extract: Row => PcViewRow, val merge: (Row, PcViewRow) => Row)
-    extends Relation[PcViewFields, PcViewRow, Row] { 
+  private final class Impl(val _path: List[Path])
+    extends Relation[PcViewFields, PcViewRow] {
   
-    override val fields: PcViewFields[Row] = new PcViewFields[Row] {
-      override val id = new Field[ProductcategoryId, Row](prefix, "id", None, None)(x => extract(x).id, (row, value) => merge(row, extract(row).copy(id = value)))
-      override val productcategoryid = new Field[ProductcategoryId, Row](prefix, "productcategoryid", None, None)(x => extract(x).productcategoryid, (row, value) => merge(row, extract(row).copy(productcategoryid = value)))
-      override val name = new Field[Name, Row](prefix, "name", None, None)(x => extract(x).name, (row, value) => merge(row, extract(row).copy(name = value)))
-      override val rowguid = new Field[TypoUUID, Row](prefix, "rowguid", None, None)(x => extract(x).rowguid, (row, value) => merge(row, extract(row).copy(rowguid = value)))
-      override val modifieddate = new Field[TypoLocalDateTime, Row](prefix, "modifieddate", Some("text"), None)(x => extract(x).modifieddate, (row, value) => merge(row, extract(row).copy(modifieddate = value)))
+    override lazy val fields: PcViewFields = new PcViewFields {
+      override def id = Field[ProductcategoryId, PcViewRow](_path, "id", None, None, x => x.id, (row, value) => row.copy(id = value))
+      override def productcategoryid = Field[ProductcategoryId, PcViewRow](_path, "productcategoryid", None, None, x => x.productcategoryid, (row, value) => row.copy(productcategoryid = value))
+      override def name = Field[Name, PcViewRow](_path, "name", None, None, x => x.name, (row, value) => row.copy(name = value))
+      override def rowguid = Field[TypoUUID, PcViewRow](_path, "rowguid", None, None, x => x.rowguid, (row, value) => row.copy(rowguid = value))
+      override def modifieddate = Field[TypoLocalDateTime, PcViewRow](_path, "modifieddate", Some("text"), None, x => x.modifieddate, (row, value) => row.copy(modifieddate = value))
     }
   
-    override val columns: List[FieldLikeNoHkt[?, Row]] =
-      List[FieldLikeNoHkt[?, Row]](fields.id, fields.productcategoryid, fields.name, fields.rowguid, fields.modifieddate)
+    override lazy val columns: List[FieldLikeNoHkt[?, PcViewRow]] =
+      List[FieldLikeNoHkt[?, PcViewRow]](fields.id, fields.productcategoryid, fields.name, fields.rowguid, fields.modifieddate)
   
-    override def copy[NewRow](prefix: Option[String], extract: NewRow => PcViewRow, merge: (NewRow, PcViewRow) => NewRow): Impl[NewRow] =
-      new Impl(prefix, extract, merge)
+    override def copy(path: List[Path]): Impl =
+      new Impl(path)
   }
   
 }

--- a/typo-tester-doobie/generated-and-checked-in/adventureworks/pr/pch/PchViewFields.scala
+++ b/typo-tester-doobie/generated-and-checked-in/adventureworks/pr/pch/PchViewFields.scala
@@ -9,41 +9,42 @@ package pch
 
 import adventureworks.customtypes.TypoLocalDateTime
 import adventureworks.production.product.ProductId
+import typo.dsl.Path
 import typo.dsl.SqlExpr.Field
 import typo.dsl.SqlExpr.FieldLikeNoHkt
 import typo.dsl.SqlExpr.OptField
 import typo.dsl.Structure.Relation
 
-trait PchViewFields[Row] {
-  val id: Field[ProductId, Row]
-  val productid: Field[ProductId, Row]
-  val startdate: Field[TypoLocalDateTime, Row]
-  val enddate: OptField[TypoLocalDateTime, Row]
-  val standardcost: Field[BigDecimal, Row]
-  val modifieddate: Field[TypoLocalDateTime, Row]
+trait PchViewFields {
+  def id: Field[ProductId, PchViewRow]
+  def productid: Field[ProductId, PchViewRow]
+  def startdate: Field[TypoLocalDateTime, PchViewRow]
+  def enddate: OptField[TypoLocalDateTime, PchViewRow]
+  def standardcost: Field[BigDecimal, PchViewRow]
+  def modifieddate: Field[TypoLocalDateTime, PchViewRow]
 }
 
 object PchViewFields {
-  val structure: Relation[PchViewFields, PchViewRow, PchViewRow] = 
-    new Impl(None, identity, (_, x) => x)
+  lazy val structure: Relation[PchViewFields, PchViewRow] =
+    new Impl(Nil)
     
-  private final class Impl[Row](val prefix: Option[String], val extract: Row => PchViewRow, val merge: (Row, PchViewRow) => Row)
-    extends Relation[PchViewFields, PchViewRow, Row] { 
+  private final class Impl(val _path: List[Path])
+    extends Relation[PchViewFields, PchViewRow] {
   
-    override val fields: PchViewFields[Row] = new PchViewFields[Row] {
-      override val id = new Field[ProductId, Row](prefix, "id", None, None)(x => extract(x).id, (row, value) => merge(row, extract(row).copy(id = value)))
-      override val productid = new Field[ProductId, Row](prefix, "productid", None, None)(x => extract(x).productid, (row, value) => merge(row, extract(row).copy(productid = value)))
-      override val startdate = new Field[TypoLocalDateTime, Row](prefix, "startdate", Some("text"), None)(x => extract(x).startdate, (row, value) => merge(row, extract(row).copy(startdate = value)))
-      override val enddate = new OptField[TypoLocalDateTime, Row](prefix, "enddate", Some("text"), None)(x => extract(x).enddate, (row, value) => merge(row, extract(row).copy(enddate = value)))
-      override val standardcost = new Field[BigDecimal, Row](prefix, "standardcost", None, None)(x => extract(x).standardcost, (row, value) => merge(row, extract(row).copy(standardcost = value)))
-      override val modifieddate = new Field[TypoLocalDateTime, Row](prefix, "modifieddate", Some("text"), None)(x => extract(x).modifieddate, (row, value) => merge(row, extract(row).copy(modifieddate = value)))
+    override lazy val fields: PchViewFields = new PchViewFields {
+      override def id = Field[ProductId, PchViewRow](_path, "id", None, None, x => x.id, (row, value) => row.copy(id = value))
+      override def productid = Field[ProductId, PchViewRow](_path, "productid", None, None, x => x.productid, (row, value) => row.copy(productid = value))
+      override def startdate = Field[TypoLocalDateTime, PchViewRow](_path, "startdate", Some("text"), None, x => x.startdate, (row, value) => row.copy(startdate = value))
+      override def enddate = OptField[TypoLocalDateTime, PchViewRow](_path, "enddate", Some("text"), None, x => x.enddate, (row, value) => row.copy(enddate = value))
+      override def standardcost = Field[BigDecimal, PchViewRow](_path, "standardcost", None, None, x => x.standardcost, (row, value) => row.copy(standardcost = value))
+      override def modifieddate = Field[TypoLocalDateTime, PchViewRow](_path, "modifieddate", Some("text"), None, x => x.modifieddate, (row, value) => row.copy(modifieddate = value))
     }
   
-    override val columns: List[FieldLikeNoHkt[?, Row]] =
-      List[FieldLikeNoHkt[?, Row]](fields.id, fields.productid, fields.startdate, fields.enddate, fields.standardcost, fields.modifieddate)
+    override lazy val columns: List[FieldLikeNoHkt[?, PchViewRow]] =
+      List[FieldLikeNoHkt[?, PchViewRow]](fields.id, fields.productid, fields.startdate, fields.enddate, fields.standardcost, fields.modifieddate)
   
-    override def copy[NewRow](prefix: Option[String], extract: NewRow => PchViewRow, merge: (NewRow, PchViewRow) => NewRow): Impl[NewRow] =
-      new Impl(prefix, extract, merge)
+    override def copy(path: List[Path]): Impl =
+      new Impl(path)
   }
   
 }

--- a/typo-tester-doobie/generated-and-checked-in/adventureworks/pr/pd/PdViewFields.scala
+++ b/typo-tester-doobie/generated-and-checked-in/adventureworks/pr/pd/PdViewFields.scala
@@ -10,38 +10,39 @@ package pd
 import adventureworks.customtypes.TypoLocalDateTime
 import adventureworks.customtypes.TypoUUID
 import adventureworks.production.productdescription.ProductdescriptionId
+import typo.dsl.Path
 import typo.dsl.SqlExpr.Field
 import typo.dsl.SqlExpr.FieldLikeNoHkt
 import typo.dsl.Structure.Relation
 
-trait PdViewFields[Row] {
-  val id: Field[ProductdescriptionId, Row]
-  val productdescriptionid: Field[ProductdescriptionId, Row]
-  val description: Field[/* max 400 chars */ String, Row]
-  val rowguid: Field[TypoUUID, Row]
-  val modifieddate: Field[TypoLocalDateTime, Row]
+trait PdViewFields {
+  def id: Field[ProductdescriptionId, PdViewRow]
+  def productdescriptionid: Field[ProductdescriptionId, PdViewRow]
+  def description: Field[/* max 400 chars */ String, PdViewRow]
+  def rowguid: Field[TypoUUID, PdViewRow]
+  def modifieddate: Field[TypoLocalDateTime, PdViewRow]
 }
 
 object PdViewFields {
-  val structure: Relation[PdViewFields, PdViewRow, PdViewRow] = 
-    new Impl(None, identity, (_, x) => x)
+  lazy val structure: Relation[PdViewFields, PdViewRow] =
+    new Impl(Nil)
     
-  private final class Impl[Row](val prefix: Option[String], val extract: Row => PdViewRow, val merge: (Row, PdViewRow) => Row)
-    extends Relation[PdViewFields, PdViewRow, Row] { 
+  private final class Impl(val _path: List[Path])
+    extends Relation[PdViewFields, PdViewRow] {
   
-    override val fields: PdViewFields[Row] = new PdViewFields[Row] {
-      override val id = new Field[ProductdescriptionId, Row](prefix, "id", None, None)(x => extract(x).id, (row, value) => merge(row, extract(row).copy(id = value)))
-      override val productdescriptionid = new Field[ProductdescriptionId, Row](prefix, "productdescriptionid", None, None)(x => extract(x).productdescriptionid, (row, value) => merge(row, extract(row).copy(productdescriptionid = value)))
-      override val description = new Field[/* max 400 chars */ String, Row](prefix, "description", None, None)(x => extract(x).description, (row, value) => merge(row, extract(row).copy(description = value)))
-      override val rowguid = new Field[TypoUUID, Row](prefix, "rowguid", None, None)(x => extract(x).rowguid, (row, value) => merge(row, extract(row).copy(rowguid = value)))
-      override val modifieddate = new Field[TypoLocalDateTime, Row](prefix, "modifieddate", Some("text"), None)(x => extract(x).modifieddate, (row, value) => merge(row, extract(row).copy(modifieddate = value)))
+    override lazy val fields: PdViewFields = new PdViewFields {
+      override def id = Field[ProductdescriptionId, PdViewRow](_path, "id", None, None, x => x.id, (row, value) => row.copy(id = value))
+      override def productdescriptionid = Field[ProductdescriptionId, PdViewRow](_path, "productdescriptionid", None, None, x => x.productdescriptionid, (row, value) => row.copy(productdescriptionid = value))
+      override def description = Field[/* max 400 chars */ String, PdViewRow](_path, "description", None, None, x => x.description, (row, value) => row.copy(description = value))
+      override def rowguid = Field[TypoUUID, PdViewRow](_path, "rowguid", None, None, x => x.rowguid, (row, value) => row.copy(rowguid = value))
+      override def modifieddate = Field[TypoLocalDateTime, PdViewRow](_path, "modifieddate", Some("text"), None, x => x.modifieddate, (row, value) => row.copy(modifieddate = value))
     }
   
-    override val columns: List[FieldLikeNoHkt[?, Row]] =
-      List[FieldLikeNoHkt[?, Row]](fields.id, fields.productdescriptionid, fields.description, fields.rowguid, fields.modifieddate)
+    override lazy val columns: List[FieldLikeNoHkt[?, PdViewRow]] =
+      List[FieldLikeNoHkt[?, PdViewRow]](fields.id, fields.productdescriptionid, fields.description, fields.rowguid, fields.modifieddate)
   
-    override def copy[NewRow](prefix: Option[String], extract: NewRow => PdViewRow, merge: (NewRow, PdViewRow) => NewRow): Impl[NewRow] =
-      new Impl(prefix, extract, merge)
+    override def copy(path: List[Path]): Impl =
+      new Impl(path)
   }
   
 }

--- a/typo-tester-doobie/generated-and-checked-in/adventureworks/pr/pi/PiViewFields.scala
+++ b/typo-tester-doobie/generated-and-checked-in/adventureworks/pr/pi/PiViewFields.scala
@@ -12,44 +12,45 @@ import adventureworks.customtypes.TypoShort
 import adventureworks.customtypes.TypoUUID
 import adventureworks.production.location.LocationId
 import adventureworks.production.product.ProductId
+import typo.dsl.Path
 import typo.dsl.SqlExpr.Field
 import typo.dsl.SqlExpr.FieldLikeNoHkt
 import typo.dsl.Structure.Relation
 
-trait PiViewFields[Row] {
-  val id: Field[ProductId, Row]
-  val productid: Field[ProductId, Row]
-  val locationid: Field[LocationId, Row]
-  val shelf: Field[/* max 10 chars */ String, Row]
-  val bin: Field[TypoShort, Row]
-  val quantity: Field[TypoShort, Row]
-  val rowguid: Field[TypoUUID, Row]
-  val modifieddate: Field[TypoLocalDateTime, Row]
+trait PiViewFields {
+  def id: Field[ProductId, PiViewRow]
+  def productid: Field[ProductId, PiViewRow]
+  def locationid: Field[LocationId, PiViewRow]
+  def shelf: Field[/* max 10 chars */ String, PiViewRow]
+  def bin: Field[TypoShort, PiViewRow]
+  def quantity: Field[TypoShort, PiViewRow]
+  def rowguid: Field[TypoUUID, PiViewRow]
+  def modifieddate: Field[TypoLocalDateTime, PiViewRow]
 }
 
 object PiViewFields {
-  val structure: Relation[PiViewFields, PiViewRow, PiViewRow] = 
-    new Impl(None, identity, (_, x) => x)
+  lazy val structure: Relation[PiViewFields, PiViewRow] =
+    new Impl(Nil)
     
-  private final class Impl[Row](val prefix: Option[String], val extract: Row => PiViewRow, val merge: (Row, PiViewRow) => Row)
-    extends Relation[PiViewFields, PiViewRow, Row] { 
+  private final class Impl(val _path: List[Path])
+    extends Relation[PiViewFields, PiViewRow] {
   
-    override val fields: PiViewFields[Row] = new PiViewFields[Row] {
-      override val id = new Field[ProductId, Row](prefix, "id", None, None)(x => extract(x).id, (row, value) => merge(row, extract(row).copy(id = value)))
-      override val productid = new Field[ProductId, Row](prefix, "productid", None, None)(x => extract(x).productid, (row, value) => merge(row, extract(row).copy(productid = value)))
-      override val locationid = new Field[LocationId, Row](prefix, "locationid", None, None)(x => extract(x).locationid, (row, value) => merge(row, extract(row).copy(locationid = value)))
-      override val shelf = new Field[/* max 10 chars */ String, Row](prefix, "shelf", None, None)(x => extract(x).shelf, (row, value) => merge(row, extract(row).copy(shelf = value)))
-      override val bin = new Field[TypoShort, Row](prefix, "bin", None, None)(x => extract(x).bin, (row, value) => merge(row, extract(row).copy(bin = value)))
-      override val quantity = new Field[TypoShort, Row](prefix, "quantity", None, None)(x => extract(x).quantity, (row, value) => merge(row, extract(row).copy(quantity = value)))
-      override val rowguid = new Field[TypoUUID, Row](prefix, "rowguid", None, None)(x => extract(x).rowguid, (row, value) => merge(row, extract(row).copy(rowguid = value)))
-      override val modifieddate = new Field[TypoLocalDateTime, Row](prefix, "modifieddate", Some("text"), None)(x => extract(x).modifieddate, (row, value) => merge(row, extract(row).copy(modifieddate = value)))
+    override lazy val fields: PiViewFields = new PiViewFields {
+      override def id = Field[ProductId, PiViewRow](_path, "id", None, None, x => x.id, (row, value) => row.copy(id = value))
+      override def productid = Field[ProductId, PiViewRow](_path, "productid", None, None, x => x.productid, (row, value) => row.copy(productid = value))
+      override def locationid = Field[LocationId, PiViewRow](_path, "locationid", None, None, x => x.locationid, (row, value) => row.copy(locationid = value))
+      override def shelf = Field[/* max 10 chars */ String, PiViewRow](_path, "shelf", None, None, x => x.shelf, (row, value) => row.copy(shelf = value))
+      override def bin = Field[TypoShort, PiViewRow](_path, "bin", None, None, x => x.bin, (row, value) => row.copy(bin = value))
+      override def quantity = Field[TypoShort, PiViewRow](_path, "quantity", None, None, x => x.quantity, (row, value) => row.copy(quantity = value))
+      override def rowguid = Field[TypoUUID, PiViewRow](_path, "rowguid", None, None, x => x.rowguid, (row, value) => row.copy(rowguid = value))
+      override def modifieddate = Field[TypoLocalDateTime, PiViewRow](_path, "modifieddate", Some("text"), None, x => x.modifieddate, (row, value) => row.copy(modifieddate = value))
     }
   
-    override val columns: List[FieldLikeNoHkt[?, Row]] =
-      List[FieldLikeNoHkt[?, Row]](fields.id, fields.productid, fields.locationid, fields.shelf, fields.bin, fields.quantity, fields.rowguid, fields.modifieddate)
+    override lazy val columns: List[FieldLikeNoHkt[?, PiViewRow]] =
+      List[FieldLikeNoHkt[?, PiViewRow]](fields.id, fields.productid, fields.locationid, fields.shelf, fields.bin, fields.quantity, fields.rowguid, fields.modifieddate)
   
-    override def copy[NewRow](prefix: Option[String], extract: NewRow => PiViewRow, merge: (NewRow, PiViewRow) => NewRow): Impl[NewRow] =
-      new Impl(prefix, extract, merge)
+    override def copy(path: List[Path]): Impl =
+      new Impl(path)
   }
   
 }

--- a/typo-tester-doobie/generated-and-checked-in/adventureworks/pr/plph/PlphViewFields.scala
+++ b/typo-tester-doobie/generated-and-checked-in/adventureworks/pr/plph/PlphViewFields.scala
@@ -9,41 +9,42 @@ package plph
 
 import adventureworks.customtypes.TypoLocalDateTime
 import adventureworks.production.product.ProductId
+import typo.dsl.Path
 import typo.dsl.SqlExpr.Field
 import typo.dsl.SqlExpr.FieldLikeNoHkt
 import typo.dsl.SqlExpr.OptField
 import typo.dsl.Structure.Relation
 
-trait PlphViewFields[Row] {
-  val id: Field[ProductId, Row]
-  val productid: Field[ProductId, Row]
-  val startdate: Field[TypoLocalDateTime, Row]
-  val enddate: OptField[TypoLocalDateTime, Row]
-  val listprice: Field[BigDecimal, Row]
-  val modifieddate: Field[TypoLocalDateTime, Row]
+trait PlphViewFields {
+  def id: Field[ProductId, PlphViewRow]
+  def productid: Field[ProductId, PlphViewRow]
+  def startdate: Field[TypoLocalDateTime, PlphViewRow]
+  def enddate: OptField[TypoLocalDateTime, PlphViewRow]
+  def listprice: Field[BigDecimal, PlphViewRow]
+  def modifieddate: Field[TypoLocalDateTime, PlphViewRow]
 }
 
 object PlphViewFields {
-  val structure: Relation[PlphViewFields, PlphViewRow, PlphViewRow] = 
-    new Impl(None, identity, (_, x) => x)
+  lazy val structure: Relation[PlphViewFields, PlphViewRow] =
+    new Impl(Nil)
     
-  private final class Impl[Row](val prefix: Option[String], val extract: Row => PlphViewRow, val merge: (Row, PlphViewRow) => Row)
-    extends Relation[PlphViewFields, PlphViewRow, Row] { 
+  private final class Impl(val _path: List[Path])
+    extends Relation[PlphViewFields, PlphViewRow] {
   
-    override val fields: PlphViewFields[Row] = new PlphViewFields[Row] {
-      override val id = new Field[ProductId, Row](prefix, "id", None, None)(x => extract(x).id, (row, value) => merge(row, extract(row).copy(id = value)))
-      override val productid = new Field[ProductId, Row](prefix, "productid", None, None)(x => extract(x).productid, (row, value) => merge(row, extract(row).copy(productid = value)))
-      override val startdate = new Field[TypoLocalDateTime, Row](prefix, "startdate", Some("text"), None)(x => extract(x).startdate, (row, value) => merge(row, extract(row).copy(startdate = value)))
-      override val enddate = new OptField[TypoLocalDateTime, Row](prefix, "enddate", Some("text"), None)(x => extract(x).enddate, (row, value) => merge(row, extract(row).copy(enddate = value)))
-      override val listprice = new Field[BigDecimal, Row](prefix, "listprice", None, None)(x => extract(x).listprice, (row, value) => merge(row, extract(row).copy(listprice = value)))
-      override val modifieddate = new Field[TypoLocalDateTime, Row](prefix, "modifieddate", Some("text"), None)(x => extract(x).modifieddate, (row, value) => merge(row, extract(row).copy(modifieddate = value)))
+    override lazy val fields: PlphViewFields = new PlphViewFields {
+      override def id = Field[ProductId, PlphViewRow](_path, "id", None, None, x => x.id, (row, value) => row.copy(id = value))
+      override def productid = Field[ProductId, PlphViewRow](_path, "productid", None, None, x => x.productid, (row, value) => row.copy(productid = value))
+      override def startdate = Field[TypoLocalDateTime, PlphViewRow](_path, "startdate", Some("text"), None, x => x.startdate, (row, value) => row.copy(startdate = value))
+      override def enddate = OptField[TypoLocalDateTime, PlphViewRow](_path, "enddate", Some("text"), None, x => x.enddate, (row, value) => row.copy(enddate = value))
+      override def listprice = Field[BigDecimal, PlphViewRow](_path, "listprice", None, None, x => x.listprice, (row, value) => row.copy(listprice = value))
+      override def modifieddate = Field[TypoLocalDateTime, PlphViewRow](_path, "modifieddate", Some("text"), None, x => x.modifieddate, (row, value) => row.copy(modifieddate = value))
     }
   
-    override val columns: List[FieldLikeNoHkt[?, Row]] =
-      List[FieldLikeNoHkt[?, Row]](fields.id, fields.productid, fields.startdate, fields.enddate, fields.listprice, fields.modifieddate)
+    override lazy val columns: List[FieldLikeNoHkt[?, PlphViewRow]] =
+      List[FieldLikeNoHkt[?, PlphViewRow]](fields.id, fields.productid, fields.startdate, fields.enddate, fields.listprice, fields.modifieddate)
   
-    override def copy[NewRow](prefix: Option[String], extract: NewRow => PlphViewRow, merge: (NewRow, PlphViewRow) => NewRow): Impl[NewRow] =
-      new Impl(prefix, extract, merge)
+    override def copy(path: List[Path]): Impl =
+      new Impl(path)
   }
   
 }

--- a/typo-tester-doobie/generated-and-checked-in/adventureworks/pr/pm/PmViewFields.scala
+++ b/typo-tester-doobie/generated-and-checked-in/adventureworks/pr/pm/PmViewFields.scala
@@ -12,43 +12,44 @@ import adventureworks.customtypes.TypoUUID
 import adventureworks.customtypes.TypoXml
 import adventureworks.production.productmodel.ProductmodelId
 import adventureworks.public.Name
+import typo.dsl.Path
 import typo.dsl.SqlExpr.Field
 import typo.dsl.SqlExpr.FieldLikeNoHkt
 import typo.dsl.SqlExpr.OptField
 import typo.dsl.Structure.Relation
 
-trait PmViewFields[Row] {
-  val id: Field[ProductmodelId, Row]
-  val productmodelid: Field[ProductmodelId, Row]
-  val name: Field[Name, Row]
-  val catalogdescription: OptField[TypoXml, Row]
-  val instructions: OptField[TypoXml, Row]
-  val rowguid: Field[TypoUUID, Row]
-  val modifieddate: Field[TypoLocalDateTime, Row]
+trait PmViewFields {
+  def id: Field[ProductmodelId, PmViewRow]
+  def productmodelid: Field[ProductmodelId, PmViewRow]
+  def name: Field[Name, PmViewRow]
+  def catalogdescription: OptField[TypoXml, PmViewRow]
+  def instructions: OptField[TypoXml, PmViewRow]
+  def rowguid: Field[TypoUUID, PmViewRow]
+  def modifieddate: Field[TypoLocalDateTime, PmViewRow]
 }
 
 object PmViewFields {
-  val structure: Relation[PmViewFields, PmViewRow, PmViewRow] = 
-    new Impl(None, identity, (_, x) => x)
+  lazy val structure: Relation[PmViewFields, PmViewRow] =
+    new Impl(Nil)
     
-  private final class Impl[Row](val prefix: Option[String], val extract: Row => PmViewRow, val merge: (Row, PmViewRow) => Row)
-    extends Relation[PmViewFields, PmViewRow, Row] { 
+  private final class Impl(val _path: List[Path])
+    extends Relation[PmViewFields, PmViewRow] {
   
-    override val fields: PmViewFields[Row] = new PmViewFields[Row] {
-      override val id = new Field[ProductmodelId, Row](prefix, "id", None, None)(x => extract(x).id, (row, value) => merge(row, extract(row).copy(id = value)))
-      override val productmodelid = new Field[ProductmodelId, Row](prefix, "productmodelid", None, None)(x => extract(x).productmodelid, (row, value) => merge(row, extract(row).copy(productmodelid = value)))
-      override val name = new Field[Name, Row](prefix, "name", None, None)(x => extract(x).name, (row, value) => merge(row, extract(row).copy(name = value)))
-      override val catalogdescription = new OptField[TypoXml, Row](prefix, "catalogdescription", None, None)(x => extract(x).catalogdescription, (row, value) => merge(row, extract(row).copy(catalogdescription = value)))
-      override val instructions = new OptField[TypoXml, Row](prefix, "instructions", None, None)(x => extract(x).instructions, (row, value) => merge(row, extract(row).copy(instructions = value)))
-      override val rowguid = new Field[TypoUUID, Row](prefix, "rowguid", None, None)(x => extract(x).rowguid, (row, value) => merge(row, extract(row).copy(rowguid = value)))
-      override val modifieddate = new Field[TypoLocalDateTime, Row](prefix, "modifieddate", Some("text"), None)(x => extract(x).modifieddate, (row, value) => merge(row, extract(row).copy(modifieddate = value)))
+    override lazy val fields: PmViewFields = new PmViewFields {
+      override def id = Field[ProductmodelId, PmViewRow](_path, "id", None, None, x => x.id, (row, value) => row.copy(id = value))
+      override def productmodelid = Field[ProductmodelId, PmViewRow](_path, "productmodelid", None, None, x => x.productmodelid, (row, value) => row.copy(productmodelid = value))
+      override def name = Field[Name, PmViewRow](_path, "name", None, None, x => x.name, (row, value) => row.copy(name = value))
+      override def catalogdescription = OptField[TypoXml, PmViewRow](_path, "catalogdescription", None, None, x => x.catalogdescription, (row, value) => row.copy(catalogdescription = value))
+      override def instructions = OptField[TypoXml, PmViewRow](_path, "instructions", None, None, x => x.instructions, (row, value) => row.copy(instructions = value))
+      override def rowguid = Field[TypoUUID, PmViewRow](_path, "rowguid", None, None, x => x.rowguid, (row, value) => row.copy(rowguid = value))
+      override def modifieddate = Field[TypoLocalDateTime, PmViewRow](_path, "modifieddate", Some("text"), None, x => x.modifieddate, (row, value) => row.copy(modifieddate = value))
     }
   
-    override val columns: List[FieldLikeNoHkt[?, Row]] =
-      List[FieldLikeNoHkt[?, Row]](fields.id, fields.productmodelid, fields.name, fields.catalogdescription, fields.instructions, fields.rowguid, fields.modifieddate)
+    override lazy val columns: List[FieldLikeNoHkt[?, PmViewRow]] =
+      List[FieldLikeNoHkt[?, PmViewRow]](fields.id, fields.productmodelid, fields.name, fields.catalogdescription, fields.instructions, fields.rowguid, fields.modifieddate)
   
-    override def copy[NewRow](prefix: Option[String], extract: NewRow => PmViewRow, merge: (NewRow, PmViewRow) => NewRow): Impl[NewRow] =
-      new Impl(prefix, extract, merge)
+    override def copy(path: List[Path]): Impl =
+      new Impl(path)
   }
   
 }

--- a/typo-tester-doobie/generated-and-checked-in/adventureworks/pr/pmpdc/PmpdcViewFields.scala
+++ b/typo-tester-doobie/generated-and-checked-in/adventureworks/pr/pmpdc/PmpdcViewFields.scala
@@ -11,36 +11,37 @@ import adventureworks.customtypes.TypoLocalDateTime
 import adventureworks.production.culture.CultureId
 import adventureworks.production.productdescription.ProductdescriptionId
 import adventureworks.production.productmodel.ProductmodelId
+import typo.dsl.Path
 import typo.dsl.SqlExpr.Field
 import typo.dsl.SqlExpr.FieldLikeNoHkt
 import typo.dsl.Structure.Relation
 
-trait PmpdcViewFields[Row] {
-  val productmodelid: Field[ProductmodelId, Row]
-  val productdescriptionid: Field[ProductdescriptionId, Row]
-  val cultureid: Field[CultureId, Row]
-  val modifieddate: Field[TypoLocalDateTime, Row]
+trait PmpdcViewFields {
+  def productmodelid: Field[ProductmodelId, PmpdcViewRow]
+  def productdescriptionid: Field[ProductdescriptionId, PmpdcViewRow]
+  def cultureid: Field[CultureId, PmpdcViewRow]
+  def modifieddate: Field[TypoLocalDateTime, PmpdcViewRow]
 }
 
 object PmpdcViewFields {
-  val structure: Relation[PmpdcViewFields, PmpdcViewRow, PmpdcViewRow] = 
-    new Impl(None, identity, (_, x) => x)
+  lazy val structure: Relation[PmpdcViewFields, PmpdcViewRow] =
+    new Impl(Nil)
     
-  private final class Impl[Row](val prefix: Option[String], val extract: Row => PmpdcViewRow, val merge: (Row, PmpdcViewRow) => Row)
-    extends Relation[PmpdcViewFields, PmpdcViewRow, Row] { 
+  private final class Impl(val _path: List[Path])
+    extends Relation[PmpdcViewFields, PmpdcViewRow] {
   
-    override val fields: PmpdcViewFields[Row] = new PmpdcViewFields[Row] {
-      override val productmodelid = new Field[ProductmodelId, Row](prefix, "productmodelid", None, None)(x => extract(x).productmodelid, (row, value) => merge(row, extract(row).copy(productmodelid = value)))
-      override val productdescriptionid = new Field[ProductdescriptionId, Row](prefix, "productdescriptionid", None, None)(x => extract(x).productdescriptionid, (row, value) => merge(row, extract(row).copy(productdescriptionid = value)))
-      override val cultureid = new Field[CultureId, Row](prefix, "cultureid", None, None)(x => extract(x).cultureid, (row, value) => merge(row, extract(row).copy(cultureid = value)))
-      override val modifieddate = new Field[TypoLocalDateTime, Row](prefix, "modifieddate", Some("text"), None)(x => extract(x).modifieddate, (row, value) => merge(row, extract(row).copy(modifieddate = value)))
+    override lazy val fields: PmpdcViewFields = new PmpdcViewFields {
+      override def productmodelid = Field[ProductmodelId, PmpdcViewRow](_path, "productmodelid", None, None, x => x.productmodelid, (row, value) => row.copy(productmodelid = value))
+      override def productdescriptionid = Field[ProductdescriptionId, PmpdcViewRow](_path, "productdescriptionid", None, None, x => x.productdescriptionid, (row, value) => row.copy(productdescriptionid = value))
+      override def cultureid = Field[CultureId, PmpdcViewRow](_path, "cultureid", None, None, x => x.cultureid, (row, value) => row.copy(cultureid = value))
+      override def modifieddate = Field[TypoLocalDateTime, PmpdcViewRow](_path, "modifieddate", Some("text"), None, x => x.modifieddate, (row, value) => row.copy(modifieddate = value))
     }
   
-    override val columns: List[FieldLikeNoHkt[?, Row]] =
-      List[FieldLikeNoHkt[?, Row]](fields.productmodelid, fields.productdescriptionid, fields.cultureid, fields.modifieddate)
+    override lazy val columns: List[FieldLikeNoHkt[?, PmpdcViewRow]] =
+      List[FieldLikeNoHkt[?, PmpdcViewRow]](fields.productmodelid, fields.productdescriptionid, fields.cultureid, fields.modifieddate)
   
-    override def copy[NewRow](prefix: Option[String], extract: NewRow => PmpdcViewRow, merge: (NewRow, PmpdcViewRow) => NewRow): Impl[NewRow] =
-      new Impl(prefix, extract, merge)
+    override def copy(path: List[Path]): Impl =
+      new Impl(path)
   }
   
 }

--- a/typo-tester-doobie/generated-and-checked-in/adventureworks/pr/pp/PpViewFields.scala
+++ b/typo-tester-doobie/generated-and-checked-in/adventureworks/pr/pp/PpViewFields.scala
@@ -10,43 +10,44 @@ package pp
 import adventureworks.customtypes.TypoBytea
 import adventureworks.customtypes.TypoLocalDateTime
 import adventureworks.production.productphoto.ProductphotoId
+import typo.dsl.Path
 import typo.dsl.SqlExpr.Field
 import typo.dsl.SqlExpr.FieldLikeNoHkt
 import typo.dsl.SqlExpr.OptField
 import typo.dsl.Structure.Relation
 
-trait PpViewFields[Row] {
-  val id: Field[ProductphotoId, Row]
-  val productphotoid: Field[ProductphotoId, Row]
-  val thumbnailphoto: OptField[TypoBytea, Row]
-  val thumbnailphotofilename: OptField[/* max 50 chars */ String, Row]
-  val largephoto: OptField[TypoBytea, Row]
-  val largephotofilename: OptField[/* max 50 chars */ String, Row]
-  val modifieddate: Field[TypoLocalDateTime, Row]
+trait PpViewFields {
+  def id: Field[ProductphotoId, PpViewRow]
+  def productphotoid: Field[ProductphotoId, PpViewRow]
+  def thumbnailphoto: OptField[TypoBytea, PpViewRow]
+  def thumbnailphotofilename: OptField[/* max 50 chars */ String, PpViewRow]
+  def largephoto: OptField[TypoBytea, PpViewRow]
+  def largephotofilename: OptField[/* max 50 chars */ String, PpViewRow]
+  def modifieddate: Field[TypoLocalDateTime, PpViewRow]
 }
 
 object PpViewFields {
-  val structure: Relation[PpViewFields, PpViewRow, PpViewRow] = 
-    new Impl(None, identity, (_, x) => x)
+  lazy val structure: Relation[PpViewFields, PpViewRow] =
+    new Impl(Nil)
     
-  private final class Impl[Row](val prefix: Option[String], val extract: Row => PpViewRow, val merge: (Row, PpViewRow) => Row)
-    extends Relation[PpViewFields, PpViewRow, Row] { 
+  private final class Impl(val _path: List[Path])
+    extends Relation[PpViewFields, PpViewRow] {
   
-    override val fields: PpViewFields[Row] = new PpViewFields[Row] {
-      override val id = new Field[ProductphotoId, Row](prefix, "id", None, None)(x => extract(x).id, (row, value) => merge(row, extract(row).copy(id = value)))
-      override val productphotoid = new Field[ProductphotoId, Row](prefix, "productphotoid", None, None)(x => extract(x).productphotoid, (row, value) => merge(row, extract(row).copy(productphotoid = value)))
-      override val thumbnailphoto = new OptField[TypoBytea, Row](prefix, "thumbnailphoto", None, None)(x => extract(x).thumbnailphoto, (row, value) => merge(row, extract(row).copy(thumbnailphoto = value)))
-      override val thumbnailphotofilename = new OptField[/* max 50 chars */ String, Row](prefix, "thumbnailphotofilename", None, None)(x => extract(x).thumbnailphotofilename, (row, value) => merge(row, extract(row).copy(thumbnailphotofilename = value)))
-      override val largephoto = new OptField[TypoBytea, Row](prefix, "largephoto", None, None)(x => extract(x).largephoto, (row, value) => merge(row, extract(row).copy(largephoto = value)))
-      override val largephotofilename = new OptField[/* max 50 chars */ String, Row](prefix, "largephotofilename", None, None)(x => extract(x).largephotofilename, (row, value) => merge(row, extract(row).copy(largephotofilename = value)))
-      override val modifieddate = new Field[TypoLocalDateTime, Row](prefix, "modifieddate", Some("text"), None)(x => extract(x).modifieddate, (row, value) => merge(row, extract(row).copy(modifieddate = value)))
+    override lazy val fields: PpViewFields = new PpViewFields {
+      override def id = Field[ProductphotoId, PpViewRow](_path, "id", None, None, x => x.id, (row, value) => row.copy(id = value))
+      override def productphotoid = Field[ProductphotoId, PpViewRow](_path, "productphotoid", None, None, x => x.productphotoid, (row, value) => row.copy(productphotoid = value))
+      override def thumbnailphoto = OptField[TypoBytea, PpViewRow](_path, "thumbnailphoto", None, None, x => x.thumbnailphoto, (row, value) => row.copy(thumbnailphoto = value))
+      override def thumbnailphotofilename = OptField[/* max 50 chars */ String, PpViewRow](_path, "thumbnailphotofilename", None, None, x => x.thumbnailphotofilename, (row, value) => row.copy(thumbnailphotofilename = value))
+      override def largephoto = OptField[TypoBytea, PpViewRow](_path, "largephoto", None, None, x => x.largephoto, (row, value) => row.copy(largephoto = value))
+      override def largephotofilename = OptField[/* max 50 chars */ String, PpViewRow](_path, "largephotofilename", None, None, x => x.largephotofilename, (row, value) => row.copy(largephotofilename = value))
+      override def modifieddate = Field[TypoLocalDateTime, PpViewRow](_path, "modifieddate", Some("text"), None, x => x.modifieddate, (row, value) => row.copy(modifieddate = value))
     }
   
-    override val columns: List[FieldLikeNoHkt[?, Row]] =
-      List[FieldLikeNoHkt[?, Row]](fields.id, fields.productphotoid, fields.thumbnailphoto, fields.thumbnailphotofilename, fields.largephoto, fields.largephotofilename, fields.modifieddate)
+    override lazy val columns: List[FieldLikeNoHkt[?, PpViewRow]] =
+      List[FieldLikeNoHkt[?, PpViewRow]](fields.id, fields.productphotoid, fields.thumbnailphoto, fields.thumbnailphotofilename, fields.largephoto, fields.largephotofilename, fields.modifieddate)
   
-    override def copy[NewRow](prefix: Option[String], extract: NewRow => PpViewRow, merge: (NewRow, PpViewRow) => NewRow): Impl[NewRow] =
-      new Impl(prefix, extract, merge)
+    override def copy(path: List[Path]): Impl =
+      new Impl(path)
   }
   
 }

--- a/typo-tester-doobie/generated-and-checked-in/adventureworks/pr/ppp/PppViewFields.scala
+++ b/typo-tester-doobie/generated-and-checked-in/adventureworks/pr/ppp/PppViewFields.scala
@@ -11,36 +11,37 @@ import adventureworks.customtypes.TypoLocalDateTime
 import adventureworks.production.product.ProductId
 import adventureworks.production.productphoto.ProductphotoId
 import adventureworks.public.Flag
+import typo.dsl.Path
 import typo.dsl.SqlExpr.Field
 import typo.dsl.SqlExpr.FieldLikeNoHkt
 import typo.dsl.Structure.Relation
 
-trait PppViewFields[Row] {
-  val productid: Field[ProductId, Row]
-  val productphotoid: Field[ProductphotoId, Row]
-  val primary: Field[Flag, Row]
-  val modifieddate: Field[TypoLocalDateTime, Row]
+trait PppViewFields {
+  def productid: Field[ProductId, PppViewRow]
+  def productphotoid: Field[ProductphotoId, PppViewRow]
+  def primary: Field[Flag, PppViewRow]
+  def modifieddate: Field[TypoLocalDateTime, PppViewRow]
 }
 
 object PppViewFields {
-  val structure: Relation[PppViewFields, PppViewRow, PppViewRow] = 
-    new Impl(None, identity, (_, x) => x)
+  lazy val structure: Relation[PppViewFields, PppViewRow] =
+    new Impl(Nil)
     
-  private final class Impl[Row](val prefix: Option[String], val extract: Row => PppViewRow, val merge: (Row, PppViewRow) => Row)
-    extends Relation[PppViewFields, PppViewRow, Row] { 
+  private final class Impl(val _path: List[Path])
+    extends Relation[PppViewFields, PppViewRow] {
   
-    override val fields: PppViewFields[Row] = new PppViewFields[Row] {
-      override val productid = new Field[ProductId, Row](prefix, "productid", None, None)(x => extract(x).productid, (row, value) => merge(row, extract(row).copy(productid = value)))
-      override val productphotoid = new Field[ProductphotoId, Row](prefix, "productphotoid", None, None)(x => extract(x).productphotoid, (row, value) => merge(row, extract(row).copy(productphotoid = value)))
-      override val primary = new Field[Flag, Row](prefix, "primary", None, None)(x => extract(x).primary, (row, value) => merge(row, extract(row).copy(primary = value)))
-      override val modifieddate = new Field[TypoLocalDateTime, Row](prefix, "modifieddate", Some("text"), None)(x => extract(x).modifieddate, (row, value) => merge(row, extract(row).copy(modifieddate = value)))
+    override lazy val fields: PppViewFields = new PppViewFields {
+      override def productid = Field[ProductId, PppViewRow](_path, "productid", None, None, x => x.productid, (row, value) => row.copy(productid = value))
+      override def productphotoid = Field[ProductphotoId, PppViewRow](_path, "productphotoid", None, None, x => x.productphotoid, (row, value) => row.copy(productphotoid = value))
+      override def primary = Field[Flag, PppViewRow](_path, "primary", None, None, x => x.primary, (row, value) => row.copy(primary = value))
+      override def modifieddate = Field[TypoLocalDateTime, PppViewRow](_path, "modifieddate", Some("text"), None, x => x.modifieddate, (row, value) => row.copy(modifieddate = value))
     }
   
-    override val columns: List[FieldLikeNoHkt[?, Row]] =
-      List[FieldLikeNoHkt[?, Row]](fields.productid, fields.productphotoid, fields.primary, fields.modifieddate)
+    override lazy val columns: List[FieldLikeNoHkt[?, PppViewRow]] =
+      List[FieldLikeNoHkt[?, PppViewRow]](fields.productid, fields.productphotoid, fields.primary, fields.modifieddate)
   
-    override def copy[NewRow](prefix: Option[String], extract: NewRow => PppViewRow, merge: (NewRow, PppViewRow) => NewRow): Impl[NewRow] =
-      new Impl(prefix, extract, merge)
+    override def copy(path: List[Path]): Impl =
+      new Impl(path)
   }
   
 }

--- a/typo-tester-doobie/generated-and-checked-in/adventureworks/pr/pr/PrViewFields.scala
+++ b/typo-tester-doobie/generated-and-checked-in/adventureworks/pr/pr/PrViewFields.scala
@@ -11,47 +11,48 @@ import adventureworks.customtypes.TypoLocalDateTime
 import adventureworks.production.product.ProductId
 import adventureworks.production.productreview.ProductreviewId
 import adventureworks.public.Name
+import typo.dsl.Path
 import typo.dsl.SqlExpr.Field
 import typo.dsl.SqlExpr.FieldLikeNoHkt
 import typo.dsl.SqlExpr.OptField
 import typo.dsl.Structure.Relation
 
-trait PrViewFields[Row] {
-  val id: Field[ProductreviewId, Row]
-  val productreviewid: Field[ProductreviewId, Row]
-  val productid: Field[ProductId, Row]
-  val reviewername: Field[Name, Row]
-  val reviewdate: Field[TypoLocalDateTime, Row]
-  val emailaddress: Field[/* max 50 chars */ String, Row]
-  val rating: Field[Int, Row]
-  val comments: OptField[/* max 3850 chars */ String, Row]
-  val modifieddate: Field[TypoLocalDateTime, Row]
+trait PrViewFields {
+  def id: Field[ProductreviewId, PrViewRow]
+  def productreviewid: Field[ProductreviewId, PrViewRow]
+  def productid: Field[ProductId, PrViewRow]
+  def reviewername: Field[Name, PrViewRow]
+  def reviewdate: Field[TypoLocalDateTime, PrViewRow]
+  def emailaddress: Field[/* max 50 chars */ String, PrViewRow]
+  def rating: Field[Int, PrViewRow]
+  def comments: OptField[/* max 3850 chars */ String, PrViewRow]
+  def modifieddate: Field[TypoLocalDateTime, PrViewRow]
 }
 
 object PrViewFields {
-  val structure: Relation[PrViewFields, PrViewRow, PrViewRow] = 
-    new Impl(None, identity, (_, x) => x)
+  lazy val structure: Relation[PrViewFields, PrViewRow] =
+    new Impl(Nil)
     
-  private final class Impl[Row](val prefix: Option[String], val extract: Row => PrViewRow, val merge: (Row, PrViewRow) => Row)
-    extends Relation[PrViewFields, PrViewRow, Row] { 
+  private final class Impl(val _path: List[Path])
+    extends Relation[PrViewFields, PrViewRow] {
   
-    override val fields: PrViewFields[Row] = new PrViewFields[Row] {
-      override val id = new Field[ProductreviewId, Row](prefix, "id", None, None)(x => extract(x).id, (row, value) => merge(row, extract(row).copy(id = value)))
-      override val productreviewid = new Field[ProductreviewId, Row](prefix, "productreviewid", None, None)(x => extract(x).productreviewid, (row, value) => merge(row, extract(row).copy(productreviewid = value)))
-      override val productid = new Field[ProductId, Row](prefix, "productid", None, None)(x => extract(x).productid, (row, value) => merge(row, extract(row).copy(productid = value)))
-      override val reviewername = new Field[Name, Row](prefix, "reviewername", None, None)(x => extract(x).reviewername, (row, value) => merge(row, extract(row).copy(reviewername = value)))
-      override val reviewdate = new Field[TypoLocalDateTime, Row](prefix, "reviewdate", Some("text"), None)(x => extract(x).reviewdate, (row, value) => merge(row, extract(row).copy(reviewdate = value)))
-      override val emailaddress = new Field[/* max 50 chars */ String, Row](prefix, "emailaddress", None, None)(x => extract(x).emailaddress, (row, value) => merge(row, extract(row).copy(emailaddress = value)))
-      override val rating = new Field[Int, Row](prefix, "rating", None, None)(x => extract(x).rating, (row, value) => merge(row, extract(row).copy(rating = value)))
-      override val comments = new OptField[/* max 3850 chars */ String, Row](prefix, "comments", None, None)(x => extract(x).comments, (row, value) => merge(row, extract(row).copy(comments = value)))
-      override val modifieddate = new Field[TypoLocalDateTime, Row](prefix, "modifieddate", Some("text"), None)(x => extract(x).modifieddate, (row, value) => merge(row, extract(row).copy(modifieddate = value)))
+    override lazy val fields: PrViewFields = new PrViewFields {
+      override def id = Field[ProductreviewId, PrViewRow](_path, "id", None, None, x => x.id, (row, value) => row.copy(id = value))
+      override def productreviewid = Field[ProductreviewId, PrViewRow](_path, "productreviewid", None, None, x => x.productreviewid, (row, value) => row.copy(productreviewid = value))
+      override def productid = Field[ProductId, PrViewRow](_path, "productid", None, None, x => x.productid, (row, value) => row.copy(productid = value))
+      override def reviewername = Field[Name, PrViewRow](_path, "reviewername", None, None, x => x.reviewername, (row, value) => row.copy(reviewername = value))
+      override def reviewdate = Field[TypoLocalDateTime, PrViewRow](_path, "reviewdate", Some("text"), None, x => x.reviewdate, (row, value) => row.copy(reviewdate = value))
+      override def emailaddress = Field[/* max 50 chars */ String, PrViewRow](_path, "emailaddress", None, None, x => x.emailaddress, (row, value) => row.copy(emailaddress = value))
+      override def rating = Field[Int, PrViewRow](_path, "rating", None, None, x => x.rating, (row, value) => row.copy(rating = value))
+      override def comments = OptField[/* max 3850 chars */ String, PrViewRow](_path, "comments", None, None, x => x.comments, (row, value) => row.copy(comments = value))
+      override def modifieddate = Field[TypoLocalDateTime, PrViewRow](_path, "modifieddate", Some("text"), None, x => x.modifieddate, (row, value) => row.copy(modifieddate = value))
     }
   
-    override val columns: List[FieldLikeNoHkt[?, Row]] =
-      List[FieldLikeNoHkt[?, Row]](fields.id, fields.productreviewid, fields.productid, fields.reviewername, fields.reviewdate, fields.emailaddress, fields.rating, fields.comments, fields.modifieddate)
+    override lazy val columns: List[FieldLikeNoHkt[?, PrViewRow]] =
+      List[FieldLikeNoHkt[?, PrViewRow]](fields.id, fields.productreviewid, fields.productid, fields.reviewername, fields.reviewdate, fields.emailaddress, fields.rating, fields.comments, fields.modifieddate)
   
-    override def copy[NewRow](prefix: Option[String], extract: NewRow => PrViewRow, merge: (NewRow, PrViewRow) => NewRow): Impl[NewRow] =
-      new Impl(prefix, extract, merge)
+    override def copy(path: List[Path]): Impl =
+      new Impl(path)
   }
   
 }

--- a/typo-tester-doobie/generated-and-checked-in/adventureworks/pr/psc/PscViewFields.scala
+++ b/typo-tester-doobie/generated-and-checked-in/adventureworks/pr/psc/PscViewFields.scala
@@ -12,40 +12,41 @@ import adventureworks.customtypes.TypoUUID
 import adventureworks.production.productcategory.ProductcategoryId
 import adventureworks.production.productsubcategory.ProductsubcategoryId
 import adventureworks.public.Name
+import typo.dsl.Path
 import typo.dsl.SqlExpr.Field
 import typo.dsl.SqlExpr.FieldLikeNoHkt
 import typo.dsl.Structure.Relation
 
-trait PscViewFields[Row] {
-  val id: Field[ProductsubcategoryId, Row]
-  val productsubcategoryid: Field[ProductsubcategoryId, Row]
-  val productcategoryid: Field[ProductcategoryId, Row]
-  val name: Field[Name, Row]
-  val rowguid: Field[TypoUUID, Row]
-  val modifieddate: Field[TypoLocalDateTime, Row]
+trait PscViewFields {
+  def id: Field[ProductsubcategoryId, PscViewRow]
+  def productsubcategoryid: Field[ProductsubcategoryId, PscViewRow]
+  def productcategoryid: Field[ProductcategoryId, PscViewRow]
+  def name: Field[Name, PscViewRow]
+  def rowguid: Field[TypoUUID, PscViewRow]
+  def modifieddate: Field[TypoLocalDateTime, PscViewRow]
 }
 
 object PscViewFields {
-  val structure: Relation[PscViewFields, PscViewRow, PscViewRow] = 
-    new Impl(None, identity, (_, x) => x)
+  lazy val structure: Relation[PscViewFields, PscViewRow] =
+    new Impl(Nil)
     
-  private final class Impl[Row](val prefix: Option[String], val extract: Row => PscViewRow, val merge: (Row, PscViewRow) => Row)
-    extends Relation[PscViewFields, PscViewRow, Row] { 
+  private final class Impl(val _path: List[Path])
+    extends Relation[PscViewFields, PscViewRow] {
   
-    override val fields: PscViewFields[Row] = new PscViewFields[Row] {
-      override val id = new Field[ProductsubcategoryId, Row](prefix, "id", None, None)(x => extract(x).id, (row, value) => merge(row, extract(row).copy(id = value)))
-      override val productsubcategoryid = new Field[ProductsubcategoryId, Row](prefix, "productsubcategoryid", None, None)(x => extract(x).productsubcategoryid, (row, value) => merge(row, extract(row).copy(productsubcategoryid = value)))
-      override val productcategoryid = new Field[ProductcategoryId, Row](prefix, "productcategoryid", None, None)(x => extract(x).productcategoryid, (row, value) => merge(row, extract(row).copy(productcategoryid = value)))
-      override val name = new Field[Name, Row](prefix, "name", None, None)(x => extract(x).name, (row, value) => merge(row, extract(row).copy(name = value)))
-      override val rowguid = new Field[TypoUUID, Row](prefix, "rowguid", None, None)(x => extract(x).rowguid, (row, value) => merge(row, extract(row).copy(rowguid = value)))
-      override val modifieddate = new Field[TypoLocalDateTime, Row](prefix, "modifieddate", Some("text"), None)(x => extract(x).modifieddate, (row, value) => merge(row, extract(row).copy(modifieddate = value)))
+    override lazy val fields: PscViewFields = new PscViewFields {
+      override def id = Field[ProductsubcategoryId, PscViewRow](_path, "id", None, None, x => x.id, (row, value) => row.copy(id = value))
+      override def productsubcategoryid = Field[ProductsubcategoryId, PscViewRow](_path, "productsubcategoryid", None, None, x => x.productsubcategoryid, (row, value) => row.copy(productsubcategoryid = value))
+      override def productcategoryid = Field[ProductcategoryId, PscViewRow](_path, "productcategoryid", None, None, x => x.productcategoryid, (row, value) => row.copy(productcategoryid = value))
+      override def name = Field[Name, PscViewRow](_path, "name", None, None, x => x.name, (row, value) => row.copy(name = value))
+      override def rowguid = Field[TypoUUID, PscViewRow](_path, "rowguid", None, None, x => x.rowguid, (row, value) => row.copy(rowguid = value))
+      override def modifieddate = Field[TypoLocalDateTime, PscViewRow](_path, "modifieddate", Some("text"), None, x => x.modifieddate, (row, value) => row.copy(modifieddate = value))
     }
   
-    override val columns: List[FieldLikeNoHkt[?, Row]] =
-      List[FieldLikeNoHkt[?, Row]](fields.id, fields.productsubcategoryid, fields.productcategoryid, fields.name, fields.rowguid, fields.modifieddate)
+    override lazy val columns: List[FieldLikeNoHkt[?, PscViewRow]] =
+      List[FieldLikeNoHkt[?, PscViewRow]](fields.id, fields.productsubcategoryid, fields.productcategoryid, fields.name, fields.rowguid, fields.modifieddate)
   
-    override def copy[NewRow](prefix: Option[String], extract: NewRow => PscViewRow, merge: (NewRow, PscViewRow) => NewRow): Impl[NewRow] =
-      new Impl(prefix, extract, merge)
+    override def copy(path: List[Path]): Impl =
+      new Impl(path)
   }
   
 }

--- a/typo-tester-doobie/generated-and-checked-in/adventureworks/pr/sr/SrViewFields.scala
+++ b/typo-tester-doobie/generated-and-checked-in/adventureworks/pr/sr/SrViewFields.scala
@@ -10,36 +10,37 @@ package sr
 import adventureworks.customtypes.TypoLocalDateTime
 import adventureworks.production.scrapreason.ScrapreasonId
 import adventureworks.public.Name
+import typo.dsl.Path
 import typo.dsl.SqlExpr.Field
 import typo.dsl.SqlExpr.FieldLikeNoHkt
 import typo.dsl.Structure.Relation
 
-trait SrViewFields[Row] {
-  val id: Field[ScrapreasonId, Row]
-  val scrapreasonid: Field[ScrapreasonId, Row]
-  val name: Field[Name, Row]
-  val modifieddate: Field[TypoLocalDateTime, Row]
+trait SrViewFields {
+  def id: Field[ScrapreasonId, SrViewRow]
+  def scrapreasonid: Field[ScrapreasonId, SrViewRow]
+  def name: Field[Name, SrViewRow]
+  def modifieddate: Field[TypoLocalDateTime, SrViewRow]
 }
 
 object SrViewFields {
-  val structure: Relation[SrViewFields, SrViewRow, SrViewRow] = 
-    new Impl(None, identity, (_, x) => x)
+  lazy val structure: Relation[SrViewFields, SrViewRow] =
+    new Impl(Nil)
     
-  private final class Impl[Row](val prefix: Option[String], val extract: Row => SrViewRow, val merge: (Row, SrViewRow) => Row)
-    extends Relation[SrViewFields, SrViewRow, Row] { 
+  private final class Impl(val _path: List[Path])
+    extends Relation[SrViewFields, SrViewRow] {
   
-    override val fields: SrViewFields[Row] = new SrViewFields[Row] {
-      override val id = new Field[ScrapreasonId, Row](prefix, "id", None, None)(x => extract(x).id, (row, value) => merge(row, extract(row).copy(id = value)))
-      override val scrapreasonid = new Field[ScrapreasonId, Row](prefix, "scrapreasonid", None, None)(x => extract(x).scrapreasonid, (row, value) => merge(row, extract(row).copy(scrapreasonid = value)))
-      override val name = new Field[Name, Row](prefix, "name", None, None)(x => extract(x).name, (row, value) => merge(row, extract(row).copy(name = value)))
-      override val modifieddate = new Field[TypoLocalDateTime, Row](prefix, "modifieddate", Some("text"), None)(x => extract(x).modifieddate, (row, value) => merge(row, extract(row).copy(modifieddate = value)))
+    override lazy val fields: SrViewFields = new SrViewFields {
+      override def id = Field[ScrapreasonId, SrViewRow](_path, "id", None, None, x => x.id, (row, value) => row.copy(id = value))
+      override def scrapreasonid = Field[ScrapreasonId, SrViewRow](_path, "scrapreasonid", None, None, x => x.scrapreasonid, (row, value) => row.copy(scrapreasonid = value))
+      override def name = Field[Name, SrViewRow](_path, "name", None, None, x => x.name, (row, value) => row.copy(name = value))
+      override def modifieddate = Field[TypoLocalDateTime, SrViewRow](_path, "modifieddate", Some("text"), None, x => x.modifieddate, (row, value) => row.copy(modifieddate = value))
     }
   
-    override val columns: List[FieldLikeNoHkt[?, Row]] =
-      List[FieldLikeNoHkt[?, Row]](fields.id, fields.scrapreasonid, fields.name, fields.modifieddate)
+    override lazy val columns: List[FieldLikeNoHkt[?, SrViewRow]] =
+      List[FieldLikeNoHkt[?, SrViewRow]](fields.id, fields.scrapreasonid, fields.name, fields.modifieddate)
   
-    override def copy[NewRow](prefix: Option[String], extract: NewRow => SrViewRow, merge: (NewRow, SrViewRow) => NewRow): Impl[NewRow] =
-      new Impl(prefix, extract, merge)
+    override def copy(path: List[Path]): Impl =
+      new Impl(path)
   }
   
 }

--- a/typo-tester-doobie/generated-and-checked-in/adventureworks/pr/th/ThViewFields.scala
+++ b/typo-tester-doobie/generated-and-checked-in/adventureworks/pr/th/ThViewFields.scala
@@ -10,48 +10,49 @@ package th
 import adventureworks.customtypes.TypoLocalDateTime
 import adventureworks.production.product.ProductId
 import adventureworks.production.transactionhistory.TransactionhistoryId
+import typo.dsl.Path
 import typo.dsl.SqlExpr.Field
 import typo.dsl.SqlExpr.FieldLikeNoHkt
 import typo.dsl.Structure.Relation
 
-trait ThViewFields[Row] {
-  val id: Field[TransactionhistoryId, Row]
-  val transactionid: Field[TransactionhistoryId, Row]
-  val productid: Field[ProductId, Row]
-  val referenceorderid: Field[Int, Row]
-  val referenceorderlineid: Field[Int, Row]
-  val transactiondate: Field[TypoLocalDateTime, Row]
-  val transactiontype: Field[/* bpchar, max 1 chars */ String, Row]
-  val quantity: Field[Int, Row]
-  val actualcost: Field[BigDecimal, Row]
-  val modifieddate: Field[TypoLocalDateTime, Row]
+trait ThViewFields {
+  def id: Field[TransactionhistoryId, ThViewRow]
+  def transactionid: Field[TransactionhistoryId, ThViewRow]
+  def productid: Field[ProductId, ThViewRow]
+  def referenceorderid: Field[Int, ThViewRow]
+  def referenceorderlineid: Field[Int, ThViewRow]
+  def transactiondate: Field[TypoLocalDateTime, ThViewRow]
+  def transactiontype: Field[/* bpchar, max 1 chars */ String, ThViewRow]
+  def quantity: Field[Int, ThViewRow]
+  def actualcost: Field[BigDecimal, ThViewRow]
+  def modifieddate: Field[TypoLocalDateTime, ThViewRow]
 }
 
 object ThViewFields {
-  val structure: Relation[ThViewFields, ThViewRow, ThViewRow] = 
-    new Impl(None, identity, (_, x) => x)
+  lazy val structure: Relation[ThViewFields, ThViewRow] =
+    new Impl(Nil)
     
-  private final class Impl[Row](val prefix: Option[String], val extract: Row => ThViewRow, val merge: (Row, ThViewRow) => Row)
-    extends Relation[ThViewFields, ThViewRow, Row] { 
+  private final class Impl(val _path: List[Path])
+    extends Relation[ThViewFields, ThViewRow] {
   
-    override val fields: ThViewFields[Row] = new ThViewFields[Row] {
-      override val id = new Field[TransactionhistoryId, Row](prefix, "id", None, None)(x => extract(x).id, (row, value) => merge(row, extract(row).copy(id = value)))
-      override val transactionid = new Field[TransactionhistoryId, Row](prefix, "transactionid", None, None)(x => extract(x).transactionid, (row, value) => merge(row, extract(row).copy(transactionid = value)))
-      override val productid = new Field[ProductId, Row](prefix, "productid", None, None)(x => extract(x).productid, (row, value) => merge(row, extract(row).copy(productid = value)))
-      override val referenceorderid = new Field[Int, Row](prefix, "referenceorderid", None, None)(x => extract(x).referenceorderid, (row, value) => merge(row, extract(row).copy(referenceorderid = value)))
-      override val referenceorderlineid = new Field[Int, Row](prefix, "referenceorderlineid", None, None)(x => extract(x).referenceorderlineid, (row, value) => merge(row, extract(row).copy(referenceorderlineid = value)))
-      override val transactiondate = new Field[TypoLocalDateTime, Row](prefix, "transactiondate", Some("text"), None)(x => extract(x).transactiondate, (row, value) => merge(row, extract(row).copy(transactiondate = value)))
-      override val transactiontype = new Field[/* bpchar, max 1 chars */ String, Row](prefix, "transactiontype", None, None)(x => extract(x).transactiontype, (row, value) => merge(row, extract(row).copy(transactiontype = value)))
-      override val quantity = new Field[Int, Row](prefix, "quantity", None, None)(x => extract(x).quantity, (row, value) => merge(row, extract(row).copy(quantity = value)))
-      override val actualcost = new Field[BigDecimal, Row](prefix, "actualcost", None, None)(x => extract(x).actualcost, (row, value) => merge(row, extract(row).copy(actualcost = value)))
-      override val modifieddate = new Field[TypoLocalDateTime, Row](prefix, "modifieddate", Some("text"), None)(x => extract(x).modifieddate, (row, value) => merge(row, extract(row).copy(modifieddate = value)))
+    override lazy val fields: ThViewFields = new ThViewFields {
+      override def id = Field[TransactionhistoryId, ThViewRow](_path, "id", None, None, x => x.id, (row, value) => row.copy(id = value))
+      override def transactionid = Field[TransactionhistoryId, ThViewRow](_path, "transactionid", None, None, x => x.transactionid, (row, value) => row.copy(transactionid = value))
+      override def productid = Field[ProductId, ThViewRow](_path, "productid", None, None, x => x.productid, (row, value) => row.copy(productid = value))
+      override def referenceorderid = Field[Int, ThViewRow](_path, "referenceorderid", None, None, x => x.referenceorderid, (row, value) => row.copy(referenceorderid = value))
+      override def referenceorderlineid = Field[Int, ThViewRow](_path, "referenceorderlineid", None, None, x => x.referenceorderlineid, (row, value) => row.copy(referenceorderlineid = value))
+      override def transactiondate = Field[TypoLocalDateTime, ThViewRow](_path, "transactiondate", Some("text"), None, x => x.transactiondate, (row, value) => row.copy(transactiondate = value))
+      override def transactiontype = Field[/* bpchar, max 1 chars */ String, ThViewRow](_path, "transactiontype", None, None, x => x.transactiontype, (row, value) => row.copy(transactiontype = value))
+      override def quantity = Field[Int, ThViewRow](_path, "quantity", None, None, x => x.quantity, (row, value) => row.copy(quantity = value))
+      override def actualcost = Field[BigDecimal, ThViewRow](_path, "actualcost", None, None, x => x.actualcost, (row, value) => row.copy(actualcost = value))
+      override def modifieddate = Field[TypoLocalDateTime, ThViewRow](_path, "modifieddate", Some("text"), None, x => x.modifieddate, (row, value) => row.copy(modifieddate = value))
     }
   
-    override val columns: List[FieldLikeNoHkt[?, Row]] =
-      List[FieldLikeNoHkt[?, Row]](fields.id, fields.transactionid, fields.productid, fields.referenceorderid, fields.referenceorderlineid, fields.transactiondate, fields.transactiontype, fields.quantity, fields.actualcost, fields.modifieddate)
+    override lazy val columns: List[FieldLikeNoHkt[?, ThViewRow]] =
+      List[FieldLikeNoHkt[?, ThViewRow]](fields.id, fields.transactionid, fields.productid, fields.referenceorderid, fields.referenceorderlineid, fields.transactiondate, fields.transactiontype, fields.quantity, fields.actualcost, fields.modifieddate)
   
-    override def copy[NewRow](prefix: Option[String], extract: NewRow => ThViewRow, merge: (NewRow, ThViewRow) => NewRow): Impl[NewRow] =
-      new Impl(prefix, extract, merge)
+    override def copy(path: List[Path]): Impl =
+      new Impl(path)
   }
   
 }

--- a/typo-tester-doobie/generated-and-checked-in/adventureworks/pr/tha/ThaViewFields.scala
+++ b/typo-tester-doobie/generated-and-checked-in/adventureworks/pr/tha/ThaViewFields.scala
@@ -9,48 +9,49 @@ package tha
 
 import adventureworks.customtypes.TypoLocalDateTime
 import adventureworks.production.transactionhistoryarchive.TransactionhistoryarchiveId
+import typo.dsl.Path
 import typo.dsl.SqlExpr.Field
 import typo.dsl.SqlExpr.FieldLikeNoHkt
 import typo.dsl.Structure.Relation
 
-trait ThaViewFields[Row] {
-  val id: Field[TransactionhistoryarchiveId, Row]
-  val transactionid: Field[TransactionhistoryarchiveId, Row]
-  val productid: Field[Int, Row]
-  val referenceorderid: Field[Int, Row]
-  val referenceorderlineid: Field[Int, Row]
-  val transactiondate: Field[TypoLocalDateTime, Row]
-  val transactiontype: Field[/* bpchar, max 1 chars */ String, Row]
-  val quantity: Field[Int, Row]
-  val actualcost: Field[BigDecimal, Row]
-  val modifieddate: Field[TypoLocalDateTime, Row]
+trait ThaViewFields {
+  def id: Field[TransactionhistoryarchiveId, ThaViewRow]
+  def transactionid: Field[TransactionhistoryarchiveId, ThaViewRow]
+  def productid: Field[Int, ThaViewRow]
+  def referenceorderid: Field[Int, ThaViewRow]
+  def referenceorderlineid: Field[Int, ThaViewRow]
+  def transactiondate: Field[TypoLocalDateTime, ThaViewRow]
+  def transactiontype: Field[/* bpchar, max 1 chars */ String, ThaViewRow]
+  def quantity: Field[Int, ThaViewRow]
+  def actualcost: Field[BigDecimal, ThaViewRow]
+  def modifieddate: Field[TypoLocalDateTime, ThaViewRow]
 }
 
 object ThaViewFields {
-  val structure: Relation[ThaViewFields, ThaViewRow, ThaViewRow] = 
-    new Impl(None, identity, (_, x) => x)
+  lazy val structure: Relation[ThaViewFields, ThaViewRow] =
+    new Impl(Nil)
     
-  private final class Impl[Row](val prefix: Option[String], val extract: Row => ThaViewRow, val merge: (Row, ThaViewRow) => Row)
-    extends Relation[ThaViewFields, ThaViewRow, Row] { 
+  private final class Impl(val _path: List[Path])
+    extends Relation[ThaViewFields, ThaViewRow] {
   
-    override val fields: ThaViewFields[Row] = new ThaViewFields[Row] {
-      override val id = new Field[TransactionhistoryarchiveId, Row](prefix, "id", None, None)(x => extract(x).id, (row, value) => merge(row, extract(row).copy(id = value)))
-      override val transactionid = new Field[TransactionhistoryarchiveId, Row](prefix, "transactionid", None, None)(x => extract(x).transactionid, (row, value) => merge(row, extract(row).copy(transactionid = value)))
-      override val productid = new Field[Int, Row](prefix, "productid", None, None)(x => extract(x).productid, (row, value) => merge(row, extract(row).copy(productid = value)))
-      override val referenceorderid = new Field[Int, Row](prefix, "referenceorderid", None, None)(x => extract(x).referenceorderid, (row, value) => merge(row, extract(row).copy(referenceorderid = value)))
-      override val referenceorderlineid = new Field[Int, Row](prefix, "referenceorderlineid", None, None)(x => extract(x).referenceorderlineid, (row, value) => merge(row, extract(row).copy(referenceorderlineid = value)))
-      override val transactiondate = new Field[TypoLocalDateTime, Row](prefix, "transactiondate", Some("text"), None)(x => extract(x).transactiondate, (row, value) => merge(row, extract(row).copy(transactiondate = value)))
-      override val transactiontype = new Field[/* bpchar, max 1 chars */ String, Row](prefix, "transactiontype", None, None)(x => extract(x).transactiontype, (row, value) => merge(row, extract(row).copy(transactiontype = value)))
-      override val quantity = new Field[Int, Row](prefix, "quantity", None, None)(x => extract(x).quantity, (row, value) => merge(row, extract(row).copy(quantity = value)))
-      override val actualcost = new Field[BigDecimal, Row](prefix, "actualcost", None, None)(x => extract(x).actualcost, (row, value) => merge(row, extract(row).copy(actualcost = value)))
-      override val modifieddate = new Field[TypoLocalDateTime, Row](prefix, "modifieddate", Some("text"), None)(x => extract(x).modifieddate, (row, value) => merge(row, extract(row).copy(modifieddate = value)))
+    override lazy val fields: ThaViewFields = new ThaViewFields {
+      override def id = Field[TransactionhistoryarchiveId, ThaViewRow](_path, "id", None, None, x => x.id, (row, value) => row.copy(id = value))
+      override def transactionid = Field[TransactionhistoryarchiveId, ThaViewRow](_path, "transactionid", None, None, x => x.transactionid, (row, value) => row.copy(transactionid = value))
+      override def productid = Field[Int, ThaViewRow](_path, "productid", None, None, x => x.productid, (row, value) => row.copy(productid = value))
+      override def referenceorderid = Field[Int, ThaViewRow](_path, "referenceorderid", None, None, x => x.referenceorderid, (row, value) => row.copy(referenceorderid = value))
+      override def referenceorderlineid = Field[Int, ThaViewRow](_path, "referenceorderlineid", None, None, x => x.referenceorderlineid, (row, value) => row.copy(referenceorderlineid = value))
+      override def transactiondate = Field[TypoLocalDateTime, ThaViewRow](_path, "transactiondate", Some("text"), None, x => x.transactiondate, (row, value) => row.copy(transactiondate = value))
+      override def transactiontype = Field[/* bpchar, max 1 chars */ String, ThaViewRow](_path, "transactiontype", None, None, x => x.transactiontype, (row, value) => row.copy(transactiontype = value))
+      override def quantity = Field[Int, ThaViewRow](_path, "quantity", None, None, x => x.quantity, (row, value) => row.copy(quantity = value))
+      override def actualcost = Field[BigDecimal, ThaViewRow](_path, "actualcost", None, None, x => x.actualcost, (row, value) => row.copy(actualcost = value))
+      override def modifieddate = Field[TypoLocalDateTime, ThaViewRow](_path, "modifieddate", Some("text"), None, x => x.modifieddate, (row, value) => row.copy(modifieddate = value))
     }
   
-    override val columns: List[FieldLikeNoHkt[?, Row]] =
-      List[FieldLikeNoHkt[?, Row]](fields.id, fields.transactionid, fields.productid, fields.referenceorderid, fields.referenceorderlineid, fields.transactiondate, fields.transactiontype, fields.quantity, fields.actualcost, fields.modifieddate)
+    override lazy val columns: List[FieldLikeNoHkt[?, ThaViewRow]] =
+      List[FieldLikeNoHkt[?, ThaViewRow]](fields.id, fields.transactionid, fields.productid, fields.referenceorderid, fields.referenceorderlineid, fields.transactiondate, fields.transactiontype, fields.quantity, fields.actualcost, fields.modifieddate)
   
-    override def copy[NewRow](prefix: Option[String], extract: NewRow => ThaViewRow, merge: (NewRow, ThaViewRow) => NewRow): Impl[NewRow] =
-      new Impl(prefix, extract, merge)
+    override def copy(path: List[Path]): Impl =
+      new Impl(path)
   }
   
 }

--- a/typo-tester-doobie/generated-and-checked-in/adventureworks/pr/um/UmViewFields.scala
+++ b/typo-tester-doobie/generated-and-checked-in/adventureworks/pr/um/UmViewFields.scala
@@ -10,36 +10,37 @@ package um
 import adventureworks.customtypes.TypoLocalDateTime
 import adventureworks.production.unitmeasure.UnitmeasureId
 import adventureworks.public.Name
+import typo.dsl.Path
 import typo.dsl.SqlExpr.Field
 import typo.dsl.SqlExpr.FieldLikeNoHkt
 import typo.dsl.Structure.Relation
 
-trait UmViewFields[Row] {
-  val id: Field[UnitmeasureId, Row]
-  val unitmeasurecode: Field[UnitmeasureId, Row]
-  val name: Field[Name, Row]
-  val modifieddate: Field[TypoLocalDateTime, Row]
+trait UmViewFields {
+  def id: Field[UnitmeasureId, UmViewRow]
+  def unitmeasurecode: Field[UnitmeasureId, UmViewRow]
+  def name: Field[Name, UmViewRow]
+  def modifieddate: Field[TypoLocalDateTime, UmViewRow]
 }
 
 object UmViewFields {
-  val structure: Relation[UmViewFields, UmViewRow, UmViewRow] = 
-    new Impl(None, identity, (_, x) => x)
+  lazy val structure: Relation[UmViewFields, UmViewRow] =
+    new Impl(Nil)
     
-  private final class Impl[Row](val prefix: Option[String], val extract: Row => UmViewRow, val merge: (Row, UmViewRow) => Row)
-    extends Relation[UmViewFields, UmViewRow, Row] { 
+  private final class Impl(val _path: List[Path])
+    extends Relation[UmViewFields, UmViewRow] {
   
-    override val fields: UmViewFields[Row] = new UmViewFields[Row] {
-      override val id = new Field[UnitmeasureId, Row](prefix, "id", None, None)(x => extract(x).id, (row, value) => merge(row, extract(row).copy(id = value)))
-      override val unitmeasurecode = new Field[UnitmeasureId, Row](prefix, "unitmeasurecode", None, None)(x => extract(x).unitmeasurecode, (row, value) => merge(row, extract(row).copy(unitmeasurecode = value)))
-      override val name = new Field[Name, Row](prefix, "name", None, None)(x => extract(x).name, (row, value) => merge(row, extract(row).copy(name = value)))
-      override val modifieddate = new Field[TypoLocalDateTime, Row](prefix, "modifieddate", Some("text"), None)(x => extract(x).modifieddate, (row, value) => merge(row, extract(row).copy(modifieddate = value)))
+    override lazy val fields: UmViewFields = new UmViewFields {
+      override def id = Field[UnitmeasureId, UmViewRow](_path, "id", None, None, x => x.id, (row, value) => row.copy(id = value))
+      override def unitmeasurecode = Field[UnitmeasureId, UmViewRow](_path, "unitmeasurecode", None, None, x => x.unitmeasurecode, (row, value) => row.copy(unitmeasurecode = value))
+      override def name = Field[Name, UmViewRow](_path, "name", None, None, x => x.name, (row, value) => row.copy(name = value))
+      override def modifieddate = Field[TypoLocalDateTime, UmViewRow](_path, "modifieddate", Some("text"), None, x => x.modifieddate, (row, value) => row.copy(modifieddate = value))
     }
   
-    override val columns: List[FieldLikeNoHkt[?, Row]] =
-      List[FieldLikeNoHkt[?, Row]](fields.id, fields.unitmeasurecode, fields.name, fields.modifieddate)
+    override lazy val columns: List[FieldLikeNoHkt[?, UmViewRow]] =
+      List[FieldLikeNoHkt[?, UmViewRow]](fields.id, fields.unitmeasurecode, fields.name, fields.modifieddate)
   
-    override def copy[NewRow](prefix: Option[String], extract: NewRow => UmViewRow, merge: (NewRow, UmViewRow) => NewRow): Impl[NewRow] =
-      new Impl(prefix, extract, merge)
+    override def copy(path: List[Path]): Impl =
+      new Impl(path)
   }
   
 }

--- a/typo-tester-doobie/generated-and-checked-in/adventureworks/pr/w/WViewFields.scala
+++ b/typo-tester-doobie/generated-and-checked-in/adventureworks/pr/w/WViewFields.scala
@@ -12,49 +12,50 @@ import adventureworks.customtypes.TypoShort
 import adventureworks.production.product.ProductId
 import adventureworks.production.scrapreason.ScrapreasonId
 import adventureworks.production.workorder.WorkorderId
+import typo.dsl.Path
 import typo.dsl.SqlExpr.Field
 import typo.dsl.SqlExpr.FieldLikeNoHkt
 import typo.dsl.SqlExpr.OptField
 import typo.dsl.Structure.Relation
 
-trait WViewFields[Row] {
-  val id: Field[WorkorderId, Row]
-  val workorderid: Field[WorkorderId, Row]
-  val productid: Field[ProductId, Row]
-  val orderqty: Field[Int, Row]
-  val scrappedqty: Field[TypoShort, Row]
-  val startdate: Field[TypoLocalDateTime, Row]
-  val enddate: OptField[TypoLocalDateTime, Row]
-  val duedate: Field[TypoLocalDateTime, Row]
-  val scrapreasonid: OptField[ScrapreasonId, Row]
-  val modifieddate: Field[TypoLocalDateTime, Row]
+trait WViewFields {
+  def id: Field[WorkorderId, WViewRow]
+  def workorderid: Field[WorkorderId, WViewRow]
+  def productid: Field[ProductId, WViewRow]
+  def orderqty: Field[Int, WViewRow]
+  def scrappedqty: Field[TypoShort, WViewRow]
+  def startdate: Field[TypoLocalDateTime, WViewRow]
+  def enddate: OptField[TypoLocalDateTime, WViewRow]
+  def duedate: Field[TypoLocalDateTime, WViewRow]
+  def scrapreasonid: OptField[ScrapreasonId, WViewRow]
+  def modifieddate: Field[TypoLocalDateTime, WViewRow]
 }
 
 object WViewFields {
-  val structure: Relation[WViewFields, WViewRow, WViewRow] = 
-    new Impl(None, identity, (_, x) => x)
+  lazy val structure: Relation[WViewFields, WViewRow] =
+    new Impl(Nil)
     
-  private final class Impl[Row](val prefix: Option[String], val extract: Row => WViewRow, val merge: (Row, WViewRow) => Row)
-    extends Relation[WViewFields, WViewRow, Row] { 
+  private final class Impl(val _path: List[Path])
+    extends Relation[WViewFields, WViewRow] {
   
-    override val fields: WViewFields[Row] = new WViewFields[Row] {
-      override val id = new Field[WorkorderId, Row](prefix, "id", None, None)(x => extract(x).id, (row, value) => merge(row, extract(row).copy(id = value)))
-      override val workorderid = new Field[WorkorderId, Row](prefix, "workorderid", None, None)(x => extract(x).workorderid, (row, value) => merge(row, extract(row).copy(workorderid = value)))
-      override val productid = new Field[ProductId, Row](prefix, "productid", None, None)(x => extract(x).productid, (row, value) => merge(row, extract(row).copy(productid = value)))
-      override val orderqty = new Field[Int, Row](prefix, "orderqty", None, None)(x => extract(x).orderqty, (row, value) => merge(row, extract(row).copy(orderqty = value)))
-      override val scrappedqty = new Field[TypoShort, Row](prefix, "scrappedqty", None, None)(x => extract(x).scrappedqty, (row, value) => merge(row, extract(row).copy(scrappedqty = value)))
-      override val startdate = new Field[TypoLocalDateTime, Row](prefix, "startdate", Some("text"), None)(x => extract(x).startdate, (row, value) => merge(row, extract(row).copy(startdate = value)))
-      override val enddate = new OptField[TypoLocalDateTime, Row](prefix, "enddate", Some("text"), None)(x => extract(x).enddate, (row, value) => merge(row, extract(row).copy(enddate = value)))
-      override val duedate = new Field[TypoLocalDateTime, Row](prefix, "duedate", Some("text"), None)(x => extract(x).duedate, (row, value) => merge(row, extract(row).copy(duedate = value)))
-      override val scrapreasonid = new OptField[ScrapreasonId, Row](prefix, "scrapreasonid", None, None)(x => extract(x).scrapreasonid, (row, value) => merge(row, extract(row).copy(scrapreasonid = value)))
-      override val modifieddate = new Field[TypoLocalDateTime, Row](prefix, "modifieddate", Some("text"), None)(x => extract(x).modifieddate, (row, value) => merge(row, extract(row).copy(modifieddate = value)))
+    override lazy val fields: WViewFields = new WViewFields {
+      override def id = Field[WorkorderId, WViewRow](_path, "id", None, None, x => x.id, (row, value) => row.copy(id = value))
+      override def workorderid = Field[WorkorderId, WViewRow](_path, "workorderid", None, None, x => x.workorderid, (row, value) => row.copy(workorderid = value))
+      override def productid = Field[ProductId, WViewRow](_path, "productid", None, None, x => x.productid, (row, value) => row.copy(productid = value))
+      override def orderqty = Field[Int, WViewRow](_path, "orderqty", None, None, x => x.orderqty, (row, value) => row.copy(orderqty = value))
+      override def scrappedqty = Field[TypoShort, WViewRow](_path, "scrappedqty", None, None, x => x.scrappedqty, (row, value) => row.copy(scrappedqty = value))
+      override def startdate = Field[TypoLocalDateTime, WViewRow](_path, "startdate", Some("text"), None, x => x.startdate, (row, value) => row.copy(startdate = value))
+      override def enddate = OptField[TypoLocalDateTime, WViewRow](_path, "enddate", Some("text"), None, x => x.enddate, (row, value) => row.copy(enddate = value))
+      override def duedate = Field[TypoLocalDateTime, WViewRow](_path, "duedate", Some("text"), None, x => x.duedate, (row, value) => row.copy(duedate = value))
+      override def scrapreasonid = OptField[ScrapreasonId, WViewRow](_path, "scrapreasonid", None, None, x => x.scrapreasonid, (row, value) => row.copy(scrapreasonid = value))
+      override def modifieddate = Field[TypoLocalDateTime, WViewRow](_path, "modifieddate", Some("text"), None, x => x.modifieddate, (row, value) => row.copy(modifieddate = value))
     }
   
-    override val columns: List[FieldLikeNoHkt[?, Row]] =
-      List[FieldLikeNoHkt[?, Row]](fields.id, fields.workorderid, fields.productid, fields.orderqty, fields.scrappedqty, fields.startdate, fields.enddate, fields.duedate, fields.scrapreasonid, fields.modifieddate)
+    override lazy val columns: List[FieldLikeNoHkt[?, WViewRow]] =
+      List[FieldLikeNoHkt[?, WViewRow]](fields.id, fields.workorderid, fields.productid, fields.orderqty, fields.scrappedqty, fields.startdate, fields.enddate, fields.duedate, fields.scrapreasonid, fields.modifieddate)
   
-    override def copy[NewRow](prefix: Option[String], extract: NewRow => WViewRow, merge: (NewRow, WViewRow) => NewRow): Impl[NewRow] =
-      new Impl(prefix, extract, merge)
+    override def copy(path: List[Path]): Impl =
+      new Impl(path)
   }
   
 }

--- a/typo-tester-doobie/generated-and-checked-in/adventureworks/pr/wr/WrViewFields.scala
+++ b/typo-tester-doobie/generated-and-checked-in/adventureworks/pr/wr/WrViewFields.scala
@@ -11,55 +11,56 @@ import adventureworks.customtypes.TypoLocalDateTime
 import adventureworks.customtypes.TypoShort
 import adventureworks.production.location.LocationId
 import adventureworks.production.workorder.WorkorderId
+import typo.dsl.Path
 import typo.dsl.SqlExpr.Field
 import typo.dsl.SqlExpr.FieldLikeNoHkt
 import typo.dsl.SqlExpr.OptField
 import typo.dsl.Structure.Relation
 
-trait WrViewFields[Row] {
-  val id: Field[WorkorderId, Row]
-  val workorderid: Field[WorkorderId, Row]
-  val productid: Field[Int, Row]
-  val operationsequence: Field[TypoShort, Row]
-  val locationid: Field[LocationId, Row]
-  val scheduledstartdate: Field[TypoLocalDateTime, Row]
-  val scheduledenddate: Field[TypoLocalDateTime, Row]
-  val actualstartdate: OptField[TypoLocalDateTime, Row]
-  val actualenddate: OptField[TypoLocalDateTime, Row]
-  val actualresourcehrs: OptField[BigDecimal, Row]
-  val plannedcost: Field[BigDecimal, Row]
-  val actualcost: OptField[BigDecimal, Row]
-  val modifieddate: Field[TypoLocalDateTime, Row]
+trait WrViewFields {
+  def id: Field[WorkorderId, WrViewRow]
+  def workorderid: Field[WorkorderId, WrViewRow]
+  def productid: Field[Int, WrViewRow]
+  def operationsequence: Field[TypoShort, WrViewRow]
+  def locationid: Field[LocationId, WrViewRow]
+  def scheduledstartdate: Field[TypoLocalDateTime, WrViewRow]
+  def scheduledenddate: Field[TypoLocalDateTime, WrViewRow]
+  def actualstartdate: OptField[TypoLocalDateTime, WrViewRow]
+  def actualenddate: OptField[TypoLocalDateTime, WrViewRow]
+  def actualresourcehrs: OptField[BigDecimal, WrViewRow]
+  def plannedcost: Field[BigDecimal, WrViewRow]
+  def actualcost: OptField[BigDecimal, WrViewRow]
+  def modifieddate: Field[TypoLocalDateTime, WrViewRow]
 }
 
 object WrViewFields {
-  val structure: Relation[WrViewFields, WrViewRow, WrViewRow] = 
-    new Impl(None, identity, (_, x) => x)
+  lazy val structure: Relation[WrViewFields, WrViewRow] =
+    new Impl(Nil)
     
-  private final class Impl[Row](val prefix: Option[String], val extract: Row => WrViewRow, val merge: (Row, WrViewRow) => Row)
-    extends Relation[WrViewFields, WrViewRow, Row] { 
+  private final class Impl(val _path: List[Path])
+    extends Relation[WrViewFields, WrViewRow] {
   
-    override val fields: WrViewFields[Row] = new WrViewFields[Row] {
-      override val id = new Field[WorkorderId, Row](prefix, "id", None, None)(x => extract(x).id, (row, value) => merge(row, extract(row).copy(id = value)))
-      override val workorderid = new Field[WorkorderId, Row](prefix, "workorderid", None, None)(x => extract(x).workorderid, (row, value) => merge(row, extract(row).copy(workorderid = value)))
-      override val productid = new Field[Int, Row](prefix, "productid", None, None)(x => extract(x).productid, (row, value) => merge(row, extract(row).copy(productid = value)))
-      override val operationsequence = new Field[TypoShort, Row](prefix, "operationsequence", None, None)(x => extract(x).operationsequence, (row, value) => merge(row, extract(row).copy(operationsequence = value)))
-      override val locationid = new Field[LocationId, Row](prefix, "locationid", None, None)(x => extract(x).locationid, (row, value) => merge(row, extract(row).copy(locationid = value)))
-      override val scheduledstartdate = new Field[TypoLocalDateTime, Row](prefix, "scheduledstartdate", Some("text"), None)(x => extract(x).scheduledstartdate, (row, value) => merge(row, extract(row).copy(scheduledstartdate = value)))
-      override val scheduledenddate = new Field[TypoLocalDateTime, Row](prefix, "scheduledenddate", Some("text"), None)(x => extract(x).scheduledenddate, (row, value) => merge(row, extract(row).copy(scheduledenddate = value)))
-      override val actualstartdate = new OptField[TypoLocalDateTime, Row](prefix, "actualstartdate", Some("text"), None)(x => extract(x).actualstartdate, (row, value) => merge(row, extract(row).copy(actualstartdate = value)))
-      override val actualenddate = new OptField[TypoLocalDateTime, Row](prefix, "actualenddate", Some("text"), None)(x => extract(x).actualenddate, (row, value) => merge(row, extract(row).copy(actualenddate = value)))
-      override val actualresourcehrs = new OptField[BigDecimal, Row](prefix, "actualresourcehrs", None, None)(x => extract(x).actualresourcehrs, (row, value) => merge(row, extract(row).copy(actualresourcehrs = value)))
-      override val plannedcost = new Field[BigDecimal, Row](prefix, "plannedcost", None, None)(x => extract(x).plannedcost, (row, value) => merge(row, extract(row).copy(plannedcost = value)))
-      override val actualcost = new OptField[BigDecimal, Row](prefix, "actualcost", None, None)(x => extract(x).actualcost, (row, value) => merge(row, extract(row).copy(actualcost = value)))
-      override val modifieddate = new Field[TypoLocalDateTime, Row](prefix, "modifieddate", Some("text"), None)(x => extract(x).modifieddate, (row, value) => merge(row, extract(row).copy(modifieddate = value)))
+    override lazy val fields: WrViewFields = new WrViewFields {
+      override def id = Field[WorkorderId, WrViewRow](_path, "id", None, None, x => x.id, (row, value) => row.copy(id = value))
+      override def workorderid = Field[WorkorderId, WrViewRow](_path, "workorderid", None, None, x => x.workorderid, (row, value) => row.copy(workorderid = value))
+      override def productid = Field[Int, WrViewRow](_path, "productid", None, None, x => x.productid, (row, value) => row.copy(productid = value))
+      override def operationsequence = Field[TypoShort, WrViewRow](_path, "operationsequence", None, None, x => x.operationsequence, (row, value) => row.copy(operationsequence = value))
+      override def locationid = Field[LocationId, WrViewRow](_path, "locationid", None, None, x => x.locationid, (row, value) => row.copy(locationid = value))
+      override def scheduledstartdate = Field[TypoLocalDateTime, WrViewRow](_path, "scheduledstartdate", Some("text"), None, x => x.scheduledstartdate, (row, value) => row.copy(scheduledstartdate = value))
+      override def scheduledenddate = Field[TypoLocalDateTime, WrViewRow](_path, "scheduledenddate", Some("text"), None, x => x.scheduledenddate, (row, value) => row.copy(scheduledenddate = value))
+      override def actualstartdate = OptField[TypoLocalDateTime, WrViewRow](_path, "actualstartdate", Some("text"), None, x => x.actualstartdate, (row, value) => row.copy(actualstartdate = value))
+      override def actualenddate = OptField[TypoLocalDateTime, WrViewRow](_path, "actualenddate", Some("text"), None, x => x.actualenddate, (row, value) => row.copy(actualenddate = value))
+      override def actualresourcehrs = OptField[BigDecimal, WrViewRow](_path, "actualresourcehrs", None, None, x => x.actualresourcehrs, (row, value) => row.copy(actualresourcehrs = value))
+      override def plannedcost = Field[BigDecimal, WrViewRow](_path, "plannedcost", None, None, x => x.plannedcost, (row, value) => row.copy(plannedcost = value))
+      override def actualcost = OptField[BigDecimal, WrViewRow](_path, "actualcost", None, None, x => x.actualcost, (row, value) => row.copy(actualcost = value))
+      override def modifieddate = Field[TypoLocalDateTime, WrViewRow](_path, "modifieddate", Some("text"), None, x => x.modifieddate, (row, value) => row.copy(modifieddate = value))
     }
   
-    override val columns: List[FieldLikeNoHkt[?, Row]] =
-      List[FieldLikeNoHkt[?, Row]](fields.id, fields.workorderid, fields.productid, fields.operationsequence, fields.locationid, fields.scheduledstartdate, fields.scheduledenddate, fields.actualstartdate, fields.actualenddate, fields.actualresourcehrs, fields.plannedcost, fields.actualcost, fields.modifieddate)
+    override lazy val columns: List[FieldLikeNoHkt[?, WrViewRow]] =
+      List[FieldLikeNoHkt[?, WrViewRow]](fields.id, fields.workorderid, fields.productid, fields.operationsequence, fields.locationid, fields.scheduledstartdate, fields.scheduledenddate, fields.actualstartdate, fields.actualenddate, fields.actualresourcehrs, fields.plannedcost, fields.actualcost, fields.modifieddate)
   
-    override def copy[NewRow](prefix: Option[String], extract: NewRow => WrViewRow, merge: (NewRow, WrViewRow) => NewRow): Impl[NewRow] =
-      new Impl(prefix, extract, merge)
+    override def copy(path: List[Path]): Impl =
+      new Impl(path)
   }
   
 }

--- a/typo-tester-doobie/generated-and-checked-in/adventureworks/production/billofmaterials/BillofmaterialsFields.scala
+++ b/typo-tester-doobie/generated-and-checked-in/adventureworks/production/billofmaterials/BillofmaterialsFields.scala
@@ -11,48 +11,49 @@ import adventureworks.customtypes.TypoLocalDateTime
 import adventureworks.customtypes.TypoShort
 import adventureworks.production.product.ProductId
 import adventureworks.production.unitmeasure.UnitmeasureId
+import typo.dsl.Path
 import typo.dsl.SqlExpr.Field
 import typo.dsl.SqlExpr.FieldLikeNoHkt
 import typo.dsl.SqlExpr.IdField
 import typo.dsl.SqlExpr.OptField
 import typo.dsl.Structure.Relation
 
-trait BillofmaterialsFields[Row] {
-  val billofmaterialsid: IdField[Int, Row]
-  val productassemblyid: OptField[ProductId, Row]
-  val componentid: Field[ProductId, Row]
-  val startdate: Field[TypoLocalDateTime, Row]
-  val enddate: OptField[TypoLocalDateTime, Row]
-  val unitmeasurecode: Field[UnitmeasureId, Row]
-  val bomlevel: Field[TypoShort, Row]
-  val perassemblyqty: Field[BigDecimal, Row]
-  val modifieddate: Field[TypoLocalDateTime, Row]
+trait BillofmaterialsFields {
+  def billofmaterialsid: IdField[Int, BillofmaterialsRow]
+  def productassemblyid: OptField[ProductId, BillofmaterialsRow]
+  def componentid: Field[ProductId, BillofmaterialsRow]
+  def startdate: Field[TypoLocalDateTime, BillofmaterialsRow]
+  def enddate: OptField[TypoLocalDateTime, BillofmaterialsRow]
+  def unitmeasurecode: Field[UnitmeasureId, BillofmaterialsRow]
+  def bomlevel: Field[TypoShort, BillofmaterialsRow]
+  def perassemblyqty: Field[BigDecimal, BillofmaterialsRow]
+  def modifieddate: Field[TypoLocalDateTime, BillofmaterialsRow]
 }
 
 object BillofmaterialsFields {
-  val structure: Relation[BillofmaterialsFields, BillofmaterialsRow, BillofmaterialsRow] = 
-    new Impl(None, identity, (_, x) => x)
+  lazy val structure: Relation[BillofmaterialsFields, BillofmaterialsRow] =
+    new Impl(Nil)
     
-  private final class Impl[Row](val prefix: Option[String], val extract: Row => BillofmaterialsRow, val merge: (Row, BillofmaterialsRow) => Row)
-    extends Relation[BillofmaterialsFields, BillofmaterialsRow, Row] { 
+  private final class Impl(val _path: List[Path])
+    extends Relation[BillofmaterialsFields, BillofmaterialsRow] {
   
-    override val fields: BillofmaterialsFields[Row] = new BillofmaterialsFields[Row] {
-      override val billofmaterialsid = new IdField[Int, Row](prefix, "billofmaterialsid", None, Some("int4"))(x => extract(x).billofmaterialsid, (row, value) => merge(row, extract(row).copy(billofmaterialsid = value)))
-      override val productassemblyid = new OptField[ProductId, Row](prefix, "productassemblyid", None, Some("int4"))(x => extract(x).productassemblyid, (row, value) => merge(row, extract(row).copy(productassemblyid = value)))
-      override val componentid = new Field[ProductId, Row](prefix, "componentid", None, Some("int4"))(x => extract(x).componentid, (row, value) => merge(row, extract(row).copy(componentid = value)))
-      override val startdate = new Field[TypoLocalDateTime, Row](prefix, "startdate", Some("text"), Some("timestamp"))(x => extract(x).startdate, (row, value) => merge(row, extract(row).copy(startdate = value)))
-      override val enddate = new OptField[TypoLocalDateTime, Row](prefix, "enddate", Some("text"), Some("timestamp"))(x => extract(x).enddate, (row, value) => merge(row, extract(row).copy(enddate = value)))
-      override val unitmeasurecode = new Field[UnitmeasureId, Row](prefix, "unitmeasurecode", None, Some("bpchar"))(x => extract(x).unitmeasurecode, (row, value) => merge(row, extract(row).copy(unitmeasurecode = value)))
-      override val bomlevel = new Field[TypoShort, Row](prefix, "bomlevel", None, Some("int2"))(x => extract(x).bomlevel, (row, value) => merge(row, extract(row).copy(bomlevel = value)))
-      override val perassemblyqty = new Field[BigDecimal, Row](prefix, "perassemblyqty", None, Some("numeric"))(x => extract(x).perassemblyqty, (row, value) => merge(row, extract(row).copy(perassemblyqty = value)))
-      override val modifieddate = new Field[TypoLocalDateTime, Row](prefix, "modifieddate", Some("text"), Some("timestamp"))(x => extract(x).modifieddate, (row, value) => merge(row, extract(row).copy(modifieddate = value)))
+    override lazy val fields: BillofmaterialsFields = new BillofmaterialsFields {
+      override def billofmaterialsid = IdField[Int, BillofmaterialsRow](_path, "billofmaterialsid", None, Some("int4"), x => x.billofmaterialsid, (row, value) => row.copy(billofmaterialsid = value))
+      override def productassemblyid = OptField[ProductId, BillofmaterialsRow](_path, "productassemblyid", None, Some("int4"), x => x.productassemblyid, (row, value) => row.copy(productassemblyid = value))
+      override def componentid = Field[ProductId, BillofmaterialsRow](_path, "componentid", None, Some("int4"), x => x.componentid, (row, value) => row.copy(componentid = value))
+      override def startdate = Field[TypoLocalDateTime, BillofmaterialsRow](_path, "startdate", Some("text"), Some("timestamp"), x => x.startdate, (row, value) => row.copy(startdate = value))
+      override def enddate = OptField[TypoLocalDateTime, BillofmaterialsRow](_path, "enddate", Some("text"), Some("timestamp"), x => x.enddate, (row, value) => row.copy(enddate = value))
+      override def unitmeasurecode = Field[UnitmeasureId, BillofmaterialsRow](_path, "unitmeasurecode", None, Some("bpchar"), x => x.unitmeasurecode, (row, value) => row.copy(unitmeasurecode = value))
+      override def bomlevel = Field[TypoShort, BillofmaterialsRow](_path, "bomlevel", None, Some("int2"), x => x.bomlevel, (row, value) => row.copy(bomlevel = value))
+      override def perassemblyqty = Field[BigDecimal, BillofmaterialsRow](_path, "perassemblyqty", None, Some("numeric"), x => x.perassemblyqty, (row, value) => row.copy(perassemblyqty = value))
+      override def modifieddate = Field[TypoLocalDateTime, BillofmaterialsRow](_path, "modifieddate", Some("text"), Some("timestamp"), x => x.modifieddate, (row, value) => row.copy(modifieddate = value))
     }
   
-    override val columns: List[FieldLikeNoHkt[?, Row]] =
-      List[FieldLikeNoHkt[?, Row]](fields.billofmaterialsid, fields.productassemblyid, fields.componentid, fields.startdate, fields.enddate, fields.unitmeasurecode, fields.bomlevel, fields.perassemblyqty, fields.modifieddate)
+    override lazy val columns: List[FieldLikeNoHkt[?, BillofmaterialsRow]] =
+      List[FieldLikeNoHkt[?, BillofmaterialsRow]](fields.billofmaterialsid, fields.productassemblyid, fields.componentid, fields.startdate, fields.enddate, fields.unitmeasurecode, fields.bomlevel, fields.perassemblyqty, fields.modifieddate)
   
-    override def copy[NewRow](prefix: Option[String], extract: NewRow => BillofmaterialsRow, merge: (NewRow, BillofmaterialsRow) => NewRow): Impl[NewRow] =
-      new Impl(prefix, extract, merge)
+    override def copy(path: List[Path]): Impl =
+      new Impl(path)
   }
   
 }

--- a/typo-tester-doobie/generated-and-checked-in/adventureworks/production/billofmaterials/BillofmaterialsRepoMock.scala
+++ b/typo-tester-doobie/generated-and-checked-in/adventureworks/production/billofmaterials/BillofmaterialsRepoMock.scala
@@ -24,7 +24,7 @@ import typo.dsl.UpdateParams
 class BillofmaterialsRepoMock(toRow: Function1[BillofmaterialsRowUnsaved, BillofmaterialsRow],
                               map: scala.collection.mutable.Map[Int, BillofmaterialsRow] = scala.collection.mutable.Map.empty) extends BillofmaterialsRepo {
   override def delete: DeleteBuilder[BillofmaterialsFields, BillofmaterialsRow] = {
-    DeleteBuilderMock(DeleteParams.empty, BillofmaterialsFields.structure.fields, map)
+    DeleteBuilderMock(DeleteParams.empty, BillofmaterialsFields.structure, map)
   }
   override def deleteById(billofmaterialsid: Int): ConnectionIO[Boolean] = {
     delay(map.remove(billofmaterialsid).isDefined)
@@ -86,7 +86,7 @@ class BillofmaterialsRepoMock(toRow: Function1[BillofmaterialsRowUnsaved, Billof
     }
   }
   override def update: UpdateBuilder[BillofmaterialsFields, BillofmaterialsRow] = {
-    UpdateBuilderMock(UpdateParams.empty, BillofmaterialsFields.structure.fields, map)
+    UpdateBuilderMock(UpdateParams.empty, BillofmaterialsFields.structure, map)
   }
   override def update(row: BillofmaterialsRow): ConnectionIO[Boolean] = {
     delay {

--- a/typo-tester-doobie/generated-and-checked-in/adventureworks/production/culture/CultureFields.scala
+++ b/typo-tester-doobie/generated-and-checked-in/adventureworks/production/culture/CultureFields.scala
@@ -9,35 +9,36 @@ package culture
 
 import adventureworks.customtypes.TypoLocalDateTime
 import adventureworks.public.Name
+import typo.dsl.Path
 import typo.dsl.SqlExpr.Field
 import typo.dsl.SqlExpr.FieldLikeNoHkt
 import typo.dsl.SqlExpr.IdField
 import typo.dsl.Structure.Relation
 
-trait CultureFields[Row] {
-  val cultureid: IdField[CultureId, Row]
-  val name: Field[Name, Row]
-  val modifieddate: Field[TypoLocalDateTime, Row]
+trait CultureFields {
+  def cultureid: IdField[CultureId, CultureRow]
+  def name: Field[Name, CultureRow]
+  def modifieddate: Field[TypoLocalDateTime, CultureRow]
 }
 
 object CultureFields {
-  val structure: Relation[CultureFields, CultureRow, CultureRow] = 
-    new Impl(None, identity, (_, x) => x)
+  lazy val structure: Relation[CultureFields, CultureRow] =
+    new Impl(Nil)
     
-  private final class Impl[Row](val prefix: Option[String], val extract: Row => CultureRow, val merge: (Row, CultureRow) => Row)
-    extends Relation[CultureFields, CultureRow, Row] { 
+  private final class Impl(val _path: List[Path])
+    extends Relation[CultureFields, CultureRow] {
   
-    override val fields: CultureFields[Row] = new CultureFields[Row] {
-      override val cultureid = new IdField[CultureId, Row](prefix, "cultureid", None, Some("bpchar"))(x => extract(x).cultureid, (row, value) => merge(row, extract(row).copy(cultureid = value)))
-      override val name = new Field[Name, Row](prefix, "name", None, Some("varchar"))(x => extract(x).name, (row, value) => merge(row, extract(row).copy(name = value)))
-      override val modifieddate = new Field[TypoLocalDateTime, Row](prefix, "modifieddate", Some("text"), Some("timestamp"))(x => extract(x).modifieddate, (row, value) => merge(row, extract(row).copy(modifieddate = value)))
+    override lazy val fields: CultureFields = new CultureFields {
+      override def cultureid = IdField[CultureId, CultureRow](_path, "cultureid", None, Some("bpchar"), x => x.cultureid, (row, value) => row.copy(cultureid = value))
+      override def name = Field[Name, CultureRow](_path, "name", None, Some("varchar"), x => x.name, (row, value) => row.copy(name = value))
+      override def modifieddate = Field[TypoLocalDateTime, CultureRow](_path, "modifieddate", Some("text"), Some("timestamp"), x => x.modifieddate, (row, value) => row.copy(modifieddate = value))
     }
   
-    override val columns: List[FieldLikeNoHkt[?, Row]] =
-      List[FieldLikeNoHkt[?, Row]](fields.cultureid, fields.name, fields.modifieddate)
+    override lazy val columns: List[FieldLikeNoHkt[?, CultureRow]] =
+      List[FieldLikeNoHkt[?, CultureRow]](fields.cultureid, fields.name, fields.modifieddate)
   
-    override def copy[NewRow](prefix: Option[String], extract: NewRow => CultureRow, merge: (NewRow, CultureRow) => NewRow): Impl[NewRow] =
-      new Impl(prefix, extract, merge)
+    override def copy(path: List[Path]): Impl =
+      new Impl(path)
   }
   
 }

--- a/typo-tester-doobie/generated-and-checked-in/adventureworks/production/culture/CultureRepoMock.scala
+++ b/typo-tester-doobie/generated-and-checked-in/adventureworks/production/culture/CultureRepoMock.scala
@@ -24,7 +24,7 @@ import typo.dsl.UpdateParams
 class CultureRepoMock(toRow: Function1[CultureRowUnsaved, CultureRow],
                       map: scala.collection.mutable.Map[CultureId, CultureRow] = scala.collection.mutable.Map.empty) extends CultureRepo {
   override def delete: DeleteBuilder[CultureFields, CultureRow] = {
-    DeleteBuilderMock(DeleteParams.empty, CultureFields.structure.fields, map)
+    DeleteBuilderMock(DeleteParams.empty, CultureFields.structure, map)
   }
   override def deleteById(cultureid: CultureId): ConnectionIO[Boolean] = {
     delay(map.remove(cultureid).isDefined)
@@ -86,7 +86,7 @@ class CultureRepoMock(toRow: Function1[CultureRowUnsaved, CultureRow],
     }
   }
   override def update: UpdateBuilder[CultureFields, CultureRow] = {
-    UpdateBuilderMock(UpdateParams.empty, CultureFields.structure.fields, map)
+    UpdateBuilderMock(UpdateParams.empty, CultureFields.structure, map)
   }
   override def update(row: CultureRow): ConnectionIO[Boolean] = {
     delay {

--- a/typo-tester-doobie/generated-and-checked-in/adventureworks/production/document/DocumentFields.scala
+++ b/typo-tester-doobie/generated-and-checked-in/adventureworks/production/document/DocumentFields.scala
@@ -13,56 +13,57 @@ import adventureworks.customtypes.TypoShort
 import adventureworks.customtypes.TypoUUID
 import adventureworks.person.businessentity.BusinessentityId
 import adventureworks.public.Flag
+import typo.dsl.Path
 import typo.dsl.SqlExpr.Field
 import typo.dsl.SqlExpr.FieldLikeNoHkt
 import typo.dsl.SqlExpr.IdField
 import typo.dsl.SqlExpr.OptField
 import typo.dsl.Structure.Relation
 
-trait DocumentFields[Row] {
-  val title: Field[/* max 50 chars */ String, Row]
-  val owner: Field[BusinessentityId, Row]
-  val folderflag: Field[Flag, Row]
-  val filename: Field[/* max 400 chars */ String, Row]
-  val fileextension: OptField[/* max 8 chars */ String, Row]
-  val revision: Field[/* bpchar, max 5 chars */ String, Row]
-  val changenumber: Field[Int, Row]
-  val status: Field[TypoShort, Row]
-  val documentsummary: OptField[String, Row]
-  val document: OptField[TypoBytea, Row]
-  val rowguid: Field[TypoUUID, Row]
-  val modifieddate: Field[TypoLocalDateTime, Row]
-  val documentnode: IdField[DocumentId, Row]
+trait DocumentFields {
+  def title: Field[/* max 50 chars */ String, DocumentRow]
+  def owner: Field[BusinessentityId, DocumentRow]
+  def folderflag: Field[Flag, DocumentRow]
+  def filename: Field[/* max 400 chars */ String, DocumentRow]
+  def fileextension: OptField[/* max 8 chars */ String, DocumentRow]
+  def revision: Field[/* bpchar, max 5 chars */ String, DocumentRow]
+  def changenumber: Field[Int, DocumentRow]
+  def status: Field[TypoShort, DocumentRow]
+  def documentsummary: OptField[String, DocumentRow]
+  def document: OptField[TypoBytea, DocumentRow]
+  def rowguid: Field[TypoUUID, DocumentRow]
+  def modifieddate: Field[TypoLocalDateTime, DocumentRow]
+  def documentnode: IdField[DocumentId, DocumentRow]
 }
 
 object DocumentFields {
-  val structure: Relation[DocumentFields, DocumentRow, DocumentRow] = 
-    new Impl(None, identity, (_, x) => x)
+  lazy val structure: Relation[DocumentFields, DocumentRow] =
+    new Impl(Nil)
     
-  private final class Impl[Row](val prefix: Option[String], val extract: Row => DocumentRow, val merge: (Row, DocumentRow) => Row)
-    extends Relation[DocumentFields, DocumentRow, Row] { 
+  private final class Impl(val _path: List[Path])
+    extends Relation[DocumentFields, DocumentRow] {
   
-    override val fields: DocumentFields[Row] = new DocumentFields[Row] {
-      override val title = new Field[/* max 50 chars */ String, Row](prefix, "title", None, None)(x => extract(x).title, (row, value) => merge(row, extract(row).copy(title = value)))
-      override val owner = new Field[BusinessentityId, Row](prefix, "owner", None, Some("int4"))(x => extract(x).owner, (row, value) => merge(row, extract(row).copy(owner = value)))
-      override val folderflag = new Field[Flag, Row](prefix, "folderflag", None, Some("bool"))(x => extract(x).folderflag, (row, value) => merge(row, extract(row).copy(folderflag = value)))
-      override val filename = new Field[/* max 400 chars */ String, Row](prefix, "filename", None, None)(x => extract(x).filename, (row, value) => merge(row, extract(row).copy(filename = value)))
-      override val fileextension = new OptField[/* max 8 chars */ String, Row](prefix, "fileextension", None, None)(x => extract(x).fileextension, (row, value) => merge(row, extract(row).copy(fileextension = value)))
-      override val revision = new Field[/* bpchar, max 5 chars */ String, Row](prefix, "revision", None, Some("bpchar"))(x => extract(x).revision, (row, value) => merge(row, extract(row).copy(revision = value)))
-      override val changenumber = new Field[Int, Row](prefix, "changenumber", None, Some("int4"))(x => extract(x).changenumber, (row, value) => merge(row, extract(row).copy(changenumber = value)))
-      override val status = new Field[TypoShort, Row](prefix, "status", None, Some("int2"))(x => extract(x).status, (row, value) => merge(row, extract(row).copy(status = value)))
-      override val documentsummary = new OptField[String, Row](prefix, "documentsummary", None, None)(x => extract(x).documentsummary, (row, value) => merge(row, extract(row).copy(documentsummary = value)))
-      override val document = new OptField[TypoBytea, Row](prefix, "document", None, Some("bytea"))(x => extract(x).document, (row, value) => merge(row, extract(row).copy(document = value)))
-      override val rowguid = new Field[TypoUUID, Row](prefix, "rowguid", None, Some("uuid"))(x => extract(x).rowguid, (row, value) => merge(row, extract(row).copy(rowguid = value)))
-      override val modifieddate = new Field[TypoLocalDateTime, Row](prefix, "modifieddate", Some("text"), Some("timestamp"))(x => extract(x).modifieddate, (row, value) => merge(row, extract(row).copy(modifieddate = value)))
-      override val documentnode = new IdField[DocumentId, Row](prefix, "documentnode", None, None)(x => extract(x).documentnode, (row, value) => merge(row, extract(row).copy(documentnode = value)))
+    override lazy val fields: DocumentFields = new DocumentFields {
+      override def title = Field[/* max 50 chars */ String, DocumentRow](_path, "title", None, None, x => x.title, (row, value) => row.copy(title = value))
+      override def owner = Field[BusinessentityId, DocumentRow](_path, "owner", None, Some("int4"), x => x.owner, (row, value) => row.copy(owner = value))
+      override def folderflag = Field[Flag, DocumentRow](_path, "folderflag", None, Some("bool"), x => x.folderflag, (row, value) => row.copy(folderflag = value))
+      override def filename = Field[/* max 400 chars */ String, DocumentRow](_path, "filename", None, None, x => x.filename, (row, value) => row.copy(filename = value))
+      override def fileextension = OptField[/* max 8 chars */ String, DocumentRow](_path, "fileextension", None, None, x => x.fileextension, (row, value) => row.copy(fileextension = value))
+      override def revision = Field[/* bpchar, max 5 chars */ String, DocumentRow](_path, "revision", None, Some("bpchar"), x => x.revision, (row, value) => row.copy(revision = value))
+      override def changenumber = Field[Int, DocumentRow](_path, "changenumber", None, Some("int4"), x => x.changenumber, (row, value) => row.copy(changenumber = value))
+      override def status = Field[TypoShort, DocumentRow](_path, "status", None, Some("int2"), x => x.status, (row, value) => row.copy(status = value))
+      override def documentsummary = OptField[String, DocumentRow](_path, "documentsummary", None, None, x => x.documentsummary, (row, value) => row.copy(documentsummary = value))
+      override def document = OptField[TypoBytea, DocumentRow](_path, "document", None, Some("bytea"), x => x.document, (row, value) => row.copy(document = value))
+      override def rowguid = Field[TypoUUID, DocumentRow](_path, "rowguid", None, Some("uuid"), x => x.rowguid, (row, value) => row.copy(rowguid = value))
+      override def modifieddate = Field[TypoLocalDateTime, DocumentRow](_path, "modifieddate", Some("text"), Some("timestamp"), x => x.modifieddate, (row, value) => row.copy(modifieddate = value))
+      override def documentnode = IdField[DocumentId, DocumentRow](_path, "documentnode", None, None, x => x.documentnode, (row, value) => row.copy(documentnode = value))
     }
   
-    override val columns: List[FieldLikeNoHkt[?, Row]] =
-      List[FieldLikeNoHkt[?, Row]](fields.title, fields.owner, fields.folderflag, fields.filename, fields.fileextension, fields.revision, fields.changenumber, fields.status, fields.documentsummary, fields.document, fields.rowguid, fields.modifieddate, fields.documentnode)
+    override lazy val columns: List[FieldLikeNoHkt[?, DocumentRow]] =
+      List[FieldLikeNoHkt[?, DocumentRow]](fields.title, fields.owner, fields.folderflag, fields.filename, fields.fileextension, fields.revision, fields.changenumber, fields.status, fields.documentsummary, fields.document, fields.rowguid, fields.modifieddate, fields.documentnode)
   
-    override def copy[NewRow](prefix: Option[String], extract: NewRow => DocumentRow, merge: (NewRow, DocumentRow) => NewRow): Impl[NewRow] =
-      new Impl(prefix, extract, merge)
+    override def copy(path: List[Path]): Impl =
+      new Impl(path)
   }
   
 }

--- a/typo-tester-doobie/generated-and-checked-in/adventureworks/production/document/DocumentRepoMock.scala
+++ b/typo-tester-doobie/generated-and-checked-in/adventureworks/production/document/DocumentRepoMock.scala
@@ -25,7 +25,7 @@ import typo.dsl.UpdateParams
 class DocumentRepoMock(toRow: Function1[DocumentRowUnsaved, DocumentRow],
                        map: scala.collection.mutable.Map[DocumentId, DocumentRow] = scala.collection.mutable.Map.empty) extends DocumentRepo {
   override def delete: DeleteBuilder[DocumentFields, DocumentRow] = {
-    DeleteBuilderMock(DeleteParams.empty, DocumentFields.structure.fields, map)
+    DeleteBuilderMock(DeleteParams.empty, DocumentFields.structure, map)
   }
   override def deleteById(documentnode: DocumentId): ConnectionIO[Boolean] = {
     delay(map.remove(documentnode).isDefined)
@@ -90,7 +90,7 @@ class DocumentRepoMock(toRow: Function1[DocumentRowUnsaved, DocumentRow],
     delay(map.values.find(v => rowguid == v.rowguid))
   }
   override def update: UpdateBuilder[DocumentFields, DocumentRow] = {
-    UpdateBuilderMock(UpdateParams.empty, DocumentFields.structure.fields, map)
+    UpdateBuilderMock(UpdateParams.empty, DocumentFields.structure, map)
   }
   override def update(row: DocumentRow): ConnectionIO[Boolean] = {
     delay {

--- a/typo-tester-doobie/generated-and-checked-in/adventureworks/production/illustration/IllustrationFields.scala
+++ b/typo-tester-doobie/generated-and-checked-in/adventureworks/production/illustration/IllustrationFields.scala
@@ -9,36 +9,37 @@ package illustration
 
 import adventureworks.customtypes.TypoLocalDateTime
 import adventureworks.customtypes.TypoXml
+import typo.dsl.Path
 import typo.dsl.SqlExpr.Field
 import typo.dsl.SqlExpr.FieldLikeNoHkt
 import typo.dsl.SqlExpr.IdField
 import typo.dsl.SqlExpr.OptField
 import typo.dsl.Structure.Relation
 
-trait IllustrationFields[Row] {
-  val illustrationid: IdField[IllustrationId, Row]
-  val diagram: OptField[TypoXml, Row]
-  val modifieddate: Field[TypoLocalDateTime, Row]
+trait IllustrationFields {
+  def illustrationid: IdField[IllustrationId, IllustrationRow]
+  def diagram: OptField[TypoXml, IllustrationRow]
+  def modifieddate: Field[TypoLocalDateTime, IllustrationRow]
 }
 
 object IllustrationFields {
-  val structure: Relation[IllustrationFields, IllustrationRow, IllustrationRow] = 
-    new Impl(None, identity, (_, x) => x)
+  lazy val structure: Relation[IllustrationFields, IllustrationRow] =
+    new Impl(Nil)
     
-  private final class Impl[Row](val prefix: Option[String], val extract: Row => IllustrationRow, val merge: (Row, IllustrationRow) => Row)
-    extends Relation[IllustrationFields, IllustrationRow, Row] { 
+  private final class Impl(val _path: List[Path])
+    extends Relation[IllustrationFields, IllustrationRow] {
   
-    override val fields: IllustrationFields[Row] = new IllustrationFields[Row] {
-      override val illustrationid = new IdField[IllustrationId, Row](prefix, "illustrationid", None, Some("int4"))(x => extract(x).illustrationid, (row, value) => merge(row, extract(row).copy(illustrationid = value)))
-      override val diagram = new OptField[TypoXml, Row](prefix, "diagram", None, Some("xml"))(x => extract(x).diagram, (row, value) => merge(row, extract(row).copy(diagram = value)))
-      override val modifieddate = new Field[TypoLocalDateTime, Row](prefix, "modifieddate", Some("text"), Some("timestamp"))(x => extract(x).modifieddate, (row, value) => merge(row, extract(row).copy(modifieddate = value)))
+    override lazy val fields: IllustrationFields = new IllustrationFields {
+      override def illustrationid = IdField[IllustrationId, IllustrationRow](_path, "illustrationid", None, Some("int4"), x => x.illustrationid, (row, value) => row.copy(illustrationid = value))
+      override def diagram = OptField[TypoXml, IllustrationRow](_path, "diagram", None, Some("xml"), x => x.diagram, (row, value) => row.copy(diagram = value))
+      override def modifieddate = Field[TypoLocalDateTime, IllustrationRow](_path, "modifieddate", Some("text"), Some("timestamp"), x => x.modifieddate, (row, value) => row.copy(modifieddate = value))
     }
   
-    override val columns: List[FieldLikeNoHkt[?, Row]] =
-      List[FieldLikeNoHkt[?, Row]](fields.illustrationid, fields.diagram, fields.modifieddate)
+    override lazy val columns: List[FieldLikeNoHkt[?, IllustrationRow]] =
+      List[FieldLikeNoHkt[?, IllustrationRow]](fields.illustrationid, fields.diagram, fields.modifieddate)
   
-    override def copy[NewRow](prefix: Option[String], extract: NewRow => IllustrationRow, merge: (NewRow, IllustrationRow) => NewRow): Impl[NewRow] =
-      new Impl(prefix, extract, merge)
+    override def copy(path: List[Path]): Impl =
+      new Impl(path)
   }
   
 }

--- a/typo-tester-doobie/generated-and-checked-in/adventureworks/production/illustration/IllustrationRepoMock.scala
+++ b/typo-tester-doobie/generated-and-checked-in/adventureworks/production/illustration/IllustrationRepoMock.scala
@@ -24,7 +24,7 @@ import typo.dsl.UpdateParams
 class IllustrationRepoMock(toRow: Function1[IllustrationRowUnsaved, IllustrationRow],
                            map: scala.collection.mutable.Map[IllustrationId, IllustrationRow] = scala.collection.mutable.Map.empty) extends IllustrationRepo {
   override def delete: DeleteBuilder[IllustrationFields, IllustrationRow] = {
-    DeleteBuilderMock(DeleteParams.empty, IllustrationFields.structure.fields, map)
+    DeleteBuilderMock(DeleteParams.empty, IllustrationFields.structure, map)
   }
   override def deleteById(illustrationid: IllustrationId): ConnectionIO[Boolean] = {
     delay(map.remove(illustrationid).isDefined)
@@ -86,7 +86,7 @@ class IllustrationRepoMock(toRow: Function1[IllustrationRowUnsaved, Illustration
     }
   }
   override def update: UpdateBuilder[IllustrationFields, IllustrationRow] = {
-    UpdateBuilderMock(UpdateParams.empty, IllustrationFields.structure.fields, map)
+    UpdateBuilderMock(UpdateParams.empty, IllustrationFields.structure, map)
   }
   override def update(row: IllustrationRow): ConnectionIO[Boolean] = {
     delay {

--- a/typo-tester-doobie/generated-and-checked-in/adventureworks/production/location/LocationFields.scala
+++ b/typo-tester-doobie/generated-and-checked-in/adventureworks/production/location/LocationFields.scala
@@ -9,39 +9,40 @@ package location
 
 import adventureworks.customtypes.TypoLocalDateTime
 import adventureworks.public.Name
+import typo.dsl.Path
 import typo.dsl.SqlExpr.Field
 import typo.dsl.SqlExpr.FieldLikeNoHkt
 import typo.dsl.SqlExpr.IdField
 import typo.dsl.Structure.Relation
 
-trait LocationFields[Row] {
-  val locationid: IdField[LocationId, Row]
-  val name: Field[Name, Row]
-  val costrate: Field[BigDecimal, Row]
-  val availability: Field[BigDecimal, Row]
-  val modifieddate: Field[TypoLocalDateTime, Row]
+trait LocationFields {
+  def locationid: IdField[LocationId, LocationRow]
+  def name: Field[Name, LocationRow]
+  def costrate: Field[BigDecimal, LocationRow]
+  def availability: Field[BigDecimal, LocationRow]
+  def modifieddate: Field[TypoLocalDateTime, LocationRow]
 }
 
 object LocationFields {
-  val structure: Relation[LocationFields, LocationRow, LocationRow] = 
-    new Impl(None, identity, (_, x) => x)
+  lazy val structure: Relation[LocationFields, LocationRow] =
+    new Impl(Nil)
     
-  private final class Impl[Row](val prefix: Option[String], val extract: Row => LocationRow, val merge: (Row, LocationRow) => Row)
-    extends Relation[LocationFields, LocationRow, Row] { 
+  private final class Impl(val _path: List[Path])
+    extends Relation[LocationFields, LocationRow] {
   
-    override val fields: LocationFields[Row] = new LocationFields[Row] {
-      override val locationid = new IdField[LocationId, Row](prefix, "locationid", None, Some("int4"))(x => extract(x).locationid, (row, value) => merge(row, extract(row).copy(locationid = value)))
-      override val name = new Field[Name, Row](prefix, "name", None, Some("varchar"))(x => extract(x).name, (row, value) => merge(row, extract(row).copy(name = value)))
-      override val costrate = new Field[BigDecimal, Row](prefix, "costrate", None, Some("numeric"))(x => extract(x).costrate, (row, value) => merge(row, extract(row).copy(costrate = value)))
-      override val availability = new Field[BigDecimal, Row](prefix, "availability", None, Some("numeric"))(x => extract(x).availability, (row, value) => merge(row, extract(row).copy(availability = value)))
-      override val modifieddate = new Field[TypoLocalDateTime, Row](prefix, "modifieddate", Some("text"), Some("timestamp"))(x => extract(x).modifieddate, (row, value) => merge(row, extract(row).copy(modifieddate = value)))
+    override lazy val fields: LocationFields = new LocationFields {
+      override def locationid = IdField[LocationId, LocationRow](_path, "locationid", None, Some("int4"), x => x.locationid, (row, value) => row.copy(locationid = value))
+      override def name = Field[Name, LocationRow](_path, "name", None, Some("varchar"), x => x.name, (row, value) => row.copy(name = value))
+      override def costrate = Field[BigDecimal, LocationRow](_path, "costrate", None, Some("numeric"), x => x.costrate, (row, value) => row.copy(costrate = value))
+      override def availability = Field[BigDecimal, LocationRow](_path, "availability", None, Some("numeric"), x => x.availability, (row, value) => row.copy(availability = value))
+      override def modifieddate = Field[TypoLocalDateTime, LocationRow](_path, "modifieddate", Some("text"), Some("timestamp"), x => x.modifieddate, (row, value) => row.copy(modifieddate = value))
     }
   
-    override val columns: List[FieldLikeNoHkt[?, Row]] =
-      List[FieldLikeNoHkt[?, Row]](fields.locationid, fields.name, fields.costrate, fields.availability, fields.modifieddate)
+    override lazy val columns: List[FieldLikeNoHkt[?, LocationRow]] =
+      List[FieldLikeNoHkt[?, LocationRow]](fields.locationid, fields.name, fields.costrate, fields.availability, fields.modifieddate)
   
-    override def copy[NewRow](prefix: Option[String], extract: NewRow => LocationRow, merge: (NewRow, LocationRow) => NewRow): Impl[NewRow] =
-      new Impl(prefix, extract, merge)
+    override def copy(path: List[Path]): Impl =
+      new Impl(path)
   }
   
 }

--- a/typo-tester-doobie/generated-and-checked-in/adventureworks/production/location/LocationRepoMock.scala
+++ b/typo-tester-doobie/generated-and-checked-in/adventureworks/production/location/LocationRepoMock.scala
@@ -24,7 +24,7 @@ import typo.dsl.UpdateParams
 class LocationRepoMock(toRow: Function1[LocationRowUnsaved, LocationRow],
                        map: scala.collection.mutable.Map[LocationId, LocationRow] = scala.collection.mutable.Map.empty) extends LocationRepo {
   override def delete: DeleteBuilder[LocationFields, LocationRow] = {
-    DeleteBuilderMock(DeleteParams.empty, LocationFields.structure.fields, map)
+    DeleteBuilderMock(DeleteParams.empty, LocationFields.structure, map)
   }
   override def deleteById(locationid: LocationId): ConnectionIO[Boolean] = {
     delay(map.remove(locationid).isDefined)
@@ -86,7 +86,7 @@ class LocationRepoMock(toRow: Function1[LocationRowUnsaved, LocationRow],
     }
   }
   override def update: UpdateBuilder[LocationFields, LocationRow] = {
-    UpdateBuilderMock(UpdateParams.empty, LocationFields.structure.fields, map)
+    UpdateBuilderMock(UpdateParams.empty, LocationFields.structure, map)
   }
   override def update(row: LocationRow): ConnectionIO[Boolean] = {
     delay {

--- a/typo-tester-doobie/generated-and-checked-in/adventureworks/production/product/ProductFields.scala
+++ b/typo-tester-doobie/generated-and-checked-in/adventureworks/production/product/ProductFields.scala
@@ -15,80 +15,81 @@ import adventureworks.production.productsubcategory.ProductsubcategoryId
 import adventureworks.production.unitmeasure.UnitmeasureId
 import adventureworks.public.Flag
 import adventureworks.public.Name
+import typo.dsl.Path
 import typo.dsl.SqlExpr.Field
 import typo.dsl.SqlExpr.FieldLikeNoHkt
 import typo.dsl.SqlExpr.IdField
 import typo.dsl.SqlExpr.OptField
 import typo.dsl.Structure.Relation
 
-trait ProductFields[Row] {
-  val productid: IdField[ProductId, Row]
-  val name: Field[Name, Row]
-  val productnumber: Field[/* max 25 chars */ String, Row]
-  val makeflag: Field[Flag, Row]
-  val finishedgoodsflag: Field[Flag, Row]
-  val color: OptField[/* max 15 chars */ String, Row]
-  val safetystocklevel: Field[TypoShort, Row]
-  val reorderpoint: Field[TypoShort, Row]
-  val standardcost: Field[BigDecimal, Row]
-  val listprice: Field[BigDecimal, Row]
-  val size: OptField[/* max 5 chars */ String, Row]
-  val sizeunitmeasurecode: OptField[UnitmeasureId, Row]
-  val weightunitmeasurecode: OptField[UnitmeasureId, Row]
-  val weight: OptField[BigDecimal, Row]
-  val daystomanufacture: Field[Int, Row]
-  val productline: OptField[/* bpchar, max 2 chars */ String, Row]
-  val `class`: OptField[/* bpchar, max 2 chars */ String, Row]
-  val style: OptField[/* bpchar, max 2 chars */ String, Row]
-  val productsubcategoryid: OptField[ProductsubcategoryId, Row]
-  val productmodelid: OptField[ProductmodelId, Row]
-  val sellstartdate: Field[TypoLocalDateTime, Row]
-  val sellenddate: OptField[TypoLocalDateTime, Row]
-  val discontinueddate: OptField[TypoLocalDateTime, Row]
-  val rowguid: Field[TypoUUID, Row]
-  val modifieddate: Field[TypoLocalDateTime, Row]
+trait ProductFields {
+  def productid: IdField[ProductId, ProductRow]
+  def name: Field[Name, ProductRow]
+  def productnumber: Field[/* max 25 chars */ String, ProductRow]
+  def makeflag: Field[Flag, ProductRow]
+  def finishedgoodsflag: Field[Flag, ProductRow]
+  def color: OptField[/* max 15 chars */ String, ProductRow]
+  def safetystocklevel: Field[TypoShort, ProductRow]
+  def reorderpoint: Field[TypoShort, ProductRow]
+  def standardcost: Field[BigDecimal, ProductRow]
+  def listprice: Field[BigDecimal, ProductRow]
+  def size: OptField[/* max 5 chars */ String, ProductRow]
+  def sizeunitmeasurecode: OptField[UnitmeasureId, ProductRow]
+  def weightunitmeasurecode: OptField[UnitmeasureId, ProductRow]
+  def weight: OptField[BigDecimal, ProductRow]
+  def daystomanufacture: Field[Int, ProductRow]
+  def productline: OptField[/* bpchar, max 2 chars */ String, ProductRow]
+  def `class`: OptField[/* bpchar, max 2 chars */ String, ProductRow]
+  def style: OptField[/* bpchar, max 2 chars */ String, ProductRow]
+  def productsubcategoryid: OptField[ProductsubcategoryId, ProductRow]
+  def productmodelid: OptField[ProductmodelId, ProductRow]
+  def sellstartdate: Field[TypoLocalDateTime, ProductRow]
+  def sellenddate: OptField[TypoLocalDateTime, ProductRow]
+  def discontinueddate: OptField[TypoLocalDateTime, ProductRow]
+  def rowguid: Field[TypoUUID, ProductRow]
+  def modifieddate: Field[TypoLocalDateTime, ProductRow]
 }
 
 object ProductFields {
-  val structure: Relation[ProductFields, ProductRow, ProductRow] = 
-    new Impl(None, identity, (_, x) => x)
+  lazy val structure: Relation[ProductFields, ProductRow] =
+    new Impl(Nil)
     
-  private final class Impl[Row](val prefix: Option[String], val extract: Row => ProductRow, val merge: (Row, ProductRow) => Row)
-    extends Relation[ProductFields, ProductRow, Row] { 
+  private final class Impl(val _path: List[Path])
+    extends Relation[ProductFields, ProductRow] {
   
-    override val fields: ProductFields[Row] = new ProductFields[Row] {
-      override val productid = new IdField[ProductId, Row](prefix, "productid", None, Some("int4"))(x => extract(x).productid, (row, value) => merge(row, extract(row).copy(productid = value)))
-      override val name = new Field[Name, Row](prefix, "name", None, Some("varchar"))(x => extract(x).name, (row, value) => merge(row, extract(row).copy(name = value)))
-      override val productnumber = new Field[/* max 25 chars */ String, Row](prefix, "productnumber", None, None)(x => extract(x).productnumber, (row, value) => merge(row, extract(row).copy(productnumber = value)))
-      override val makeflag = new Field[Flag, Row](prefix, "makeflag", None, Some("bool"))(x => extract(x).makeflag, (row, value) => merge(row, extract(row).copy(makeflag = value)))
-      override val finishedgoodsflag = new Field[Flag, Row](prefix, "finishedgoodsflag", None, Some("bool"))(x => extract(x).finishedgoodsflag, (row, value) => merge(row, extract(row).copy(finishedgoodsflag = value)))
-      override val color = new OptField[/* max 15 chars */ String, Row](prefix, "color", None, None)(x => extract(x).color, (row, value) => merge(row, extract(row).copy(color = value)))
-      override val safetystocklevel = new Field[TypoShort, Row](prefix, "safetystocklevel", None, Some("int2"))(x => extract(x).safetystocklevel, (row, value) => merge(row, extract(row).copy(safetystocklevel = value)))
-      override val reorderpoint = new Field[TypoShort, Row](prefix, "reorderpoint", None, Some("int2"))(x => extract(x).reorderpoint, (row, value) => merge(row, extract(row).copy(reorderpoint = value)))
-      override val standardcost = new Field[BigDecimal, Row](prefix, "standardcost", None, Some("numeric"))(x => extract(x).standardcost, (row, value) => merge(row, extract(row).copy(standardcost = value)))
-      override val listprice = new Field[BigDecimal, Row](prefix, "listprice", None, Some("numeric"))(x => extract(x).listprice, (row, value) => merge(row, extract(row).copy(listprice = value)))
-      override val size = new OptField[/* max 5 chars */ String, Row](prefix, "size", None, None)(x => extract(x).size, (row, value) => merge(row, extract(row).copy(size = value)))
-      override val sizeunitmeasurecode = new OptField[UnitmeasureId, Row](prefix, "sizeunitmeasurecode", None, Some("bpchar"))(x => extract(x).sizeunitmeasurecode, (row, value) => merge(row, extract(row).copy(sizeunitmeasurecode = value)))
-      override val weightunitmeasurecode = new OptField[UnitmeasureId, Row](prefix, "weightunitmeasurecode", None, Some("bpchar"))(x => extract(x).weightunitmeasurecode, (row, value) => merge(row, extract(row).copy(weightunitmeasurecode = value)))
-      override val weight = new OptField[BigDecimal, Row](prefix, "weight", None, Some("numeric"))(x => extract(x).weight, (row, value) => merge(row, extract(row).copy(weight = value)))
-      override val daystomanufacture = new Field[Int, Row](prefix, "daystomanufacture", None, Some("int4"))(x => extract(x).daystomanufacture, (row, value) => merge(row, extract(row).copy(daystomanufacture = value)))
-      override val productline = new OptField[/* bpchar, max 2 chars */ String, Row](prefix, "productline", None, Some("bpchar"))(x => extract(x).productline, (row, value) => merge(row, extract(row).copy(productline = value)))
-      override val `class` = new OptField[/* bpchar, max 2 chars */ String, Row](prefix, "class", None, Some("bpchar"))(x => extract(x).`class`, (row, value) => merge(row, extract(row).copy(`class` = value)))
-      override val style = new OptField[/* bpchar, max 2 chars */ String, Row](prefix, "style", None, Some("bpchar"))(x => extract(x).style, (row, value) => merge(row, extract(row).copy(style = value)))
-      override val productsubcategoryid = new OptField[ProductsubcategoryId, Row](prefix, "productsubcategoryid", None, Some("int4"))(x => extract(x).productsubcategoryid, (row, value) => merge(row, extract(row).copy(productsubcategoryid = value)))
-      override val productmodelid = new OptField[ProductmodelId, Row](prefix, "productmodelid", None, Some("int4"))(x => extract(x).productmodelid, (row, value) => merge(row, extract(row).copy(productmodelid = value)))
-      override val sellstartdate = new Field[TypoLocalDateTime, Row](prefix, "sellstartdate", Some("text"), Some("timestamp"))(x => extract(x).sellstartdate, (row, value) => merge(row, extract(row).copy(sellstartdate = value)))
-      override val sellenddate = new OptField[TypoLocalDateTime, Row](prefix, "sellenddate", Some("text"), Some("timestamp"))(x => extract(x).sellenddate, (row, value) => merge(row, extract(row).copy(sellenddate = value)))
-      override val discontinueddate = new OptField[TypoLocalDateTime, Row](prefix, "discontinueddate", Some("text"), Some("timestamp"))(x => extract(x).discontinueddate, (row, value) => merge(row, extract(row).copy(discontinueddate = value)))
-      override val rowguid = new Field[TypoUUID, Row](prefix, "rowguid", None, Some("uuid"))(x => extract(x).rowguid, (row, value) => merge(row, extract(row).copy(rowguid = value)))
-      override val modifieddate = new Field[TypoLocalDateTime, Row](prefix, "modifieddate", Some("text"), Some("timestamp"))(x => extract(x).modifieddate, (row, value) => merge(row, extract(row).copy(modifieddate = value)))
+    override lazy val fields: ProductFields = new ProductFields {
+      override def productid = IdField[ProductId, ProductRow](_path, "productid", None, Some("int4"), x => x.productid, (row, value) => row.copy(productid = value))
+      override def name = Field[Name, ProductRow](_path, "name", None, Some("varchar"), x => x.name, (row, value) => row.copy(name = value))
+      override def productnumber = Field[/* max 25 chars */ String, ProductRow](_path, "productnumber", None, None, x => x.productnumber, (row, value) => row.copy(productnumber = value))
+      override def makeflag = Field[Flag, ProductRow](_path, "makeflag", None, Some("bool"), x => x.makeflag, (row, value) => row.copy(makeflag = value))
+      override def finishedgoodsflag = Field[Flag, ProductRow](_path, "finishedgoodsflag", None, Some("bool"), x => x.finishedgoodsflag, (row, value) => row.copy(finishedgoodsflag = value))
+      override def color = OptField[/* max 15 chars */ String, ProductRow](_path, "color", None, None, x => x.color, (row, value) => row.copy(color = value))
+      override def safetystocklevel = Field[TypoShort, ProductRow](_path, "safetystocklevel", None, Some("int2"), x => x.safetystocklevel, (row, value) => row.copy(safetystocklevel = value))
+      override def reorderpoint = Field[TypoShort, ProductRow](_path, "reorderpoint", None, Some("int2"), x => x.reorderpoint, (row, value) => row.copy(reorderpoint = value))
+      override def standardcost = Field[BigDecimal, ProductRow](_path, "standardcost", None, Some("numeric"), x => x.standardcost, (row, value) => row.copy(standardcost = value))
+      override def listprice = Field[BigDecimal, ProductRow](_path, "listprice", None, Some("numeric"), x => x.listprice, (row, value) => row.copy(listprice = value))
+      override def size = OptField[/* max 5 chars */ String, ProductRow](_path, "size", None, None, x => x.size, (row, value) => row.copy(size = value))
+      override def sizeunitmeasurecode = OptField[UnitmeasureId, ProductRow](_path, "sizeunitmeasurecode", None, Some("bpchar"), x => x.sizeunitmeasurecode, (row, value) => row.copy(sizeunitmeasurecode = value))
+      override def weightunitmeasurecode = OptField[UnitmeasureId, ProductRow](_path, "weightunitmeasurecode", None, Some("bpchar"), x => x.weightunitmeasurecode, (row, value) => row.copy(weightunitmeasurecode = value))
+      override def weight = OptField[BigDecimal, ProductRow](_path, "weight", None, Some("numeric"), x => x.weight, (row, value) => row.copy(weight = value))
+      override def daystomanufacture = Field[Int, ProductRow](_path, "daystomanufacture", None, Some("int4"), x => x.daystomanufacture, (row, value) => row.copy(daystomanufacture = value))
+      override def productline = OptField[/* bpchar, max 2 chars */ String, ProductRow](_path, "productline", None, Some("bpchar"), x => x.productline, (row, value) => row.copy(productline = value))
+      override def `class` = OptField[/* bpchar, max 2 chars */ String, ProductRow](_path, "class", None, Some("bpchar"), x => x.`class`, (row, value) => row.copy(`class` = value))
+      override def style = OptField[/* bpchar, max 2 chars */ String, ProductRow](_path, "style", None, Some("bpchar"), x => x.style, (row, value) => row.copy(style = value))
+      override def productsubcategoryid = OptField[ProductsubcategoryId, ProductRow](_path, "productsubcategoryid", None, Some("int4"), x => x.productsubcategoryid, (row, value) => row.copy(productsubcategoryid = value))
+      override def productmodelid = OptField[ProductmodelId, ProductRow](_path, "productmodelid", None, Some("int4"), x => x.productmodelid, (row, value) => row.copy(productmodelid = value))
+      override def sellstartdate = Field[TypoLocalDateTime, ProductRow](_path, "sellstartdate", Some("text"), Some("timestamp"), x => x.sellstartdate, (row, value) => row.copy(sellstartdate = value))
+      override def sellenddate = OptField[TypoLocalDateTime, ProductRow](_path, "sellenddate", Some("text"), Some("timestamp"), x => x.sellenddate, (row, value) => row.copy(sellenddate = value))
+      override def discontinueddate = OptField[TypoLocalDateTime, ProductRow](_path, "discontinueddate", Some("text"), Some("timestamp"), x => x.discontinueddate, (row, value) => row.copy(discontinueddate = value))
+      override def rowguid = Field[TypoUUID, ProductRow](_path, "rowguid", None, Some("uuid"), x => x.rowguid, (row, value) => row.copy(rowguid = value))
+      override def modifieddate = Field[TypoLocalDateTime, ProductRow](_path, "modifieddate", Some("text"), Some("timestamp"), x => x.modifieddate, (row, value) => row.copy(modifieddate = value))
     }
   
-    override val columns: List[FieldLikeNoHkt[?, Row]] =
-      List[FieldLikeNoHkt[?, Row]](fields.productid, fields.name, fields.productnumber, fields.makeflag, fields.finishedgoodsflag, fields.color, fields.safetystocklevel, fields.reorderpoint, fields.standardcost, fields.listprice, fields.size, fields.sizeunitmeasurecode, fields.weightunitmeasurecode, fields.weight, fields.daystomanufacture, fields.productline, fields.`class`, fields.style, fields.productsubcategoryid, fields.productmodelid, fields.sellstartdate, fields.sellenddate, fields.discontinueddate, fields.rowguid, fields.modifieddate)
+    override lazy val columns: List[FieldLikeNoHkt[?, ProductRow]] =
+      List[FieldLikeNoHkt[?, ProductRow]](fields.productid, fields.name, fields.productnumber, fields.makeflag, fields.finishedgoodsflag, fields.color, fields.safetystocklevel, fields.reorderpoint, fields.standardcost, fields.listprice, fields.size, fields.sizeunitmeasurecode, fields.weightunitmeasurecode, fields.weight, fields.daystomanufacture, fields.productline, fields.`class`, fields.style, fields.productsubcategoryid, fields.productmodelid, fields.sellstartdate, fields.sellenddate, fields.discontinueddate, fields.rowguid, fields.modifieddate)
   
-    override def copy[NewRow](prefix: Option[String], extract: NewRow => ProductRow, merge: (NewRow, ProductRow) => NewRow): Impl[NewRow] =
-      new Impl(prefix, extract, merge)
+    override def copy(path: List[Path]): Impl =
+      new Impl(path)
   }
   
 }

--- a/typo-tester-doobie/generated-and-checked-in/adventureworks/production/product/ProductRepoMock.scala
+++ b/typo-tester-doobie/generated-and-checked-in/adventureworks/production/product/ProductRepoMock.scala
@@ -24,7 +24,7 @@ import typo.dsl.UpdateParams
 class ProductRepoMock(toRow: Function1[ProductRowUnsaved, ProductRow],
                       map: scala.collection.mutable.Map[ProductId, ProductRow] = scala.collection.mutable.Map.empty) extends ProductRepo {
   override def delete: DeleteBuilder[ProductFields, ProductRow] = {
-    DeleteBuilderMock(DeleteParams.empty, ProductFields.structure.fields, map)
+    DeleteBuilderMock(DeleteParams.empty, ProductFields.structure, map)
   }
   override def deleteById(productid: ProductId): ConnectionIO[Boolean] = {
     delay(map.remove(productid).isDefined)
@@ -86,7 +86,7 @@ class ProductRepoMock(toRow: Function1[ProductRowUnsaved, ProductRow],
     }
   }
   override def update: UpdateBuilder[ProductFields, ProductRow] = {
-    UpdateBuilderMock(UpdateParams.empty, ProductFields.structure.fields, map)
+    UpdateBuilderMock(UpdateParams.empty, ProductFields.structure, map)
   }
   override def update(row: ProductRow): ConnectionIO[Boolean] = {
     delay {

--- a/typo-tester-doobie/generated-and-checked-in/adventureworks/production/productcategory/ProductcategoryFields.scala
+++ b/typo-tester-doobie/generated-and-checked-in/adventureworks/production/productcategory/ProductcategoryFields.scala
@@ -10,37 +10,38 @@ package productcategory
 import adventureworks.customtypes.TypoLocalDateTime
 import adventureworks.customtypes.TypoUUID
 import adventureworks.public.Name
+import typo.dsl.Path
 import typo.dsl.SqlExpr.Field
 import typo.dsl.SqlExpr.FieldLikeNoHkt
 import typo.dsl.SqlExpr.IdField
 import typo.dsl.Structure.Relation
 
-trait ProductcategoryFields[Row] {
-  val productcategoryid: IdField[ProductcategoryId, Row]
-  val name: Field[Name, Row]
-  val rowguid: Field[TypoUUID, Row]
-  val modifieddate: Field[TypoLocalDateTime, Row]
+trait ProductcategoryFields {
+  def productcategoryid: IdField[ProductcategoryId, ProductcategoryRow]
+  def name: Field[Name, ProductcategoryRow]
+  def rowguid: Field[TypoUUID, ProductcategoryRow]
+  def modifieddate: Field[TypoLocalDateTime, ProductcategoryRow]
 }
 
 object ProductcategoryFields {
-  val structure: Relation[ProductcategoryFields, ProductcategoryRow, ProductcategoryRow] = 
-    new Impl(None, identity, (_, x) => x)
+  lazy val structure: Relation[ProductcategoryFields, ProductcategoryRow] =
+    new Impl(Nil)
     
-  private final class Impl[Row](val prefix: Option[String], val extract: Row => ProductcategoryRow, val merge: (Row, ProductcategoryRow) => Row)
-    extends Relation[ProductcategoryFields, ProductcategoryRow, Row] { 
+  private final class Impl(val _path: List[Path])
+    extends Relation[ProductcategoryFields, ProductcategoryRow] {
   
-    override val fields: ProductcategoryFields[Row] = new ProductcategoryFields[Row] {
-      override val productcategoryid = new IdField[ProductcategoryId, Row](prefix, "productcategoryid", None, Some("int4"))(x => extract(x).productcategoryid, (row, value) => merge(row, extract(row).copy(productcategoryid = value)))
-      override val name = new Field[Name, Row](prefix, "name", None, Some("varchar"))(x => extract(x).name, (row, value) => merge(row, extract(row).copy(name = value)))
-      override val rowguid = new Field[TypoUUID, Row](prefix, "rowguid", None, Some("uuid"))(x => extract(x).rowguid, (row, value) => merge(row, extract(row).copy(rowguid = value)))
-      override val modifieddate = new Field[TypoLocalDateTime, Row](prefix, "modifieddate", Some("text"), Some("timestamp"))(x => extract(x).modifieddate, (row, value) => merge(row, extract(row).copy(modifieddate = value)))
+    override lazy val fields: ProductcategoryFields = new ProductcategoryFields {
+      override def productcategoryid = IdField[ProductcategoryId, ProductcategoryRow](_path, "productcategoryid", None, Some("int4"), x => x.productcategoryid, (row, value) => row.copy(productcategoryid = value))
+      override def name = Field[Name, ProductcategoryRow](_path, "name", None, Some("varchar"), x => x.name, (row, value) => row.copy(name = value))
+      override def rowguid = Field[TypoUUID, ProductcategoryRow](_path, "rowguid", None, Some("uuid"), x => x.rowguid, (row, value) => row.copy(rowguid = value))
+      override def modifieddate = Field[TypoLocalDateTime, ProductcategoryRow](_path, "modifieddate", Some("text"), Some("timestamp"), x => x.modifieddate, (row, value) => row.copy(modifieddate = value))
     }
   
-    override val columns: List[FieldLikeNoHkt[?, Row]] =
-      List[FieldLikeNoHkt[?, Row]](fields.productcategoryid, fields.name, fields.rowguid, fields.modifieddate)
+    override lazy val columns: List[FieldLikeNoHkt[?, ProductcategoryRow]] =
+      List[FieldLikeNoHkt[?, ProductcategoryRow]](fields.productcategoryid, fields.name, fields.rowguid, fields.modifieddate)
   
-    override def copy[NewRow](prefix: Option[String], extract: NewRow => ProductcategoryRow, merge: (NewRow, ProductcategoryRow) => NewRow): Impl[NewRow] =
-      new Impl(prefix, extract, merge)
+    override def copy(path: List[Path]): Impl =
+      new Impl(path)
   }
   
 }

--- a/typo-tester-doobie/generated-and-checked-in/adventureworks/production/productcategory/ProductcategoryRepoMock.scala
+++ b/typo-tester-doobie/generated-and-checked-in/adventureworks/production/productcategory/ProductcategoryRepoMock.scala
@@ -24,7 +24,7 @@ import typo.dsl.UpdateParams
 class ProductcategoryRepoMock(toRow: Function1[ProductcategoryRowUnsaved, ProductcategoryRow],
                               map: scala.collection.mutable.Map[ProductcategoryId, ProductcategoryRow] = scala.collection.mutable.Map.empty) extends ProductcategoryRepo {
   override def delete: DeleteBuilder[ProductcategoryFields, ProductcategoryRow] = {
-    DeleteBuilderMock(DeleteParams.empty, ProductcategoryFields.structure.fields, map)
+    DeleteBuilderMock(DeleteParams.empty, ProductcategoryFields.structure, map)
   }
   override def deleteById(productcategoryid: ProductcategoryId): ConnectionIO[Boolean] = {
     delay(map.remove(productcategoryid).isDefined)
@@ -86,7 +86,7 @@ class ProductcategoryRepoMock(toRow: Function1[ProductcategoryRowUnsaved, Produc
     }
   }
   override def update: UpdateBuilder[ProductcategoryFields, ProductcategoryRow] = {
-    UpdateBuilderMock(UpdateParams.empty, ProductcategoryFields.structure.fields, map)
+    UpdateBuilderMock(UpdateParams.empty, ProductcategoryFields.structure, map)
   }
   override def update(row: ProductcategoryRow): ConnectionIO[Boolean] = {
     delay {

--- a/typo-tester-doobie/generated-and-checked-in/adventureworks/production/productcosthistory/ProductcosthistoryFields.scala
+++ b/typo-tester-doobie/generated-and-checked-in/adventureworks/production/productcosthistory/ProductcosthistoryFields.scala
@@ -9,40 +9,41 @@ package productcosthistory
 
 import adventureworks.customtypes.TypoLocalDateTime
 import adventureworks.production.product.ProductId
+import typo.dsl.Path
 import typo.dsl.SqlExpr.Field
 import typo.dsl.SqlExpr.FieldLikeNoHkt
 import typo.dsl.SqlExpr.IdField
 import typo.dsl.SqlExpr.OptField
 import typo.dsl.Structure.Relation
 
-trait ProductcosthistoryFields[Row] {
-  val productid: IdField[ProductId, Row]
-  val startdate: IdField[TypoLocalDateTime, Row]
-  val enddate: OptField[TypoLocalDateTime, Row]
-  val standardcost: Field[BigDecimal, Row]
-  val modifieddate: Field[TypoLocalDateTime, Row]
+trait ProductcosthistoryFields {
+  def productid: IdField[ProductId, ProductcosthistoryRow]
+  def startdate: IdField[TypoLocalDateTime, ProductcosthistoryRow]
+  def enddate: OptField[TypoLocalDateTime, ProductcosthistoryRow]
+  def standardcost: Field[BigDecimal, ProductcosthistoryRow]
+  def modifieddate: Field[TypoLocalDateTime, ProductcosthistoryRow]
 }
 
 object ProductcosthistoryFields {
-  val structure: Relation[ProductcosthistoryFields, ProductcosthistoryRow, ProductcosthistoryRow] = 
-    new Impl(None, identity, (_, x) => x)
+  lazy val structure: Relation[ProductcosthistoryFields, ProductcosthistoryRow] =
+    new Impl(Nil)
     
-  private final class Impl[Row](val prefix: Option[String], val extract: Row => ProductcosthistoryRow, val merge: (Row, ProductcosthistoryRow) => Row)
-    extends Relation[ProductcosthistoryFields, ProductcosthistoryRow, Row] { 
+  private final class Impl(val _path: List[Path])
+    extends Relation[ProductcosthistoryFields, ProductcosthistoryRow] {
   
-    override val fields: ProductcosthistoryFields[Row] = new ProductcosthistoryFields[Row] {
-      override val productid = new IdField[ProductId, Row](prefix, "productid", None, Some("int4"))(x => extract(x).productid, (row, value) => merge(row, extract(row).copy(productid = value)))
-      override val startdate = new IdField[TypoLocalDateTime, Row](prefix, "startdate", Some("text"), Some("timestamp"))(x => extract(x).startdate, (row, value) => merge(row, extract(row).copy(startdate = value)))
-      override val enddate = new OptField[TypoLocalDateTime, Row](prefix, "enddate", Some("text"), Some("timestamp"))(x => extract(x).enddate, (row, value) => merge(row, extract(row).copy(enddate = value)))
-      override val standardcost = new Field[BigDecimal, Row](prefix, "standardcost", None, Some("numeric"))(x => extract(x).standardcost, (row, value) => merge(row, extract(row).copy(standardcost = value)))
-      override val modifieddate = new Field[TypoLocalDateTime, Row](prefix, "modifieddate", Some("text"), Some("timestamp"))(x => extract(x).modifieddate, (row, value) => merge(row, extract(row).copy(modifieddate = value)))
+    override lazy val fields: ProductcosthistoryFields = new ProductcosthistoryFields {
+      override def productid = IdField[ProductId, ProductcosthistoryRow](_path, "productid", None, Some("int4"), x => x.productid, (row, value) => row.copy(productid = value))
+      override def startdate = IdField[TypoLocalDateTime, ProductcosthistoryRow](_path, "startdate", Some("text"), Some("timestamp"), x => x.startdate, (row, value) => row.copy(startdate = value))
+      override def enddate = OptField[TypoLocalDateTime, ProductcosthistoryRow](_path, "enddate", Some("text"), Some("timestamp"), x => x.enddate, (row, value) => row.copy(enddate = value))
+      override def standardcost = Field[BigDecimal, ProductcosthistoryRow](_path, "standardcost", None, Some("numeric"), x => x.standardcost, (row, value) => row.copy(standardcost = value))
+      override def modifieddate = Field[TypoLocalDateTime, ProductcosthistoryRow](_path, "modifieddate", Some("text"), Some("timestamp"), x => x.modifieddate, (row, value) => row.copy(modifieddate = value))
     }
   
-    override val columns: List[FieldLikeNoHkt[?, Row]] =
-      List[FieldLikeNoHkt[?, Row]](fields.productid, fields.startdate, fields.enddate, fields.standardcost, fields.modifieddate)
+    override lazy val columns: List[FieldLikeNoHkt[?, ProductcosthistoryRow]] =
+      List[FieldLikeNoHkt[?, ProductcosthistoryRow]](fields.productid, fields.startdate, fields.enddate, fields.standardcost, fields.modifieddate)
   
-    override def copy[NewRow](prefix: Option[String], extract: NewRow => ProductcosthistoryRow, merge: (NewRow, ProductcosthistoryRow) => NewRow): Impl[NewRow] =
-      new Impl(prefix, extract, merge)
+    override def copy(path: List[Path]): Impl =
+      new Impl(path)
   }
   
 }

--- a/typo-tester-doobie/generated-and-checked-in/adventureworks/production/productcosthistory/ProductcosthistoryRepoMock.scala
+++ b/typo-tester-doobie/generated-and-checked-in/adventureworks/production/productcosthistory/ProductcosthistoryRepoMock.scala
@@ -24,7 +24,7 @@ import typo.dsl.UpdateParams
 class ProductcosthistoryRepoMock(toRow: Function1[ProductcosthistoryRowUnsaved, ProductcosthistoryRow],
                                  map: scala.collection.mutable.Map[ProductcosthistoryId, ProductcosthistoryRow] = scala.collection.mutable.Map.empty) extends ProductcosthistoryRepo {
   override def delete: DeleteBuilder[ProductcosthistoryFields, ProductcosthistoryRow] = {
-    DeleteBuilderMock(DeleteParams.empty, ProductcosthistoryFields.structure.fields, map)
+    DeleteBuilderMock(DeleteParams.empty, ProductcosthistoryFields.structure, map)
   }
   override def deleteById(compositeId: ProductcosthistoryId): ConnectionIO[Boolean] = {
     delay(map.remove(compositeId).isDefined)
@@ -86,7 +86,7 @@ class ProductcosthistoryRepoMock(toRow: Function1[ProductcosthistoryRowUnsaved, 
     }
   }
   override def update: UpdateBuilder[ProductcosthistoryFields, ProductcosthistoryRow] = {
-    UpdateBuilderMock(UpdateParams.empty, ProductcosthistoryFields.structure.fields, map)
+    UpdateBuilderMock(UpdateParams.empty, ProductcosthistoryFields.structure, map)
   }
   override def update(row: ProductcosthistoryRow): ConnectionIO[Boolean] = {
     delay {

--- a/typo-tester-doobie/generated-and-checked-in/adventureworks/production/productdescription/ProductdescriptionFields.scala
+++ b/typo-tester-doobie/generated-and-checked-in/adventureworks/production/productdescription/ProductdescriptionFields.scala
@@ -9,37 +9,38 @@ package productdescription
 
 import adventureworks.customtypes.TypoLocalDateTime
 import adventureworks.customtypes.TypoUUID
+import typo.dsl.Path
 import typo.dsl.SqlExpr.Field
 import typo.dsl.SqlExpr.FieldLikeNoHkt
 import typo.dsl.SqlExpr.IdField
 import typo.dsl.Structure.Relation
 
-trait ProductdescriptionFields[Row] {
-  val productdescriptionid: IdField[ProductdescriptionId, Row]
-  val description: Field[/* max 400 chars */ String, Row]
-  val rowguid: Field[TypoUUID, Row]
-  val modifieddate: Field[TypoLocalDateTime, Row]
+trait ProductdescriptionFields {
+  def productdescriptionid: IdField[ProductdescriptionId, ProductdescriptionRow]
+  def description: Field[/* max 400 chars */ String, ProductdescriptionRow]
+  def rowguid: Field[TypoUUID, ProductdescriptionRow]
+  def modifieddate: Field[TypoLocalDateTime, ProductdescriptionRow]
 }
 
 object ProductdescriptionFields {
-  val structure: Relation[ProductdescriptionFields, ProductdescriptionRow, ProductdescriptionRow] = 
-    new Impl(None, identity, (_, x) => x)
+  lazy val structure: Relation[ProductdescriptionFields, ProductdescriptionRow] =
+    new Impl(Nil)
     
-  private final class Impl[Row](val prefix: Option[String], val extract: Row => ProductdescriptionRow, val merge: (Row, ProductdescriptionRow) => Row)
-    extends Relation[ProductdescriptionFields, ProductdescriptionRow, Row] { 
+  private final class Impl(val _path: List[Path])
+    extends Relation[ProductdescriptionFields, ProductdescriptionRow] {
   
-    override val fields: ProductdescriptionFields[Row] = new ProductdescriptionFields[Row] {
-      override val productdescriptionid = new IdField[ProductdescriptionId, Row](prefix, "productdescriptionid", None, Some("int4"))(x => extract(x).productdescriptionid, (row, value) => merge(row, extract(row).copy(productdescriptionid = value)))
-      override val description = new Field[/* max 400 chars */ String, Row](prefix, "description", None, None)(x => extract(x).description, (row, value) => merge(row, extract(row).copy(description = value)))
-      override val rowguid = new Field[TypoUUID, Row](prefix, "rowguid", None, Some("uuid"))(x => extract(x).rowguid, (row, value) => merge(row, extract(row).copy(rowguid = value)))
-      override val modifieddate = new Field[TypoLocalDateTime, Row](prefix, "modifieddate", Some("text"), Some("timestamp"))(x => extract(x).modifieddate, (row, value) => merge(row, extract(row).copy(modifieddate = value)))
+    override lazy val fields: ProductdescriptionFields = new ProductdescriptionFields {
+      override def productdescriptionid = IdField[ProductdescriptionId, ProductdescriptionRow](_path, "productdescriptionid", None, Some("int4"), x => x.productdescriptionid, (row, value) => row.copy(productdescriptionid = value))
+      override def description = Field[/* max 400 chars */ String, ProductdescriptionRow](_path, "description", None, None, x => x.description, (row, value) => row.copy(description = value))
+      override def rowguid = Field[TypoUUID, ProductdescriptionRow](_path, "rowguid", None, Some("uuid"), x => x.rowguid, (row, value) => row.copy(rowguid = value))
+      override def modifieddate = Field[TypoLocalDateTime, ProductdescriptionRow](_path, "modifieddate", Some("text"), Some("timestamp"), x => x.modifieddate, (row, value) => row.copy(modifieddate = value))
     }
   
-    override val columns: List[FieldLikeNoHkt[?, Row]] =
-      List[FieldLikeNoHkt[?, Row]](fields.productdescriptionid, fields.description, fields.rowguid, fields.modifieddate)
+    override lazy val columns: List[FieldLikeNoHkt[?, ProductdescriptionRow]] =
+      List[FieldLikeNoHkt[?, ProductdescriptionRow]](fields.productdescriptionid, fields.description, fields.rowguid, fields.modifieddate)
   
-    override def copy[NewRow](prefix: Option[String], extract: NewRow => ProductdescriptionRow, merge: (NewRow, ProductdescriptionRow) => NewRow): Impl[NewRow] =
-      new Impl(prefix, extract, merge)
+    override def copy(path: List[Path]): Impl =
+      new Impl(path)
   }
   
 }

--- a/typo-tester-doobie/generated-and-checked-in/adventureworks/production/productdescription/ProductdescriptionRepoMock.scala
+++ b/typo-tester-doobie/generated-and-checked-in/adventureworks/production/productdescription/ProductdescriptionRepoMock.scala
@@ -24,7 +24,7 @@ import typo.dsl.UpdateParams
 class ProductdescriptionRepoMock(toRow: Function1[ProductdescriptionRowUnsaved, ProductdescriptionRow],
                                  map: scala.collection.mutable.Map[ProductdescriptionId, ProductdescriptionRow] = scala.collection.mutable.Map.empty) extends ProductdescriptionRepo {
   override def delete: DeleteBuilder[ProductdescriptionFields, ProductdescriptionRow] = {
-    DeleteBuilderMock(DeleteParams.empty, ProductdescriptionFields.structure.fields, map)
+    DeleteBuilderMock(DeleteParams.empty, ProductdescriptionFields.structure, map)
   }
   override def deleteById(productdescriptionid: ProductdescriptionId): ConnectionIO[Boolean] = {
     delay(map.remove(productdescriptionid).isDefined)
@@ -86,7 +86,7 @@ class ProductdescriptionRepoMock(toRow: Function1[ProductdescriptionRowUnsaved, 
     }
   }
   override def update: UpdateBuilder[ProductdescriptionFields, ProductdescriptionRow] = {
-    UpdateBuilderMock(UpdateParams.empty, ProductdescriptionFields.structure.fields, map)
+    UpdateBuilderMock(UpdateParams.empty, ProductdescriptionFields.structure, map)
   }
   override def update(row: ProductdescriptionRow): ConnectionIO[Boolean] = {
     delay {

--- a/typo-tester-doobie/generated-and-checked-in/adventureworks/production/productdocument/ProductdocumentFields.scala
+++ b/typo-tester-doobie/generated-and-checked-in/adventureworks/production/productdocument/ProductdocumentFields.scala
@@ -10,35 +10,36 @@ package productdocument
 import adventureworks.customtypes.TypoLocalDateTime
 import adventureworks.production.document.DocumentId
 import adventureworks.production.product.ProductId
+import typo.dsl.Path
 import typo.dsl.SqlExpr.Field
 import typo.dsl.SqlExpr.FieldLikeNoHkt
 import typo.dsl.SqlExpr.IdField
 import typo.dsl.Structure.Relation
 
-trait ProductdocumentFields[Row] {
-  val productid: IdField[ProductId, Row]
-  val modifieddate: Field[TypoLocalDateTime, Row]
-  val documentnode: IdField[DocumentId, Row]
+trait ProductdocumentFields {
+  def productid: IdField[ProductId, ProductdocumentRow]
+  def modifieddate: Field[TypoLocalDateTime, ProductdocumentRow]
+  def documentnode: IdField[DocumentId, ProductdocumentRow]
 }
 
 object ProductdocumentFields {
-  val structure: Relation[ProductdocumentFields, ProductdocumentRow, ProductdocumentRow] = 
-    new Impl(None, identity, (_, x) => x)
+  lazy val structure: Relation[ProductdocumentFields, ProductdocumentRow] =
+    new Impl(Nil)
     
-  private final class Impl[Row](val prefix: Option[String], val extract: Row => ProductdocumentRow, val merge: (Row, ProductdocumentRow) => Row)
-    extends Relation[ProductdocumentFields, ProductdocumentRow, Row] { 
+  private final class Impl(val _path: List[Path])
+    extends Relation[ProductdocumentFields, ProductdocumentRow] {
   
-    override val fields: ProductdocumentFields[Row] = new ProductdocumentFields[Row] {
-      override val productid = new IdField[ProductId, Row](prefix, "productid", None, Some("int4"))(x => extract(x).productid, (row, value) => merge(row, extract(row).copy(productid = value)))
-      override val modifieddate = new Field[TypoLocalDateTime, Row](prefix, "modifieddate", Some("text"), Some("timestamp"))(x => extract(x).modifieddate, (row, value) => merge(row, extract(row).copy(modifieddate = value)))
-      override val documentnode = new IdField[DocumentId, Row](prefix, "documentnode", None, None)(x => extract(x).documentnode, (row, value) => merge(row, extract(row).copy(documentnode = value)))
+    override lazy val fields: ProductdocumentFields = new ProductdocumentFields {
+      override def productid = IdField[ProductId, ProductdocumentRow](_path, "productid", None, Some("int4"), x => x.productid, (row, value) => row.copy(productid = value))
+      override def modifieddate = Field[TypoLocalDateTime, ProductdocumentRow](_path, "modifieddate", Some("text"), Some("timestamp"), x => x.modifieddate, (row, value) => row.copy(modifieddate = value))
+      override def documentnode = IdField[DocumentId, ProductdocumentRow](_path, "documentnode", None, None, x => x.documentnode, (row, value) => row.copy(documentnode = value))
     }
   
-    override val columns: List[FieldLikeNoHkt[?, Row]] =
-      List[FieldLikeNoHkt[?, Row]](fields.productid, fields.modifieddate, fields.documentnode)
+    override lazy val columns: List[FieldLikeNoHkt[?, ProductdocumentRow]] =
+      List[FieldLikeNoHkt[?, ProductdocumentRow]](fields.productid, fields.modifieddate, fields.documentnode)
   
-    override def copy[NewRow](prefix: Option[String], extract: NewRow => ProductdocumentRow, merge: (NewRow, ProductdocumentRow) => NewRow): Impl[NewRow] =
-      new Impl(prefix, extract, merge)
+    override def copy(path: List[Path]): Impl =
+      new Impl(path)
   }
   
 }

--- a/typo-tester-doobie/generated-and-checked-in/adventureworks/production/productdocument/ProductdocumentRepoMock.scala
+++ b/typo-tester-doobie/generated-and-checked-in/adventureworks/production/productdocument/ProductdocumentRepoMock.scala
@@ -24,7 +24,7 @@ import typo.dsl.UpdateParams
 class ProductdocumentRepoMock(toRow: Function1[ProductdocumentRowUnsaved, ProductdocumentRow],
                               map: scala.collection.mutable.Map[ProductdocumentId, ProductdocumentRow] = scala.collection.mutable.Map.empty) extends ProductdocumentRepo {
   override def delete: DeleteBuilder[ProductdocumentFields, ProductdocumentRow] = {
-    DeleteBuilderMock(DeleteParams.empty, ProductdocumentFields.structure.fields, map)
+    DeleteBuilderMock(DeleteParams.empty, ProductdocumentFields.structure, map)
   }
   override def deleteById(compositeId: ProductdocumentId): ConnectionIO[Boolean] = {
     delay(map.remove(compositeId).isDefined)
@@ -86,7 +86,7 @@ class ProductdocumentRepoMock(toRow: Function1[ProductdocumentRowUnsaved, Produc
     }
   }
   override def update: UpdateBuilder[ProductdocumentFields, ProductdocumentRow] = {
-    UpdateBuilderMock(UpdateParams.empty, ProductdocumentFields.structure.fields, map)
+    UpdateBuilderMock(UpdateParams.empty, ProductdocumentFields.structure, map)
   }
   override def update(row: ProductdocumentRow): ConnectionIO[Boolean] = {
     delay {

--- a/typo-tester-doobie/generated-and-checked-in/adventureworks/production/productinventory/ProductinventoryFields.scala
+++ b/typo-tester-doobie/generated-and-checked-in/adventureworks/production/productinventory/ProductinventoryFields.scala
@@ -12,43 +12,44 @@ import adventureworks.customtypes.TypoShort
 import adventureworks.customtypes.TypoUUID
 import adventureworks.production.location.LocationId
 import adventureworks.production.product.ProductId
+import typo.dsl.Path
 import typo.dsl.SqlExpr.Field
 import typo.dsl.SqlExpr.FieldLikeNoHkt
 import typo.dsl.SqlExpr.IdField
 import typo.dsl.Structure.Relation
 
-trait ProductinventoryFields[Row] {
-  val productid: IdField[ProductId, Row]
-  val locationid: IdField[LocationId, Row]
-  val shelf: Field[/* max 10 chars */ String, Row]
-  val bin: Field[TypoShort, Row]
-  val quantity: Field[TypoShort, Row]
-  val rowguid: Field[TypoUUID, Row]
-  val modifieddate: Field[TypoLocalDateTime, Row]
+trait ProductinventoryFields {
+  def productid: IdField[ProductId, ProductinventoryRow]
+  def locationid: IdField[LocationId, ProductinventoryRow]
+  def shelf: Field[/* max 10 chars */ String, ProductinventoryRow]
+  def bin: Field[TypoShort, ProductinventoryRow]
+  def quantity: Field[TypoShort, ProductinventoryRow]
+  def rowguid: Field[TypoUUID, ProductinventoryRow]
+  def modifieddate: Field[TypoLocalDateTime, ProductinventoryRow]
 }
 
 object ProductinventoryFields {
-  val structure: Relation[ProductinventoryFields, ProductinventoryRow, ProductinventoryRow] = 
-    new Impl(None, identity, (_, x) => x)
+  lazy val structure: Relation[ProductinventoryFields, ProductinventoryRow] =
+    new Impl(Nil)
     
-  private final class Impl[Row](val prefix: Option[String], val extract: Row => ProductinventoryRow, val merge: (Row, ProductinventoryRow) => Row)
-    extends Relation[ProductinventoryFields, ProductinventoryRow, Row] { 
+  private final class Impl(val _path: List[Path])
+    extends Relation[ProductinventoryFields, ProductinventoryRow] {
   
-    override val fields: ProductinventoryFields[Row] = new ProductinventoryFields[Row] {
-      override val productid = new IdField[ProductId, Row](prefix, "productid", None, Some("int4"))(x => extract(x).productid, (row, value) => merge(row, extract(row).copy(productid = value)))
-      override val locationid = new IdField[LocationId, Row](prefix, "locationid", None, Some("int2"))(x => extract(x).locationid, (row, value) => merge(row, extract(row).copy(locationid = value)))
-      override val shelf = new Field[/* max 10 chars */ String, Row](prefix, "shelf", None, None)(x => extract(x).shelf, (row, value) => merge(row, extract(row).copy(shelf = value)))
-      override val bin = new Field[TypoShort, Row](prefix, "bin", None, Some("int2"))(x => extract(x).bin, (row, value) => merge(row, extract(row).copy(bin = value)))
-      override val quantity = new Field[TypoShort, Row](prefix, "quantity", None, Some("int2"))(x => extract(x).quantity, (row, value) => merge(row, extract(row).copy(quantity = value)))
-      override val rowguid = new Field[TypoUUID, Row](prefix, "rowguid", None, Some("uuid"))(x => extract(x).rowguid, (row, value) => merge(row, extract(row).copy(rowguid = value)))
-      override val modifieddate = new Field[TypoLocalDateTime, Row](prefix, "modifieddate", Some("text"), Some("timestamp"))(x => extract(x).modifieddate, (row, value) => merge(row, extract(row).copy(modifieddate = value)))
+    override lazy val fields: ProductinventoryFields = new ProductinventoryFields {
+      override def productid = IdField[ProductId, ProductinventoryRow](_path, "productid", None, Some("int4"), x => x.productid, (row, value) => row.copy(productid = value))
+      override def locationid = IdField[LocationId, ProductinventoryRow](_path, "locationid", None, Some("int2"), x => x.locationid, (row, value) => row.copy(locationid = value))
+      override def shelf = Field[/* max 10 chars */ String, ProductinventoryRow](_path, "shelf", None, None, x => x.shelf, (row, value) => row.copy(shelf = value))
+      override def bin = Field[TypoShort, ProductinventoryRow](_path, "bin", None, Some("int2"), x => x.bin, (row, value) => row.copy(bin = value))
+      override def quantity = Field[TypoShort, ProductinventoryRow](_path, "quantity", None, Some("int2"), x => x.quantity, (row, value) => row.copy(quantity = value))
+      override def rowguid = Field[TypoUUID, ProductinventoryRow](_path, "rowguid", None, Some("uuid"), x => x.rowguid, (row, value) => row.copy(rowguid = value))
+      override def modifieddate = Field[TypoLocalDateTime, ProductinventoryRow](_path, "modifieddate", Some("text"), Some("timestamp"), x => x.modifieddate, (row, value) => row.copy(modifieddate = value))
     }
   
-    override val columns: List[FieldLikeNoHkt[?, Row]] =
-      List[FieldLikeNoHkt[?, Row]](fields.productid, fields.locationid, fields.shelf, fields.bin, fields.quantity, fields.rowguid, fields.modifieddate)
+    override lazy val columns: List[FieldLikeNoHkt[?, ProductinventoryRow]] =
+      List[FieldLikeNoHkt[?, ProductinventoryRow]](fields.productid, fields.locationid, fields.shelf, fields.bin, fields.quantity, fields.rowguid, fields.modifieddate)
   
-    override def copy[NewRow](prefix: Option[String], extract: NewRow => ProductinventoryRow, merge: (NewRow, ProductinventoryRow) => NewRow): Impl[NewRow] =
-      new Impl(prefix, extract, merge)
+    override def copy(path: List[Path]): Impl =
+      new Impl(path)
   }
   
 }

--- a/typo-tester-doobie/generated-and-checked-in/adventureworks/production/productinventory/ProductinventoryRepoMock.scala
+++ b/typo-tester-doobie/generated-and-checked-in/adventureworks/production/productinventory/ProductinventoryRepoMock.scala
@@ -24,7 +24,7 @@ import typo.dsl.UpdateParams
 class ProductinventoryRepoMock(toRow: Function1[ProductinventoryRowUnsaved, ProductinventoryRow],
                                map: scala.collection.mutable.Map[ProductinventoryId, ProductinventoryRow] = scala.collection.mutable.Map.empty) extends ProductinventoryRepo {
   override def delete: DeleteBuilder[ProductinventoryFields, ProductinventoryRow] = {
-    DeleteBuilderMock(DeleteParams.empty, ProductinventoryFields.structure.fields, map)
+    DeleteBuilderMock(DeleteParams.empty, ProductinventoryFields.structure, map)
   }
   override def deleteById(compositeId: ProductinventoryId): ConnectionIO[Boolean] = {
     delay(map.remove(compositeId).isDefined)
@@ -86,7 +86,7 @@ class ProductinventoryRepoMock(toRow: Function1[ProductinventoryRowUnsaved, Prod
     }
   }
   override def update: UpdateBuilder[ProductinventoryFields, ProductinventoryRow] = {
-    UpdateBuilderMock(UpdateParams.empty, ProductinventoryFields.structure.fields, map)
+    UpdateBuilderMock(UpdateParams.empty, ProductinventoryFields.structure, map)
   }
   override def update(row: ProductinventoryRow): ConnectionIO[Boolean] = {
     delay {

--- a/typo-tester-doobie/generated-and-checked-in/adventureworks/production/productlistpricehistory/ProductlistpricehistoryFields.scala
+++ b/typo-tester-doobie/generated-and-checked-in/adventureworks/production/productlistpricehistory/ProductlistpricehistoryFields.scala
@@ -9,40 +9,41 @@ package productlistpricehistory
 
 import adventureworks.customtypes.TypoLocalDateTime
 import adventureworks.production.product.ProductId
+import typo.dsl.Path
 import typo.dsl.SqlExpr.Field
 import typo.dsl.SqlExpr.FieldLikeNoHkt
 import typo.dsl.SqlExpr.IdField
 import typo.dsl.SqlExpr.OptField
 import typo.dsl.Structure.Relation
 
-trait ProductlistpricehistoryFields[Row] {
-  val productid: IdField[ProductId, Row]
-  val startdate: IdField[TypoLocalDateTime, Row]
-  val enddate: OptField[TypoLocalDateTime, Row]
-  val listprice: Field[BigDecimal, Row]
-  val modifieddate: Field[TypoLocalDateTime, Row]
+trait ProductlistpricehistoryFields {
+  def productid: IdField[ProductId, ProductlistpricehistoryRow]
+  def startdate: IdField[TypoLocalDateTime, ProductlistpricehistoryRow]
+  def enddate: OptField[TypoLocalDateTime, ProductlistpricehistoryRow]
+  def listprice: Field[BigDecimal, ProductlistpricehistoryRow]
+  def modifieddate: Field[TypoLocalDateTime, ProductlistpricehistoryRow]
 }
 
 object ProductlistpricehistoryFields {
-  val structure: Relation[ProductlistpricehistoryFields, ProductlistpricehistoryRow, ProductlistpricehistoryRow] = 
-    new Impl(None, identity, (_, x) => x)
+  lazy val structure: Relation[ProductlistpricehistoryFields, ProductlistpricehistoryRow] =
+    new Impl(Nil)
     
-  private final class Impl[Row](val prefix: Option[String], val extract: Row => ProductlistpricehistoryRow, val merge: (Row, ProductlistpricehistoryRow) => Row)
-    extends Relation[ProductlistpricehistoryFields, ProductlistpricehistoryRow, Row] { 
+  private final class Impl(val _path: List[Path])
+    extends Relation[ProductlistpricehistoryFields, ProductlistpricehistoryRow] {
   
-    override val fields: ProductlistpricehistoryFields[Row] = new ProductlistpricehistoryFields[Row] {
-      override val productid = new IdField[ProductId, Row](prefix, "productid", None, Some("int4"))(x => extract(x).productid, (row, value) => merge(row, extract(row).copy(productid = value)))
-      override val startdate = new IdField[TypoLocalDateTime, Row](prefix, "startdate", Some("text"), Some("timestamp"))(x => extract(x).startdate, (row, value) => merge(row, extract(row).copy(startdate = value)))
-      override val enddate = new OptField[TypoLocalDateTime, Row](prefix, "enddate", Some("text"), Some("timestamp"))(x => extract(x).enddate, (row, value) => merge(row, extract(row).copy(enddate = value)))
-      override val listprice = new Field[BigDecimal, Row](prefix, "listprice", None, Some("numeric"))(x => extract(x).listprice, (row, value) => merge(row, extract(row).copy(listprice = value)))
-      override val modifieddate = new Field[TypoLocalDateTime, Row](prefix, "modifieddate", Some("text"), Some("timestamp"))(x => extract(x).modifieddate, (row, value) => merge(row, extract(row).copy(modifieddate = value)))
+    override lazy val fields: ProductlistpricehistoryFields = new ProductlistpricehistoryFields {
+      override def productid = IdField[ProductId, ProductlistpricehistoryRow](_path, "productid", None, Some("int4"), x => x.productid, (row, value) => row.copy(productid = value))
+      override def startdate = IdField[TypoLocalDateTime, ProductlistpricehistoryRow](_path, "startdate", Some("text"), Some("timestamp"), x => x.startdate, (row, value) => row.copy(startdate = value))
+      override def enddate = OptField[TypoLocalDateTime, ProductlistpricehistoryRow](_path, "enddate", Some("text"), Some("timestamp"), x => x.enddate, (row, value) => row.copy(enddate = value))
+      override def listprice = Field[BigDecimal, ProductlistpricehistoryRow](_path, "listprice", None, Some("numeric"), x => x.listprice, (row, value) => row.copy(listprice = value))
+      override def modifieddate = Field[TypoLocalDateTime, ProductlistpricehistoryRow](_path, "modifieddate", Some("text"), Some("timestamp"), x => x.modifieddate, (row, value) => row.copy(modifieddate = value))
     }
   
-    override val columns: List[FieldLikeNoHkt[?, Row]] =
-      List[FieldLikeNoHkt[?, Row]](fields.productid, fields.startdate, fields.enddate, fields.listprice, fields.modifieddate)
+    override lazy val columns: List[FieldLikeNoHkt[?, ProductlistpricehistoryRow]] =
+      List[FieldLikeNoHkt[?, ProductlistpricehistoryRow]](fields.productid, fields.startdate, fields.enddate, fields.listprice, fields.modifieddate)
   
-    override def copy[NewRow](prefix: Option[String], extract: NewRow => ProductlistpricehistoryRow, merge: (NewRow, ProductlistpricehistoryRow) => NewRow): Impl[NewRow] =
-      new Impl(prefix, extract, merge)
+    override def copy(path: List[Path]): Impl =
+      new Impl(path)
   }
   
 }

--- a/typo-tester-doobie/generated-and-checked-in/adventureworks/production/productlistpricehistory/ProductlistpricehistoryRepoMock.scala
+++ b/typo-tester-doobie/generated-and-checked-in/adventureworks/production/productlistpricehistory/ProductlistpricehistoryRepoMock.scala
@@ -24,7 +24,7 @@ import typo.dsl.UpdateParams
 class ProductlistpricehistoryRepoMock(toRow: Function1[ProductlistpricehistoryRowUnsaved, ProductlistpricehistoryRow],
                                       map: scala.collection.mutable.Map[ProductlistpricehistoryId, ProductlistpricehistoryRow] = scala.collection.mutable.Map.empty) extends ProductlistpricehistoryRepo {
   override def delete: DeleteBuilder[ProductlistpricehistoryFields, ProductlistpricehistoryRow] = {
-    DeleteBuilderMock(DeleteParams.empty, ProductlistpricehistoryFields.structure.fields, map)
+    DeleteBuilderMock(DeleteParams.empty, ProductlistpricehistoryFields.structure, map)
   }
   override def deleteById(compositeId: ProductlistpricehistoryId): ConnectionIO[Boolean] = {
     delay(map.remove(compositeId).isDefined)
@@ -86,7 +86,7 @@ class ProductlistpricehistoryRepoMock(toRow: Function1[ProductlistpricehistoryRo
     }
   }
   override def update: UpdateBuilder[ProductlistpricehistoryFields, ProductlistpricehistoryRow] = {
-    UpdateBuilderMock(UpdateParams.empty, ProductlistpricehistoryFields.structure.fields, map)
+    UpdateBuilderMock(UpdateParams.empty, ProductlistpricehistoryFields.structure, map)
   }
   override def update(row: ProductlistpricehistoryRow): ConnectionIO[Boolean] = {
     delay {

--- a/typo-tester-doobie/generated-and-checked-in/adventureworks/production/productmodel/ProductmodelFields.scala
+++ b/typo-tester-doobie/generated-and-checked-in/adventureworks/production/productmodel/ProductmodelFields.scala
@@ -11,42 +11,43 @@ import adventureworks.customtypes.TypoLocalDateTime
 import adventureworks.customtypes.TypoUUID
 import adventureworks.customtypes.TypoXml
 import adventureworks.public.Name
+import typo.dsl.Path
 import typo.dsl.SqlExpr.Field
 import typo.dsl.SqlExpr.FieldLikeNoHkt
 import typo.dsl.SqlExpr.IdField
 import typo.dsl.SqlExpr.OptField
 import typo.dsl.Structure.Relation
 
-trait ProductmodelFields[Row] {
-  val productmodelid: IdField[ProductmodelId, Row]
-  val name: Field[Name, Row]
-  val catalogdescription: OptField[TypoXml, Row]
-  val instructions: OptField[TypoXml, Row]
-  val rowguid: Field[TypoUUID, Row]
-  val modifieddate: Field[TypoLocalDateTime, Row]
+trait ProductmodelFields {
+  def productmodelid: IdField[ProductmodelId, ProductmodelRow]
+  def name: Field[Name, ProductmodelRow]
+  def catalogdescription: OptField[TypoXml, ProductmodelRow]
+  def instructions: OptField[TypoXml, ProductmodelRow]
+  def rowguid: Field[TypoUUID, ProductmodelRow]
+  def modifieddate: Field[TypoLocalDateTime, ProductmodelRow]
 }
 
 object ProductmodelFields {
-  val structure: Relation[ProductmodelFields, ProductmodelRow, ProductmodelRow] = 
-    new Impl(None, identity, (_, x) => x)
+  lazy val structure: Relation[ProductmodelFields, ProductmodelRow] =
+    new Impl(Nil)
     
-  private final class Impl[Row](val prefix: Option[String], val extract: Row => ProductmodelRow, val merge: (Row, ProductmodelRow) => Row)
-    extends Relation[ProductmodelFields, ProductmodelRow, Row] { 
+  private final class Impl(val _path: List[Path])
+    extends Relation[ProductmodelFields, ProductmodelRow] {
   
-    override val fields: ProductmodelFields[Row] = new ProductmodelFields[Row] {
-      override val productmodelid = new IdField[ProductmodelId, Row](prefix, "productmodelid", None, Some("int4"))(x => extract(x).productmodelid, (row, value) => merge(row, extract(row).copy(productmodelid = value)))
-      override val name = new Field[Name, Row](prefix, "name", None, Some("varchar"))(x => extract(x).name, (row, value) => merge(row, extract(row).copy(name = value)))
-      override val catalogdescription = new OptField[TypoXml, Row](prefix, "catalogdescription", None, Some("xml"))(x => extract(x).catalogdescription, (row, value) => merge(row, extract(row).copy(catalogdescription = value)))
-      override val instructions = new OptField[TypoXml, Row](prefix, "instructions", None, Some("xml"))(x => extract(x).instructions, (row, value) => merge(row, extract(row).copy(instructions = value)))
-      override val rowguid = new Field[TypoUUID, Row](prefix, "rowguid", None, Some("uuid"))(x => extract(x).rowguid, (row, value) => merge(row, extract(row).copy(rowguid = value)))
-      override val modifieddate = new Field[TypoLocalDateTime, Row](prefix, "modifieddate", Some("text"), Some("timestamp"))(x => extract(x).modifieddate, (row, value) => merge(row, extract(row).copy(modifieddate = value)))
+    override lazy val fields: ProductmodelFields = new ProductmodelFields {
+      override def productmodelid = IdField[ProductmodelId, ProductmodelRow](_path, "productmodelid", None, Some("int4"), x => x.productmodelid, (row, value) => row.copy(productmodelid = value))
+      override def name = Field[Name, ProductmodelRow](_path, "name", None, Some("varchar"), x => x.name, (row, value) => row.copy(name = value))
+      override def catalogdescription = OptField[TypoXml, ProductmodelRow](_path, "catalogdescription", None, Some("xml"), x => x.catalogdescription, (row, value) => row.copy(catalogdescription = value))
+      override def instructions = OptField[TypoXml, ProductmodelRow](_path, "instructions", None, Some("xml"), x => x.instructions, (row, value) => row.copy(instructions = value))
+      override def rowguid = Field[TypoUUID, ProductmodelRow](_path, "rowguid", None, Some("uuid"), x => x.rowguid, (row, value) => row.copy(rowguid = value))
+      override def modifieddate = Field[TypoLocalDateTime, ProductmodelRow](_path, "modifieddate", Some("text"), Some("timestamp"), x => x.modifieddate, (row, value) => row.copy(modifieddate = value))
     }
   
-    override val columns: List[FieldLikeNoHkt[?, Row]] =
-      List[FieldLikeNoHkt[?, Row]](fields.productmodelid, fields.name, fields.catalogdescription, fields.instructions, fields.rowguid, fields.modifieddate)
+    override lazy val columns: List[FieldLikeNoHkt[?, ProductmodelRow]] =
+      List[FieldLikeNoHkt[?, ProductmodelRow]](fields.productmodelid, fields.name, fields.catalogdescription, fields.instructions, fields.rowguid, fields.modifieddate)
   
-    override def copy[NewRow](prefix: Option[String], extract: NewRow => ProductmodelRow, merge: (NewRow, ProductmodelRow) => NewRow): Impl[NewRow] =
-      new Impl(prefix, extract, merge)
+    override def copy(path: List[Path]): Impl =
+      new Impl(path)
   }
   
 }

--- a/typo-tester-doobie/generated-and-checked-in/adventureworks/production/productmodel/ProductmodelRepoMock.scala
+++ b/typo-tester-doobie/generated-and-checked-in/adventureworks/production/productmodel/ProductmodelRepoMock.scala
@@ -24,7 +24,7 @@ import typo.dsl.UpdateParams
 class ProductmodelRepoMock(toRow: Function1[ProductmodelRowUnsaved, ProductmodelRow],
                            map: scala.collection.mutable.Map[ProductmodelId, ProductmodelRow] = scala.collection.mutable.Map.empty) extends ProductmodelRepo {
   override def delete: DeleteBuilder[ProductmodelFields, ProductmodelRow] = {
-    DeleteBuilderMock(DeleteParams.empty, ProductmodelFields.structure.fields, map)
+    DeleteBuilderMock(DeleteParams.empty, ProductmodelFields.structure, map)
   }
   override def deleteById(productmodelid: ProductmodelId): ConnectionIO[Boolean] = {
     delay(map.remove(productmodelid).isDefined)
@@ -86,7 +86,7 @@ class ProductmodelRepoMock(toRow: Function1[ProductmodelRowUnsaved, Productmodel
     }
   }
   override def update: UpdateBuilder[ProductmodelFields, ProductmodelRow] = {
-    UpdateBuilderMock(UpdateParams.empty, ProductmodelFields.structure.fields, map)
+    UpdateBuilderMock(UpdateParams.empty, ProductmodelFields.structure, map)
   }
   override def update(row: ProductmodelRow): ConnectionIO[Boolean] = {
     delay {

--- a/typo-tester-doobie/generated-and-checked-in/adventureworks/production/productmodelillustration/ProductmodelillustrationFields.scala
+++ b/typo-tester-doobie/generated-and-checked-in/adventureworks/production/productmodelillustration/ProductmodelillustrationFields.scala
@@ -10,35 +10,36 @@ package productmodelillustration
 import adventureworks.customtypes.TypoLocalDateTime
 import adventureworks.production.illustration.IllustrationId
 import adventureworks.production.productmodel.ProductmodelId
+import typo.dsl.Path
 import typo.dsl.SqlExpr.Field
 import typo.dsl.SqlExpr.FieldLikeNoHkt
 import typo.dsl.SqlExpr.IdField
 import typo.dsl.Structure.Relation
 
-trait ProductmodelillustrationFields[Row] {
-  val productmodelid: IdField[ProductmodelId, Row]
-  val illustrationid: IdField[IllustrationId, Row]
-  val modifieddate: Field[TypoLocalDateTime, Row]
+trait ProductmodelillustrationFields {
+  def productmodelid: IdField[ProductmodelId, ProductmodelillustrationRow]
+  def illustrationid: IdField[IllustrationId, ProductmodelillustrationRow]
+  def modifieddate: Field[TypoLocalDateTime, ProductmodelillustrationRow]
 }
 
 object ProductmodelillustrationFields {
-  val structure: Relation[ProductmodelillustrationFields, ProductmodelillustrationRow, ProductmodelillustrationRow] = 
-    new Impl(None, identity, (_, x) => x)
+  lazy val structure: Relation[ProductmodelillustrationFields, ProductmodelillustrationRow] =
+    new Impl(Nil)
     
-  private final class Impl[Row](val prefix: Option[String], val extract: Row => ProductmodelillustrationRow, val merge: (Row, ProductmodelillustrationRow) => Row)
-    extends Relation[ProductmodelillustrationFields, ProductmodelillustrationRow, Row] { 
+  private final class Impl(val _path: List[Path])
+    extends Relation[ProductmodelillustrationFields, ProductmodelillustrationRow] {
   
-    override val fields: ProductmodelillustrationFields[Row] = new ProductmodelillustrationFields[Row] {
-      override val productmodelid = new IdField[ProductmodelId, Row](prefix, "productmodelid", None, Some("int4"))(x => extract(x).productmodelid, (row, value) => merge(row, extract(row).copy(productmodelid = value)))
-      override val illustrationid = new IdField[IllustrationId, Row](prefix, "illustrationid", None, Some("int4"))(x => extract(x).illustrationid, (row, value) => merge(row, extract(row).copy(illustrationid = value)))
-      override val modifieddate = new Field[TypoLocalDateTime, Row](prefix, "modifieddate", Some("text"), Some("timestamp"))(x => extract(x).modifieddate, (row, value) => merge(row, extract(row).copy(modifieddate = value)))
+    override lazy val fields: ProductmodelillustrationFields = new ProductmodelillustrationFields {
+      override def productmodelid = IdField[ProductmodelId, ProductmodelillustrationRow](_path, "productmodelid", None, Some("int4"), x => x.productmodelid, (row, value) => row.copy(productmodelid = value))
+      override def illustrationid = IdField[IllustrationId, ProductmodelillustrationRow](_path, "illustrationid", None, Some("int4"), x => x.illustrationid, (row, value) => row.copy(illustrationid = value))
+      override def modifieddate = Field[TypoLocalDateTime, ProductmodelillustrationRow](_path, "modifieddate", Some("text"), Some("timestamp"), x => x.modifieddate, (row, value) => row.copy(modifieddate = value))
     }
   
-    override val columns: List[FieldLikeNoHkt[?, Row]] =
-      List[FieldLikeNoHkt[?, Row]](fields.productmodelid, fields.illustrationid, fields.modifieddate)
+    override lazy val columns: List[FieldLikeNoHkt[?, ProductmodelillustrationRow]] =
+      List[FieldLikeNoHkt[?, ProductmodelillustrationRow]](fields.productmodelid, fields.illustrationid, fields.modifieddate)
   
-    override def copy[NewRow](prefix: Option[String], extract: NewRow => ProductmodelillustrationRow, merge: (NewRow, ProductmodelillustrationRow) => NewRow): Impl[NewRow] =
-      new Impl(prefix, extract, merge)
+    override def copy(path: List[Path]): Impl =
+      new Impl(path)
   }
   
 }

--- a/typo-tester-doobie/generated-and-checked-in/adventureworks/production/productmodelillustration/ProductmodelillustrationRepoMock.scala
+++ b/typo-tester-doobie/generated-and-checked-in/adventureworks/production/productmodelillustration/ProductmodelillustrationRepoMock.scala
@@ -24,7 +24,7 @@ import typo.dsl.UpdateParams
 class ProductmodelillustrationRepoMock(toRow: Function1[ProductmodelillustrationRowUnsaved, ProductmodelillustrationRow],
                                        map: scala.collection.mutable.Map[ProductmodelillustrationId, ProductmodelillustrationRow] = scala.collection.mutable.Map.empty) extends ProductmodelillustrationRepo {
   override def delete: DeleteBuilder[ProductmodelillustrationFields, ProductmodelillustrationRow] = {
-    DeleteBuilderMock(DeleteParams.empty, ProductmodelillustrationFields.structure.fields, map)
+    DeleteBuilderMock(DeleteParams.empty, ProductmodelillustrationFields.structure, map)
   }
   override def deleteById(compositeId: ProductmodelillustrationId): ConnectionIO[Boolean] = {
     delay(map.remove(compositeId).isDefined)
@@ -86,7 +86,7 @@ class ProductmodelillustrationRepoMock(toRow: Function1[Productmodelillustration
     }
   }
   override def update: UpdateBuilder[ProductmodelillustrationFields, ProductmodelillustrationRow] = {
-    UpdateBuilderMock(UpdateParams.empty, ProductmodelillustrationFields.structure.fields, map)
+    UpdateBuilderMock(UpdateParams.empty, ProductmodelillustrationFields.structure, map)
   }
   override def update(row: ProductmodelillustrationRow): ConnectionIO[Boolean] = {
     delay {

--- a/typo-tester-doobie/generated-and-checked-in/adventureworks/production/productmodelproductdescriptionculture/ProductmodelproductdescriptioncultureFields.scala
+++ b/typo-tester-doobie/generated-and-checked-in/adventureworks/production/productmodelproductdescriptionculture/ProductmodelproductdescriptioncultureFields.scala
@@ -11,37 +11,38 @@ import adventureworks.customtypes.TypoLocalDateTime
 import adventureworks.production.culture.CultureId
 import adventureworks.production.productdescription.ProductdescriptionId
 import adventureworks.production.productmodel.ProductmodelId
+import typo.dsl.Path
 import typo.dsl.SqlExpr.Field
 import typo.dsl.SqlExpr.FieldLikeNoHkt
 import typo.dsl.SqlExpr.IdField
 import typo.dsl.Structure.Relation
 
-trait ProductmodelproductdescriptioncultureFields[Row] {
-  val productmodelid: IdField[ProductmodelId, Row]
-  val productdescriptionid: IdField[ProductdescriptionId, Row]
-  val cultureid: IdField[CultureId, Row]
-  val modifieddate: Field[TypoLocalDateTime, Row]
+trait ProductmodelproductdescriptioncultureFields {
+  def productmodelid: IdField[ProductmodelId, ProductmodelproductdescriptioncultureRow]
+  def productdescriptionid: IdField[ProductdescriptionId, ProductmodelproductdescriptioncultureRow]
+  def cultureid: IdField[CultureId, ProductmodelproductdescriptioncultureRow]
+  def modifieddate: Field[TypoLocalDateTime, ProductmodelproductdescriptioncultureRow]
 }
 
 object ProductmodelproductdescriptioncultureFields {
-  val structure: Relation[ProductmodelproductdescriptioncultureFields, ProductmodelproductdescriptioncultureRow, ProductmodelproductdescriptioncultureRow] = 
-    new Impl(None, identity, (_, x) => x)
+  lazy val structure: Relation[ProductmodelproductdescriptioncultureFields, ProductmodelproductdescriptioncultureRow] =
+    new Impl(Nil)
     
-  private final class Impl[Row](val prefix: Option[String], val extract: Row => ProductmodelproductdescriptioncultureRow, val merge: (Row, ProductmodelproductdescriptioncultureRow) => Row)
-    extends Relation[ProductmodelproductdescriptioncultureFields, ProductmodelproductdescriptioncultureRow, Row] { 
+  private final class Impl(val _path: List[Path])
+    extends Relation[ProductmodelproductdescriptioncultureFields, ProductmodelproductdescriptioncultureRow] {
   
-    override val fields: ProductmodelproductdescriptioncultureFields[Row] = new ProductmodelproductdescriptioncultureFields[Row] {
-      override val productmodelid = new IdField[ProductmodelId, Row](prefix, "productmodelid", None, Some("int4"))(x => extract(x).productmodelid, (row, value) => merge(row, extract(row).copy(productmodelid = value)))
-      override val productdescriptionid = new IdField[ProductdescriptionId, Row](prefix, "productdescriptionid", None, Some("int4"))(x => extract(x).productdescriptionid, (row, value) => merge(row, extract(row).copy(productdescriptionid = value)))
-      override val cultureid = new IdField[CultureId, Row](prefix, "cultureid", None, Some("bpchar"))(x => extract(x).cultureid, (row, value) => merge(row, extract(row).copy(cultureid = value)))
-      override val modifieddate = new Field[TypoLocalDateTime, Row](prefix, "modifieddate", Some("text"), Some("timestamp"))(x => extract(x).modifieddate, (row, value) => merge(row, extract(row).copy(modifieddate = value)))
+    override lazy val fields: ProductmodelproductdescriptioncultureFields = new ProductmodelproductdescriptioncultureFields {
+      override def productmodelid = IdField[ProductmodelId, ProductmodelproductdescriptioncultureRow](_path, "productmodelid", None, Some("int4"), x => x.productmodelid, (row, value) => row.copy(productmodelid = value))
+      override def productdescriptionid = IdField[ProductdescriptionId, ProductmodelproductdescriptioncultureRow](_path, "productdescriptionid", None, Some("int4"), x => x.productdescriptionid, (row, value) => row.copy(productdescriptionid = value))
+      override def cultureid = IdField[CultureId, ProductmodelproductdescriptioncultureRow](_path, "cultureid", None, Some("bpchar"), x => x.cultureid, (row, value) => row.copy(cultureid = value))
+      override def modifieddate = Field[TypoLocalDateTime, ProductmodelproductdescriptioncultureRow](_path, "modifieddate", Some("text"), Some("timestamp"), x => x.modifieddate, (row, value) => row.copy(modifieddate = value))
     }
   
-    override val columns: List[FieldLikeNoHkt[?, Row]] =
-      List[FieldLikeNoHkt[?, Row]](fields.productmodelid, fields.productdescriptionid, fields.cultureid, fields.modifieddate)
+    override lazy val columns: List[FieldLikeNoHkt[?, ProductmodelproductdescriptioncultureRow]] =
+      List[FieldLikeNoHkt[?, ProductmodelproductdescriptioncultureRow]](fields.productmodelid, fields.productdescriptionid, fields.cultureid, fields.modifieddate)
   
-    override def copy[NewRow](prefix: Option[String], extract: NewRow => ProductmodelproductdescriptioncultureRow, merge: (NewRow, ProductmodelproductdescriptioncultureRow) => NewRow): Impl[NewRow] =
-      new Impl(prefix, extract, merge)
+    override def copy(path: List[Path]): Impl =
+      new Impl(path)
   }
   
 }

--- a/typo-tester-doobie/generated-and-checked-in/adventureworks/production/productmodelproductdescriptionculture/ProductmodelproductdescriptioncultureRepoMock.scala
+++ b/typo-tester-doobie/generated-and-checked-in/adventureworks/production/productmodelproductdescriptionculture/ProductmodelproductdescriptioncultureRepoMock.scala
@@ -24,7 +24,7 @@ import typo.dsl.UpdateParams
 class ProductmodelproductdescriptioncultureRepoMock(toRow: Function1[ProductmodelproductdescriptioncultureRowUnsaved, ProductmodelproductdescriptioncultureRow],
                                                     map: scala.collection.mutable.Map[ProductmodelproductdescriptioncultureId, ProductmodelproductdescriptioncultureRow] = scala.collection.mutable.Map.empty) extends ProductmodelproductdescriptioncultureRepo {
   override def delete: DeleteBuilder[ProductmodelproductdescriptioncultureFields, ProductmodelproductdescriptioncultureRow] = {
-    DeleteBuilderMock(DeleteParams.empty, ProductmodelproductdescriptioncultureFields.structure.fields, map)
+    DeleteBuilderMock(DeleteParams.empty, ProductmodelproductdescriptioncultureFields.structure, map)
   }
   override def deleteById(compositeId: ProductmodelproductdescriptioncultureId): ConnectionIO[Boolean] = {
     delay(map.remove(compositeId).isDefined)
@@ -86,7 +86,7 @@ class ProductmodelproductdescriptioncultureRepoMock(toRow: Function1[Productmode
     }
   }
   override def update: UpdateBuilder[ProductmodelproductdescriptioncultureFields, ProductmodelproductdescriptioncultureRow] = {
-    UpdateBuilderMock(UpdateParams.empty, ProductmodelproductdescriptioncultureFields.structure.fields, map)
+    UpdateBuilderMock(UpdateParams.empty, ProductmodelproductdescriptioncultureFields.structure, map)
   }
   override def update(row: ProductmodelproductdescriptioncultureRow): ConnectionIO[Boolean] = {
     delay {

--- a/typo-tester-doobie/generated-and-checked-in/adventureworks/production/productphoto/ProductphotoFields.scala
+++ b/typo-tester-doobie/generated-and-checked-in/adventureworks/production/productphoto/ProductphotoFields.scala
@@ -9,42 +9,43 @@ package productphoto
 
 import adventureworks.customtypes.TypoBytea
 import adventureworks.customtypes.TypoLocalDateTime
+import typo.dsl.Path
 import typo.dsl.SqlExpr.Field
 import typo.dsl.SqlExpr.FieldLikeNoHkt
 import typo.dsl.SqlExpr.IdField
 import typo.dsl.SqlExpr.OptField
 import typo.dsl.Structure.Relation
 
-trait ProductphotoFields[Row] {
-  val productphotoid: IdField[ProductphotoId, Row]
-  val thumbnailphoto: OptField[TypoBytea, Row]
-  val thumbnailphotofilename: OptField[/* max 50 chars */ String, Row]
-  val largephoto: OptField[TypoBytea, Row]
-  val largephotofilename: OptField[/* max 50 chars */ String, Row]
-  val modifieddate: Field[TypoLocalDateTime, Row]
+trait ProductphotoFields {
+  def productphotoid: IdField[ProductphotoId, ProductphotoRow]
+  def thumbnailphoto: OptField[TypoBytea, ProductphotoRow]
+  def thumbnailphotofilename: OptField[/* max 50 chars */ String, ProductphotoRow]
+  def largephoto: OptField[TypoBytea, ProductphotoRow]
+  def largephotofilename: OptField[/* max 50 chars */ String, ProductphotoRow]
+  def modifieddate: Field[TypoLocalDateTime, ProductphotoRow]
 }
 
 object ProductphotoFields {
-  val structure: Relation[ProductphotoFields, ProductphotoRow, ProductphotoRow] = 
-    new Impl(None, identity, (_, x) => x)
+  lazy val structure: Relation[ProductphotoFields, ProductphotoRow] =
+    new Impl(Nil)
     
-  private final class Impl[Row](val prefix: Option[String], val extract: Row => ProductphotoRow, val merge: (Row, ProductphotoRow) => Row)
-    extends Relation[ProductphotoFields, ProductphotoRow, Row] { 
+  private final class Impl(val _path: List[Path])
+    extends Relation[ProductphotoFields, ProductphotoRow] {
   
-    override val fields: ProductphotoFields[Row] = new ProductphotoFields[Row] {
-      override val productphotoid = new IdField[ProductphotoId, Row](prefix, "productphotoid", None, Some("int4"))(x => extract(x).productphotoid, (row, value) => merge(row, extract(row).copy(productphotoid = value)))
-      override val thumbnailphoto = new OptField[TypoBytea, Row](prefix, "thumbnailphoto", None, Some("bytea"))(x => extract(x).thumbnailphoto, (row, value) => merge(row, extract(row).copy(thumbnailphoto = value)))
-      override val thumbnailphotofilename = new OptField[/* max 50 chars */ String, Row](prefix, "thumbnailphotofilename", None, None)(x => extract(x).thumbnailphotofilename, (row, value) => merge(row, extract(row).copy(thumbnailphotofilename = value)))
-      override val largephoto = new OptField[TypoBytea, Row](prefix, "largephoto", None, Some("bytea"))(x => extract(x).largephoto, (row, value) => merge(row, extract(row).copy(largephoto = value)))
-      override val largephotofilename = new OptField[/* max 50 chars */ String, Row](prefix, "largephotofilename", None, None)(x => extract(x).largephotofilename, (row, value) => merge(row, extract(row).copy(largephotofilename = value)))
-      override val modifieddate = new Field[TypoLocalDateTime, Row](prefix, "modifieddate", Some("text"), Some("timestamp"))(x => extract(x).modifieddate, (row, value) => merge(row, extract(row).copy(modifieddate = value)))
+    override lazy val fields: ProductphotoFields = new ProductphotoFields {
+      override def productphotoid = IdField[ProductphotoId, ProductphotoRow](_path, "productphotoid", None, Some("int4"), x => x.productphotoid, (row, value) => row.copy(productphotoid = value))
+      override def thumbnailphoto = OptField[TypoBytea, ProductphotoRow](_path, "thumbnailphoto", None, Some("bytea"), x => x.thumbnailphoto, (row, value) => row.copy(thumbnailphoto = value))
+      override def thumbnailphotofilename = OptField[/* max 50 chars */ String, ProductphotoRow](_path, "thumbnailphotofilename", None, None, x => x.thumbnailphotofilename, (row, value) => row.copy(thumbnailphotofilename = value))
+      override def largephoto = OptField[TypoBytea, ProductphotoRow](_path, "largephoto", None, Some("bytea"), x => x.largephoto, (row, value) => row.copy(largephoto = value))
+      override def largephotofilename = OptField[/* max 50 chars */ String, ProductphotoRow](_path, "largephotofilename", None, None, x => x.largephotofilename, (row, value) => row.copy(largephotofilename = value))
+      override def modifieddate = Field[TypoLocalDateTime, ProductphotoRow](_path, "modifieddate", Some("text"), Some("timestamp"), x => x.modifieddate, (row, value) => row.copy(modifieddate = value))
     }
   
-    override val columns: List[FieldLikeNoHkt[?, Row]] =
-      List[FieldLikeNoHkt[?, Row]](fields.productphotoid, fields.thumbnailphoto, fields.thumbnailphotofilename, fields.largephoto, fields.largephotofilename, fields.modifieddate)
+    override lazy val columns: List[FieldLikeNoHkt[?, ProductphotoRow]] =
+      List[FieldLikeNoHkt[?, ProductphotoRow]](fields.productphotoid, fields.thumbnailphoto, fields.thumbnailphotofilename, fields.largephoto, fields.largephotofilename, fields.modifieddate)
   
-    override def copy[NewRow](prefix: Option[String], extract: NewRow => ProductphotoRow, merge: (NewRow, ProductphotoRow) => NewRow): Impl[NewRow] =
-      new Impl(prefix, extract, merge)
+    override def copy(path: List[Path]): Impl =
+      new Impl(path)
   }
   
 }

--- a/typo-tester-doobie/generated-and-checked-in/adventureworks/production/productphoto/ProductphotoRepoMock.scala
+++ b/typo-tester-doobie/generated-and-checked-in/adventureworks/production/productphoto/ProductphotoRepoMock.scala
@@ -24,7 +24,7 @@ import typo.dsl.UpdateParams
 class ProductphotoRepoMock(toRow: Function1[ProductphotoRowUnsaved, ProductphotoRow],
                            map: scala.collection.mutable.Map[ProductphotoId, ProductphotoRow] = scala.collection.mutable.Map.empty) extends ProductphotoRepo {
   override def delete: DeleteBuilder[ProductphotoFields, ProductphotoRow] = {
-    DeleteBuilderMock(DeleteParams.empty, ProductphotoFields.structure.fields, map)
+    DeleteBuilderMock(DeleteParams.empty, ProductphotoFields.structure, map)
   }
   override def deleteById(productphotoid: ProductphotoId): ConnectionIO[Boolean] = {
     delay(map.remove(productphotoid).isDefined)
@@ -86,7 +86,7 @@ class ProductphotoRepoMock(toRow: Function1[ProductphotoRowUnsaved, Productphoto
     }
   }
   override def update: UpdateBuilder[ProductphotoFields, ProductphotoRow] = {
-    UpdateBuilderMock(UpdateParams.empty, ProductphotoFields.structure.fields, map)
+    UpdateBuilderMock(UpdateParams.empty, ProductphotoFields.structure, map)
   }
   override def update(row: ProductphotoRow): ConnectionIO[Boolean] = {
     delay {

--- a/typo-tester-doobie/generated-and-checked-in/adventureworks/production/productproductphoto/ProductproductphotoFields.scala
+++ b/typo-tester-doobie/generated-and-checked-in/adventureworks/production/productproductphoto/ProductproductphotoFields.scala
@@ -11,37 +11,38 @@ import adventureworks.customtypes.TypoLocalDateTime
 import adventureworks.production.product.ProductId
 import adventureworks.production.productphoto.ProductphotoId
 import adventureworks.public.Flag
+import typo.dsl.Path
 import typo.dsl.SqlExpr.Field
 import typo.dsl.SqlExpr.FieldLikeNoHkt
 import typo.dsl.SqlExpr.IdField
 import typo.dsl.Structure.Relation
 
-trait ProductproductphotoFields[Row] {
-  val productid: IdField[ProductId, Row]
-  val productphotoid: IdField[ProductphotoId, Row]
-  val primary: Field[Flag, Row]
-  val modifieddate: Field[TypoLocalDateTime, Row]
+trait ProductproductphotoFields {
+  def productid: IdField[ProductId, ProductproductphotoRow]
+  def productphotoid: IdField[ProductphotoId, ProductproductphotoRow]
+  def primary: Field[Flag, ProductproductphotoRow]
+  def modifieddate: Field[TypoLocalDateTime, ProductproductphotoRow]
 }
 
 object ProductproductphotoFields {
-  val structure: Relation[ProductproductphotoFields, ProductproductphotoRow, ProductproductphotoRow] = 
-    new Impl(None, identity, (_, x) => x)
+  lazy val structure: Relation[ProductproductphotoFields, ProductproductphotoRow] =
+    new Impl(Nil)
     
-  private final class Impl[Row](val prefix: Option[String], val extract: Row => ProductproductphotoRow, val merge: (Row, ProductproductphotoRow) => Row)
-    extends Relation[ProductproductphotoFields, ProductproductphotoRow, Row] { 
+  private final class Impl(val _path: List[Path])
+    extends Relation[ProductproductphotoFields, ProductproductphotoRow] {
   
-    override val fields: ProductproductphotoFields[Row] = new ProductproductphotoFields[Row] {
-      override val productid = new IdField[ProductId, Row](prefix, "productid", None, Some("int4"))(x => extract(x).productid, (row, value) => merge(row, extract(row).copy(productid = value)))
-      override val productphotoid = new IdField[ProductphotoId, Row](prefix, "productphotoid", None, Some("int4"))(x => extract(x).productphotoid, (row, value) => merge(row, extract(row).copy(productphotoid = value)))
-      override val primary = new Field[Flag, Row](prefix, "primary", None, Some("bool"))(x => extract(x).primary, (row, value) => merge(row, extract(row).copy(primary = value)))
-      override val modifieddate = new Field[TypoLocalDateTime, Row](prefix, "modifieddate", Some("text"), Some("timestamp"))(x => extract(x).modifieddate, (row, value) => merge(row, extract(row).copy(modifieddate = value)))
+    override lazy val fields: ProductproductphotoFields = new ProductproductphotoFields {
+      override def productid = IdField[ProductId, ProductproductphotoRow](_path, "productid", None, Some("int4"), x => x.productid, (row, value) => row.copy(productid = value))
+      override def productphotoid = IdField[ProductphotoId, ProductproductphotoRow](_path, "productphotoid", None, Some("int4"), x => x.productphotoid, (row, value) => row.copy(productphotoid = value))
+      override def primary = Field[Flag, ProductproductphotoRow](_path, "primary", None, Some("bool"), x => x.primary, (row, value) => row.copy(primary = value))
+      override def modifieddate = Field[TypoLocalDateTime, ProductproductphotoRow](_path, "modifieddate", Some("text"), Some("timestamp"), x => x.modifieddate, (row, value) => row.copy(modifieddate = value))
     }
   
-    override val columns: List[FieldLikeNoHkt[?, Row]] =
-      List[FieldLikeNoHkt[?, Row]](fields.productid, fields.productphotoid, fields.primary, fields.modifieddate)
+    override lazy val columns: List[FieldLikeNoHkt[?, ProductproductphotoRow]] =
+      List[FieldLikeNoHkt[?, ProductproductphotoRow]](fields.productid, fields.productphotoid, fields.primary, fields.modifieddate)
   
-    override def copy[NewRow](prefix: Option[String], extract: NewRow => ProductproductphotoRow, merge: (NewRow, ProductproductphotoRow) => NewRow): Impl[NewRow] =
-      new Impl(prefix, extract, merge)
+    override def copy(path: List[Path]): Impl =
+      new Impl(path)
   }
   
 }

--- a/typo-tester-doobie/generated-and-checked-in/adventureworks/production/productproductphoto/ProductproductphotoRepoMock.scala
+++ b/typo-tester-doobie/generated-and-checked-in/adventureworks/production/productproductphoto/ProductproductphotoRepoMock.scala
@@ -24,7 +24,7 @@ import typo.dsl.UpdateParams
 class ProductproductphotoRepoMock(toRow: Function1[ProductproductphotoRowUnsaved, ProductproductphotoRow],
                                   map: scala.collection.mutable.Map[ProductproductphotoId, ProductproductphotoRow] = scala.collection.mutable.Map.empty) extends ProductproductphotoRepo {
   override def delete: DeleteBuilder[ProductproductphotoFields, ProductproductphotoRow] = {
-    DeleteBuilderMock(DeleteParams.empty, ProductproductphotoFields.structure.fields, map)
+    DeleteBuilderMock(DeleteParams.empty, ProductproductphotoFields.structure, map)
   }
   override def deleteById(compositeId: ProductproductphotoId): ConnectionIO[Boolean] = {
     delay(map.remove(compositeId).isDefined)
@@ -86,7 +86,7 @@ class ProductproductphotoRepoMock(toRow: Function1[ProductproductphotoRowUnsaved
     }
   }
   override def update: UpdateBuilder[ProductproductphotoFields, ProductproductphotoRow] = {
-    UpdateBuilderMock(UpdateParams.empty, ProductproductphotoFields.structure.fields, map)
+    UpdateBuilderMock(UpdateParams.empty, ProductproductphotoFields.structure, map)
   }
   override def update(row: ProductproductphotoRow): ConnectionIO[Boolean] = {
     delay {

--- a/typo-tester-doobie/generated-and-checked-in/adventureworks/production/productreview/ProductreviewFields.scala
+++ b/typo-tester-doobie/generated-and-checked-in/adventureworks/production/productreview/ProductreviewFields.scala
@@ -10,46 +10,47 @@ package productreview
 import adventureworks.customtypes.TypoLocalDateTime
 import adventureworks.production.product.ProductId
 import adventureworks.public.Name
+import typo.dsl.Path
 import typo.dsl.SqlExpr.Field
 import typo.dsl.SqlExpr.FieldLikeNoHkt
 import typo.dsl.SqlExpr.IdField
 import typo.dsl.SqlExpr.OptField
 import typo.dsl.Structure.Relation
 
-trait ProductreviewFields[Row] {
-  val productreviewid: IdField[ProductreviewId, Row]
-  val productid: Field[ProductId, Row]
-  val reviewername: Field[Name, Row]
-  val reviewdate: Field[TypoLocalDateTime, Row]
-  val emailaddress: Field[/* max 50 chars */ String, Row]
-  val rating: Field[Int, Row]
-  val comments: OptField[/* max 3850 chars */ String, Row]
-  val modifieddate: Field[TypoLocalDateTime, Row]
+trait ProductreviewFields {
+  def productreviewid: IdField[ProductreviewId, ProductreviewRow]
+  def productid: Field[ProductId, ProductreviewRow]
+  def reviewername: Field[Name, ProductreviewRow]
+  def reviewdate: Field[TypoLocalDateTime, ProductreviewRow]
+  def emailaddress: Field[/* max 50 chars */ String, ProductreviewRow]
+  def rating: Field[Int, ProductreviewRow]
+  def comments: OptField[/* max 3850 chars */ String, ProductreviewRow]
+  def modifieddate: Field[TypoLocalDateTime, ProductreviewRow]
 }
 
 object ProductreviewFields {
-  val structure: Relation[ProductreviewFields, ProductreviewRow, ProductreviewRow] = 
-    new Impl(None, identity, (_, x) => x)
+  lazy val structure: Relation[ProductreviewFields, ProductreviewRow] =
+    new Impl(Nil)
     
-  private final class Impl[Row](val prefix: Option[String], val extract: Row => ProductreviewRow, val merge: (Row, ProductreviewRow) => Row)
-    extends Relation[ProductreviewFields, ProductreviewRow, Row] { 
+  private final class Impl(val _path: List[Path])
+    extends Relation[ProductreviewFields, ProductreviewRow] {
   
-    override val fields: ProductreviewFields[Row] = new ProductreviewFields[Row] {
-      override val productreviewid = new IdField[ProductreviewId, Row](prefix, "productreviewid", None, Some("int4"))(x => extract(x).productreviewid, (row, value) => merge(row, extract(row).copy(productreviewid = value)))
-      override val productid = new Field[ProductId, Row](prefix, "productid", None, Some("int4"))(x => extract(x).productid, (row, value) => merge(row, extract(row).copy(productid = value)))
-      override val reviewername = new Field[Name, Row](prefix, "reviewername", None, Some("varchar"))(x => extract(x).reviewername, (row, value) => merge(row, extract(row).copy(reviewername = value)))
-      override val reviewdate = new Field[TypoLocalDateTime, Row](prefix, "reviewdate", Some("text"), Some("timestamp"))(x => extract(x).reviewdate, (row, value) => merge(row, extract(row).copy(reviewdate = value)))
-      override val emailaddress = new Field[/* max 50 chars */ String, Row](prefix, "emailaddress", None, None)(x => extract(x).emailaddress, (row, value) => merge(row, extract(row).copy(emailaddress = value)))
-      override val rating = new Field[Int, Row](prefix, "rating", None, Some("int4"))(x => extract(x).rating, (row, value) => merge(row, extract(row).copy(rating = value)))
-      override val comments = new OptField[/* max 3850 chars */ String, Row](prefix, "comments", None, None)(x => extract(x).comments, (row, value) => merge(row, extract(row).copy(comments = value)))
-      override val modifieddate = new Field[TypoLocalDateTime, Row](prefix, "modifieddate", Some("text"), Some("timestamp"))(x => extract(x).modifieddate, (row, value) => merge(row, extract(row).copy(modifieddate = value)))
+    override lazy val fields: ProductreviewFields = new ProductreviewFields {
+      override def productreviewid = IdField[ProductreviewId, ProductreviewRow](_path, "productreviewid", None, Some("int4"), x => x.productreviewid, (row, value) => row.copy(productreviewid = value))
+      override def productid = Field[ProductId, ProductreviewRow](_path, "productid", None, Some("int4"), x => x.productid, (row, value) => row.copy(productid = value))
+      override def reviewername = Field[Name, ProductreviewRow](_path, "reviewername", None, Some("varchar"), x => x.reviewername, (row, value) => row.copy(reviewername = value))
+      override def reviewdate = Field[TypoLocalDateTime, ProductreviewRow](_path, "reviewdate", Some("text"), Some("timestamp"), x => x.reviewdate, (row, value) => row.copy(reviewdate = value))
+      override def emailaddress = Field[/* max 50 chars */ String, ProductreviewRow](_path, "emailaddress", None, None, x => x.emailaddress, (row, value) => row.copy(emailaddress = value))
+      override def rating = Field[Int, ProductreviewRow](_path, "rating", None, Some("int4"), x => x.rating, (row, value) => row.copy(rating = value))
+      override def comments = OptField[/* max 3850 chars */ String, ProductreviewRow](_path, "comments", None, None, x => x.comments, (row, value) => row.copy(comments = value))
+      override def modifieddate = Field[TypoLocalDateTime, ProductreviewRow](_path, "modifieddate", Some("text"), Some("timestamp"), x => x.modifieddate, (row, value) => row.copy(modifieddate = value))
     }
   
-    override val columns: List[FieldLikeNoHkt[?, Row]] =
-      List[FieldLikeNoHkt[?, Row]](fields.productreviewid, fields.productid, fields.reviewername, fields.reviewdate, fields.emailaddress, fields.rating, fields.comments, fields.modifieddate)
+    override lazy val columns: List[FieldLikeNoHkt[?, ProductreviewRow]] =
+      List[FieldLikeNoHkt[?, ProductreviewRow]](fields.productreviewid, fields.productid, fields.reviewername, fields.reviewdate, fields.emailaddress, fields.rating, fields.comments, fields.modifieddate)
   
-    override def copy[NewRow](prefix: Option[String], extract: NewRow => ProductreviewRow, merge: (NewRow, ProductreviewRow) => NewRow): Impl[NewRow] =
-      new Impl(prefix, extract, merge)
+    override def copy(path: List[Path]): Impl =
+      new Impl(path)
   }
   
 }

--- a/typo-tester-doobie/generated-and-checked-in/adventureworks/production/productreview/ProductreviewRepoMock.scala
+++ b/typo-tester-doobie/generated-and-checked-in/adventureworks/production/productreview/ProductreviewRepoMock.scala
@@ -24,7 +24,7 @@ import typo.dsl.UpdateParams
 class ProductreviewRepoMock(toRow: Function1[ProductreviewRowUnsaved, ProductreviewRow],
                             map: scala.collection.mutable.Map[ProductreviewId, ProductreviewRow] = scala.collection.mutable.Map.empty) extends ProductreviewRepo {
   override def delete: DeleteBuilder[ProductreviewFields, ProductreviewRow] = {
-    DeleteBuilderMock(DeleteParams.empty, ProductreviewFields.structure.fields, map)
+    DeleteBuilderMock(DeleteParams.empty, ProductreviewFields.structure, map)
   }
   override def deleteById(productreviewid: ProductreviewId): ConnectionIO[Boolean] = {
     delay(map.remove(productreviewid).isDefined)
@@ -86,7 +86,7 @@ class ProductreviewRepoMock(toRow: Function1[ProductreviewRowUnsaved, Productrev
     }
   }
   override def update: UpdateBuilder[ProductreviewFields, ProductreviewRow] = {
-    UpdateBuilderMock(UpdateParams.empty, ProductreviewFields.structure.fields, map)
+    UpdateBuilderMock(UpdateParams.empty, ProductreviewFields.structure, map)
   }
   override def update(row: ProductreviewRow): ConnectionIO[Boolean] = {
     delay {

--- a/typo-tester-doobie/generated-and-checked-in/adventureworks/production/productsubcategory/ProductsubcategoryFields.scala
+++ b/typo-tester-doobie/generated-and-checked-in/adventureworks/production/productsubcategory/ProductsubcategoryFields.scala
@@ -11,39 +11,40 @@ import adventureworks.customtypes.TypoLocalDateTime
 import adventureworks.customtypes.TypoUUID
 import adventureworks.production.productcategory.ProductcategoryId
 import adventureworks.public.Name
+import typo.dsl.Path
 import typo.dsl.SqlExpr.Field
 import typo.dsl.SqlExpr.FieldLikeNoHkt
 import typo.dsl.SqlExpr.IdField
 import typo.dsl.Structure.Relation
 
-trait ProductsubcategoryFields[Row] {
-  val productsubcategoryid: IdField[ProductsubcategoryId, Row]
-  val productcategoryid: Field[ProductcategoryId, Row]
-  val name: Field[Name, Row]
-  val rowguid: Field[TypoUUID, Row]
-  val modifieddate: Field[TypoLocalDateTime, Row]
+trait ProductsubcategoryFields {
+  def productsubcategoryid: IdField[ProductsubcategoryId, ProductsubcategoryRow]
+  def productcategoryid: Field[ProductcategoryId, ProductsubcategoryRow]
+  def name: Field[Name, ProductsubcategoryRow]
+  def rowguid: Field[TypoUUID, ProductsubcategoryRow]
+  def modifieddate: Field[TypoLocalDateTime, ProductsubcategoryRow]
 }
 
 object ProductsubcategoryFields {
-  val structure: Relation[ProductsubcategoryFields, ProductsubcategoryRow, ProductsubcategoryRow] = 
-    new Impl(None, identity, (_, x) => x)
+  lazy val structure: Relation[ProductsubcategoryFields, ProductsubcategoryRow] =
+    new Impl(Nil)
     
-  private final class Impl[Row](val prefix: Option[String], val extract: Row => ProductsubcategoryRow, val merge: (Row, ProductsubcategoryRow) => Row)
-    extends Relation[ProductsubcategoryFields, ProductsubcategoryRow, Row] { 
+  private final class Impl(val _path: List[Path])
+    extends Relation[ProductsubcategoryFields, ProductsubcategoryRow] {
   
-    override val fields: ProductsubcategoryFields[Row] = new ProductsubcategoryFields[Row] {
-      override val productsubcategoryid = new IdField[ProductsubcategoryId, Row](prefix, "productsubcategoryid", None, Some("int4"))(x => extract(x).productsubcategoryid, (row, value) => merge(row, extract(row).copy(productsubcategoryid = value)))
-      override val productcategoryid = new Field[ProductcategoryId, Row](prefix, "productcategoryid", None, Some("int4"))(x => extract(x).productcategoryid, (row, value) => merge(row, extract(row).copy(productcategoryid = value)))
-      override val name = new Field[Name, Row](prefix, "name", None, Some("varchar"))(x => extract(x).name, (row, value) => merge(row, extract(row).copy(name = value)))
-      override val rowguid = new Field[TypoUUID, Row](prefix, "rowguid", None, Some("uuid"))(x => extract(x).rowguid, (row, value) => merge(row, extract(row).copy(rowguid = value)))
-      override val modifieddate = new Field[TypoLocalDateTime, Row](prefix, "modifieddate", Some("text"), Some("timestamp"))(x => extract(x).modifieddate, (row, value) => merge(row, extract(row).copy(modifieddate = value)))
+    override lazy val fields: ProductsubcategoryFields = new ProductsubcategoryFields {
+      override def productsubcategoryid = IdField[ProductsubcategoryId, ProductsubcategoryRow](_path, "productsubcategoryid", None, Some("int4"), x => x.productsubcategoryid, (row, value) => row.copy(productsubcategoryid = value))
+      override def productcategoryid = Field[ProductcategoryId, ProductsubcategoryRow](_path, "productcategoryid", None, Some("int4"), x => x.productcategoryid, (row, value) => row.copy(productcategoryid = value))
+      override def name = Field[Name, ProductsubcategoryRow](_path, "name", None, Some("varchar"), x => x.name, (row, value) => row.copy(name = value))
+      override def rowguid = Field[TypoUUID, ProductsubcategoryRow](_path, "rowguid", None, Some("uuid"), x => x.rowguid, (row, value) => row.copy(rowguid = value))
+      override def modifieddate = Field[TypoLocalDateTime, ProductsubcategoryRow](_path, "modifieddate", Some("text"), Some("timestamp"), x => x.modifieddate, (row, value) => row.copy(modifieddate = value))
     }
   
-    override val columns: List[FieldLikeNoHkt[?, Row]] =
-      List[FieldLikeNoHkt[?, Row]](fields.productsubcategoryid, fields.productcategoryid, fields.name, fields.rowguid, fields.modifieddate)
+    override lazy val columns: List[FieldLikeNoHkt[?, ProductsubcategoryRow]] =
+      List[FieldLikeNoHkt[?, ProductsubcategoryRow]](fields.productsubcategoryid, fields.productcategoryid, fields.name, fields.rowguid, fields.modifieddate)
   
-    override def copy[NewRow](prefix: Option[String], extract: NewRow => ProductsubcategoryRow, merge: (NewRow, ProductsubcategoryRow) => NewRow): Impl[NewRow] =
-      new Impl(prefix, extract, merge)
+    override def copy(path: List[Path]): Impl =
+      new Impl(path)
   }
   
 }

--- a/typo-tester-doobie/generated-and-checked-in/adventureworks/production/productsubcategory/ProductsubcategoryRepoMock.scala
+++ b/typo-tester-doobie/generated-and-checked-in/adventureworks/production/productsubcategory/ProductsubcategoryRepoMock.scala
@@ -24,7 +24,7 @@ import typo.dsl.UpdateParams
 class ProductsubcategoryRepoMock(toRow: Function1[ProductsubcategoryRowUnsaved, ProductsubcategoryRow],
                                  map: scala.collection.mutable.Map[ProductsubcategoryId, ProductsubcategoryRow] = scala.collection.mutable.Map.empty) extends ProductsubcategoryRepo {
   override def delete: DeleteBuilder[ProductsubcategoryFields, ProductsubcategoryRow] = {
-    DeleteBuilderMock(DeleteParams.empty, ProductsubcategoryFields.structure.fields, map)
+    DeleteBuilderMock(DeleteParams.empty, ProductsubcategoryFields.structure, map)
   }
   override def deleteById(productsubcategoryid: ProductsubcategoryId): ConnectionIO[Boolean] = {
     delay(map.remove(productsubcategoryid).isDefined)
@@ -86,7 +86,7 @@ class ProductsubcategoryRepoMock(toRow: Function1[ProductsubcategoryRowUnsaved, 
     }
   }
   override def update: UpdateBuilder[ProductsubcategoryFields, ProductsubcategoryRow] = {
-    UpdateBuilderMock(UpdateParams.empty, ProductsubcategoryFields.structure.fields, map)
+    UpdateBuilderMock(UpdateParams.empty, ProductsubcategoryFields.structure, map)
   }
   override def update(row: ProductsubcategoryRow): ConnectionIO[Boolean] = {
     delay {

--- a/typo-tester-doobie/generated-and-checked-in/adventureworks/production/scrapreason/ScrapreasonFields.scala
+++ b/typo-tester-doobie/generated-and-checked-in/adventureworks/production/scrapreason/ScrapreasonFields.scala
@@ -9,35 +9,36 @@ package scrapreason
 
 import adventureworks.customtypes.TypoLocalDateTime
 import adventureworks.public.Name
+import typo.dsl.Path
 import typo.dsl.SqlExpr.Field
 import typo.dsl.SqlExpr.FieldLikeNoHkt
 import typo.dsl.SqlExpr.IdField
 import typo.dsl.Structure.Relation
 
-trait ScrapreasonFields[Row] {
-  val scrapreasonid: IdField[ScrapreasonId, Row]
-  val name: Field[Name, Row]
-  val modifieddate: Field[TypoLocalDateTime, Row]
+trait ScrapreasonFields {
+  def scrapreasonid: IdField[ScrapreasonId, ScrapreasonRow]
+  def name: Field[Name, ScrapreasonRow]
+  def modifieddate: Field[TypoLocalDateTime, ScrapreasonRow]
 }
 
 object ScrapreasonFields {
-  val structure: Relation[ScrapreasonFields, ScrapreasonRow, ScrapreasonRow] = 
-    new Impl(None, identity, (_, x) => x)
+  lazy val structure: Relation[ScrapreasonFields, ScrapreasonRow] =
+    new Impl(Nil)
     
-  private final class Impl[Row](val prefix: Option[String], val extract: Row => ScrapreasonRow, val merge: (Row, ScrapreasonRow) => Row)
-    extends Relation[ScrapreasonFields, ScrapreasonRow, Row] { 
+  private final class Impl(val _path: List[Path])
+    extends Relation[ScrapreasonFields, ScrapreasonRow] {
   
-    override val fields: ScrapreasonFields[Row] = new ScrapreasonFields[Row] {
-      override val scrapreasonid = new IdField[ScrapreasonId, Row](prefix, "scrapreasonid", None, Some("int4"))(x => extract(x).scrapreasonid, (row, value) => merge(row, extract(row).copy(scrapreasonid = value)))
-      override val name = new Field[Name, Row](prefix, "name", None, Some("varchar"))(x => extract(x).name, (row, value) => merge(row, extract(row).copy(name = value)))
-      override val modifieddate = new Field[TypoLocalDateTime, Row](prefix, "modifieddate", Some("text"), Some("timestamp"))(x => extract(x).modifieddate, (row, value) => merge(row, extract(row).copy(modifieddate = value)))
+    override lazy val fields: ScrapreasonFields = new ScrapreasonFields {
+      override def scrapreasonid = IdField[ScrapreasonId, ScrapreasonRow](_path, "scrapreasonid", None, Some("int4"), x => x.scrapreasonid, (row, value) => row.copy(scrapreasonid = value))
+      override def name = Field[Name, ScrapreasonRow](_path, "name", None, Some("varchar"), x => x.name, (row, value) => row.copy(name = value))
+      override def modifieddate = Field[TypoLocalDateTime, ScrapreasonRow](_path, "modifieddate", Some("text"), Some("timestamp"), x => x.modifieddate, (row, value) => row.copy(modifieddate = value))
     }
   
-    override val columns: List[FieldLikeNoHkt[?, Row]] =
-      List[FieldLikeNoHkt[?, Row]](fields.scrapreasonid, fields.name, fields.modifieddate)
+    override lazy val columns: List[FieldLikeNoHkt[?, ScrapreasonRow]] =
+      List[FieldLikeNoHkt[?, ScrapreasonRow]](fields.scrapreasonid, fields.name, fields.modifieddate)
   
-    override def copy[NewRow](prefix: Option[String], extract: NewRow => ScrapreasonRow, merge: (NewRow, ScrapreasonRow) => NewRow): Impl[NewRow] =
-      new Impl(prefix, extract, merge)
+    override def copy(path: List[Path]): Impl =
+      new Impl(path)
   }
   
 }

--- a/typo-tester-doobie/generated-and-checked-in/adventureworks/production/scrapreason/ScrapreasonRepoMock.scala
+++ b/typo-tester-doobie/generated-and-checked-in/adventureworks/production/scrapreason/ScrapreasonRepoMock.scala
@@ -24,7 +24,7 @@ import typo.dsl.UpdateParams
 class ScrapreasonRepoMock(toRow: Function1[ScrapreasonRowUnsaved, ScrapreasonRow],
                           map: scala.collection.mutable.Map[ScrapreasonId, ScrapreasonRow] = scala.collection.mutable.Map.empty) extends ScrapreasonRepo {
   override def delete: DeleteBuilder[ScrapreasonFields, ScrapreasonRow] = {
-    DeleteBuilderMock(DeleteParams.empty, ScrapreasonFields.structure.fields, map)
+    DeleteBuilderMock(DeleteParams.empty, ScrapreasonFields.structure, map)
   }
   override def deleteById(scrapreasonid: ScrapreasonId): ConnectionIO[Boolean] = {
     delay(map.remove(scrapreasonid).isDefined)
@@ -86,7 +86,7 @@ class ScrapreasonRepoMock(toRow: Function1[ScrapreasonRowUnsaved, ScrapreasonRow
     }
   }
   override def update: UpdateBuilder[ScrapreasonFields, ScrapreasonRow] = {
-    UpdateBuilderMock(UpdateParams.empty, ScrapreasonFields.structure.fields, map)
+    UpdateBuilderMock(UpdateParams.empty, ScrapreasonFields.structure, map)
   }
   override def update(row: ScrapreasonRow): ConnectionIO[Boolean] = {
     delay {

--- a/typo-tester-doobie/generated-and-checked-in/adventureworks/production/transactionhistory/TransactionhistoryFields.scala
+++ b/typo-tester-doobie/generated-and-checked-in/adventureworks/production/transactionhistory/TransactionhistoryFields.scala
@@ -9,47 +9,48 @@ package transactionhistory
 
 import adventureworks.customtypes.TypoLocalDateTime
 import adventureworks.production.product.ProductId
+import typo.dsl.Path
 import typo.dsl.SqlExpr.Field
 import typo.dsl.SqlExpr.FieldLikeNoHkt
 import typo.dsl.SqlExpr.IdField
 import typo.dsl.Structure.Relation
 
-trait TransactionhistoryFields[Row] {
-  val transactionid: IdField[TransactionhistoryId, Row]
-  val productid: Field[ProductId, Row]
-  val referenceorderid: Field[Int, Row]
-  val referenceorderlineid: Field[Int, Row]
-  val transactiondate: Field[TypoLocalDateTime, Row]
-  val transactiontype: Field[/* bpchar, max 1 chars */ String, Row]
-  val quantity: Field[Int, Row]
-  val actualcost: Field[BigDecimal, Row]
-  val modifieddate: Field[TypoLocalDateTime, Row]
+trait TransactionhistoryFields {
+  def transactionid: IdField[TransactionhistoryId, TransactionhistoryRow]
+  def productid: Field[ProductId, TransactionhistoryRow]
+  def referenceorderid: Field[Int, TransactionhistoryRow]
+  def referenceorderlineid: Field[Int, TransactionhistoryRow]
+  def transactiondate: Field[TypoLocalDateTime, TransactionhistoryRow]
+  def transactiontype: Field[/* bpchar, max 1 chars */ String, TransactionhistoryRow]
+  def quantity: Field[Int, TransactionhistoryRow]
+  def actualcost: Field[BigDecimal, TransactionhistoryRow]
+  def modifieddate: Field[TypoLocalDateTime, TransactionhistoryRow]
 }
 
 object TransactionhistoryFields {
-  val structure: Relation[TransactionhistoryFields, TransactionhistoryRow, TransactionhistoryRow] = 
-    new Impl(None, identity, (_, x) => x)
+  lazy val structure: Relation[TransactionhistoryFields, TransactionhistoryRow] =
+    new Impl(Nil)
     
-  private final class Impl[Row](val prefix: Option[String], val extract: Row => TransactionhistoryRow, val merge: (Row, TransactionhistoryRow) => Row)
-    extends Relation[TransactionhistoryFields, TransactionhistoryRow, Row] { 
+  private final class Impl(val _path: List[Path])
+    extends Relation[TransactionhistoryFields, TransactionhistoryRow] {
   
-    override val fields: TransactionhistoryFields[Row] = new TransactionhistoryFields[Row] {
-      override val transactionid = new IdField[TransactionhistoryId, Row](prefix, "transactionid", None, Some("int4"))(x => extract(x).transactionid, (row, value) => merge(row, extract(row).copy(transactionid = value)))
-      override val productid = new Field[ProductId, Row](prefix, "productid", None, Some("int4"))(x => extract(x).productid, (row, value) => merge(row, extract(row).copy(productid = value)))
-      override val referenceorderid = new Field[Int, Row](prefix, "referenceorderid", None, Some("int4"))(x => extract(x).referenceorderid, (row, value) => merge(row, extract(row).copy(referenceorderid = value)))
-      override val referenceorderlineid = new Field[Int, Row](prefix, "referenceorderlineid", None, Some("int4"))(x => extract(x).referenceorderlineid, (row, value) => merge(row, extract(row).copy(referenceorderlineid = value)))
-      override val transactiondate = new Field[TypoLocalDateTime, Row](prefix, "transactiondate", Some("text"), Some("timestamp"))(x => extract(x).transactiondate, (row, value) => merge(row, extract(row).copy(transactiondate = value)))
-      override val transactiontype = new Field[/* bpchar, max 1 chars */ String, Row](prefix, "transactiontype", None, Some("bpchar"))(x => extract(x).transactiontype, (row, value) => merge(row, extract(row).copy(transactiontype = value)))
-      override val quantity = new Field[Int, Row](prefix, "quantity", None, Some("int4"))(x => extract(x).quantity, (row, value) => merge(row, extract(row).copy(quantity = value)))
-      override val actualcost = new Field[BigDecimal, Row](prefix, "actualcost", None, Some("numeric"))(x => extract(x).actualcost, (row, value) => merge(row, extract(row).copy(actualcost = value)))
-      override val modifieddate = new Field[TypoLocalDateTime, Row](prefix, "modifieddate", Some("text"), Some("timestamp"))(x => extract(x).modifieddate, (row, value) => merge(row, extract(row).copy(modifieddate = value)))
+    override lazy val fields: TransactionhistoryFields = new TransactionhistoryFields {
+      override def transactionid = IdField[TransactionhistoryId, TransactionhistoryRow](_path, "transactionid", None, Some("int4"), x => x.transactionid, (row, value) => row.copy(transactionid = value))
+      override def productid = Field[ProductId, TransactionhistoryRow](_path, "productid", None, Some("int4"), x => x.productid, (row, value) => row.copy(productid = value))
+      override def referenceorderid = Field[Int, TransactionhistoryRow](_path, "referenceorderid", None, Some("int4"), x => x.referenceorderid, (row, value) => row.copy(referenceorderid = value))
+      override def referenceorderlineid = Field[Int, TransactionhistoryRow](_path, "referenceorderlineid", None, Some("int4"), x => x.referenceorderlineid, (row, value) => row.copy(referenceorderlineid = value))
+      override def transactiondate = Field[TypoLocalDateTime, TransactionhistoryRow](_path, "transactiondate", Some("text"), Some("timestamp"), x => x.transactiondate, (row, value) => row.copy(transactiondate = value))
+      override def transactiontype = Field[/* bpchar, max 1 chars */ String, TransactionhistoryRow](_path, "transactiontype", None, Some("bpchar"), x => x.transactiontype, (row, value) => row.copy(transactiontype = value))
+      override def quantity = Field[Int, TransactionhistoryRow](_path, "quantity", None, Some("int4"), x => x.quantity, (row, value) => row.copy(quantity = value))
+      override def actualcost = Field[BigDecimal, TransactionhistoryRow](_path, "actualcost", None, Some("numeric"), x => x.actualcost, (row, value) => row.copy(actualcost = value))
+      override def modifieddate = Field[TypoLocalDateTime, TransactionhistoryRow](_path, "modifieddate", Some("text"), Some("timestamp"), x => x.modifieddate, (row, value) => row.copy(modifieddate = value))
     }
   
-    override val columns: List[FieldLikeNoHkt[?, Row]] =
-      List[FieldLikeNoHkt[?, Row]](fields.transactionid, fields.productid, fields.referenceorderid, fields.referenceorderlineid, fields.transactiondate, fields.transactiontype, fields.quantity, fields.actualcost, fields.modifieddate)
+    override lazy val columns: List[FieldLikeNoHkt[?, TransactionhistoryRow]] =
+      List[FieldLikeNoHkt[?, TransactionhistoryRow]](fields.transactionid, fields.productid, fields.referenceorderid, fields.referenceorderlineid, fields.transactiondate, fields.transactiontype, fields.quantity, fields.actualcost, fields.modifieddate)
   
-    override def copy[NewRow](prefix: Option[String], extract: NewRow => TransactionhistoryRow, merge: (NewRow, TransactionhistoryRow) => NewRow): Impl[NewRow] =
-      new Impl(prefix, extract, merge)
+    override def copy(path: List[Path]): Impl =
+      new Impl(path)
   }
   
 }

--- a/typo-tester-doobie/generated-and-checked-in/adventureworks/production/transactionhistory/TransactionhistoryRepoMock.scala
+++ b/typo-tester-doobie/generated-and-checked-in/adventureworks/production/transactionhistory/TransactionhistoryRepoMock.scala
@@ -24,7 +24,7 @@ import typo.dsl.UpdateParams
 class TransactionhistoryRepoMock(toRow: Function1[TransactionhistoryRowUnsaved, TransactionhistoryRow],
                                  map: scala.collection.mutable.Map[TransactionhistoryId, TransactionhistoryRow] = scala.collection.mutable.Map.empty) extends TransactionhistoryRepo {
   override def delete: DeleteBuilder[TransactionhistoryFields, TransactionhistoryRow] = {
-    DeleteBuilderMock(DeleteParams.empty, TransactionhistoryFields.structure.fields, map)
+    DeleteBuilderMock(DeleteParams.empty, TransactionhistoryFields.structure, map)
   }
   override def deleteById(transactionid: TransactionhistoryId): ConnectionIO[Boolean] = {
     delay(map.remove(transactionid).isDefined)
@@ -86,7 +86,7 @@ class TransactionhistoryRepoMock(toRow: Function1[TransactionhistoryRowUnsaved, 
     }
   }
   override def update: UpdateBuilder[TransactionhistoryFields, TransactionhistoryRow] = {
-    UpdateBuilderMock(UpdateParams.empty, TransactionhistoryFields.structure.fields, map)
+    UpdateBuilderMock(UpdateParams.empty, TransactionhistoryFields.structure, map)
   }
   override def update(row: TransactionhistoryRow): ConnectionIO[Boolean] = {
     delay {

--- a/typo-tester-doobie/generated-and-checked-in/adventureworks/production/transactionhistoryarchive/TransactionhistoryarchiveFields.scala
+++ b/typo-tester-doobie/generated-and-checked-in/adventureworks/production/transactionhistoryarchive/TransactionhistoryarchiveFields.scala
@@ -8,47 +8,48 @@ package production
 package transactionhistoryarchive
 
 import adventureworks.customtypes.TypoLocalDateTime
+import typo.dsl.Path
 import typo.dsl.SqlExpr.Field
 import typo.dsl.SqlExpr.FieldLikeNoHkt
 import typo.dsl.SqlExpr.IdField
 import typo.dsl.Structure.Relation
 
-trait TransactionhistoryarchiveFields[Row] {
-  val transactionid: IdField[TransactionhistoryarchiveId, Row]
-  val productid: Field[Int, Row]
-  val referenceorderid: Field[Int, Row]
-  val referenceorderlineid: Field[Int, Row]
-  val transactiondate: Field[TypoLocalDateTime, Row]
-  val transactiontype: Field[/* bpchar, max 1 chars */ String, Row]
-  val quantity: Field[Int, Row]
-  val actualcost: Field[BigDecimal, Row]
-  val modifieddate: Field[TypoLocalDateTime, Row]
+trait TransactionhistoryarchiveFields {
+  def transactionid: IdField[TransactionhistoryarchiveId, TransactionhistoryarchiveRow]
+  def productid: Field[Int, TransactionhistoryarchiveRow]
+  def referenceorderid: Field[Int, TransactionhistoryarchiveRow]
+  def referenceorderlineid: Field[Int, TransactionhistoryarchiveRow]
+  def transactiondate: Field[TypoLocalDateTime, TransactionhistoryarchiveRow]
+  def transactiontype: Field[/* bpchar, max 1 chars */ String, TransactionhistoryarchiveRow]
+  def quantity: Field[Int, TransactionhistoryarchiveRow]
+  def actualcost: Field[BigDecimal, TransactionhistoryarchiveRow]
+  def modifieddate: Field[TypoLocalDateTime, TransactionhistoryarchiveRow]
 }
 
 object TransactionhistoryarchiveFields {
-  val structure: Relation[TransactionhistoryarchiveFields, TransactionhistoryarchiveRow, TransactionhistoryarchiveRow] = 
-    new Impl(None, identity, (_, x) => x)
+  lazy val structure: Relation[TransactionhistoryarchiveFields, TransactionhistoryarchiveRow] =
+    new Impl(Nil)
     
-  private final class Impl[Row](val prefix: Option[String], val extract: Row => TransactionhistoryarchiveRow, val merge: (Row, TransactionhistoryarchiveRow) => Row)
-    extends Relation[TransactionhistoryarchiveFields, TransactionhistoryarchiveRow, Row] { 
+  private final class Impl(val _path: List[Path])
+    extends Relation[TransactionhistoryarchiveFields, TransactionhistoryarchiveRow] {
   
-    override val fields: TransactionhistoryarchiveFields[Row] = new TransactionhistoryarchiveFields[Row] {
-      override val transactionid = new IdField[TransactionhistoryarchiveId, Row](prefix, "transactionid", None, Some("int4"))(x => extract(x).transactionid, (row, value) => merge(row, extract(row).copy(transactionid = value)))
-      override val productid = new Field[Int, Row](prefix, "productid", None, Some("int4"))(x => extract(x).productid, (row, value) => merge(row, extract(row).copy(productid = value)))
-      override val referenceorderid = new Field[Int, Row](prefix, "referenceorderid", None, Some("int4"))(x => extract(x).referenceorderid, (row, value) => merge(row, extract(row).copy(referenceorderid = value)))
-      override val referenceorderlineid = new Field[Int, Row](prefix, "referenceorderlineid", None, Some("int4"))(x => extract(x).referenceorderlineid, (row, value) => merge(row, extract(row).copy(referenceorderlineid = value)))
-      override val transactiondate = new Field[TypoLocalDateTime, Row](prefix, "transactiondate", Some("text"), Some("timestamp"))(x => extract(x).transactiondate, (row, value) => merge(row, extract(row).copy(transactiondate = value)))
-      override val transactiontype = new Field[/* bpchar, max 1 chars */ String, Row](prefix, "transactiontype", None, Some("bpchar"))(x => extract(x).transactiontype, (row, value) => merge(row, extract(row).copy(transactiontype = value)))
-      override val quantity = new Field[Int, Row](prefix, "quantity", None, Some("int4"))(x => extract(x).quantity, (row, value) => merge(row, extract(row).copy(quantity = value)))
-      override val actualcost = new Field[BigDecimal, Row](prefix, "actualcost", None, Some("numeric"))(x => extract(x).actualcost, (row, value) => merge(row, extract(row).copy(actualcost = value)))
-      override val modifieddate = new Field[TypoLocalDateTime, Row](prefix, "modifieddate", Some("text"), Some("timestamp"))(x => extract(x).modifieddate, (row, value) => merge(row, extract(row).copy(modifieddate = value)))
+    override lazy val fields: TransactionhistoryarchiveFields = new TransactionhistoryarchiveFields {
+      override def transactionid = IdField[TransactionhistoryarchiveId, TransactionhistoryarchiveRow](_path, "transactionid", None, Some("int4"), x => x.transactionid, (row, value) => row.copy(transactionid = value))
+      override def productid = Field[Int, TransactionhistoryarchiveRow](_path, "productid", None, Some("int4"), x => x.productid, (row, value) => row.copy(productid = value))
+      override def referenceorderid = Field[Int, TransactionhistoryarchiveRow](_path, "referenceorderid", None, Some("int4"), x => x.referenceorderid, (row, value) => row.copy(referenceorderid = value))
+      override def referenceorderlineid = Field[Int, TransactionhistoryarchiveRow](_path, "referenceorderlineid", None, Some("int4"), x => x.referenceorderlineid, (row, value) => row.copy(referenceorderlineid = value))
+      override def transactiondate = Field[TypoLocalDateTime, TransactionhistoryarchiveRow](_path, "transactiondate", Some("text"), Some("timestamp"), x => x.transactiondate, (row, value) => row.copy(transactiondate = value))
+      override def transactiontype = Field[/* bpchar, max 1 chars */ String, TransactionhistoryarchiveRow](_path, "transactiontype", None, Some("bpchar"), x => x.transactiontype, (row, value) => row.copy(transactiontype = value))
+      override def quantity = Field[Int, TransactionhistoryarchiveRow](_path, "quantity", None, Some("int4"), x => x.quantity, (row, value) => row.copy(quantity = value))
+      override def actualcost = Field[BigDecimal, TransactionhistoryarchiveRow](_path, "actualcost", None, Some("numeric"), x => x.actualcost, (row, value) => row.copy(actualcost = value))
+      override def modifieddate = Field[TypoLocalDateTime, TransactionhistoryarchiveRow](_path, "modifieddate", Some("text"), Some("timestamp"), x => x.modifieddate, (row, value) => row.copy(modifieddate = value))
     }
   
-    override val columns: List[FieldLikeNoHkt[?, Row]] =
-      List[FieldLikeNoHkt[?, Row]](fields.transactionid, fields.productid, fields.referenceorderid, fields.referenceorderlineid, fields.transactiondate, fields.transactiontype, fields.quantity, fields.actualcost, fields.modifieddate)
+    override lazy val columns: List[FieldLikeNoHkt[?, TransactionhistoryarchiveRow]] =
+      List[FieldLikeNoHkt[?, TransactionhistoryarchiveRow]](fields.transactionid, fields.productid, fields.referenceorderid, fields.referenceorderlineid, fields.transactiondate, fields.transactiontype, fields.quantity, fields.actualcost, fields.modifieddate)
   
-    override def copy[NewRow](prefix: Option[String], extract: NewRow => TransactionhistoryarchiveRow, merge: (NewRow, TransactionhistoryarchiveRow) => NewRow): Impl[NewRow] =
-      new Impl(prefix, extract, merge)
+    override def copy(path: List[Path]): Impl =
+      new Impl(path)
   }
   
 }

--- a/typo-tester-doobie/generated-and-checked-in/adventureworks/production/transactionhistoryarchive/TransactionhistoryarchiveRepoMock.scala
+++ b/typo-tester-doobie/generated-and-checked-in/adventureworks/production/transactionhistoryarchive/TransactionhistoryarchiveRepoMock.scala
@@ -24,7 +24,7 @@ import typo.dsl.UpdateParams
 class TransactionhistoryarchiveRepoMock(toRow: Function1[TransactionhistoryarchiveRowUnsaved, TransactionhistoryarchiveRow],
                                         map: scala.collection.mutable.Map[TransactionhistoryarchiveId, TransactionhistoryarchiveRow] = scala.collection.mutable.Map.empty) extends TransactionhistoryarchiveRepo {
   override def delete: DeleteBuilder[TransactionhistoryarchiveFields, TransactionhistoryarchiveRow] = {
-    DeleteBuilderMock(DeleteParams.empty, TransactionhistoryarchiveFields.structure.fields, map)
+    DeleteBuilderMock(DeleteParams.empty, TransactionhistoryarchiveFields.structure, map)
   }
   override def deleteById(transactionid: TransactionhistoryarchiveId): ConnectionIO[Boolean] = {
     delay(map.remove(transactionid).isDefined)
@@ -86,7 +86,7 @@ class TransactionhistoryarchiveRepoMock(toRow: Function1[Transactionhistoryarchi
     }
   }
   override def update: UpdateBuilder[TransactionhistoryarchiveFields, TransactionhistoryarchiveRow] = {
-    UpdateBuilderMock(UpdateParams.empty, TransactionhistoryarchiveFields.structure.fields, map)
+    UpdateBuilderMock(UpdateParams.empty, TransactionhistoryarchiveFields.structure, map)
   }
   override def update(row: TransactionhistoryarchiveRow): ConnectionIO[Boolean] = {
     delay {

--- a/typo-tester-doobie/generated-and-checked-in/adventureworks/production/unitmeasure/UnitmeasureFields.scala
+++ b/typo-tester-doobie/generated-and-checked-in/adventureworks/production/unitmeasure/UnitmeasureFields.scala
@@ -9,35 +9,36 @@ package unitmeasure
 
 import adventureworks.customtypes.TypoLocalDateTime
 import adventureworks.public.Name
+import typo.dsl.Path
 import typo.dsl.SqlExpr.Field
 import typo.dsl.SqlExpr.FieldLikeNoHkt
 import typo.dsl.SqlExpr.IdField
 import typo.dsl.Structure.Relation
 
-trait UnitmeasureFields[Row] {
-  val unitmeasurecode: IdField[UnitmeasureId, Row]
-  val name: Field[Name, Row]
-  val modifieddate: Field[TypoLocalDateTime, Row]
+trait UnitmeasureFields {
+  def unitmeasurecode: IdField[UnitmeasureId, UnitmeasureRow]
+  def name: Field[Name, UnitmeasureRow]
+  def modifieddate: Field[TypoLocalDateTime, UnitmeasureRow]
 }
 
 object UnitmeasureFields {
-  val structure: Relation[UnitmeasureFields, UnitmeasureRow, UnitmeasureRow] = 
-    new Impl(None, identity, (_, x) => x)
+  lazy val structure: Relation[UnitmeasureFields, UnitmeasureRow] =
+    new Impl(Nil)
     
-  private final class Impl[Row](val prefix: Option[String], val extract: Row => UnitmeasureRow, val merge: (Row, UnitmeasureRow) => Row)
-    extends Relation[UnitmeasureFields, UnitmeasureRow, Row] { 
+  private final class Impl(val _path: List[Path])
+    extends Relation[UnitmeasureFields, UnitmeasureRow] {
   
-    override val fields: UnitmeasureFields[Row] = new UnitmeasureFields[Row] {
-      override val unitmeasurecode = new IdField[UnitmeasureId, Row](prefix, "unitmeasurecode", None, Some("bpchar"))(x => extract(x).unitmeasurecode, (row, value) => merge(row, extract(row).copy(unitmeasurecode = value)))
-      override val name = new Field[Name, Row](prefix, "name", None, Some("varchar"))(x => extract(x).name, (row, value) => merge(row, extract(row).copy(name = value)))
-      override val modifieddate = new Field[TypoLocalDateTime, Row](prefix, "modifieddate", Some("text"), Some("timestamp"))(x => extract(x).modifieddate, (row, value) => merge(row, extract(row).copy(modifieddate = value)))
+    override lazy val fields: UnitmeasureFields = new UnitmeasureFields {
+      override def unitmeasurecode = IdField[UnitmeasureId, UnitmeasureRow](_path, "unitmeasurecode", None, Some("bpchar"), x => x.unitmeasurecode, (row, value) => row.copy(unitmeasurecode = value))
+      override def name = Field[Name, UnitmeasureRow](_path, "name", None, Some("varchar"), x => x.name, (row, value) => row.copy(name = value))
+      override def modifieddate = Field[TypoLocalDateTime, UnitmeasureRow](_path, "modifieddate", Some("text"), Some("timestamp"), x => x.modifieddate, (row, value) => row.copy(modifieddate = value))
     }
   
-    override val columns: List[FieldLikeNoHkt[?, Row]] =
-      List[FieldLikeNoHkt[?, Row]](fields.unitmeasurecode, fields.name, fields.modifieddate)
+    override lazy val columns: List[FieldLikeNoHkt[?, UnitmeasureRow]] =
+      List[FieldLikeNoHkt[?, UnitmeasureRow]](fields.unitmeasurecode, fields.name, fields.modifieddate)
   
-    override def copy[NewRow](prefix: Option[String], extract: NewRow => UnitmeasureRow, merge: (NewRow, UnitmeasureRow) => NewRow): Impl[NewRow] =
-      new Impl(prefix, extract, merge)
+    override def copy(path: List[Path]): Impl =
+      new Impl(path)
   }
   
 }

--- a/typo-tester-doobie/generated-and-checked-in/adventureworks/production/unitmeasure/UnitmeasureRepoMock.scala
+++ b/typo-tester-doobie/generated-and-checked-in/adventureworks/production/unitmeasure/UnitmeasureRepoMock.scala
@@ -24,7 +24,7 @@ import typo.dsl.UpdateParams
 class UnitmeasureRepoMock(toRow: Function1[UnitmeasureRowUnsaved, UnitmeasureRow],
                           map: scala.collection.mutable.Map[UnitmeasureId, UnitmeasureRow] = scala.collection.mutable.Map.empty) extends UnitmeasureRepo {
   override def delete: DeleteBuilder[UnitmeasureFields, UnitmeasureRow] = {
-    DeleteBuilderMock(DeleteParams.empty, UnitmeasureFields.structure.fields, map)
+    DeleteBuilderMock(DeleteParams.empty, UnitmeasureFields.structure, map)
   }
   override def deleteById(unitmeasurecode: UnitmeasureId): ConnectionIO[Boolean] = {
     delay(map.remove(unitmeasurecode).isDefined)
@@ -86,7 +86,7 @@ class UnitmeasureRepoMock(toRow: Function1[UnitmeasureRowUnsaved, UnitmeasureRow
     }
   }
   override def update: UpdateBuilder[UnitmeasureFields, UnitmeasureRow] = {
-    UpdateBuilderMock(UpdateParams.empty, UnitmeasureFields.structure.fields, map)
+    UpdateBuilderMock(UpdateParams.empty, UnitmeasureFields.structure, map)
   }
   override def update(row: UnitmeasureRow): ConnectionIO[Boolean] = {
     delay {

--- a/typo-tester-doobie/generated-and-checked-in/adventureworks/production/vproductanddescription/VproductanddescriptionMVFields.scala
+++ b/typo-tester-doobie/generated-and-checked-in/adventureworks/production/vproductanddescription/VproductanddescriptionMVFields.scala
@@ -10,38 +10,39 @@ package vproductanddescription
 import adventureworks.production.culture.CultureId
 import adventureworks.production.product.ProductId
 import adventureworks.public.Name
+import typo.dsl.Path
 import typo.dsl.SqlExpr.Field
 import typo.dsl.SqlExpr.FieldLikeNoHkt
 import typo.dsl.Structure.Relation
 
-trait VproductanddescriptionMVFields[Row] {
-  val productid: Field[ProductId, Row]
-  val name: Field[Name, Row]
-  val productmodel: Field[Name, Row]
-  val cultureid: Field[CultureId, Row]
-  val description: Field[/* max 400 chars */ String, Row]
+trait VproductanddescriptionMVFields {
+  def productid: Field[ProductId, VproductanddescriptionMVRow]
+  def name: Field[Name, VproductanddescriptionMVRow]
+  def productmodel: Field[Name, VproductanddescriptionMVRow]
+  def cultureid: Field[CultureId, VproductanddescriptionMVRow]
+  def description: Field[/* max 400 chars */ String, VproductanddescriptionMVRow]
 }
 
 object VproductanddescriptionMVFields {
-  val structure: Relation[VproductanddescriptionMVFields, VproductanddescriptionMVRow, VproductanddescriptionMVRow] = 
-    new Impl(None, identity, (_, x) => x)
+  lazy val structure: Relation[VproductanddescriptionMVFields, VproductanddescriptionMVRow] =
+    new Impl(Nil)
     
-  private final class Impl[Row](val prefix: Option[String], val extract: Row => VproductanddescriptionMVRow, val merge: (Row, VproductanddescriptionMVRow) => Row)
-    extends Relation[VproductanddescriptionMVFields, VproductanddescriptionMVRow, Row] { 
+  private final class Impl(val _path: List[Path])
+    extends Relation[VproductanddescriptionMVFields, VproductanddescriptionMVRow] {
   
-    override val fields: VproductanddescriptionMVFields[Row] = new VproductanddescriptionMVFields[Row] {
-      override val productid = new Field[ProductId, Row](prefix, "productid", None, None)(x => extract(x).productid, (row, value) => merge(row, extract(row).copy(productid = value)))
-      override val name = new Field[Name, Row](prefix, "name", None, None)(x => extract(x).name, (row, value) => merge(row, extract(row).copy(name = value)))
-      override val productmodel = new Field[Name, Row](prefix, "productmodel", None, None)(x => extract(x).productmodel, (row, value) => merge(row, extract(row).copy(productmodel = value)))
-      override val cultureid = new Field[CultureId, Row](prefix, "cultureid", None, None)(x => extract(x).cultureid, (row, value) => merge(row, extract(row).copy(cultureid = value)))
-      override val description = new Field[/* max 400 chars */ String, Row](prefix, "description", None, None)(x => extract(x).description, (row, value) => merge(row, extract(row).copy(description = value)))
+    override lazy val fields: VproductanddescriptionMVFields = new VproductanddescriptionMVFields {
+      override def productid = Field[ProductId, VproductanddescriptionMVRow](_path, "productid", None, None, x => x.productid, (row, value) => row.copy(productid = value))
+      override def name = Field[Name, VproductanddescriptionMVRow](_path, "name", None, None, x => x.name, (row, value) => row.copy(name = value))
+      override def productmodel = Field[Name, VproductanddescriptionMVRow](_path, "productmodel", None, None, x => x.productmodel, (row, value) => row.copy(productmodel = value))
+      override def cultureid = Field[CultureId, VproductanddescriptionMVRow](_path, "cultureid", None, None, x => x.cultureid, (row, value) => row.copy(cultureid = value))
+      override def description = Field[/* max 400 chars */ String, VproductanddescriptionMVRow](_path, "description", None, None, x => x.description, (row, value) => row.copy(description = value))
     }
   
-    override val columns: List[FieldLikeNoHkt[?, Row]] =
-      List[FieldLikeNoHkt[?, Row]](fields.productid, fields.name, fields.productmodel, fields.cultureid, fields.description)
+    override lazy val columns: List[FieldLikeNoHkt[?, VproductanddescriptionMVRow]] =
+      List[FieldLikeNoHkt[?, VproductanddescriptionMVRow]](fields.productid, fields.name, fields.productmodel, fields.cultureid, fields.description)
   
-    override def copy[NewRow](prefix: Option[String], extract: NewRow => VproductanddescriptionMVRow, merge: (NewRow, VproductanddescriptionMVRow) => NewRow): Impl[NewRow] =
-      new Impl(prefix, extract, merge)
+    override def copy(path: List[Path]): Impl =
+      new Impl(path)
   }
   
 }

--- a/typo-tester-doobie/generated-and-checked-in/adventureworks/production/vproductmodelcatalogdescription/VproductmodelcatalogdescriptionViewFields.scala
+++ b/typo-tester-doobie/generated-and-checked-in/adventureworks/production/vproductmodelcatalogdescription/VproductmodelcatalogdescriptionViewFields.scala
@@ -11,79 +11,80 @@ import adventureworks.customtypes.TypoLocalDateTime
 import adventureworks.customtypes.TypoUUID
 import adventureworks.production.productmodel.ProductmodelId
 import adventureworks.public.Name
+import typo.dsl.Path
 import typo.dsl.SqlExpr.Field
 import typo.dsl.SqlExpr.FieldLikeNoHkt
 import typo.dsl.SqlExpr.OptField
 import typo.dsl.Structure.Relation
 
-trait VproductmodelcatalogdescriptionViewFields[Row] {
-  val productmodelid: Field[ProductmodelId, Row]
-  val name: Field[Name, Row]
-  val Summary: OptField[String, Row]
-  val manufacturer: OptField[String, Row]
-  val copyright: OptField[/* max 30 chars */ String, Row]
-  val producturl: OptField[/* max 256 chars */ String, Row]
-  val warrantyperiod: OptField[/* max 256 chars */ String, Row]
-  val warrantydescription: OptField[/* max 256 chars */ String, Row]
-  val noofyears: OptField[/* max 256 chars */ String, Row]
-  val maintenancedescription: OptField[/* max 256 chars */ String, Row]
-  val wheel: OptField[/* max 256 chars */ String, Row]
-  val saddle: OptField[/* max 256 chars */ String, Row]
-  val pedal: OptField[/* max 256 chars */ String, Row]
-  val bikeframe: OptField[String, Row]
-  val crankset: OptField[/* max 256 chars */ String, Row]
-  val pictureangle: OptField[/* max 256 chars */ String, Row]
-  val picturesize: OptField[/* max 256 chars */ String, Row]
-  val productphotoid: OptField[/* max 256 chars */ String, Row]
-  val material: OptField[/* max 256 chars */ String, Row]
-  val color: OptField[/* max 256 chars */ String, Row]
-  val productline: OptField[/* max 256 chars */ String, Row]
-  val style: OptField[/* max 256 chars */ String, Row]
-  val riderexperience: OptField[/* max 1024 chars */ String, Row]
-  val rowguid: Field[TypoUUID, Row]
-  val modifieddate: Field[TypoLocalDateTime, Row]
+trait VproductmodelcatalogdescriptionViewFields {
+  def productmodelid: Field[ProductmodelId, VproductmodelcatalogdescriptionViewRow]
+  def name: Field[Name, VproductmodelcatalogdescriptionViewRow]
+  def Summary: OptField[String, VproductmodelcatalogdescriptionViewRow]
+  def manufacturer: OptField[String, VproductmodelcatalogdescriptionViewRow]
+  def copyright: OptField[/* max 30 chars */ String, VproductmodelcatalogdescriptionViewRow]
+  def producturl: OptField[/* max 256 chars */ String, VproductmodelcatalogdescriptionViewRow]
+  def warrantyperiod: OptField[/* max 256 chars */ String, VproductmodelcatalogdescriptionViewRow]
+  def warrantydescription: OptField[/* max 256 chars */ String, VproductmodelcatalogdescriptionViewRow]
+  def noofyears: OptField[/* max 256 chars */ String, VproductmodelcatalogdescriptionViewRow]
+  def maintenancedescription: OptField[/* max 256 chars */ String, VproductmodelcatalogdescriptionViewRow]
+  def wheel: OptField[/* max 256 chars */ String, VproductmodelcatalogdescriptionViewRow]
+  def saddle: OptField[/* max 256 chars */ String, VproductmodelcatalogdescriptionViewRow]
+  def pedal: OptField[/* max 256 chars */ String, VproductmodelcatalogdescriptionViewRow]
+  def bikeframe: OptField[String, VproductmodelcatalogdescriptionViewRow]
+  def crankset: OptField[/* max 256 chars */ String, VproductmodelcatalogdescriptionViewRow]
+  def pictureangle: OptField[/* max 256 chars */ String, VproductmodelcatalogdescriptionViewRow]
+  def picturesize: OptField[/* max 256 chars */ String, VproductmodelcatalogdescriptionViewRow]
+  def productphotoid: OptField[/* max 256 chars */ String, VproductmodelcatalogdescriptionViewRow]
+  def material: OptField[/* max 256 chars */ String, VproductmodelcatalogdescriptionViewRow]
+  def color: OptField[/* max 256 chars */ String, VproductmodelcatalogdescriptionViewRow]
+  def productline: OptField[/* max 256 chars */ String, VproductmodelcatalogdescriptionViewRow]
+  def style: OptField[/* max 256 chars */ String, VproductmodelcatalogdescriptionViewRow]
+  def riderexperience: OptField[/* max 1024 chars */ String, VproductmodelcatalogdescriptionViewRow]
+  def rowguid: Field[TypoUUID, VproductmodelcatalogdescriptionViewRow]
+  def modifieddate: Field[TypoLocalDateTime, VproductmodelcatalogdescriptionViewRow]
 }
 
 object VproductmodelcatalogdescriptionViewFields {
-  val structure: Relation[VproductmodelcatalogdescriptionViewFields, VproductmodelcatalogdescriptionViewRow, VproductmodelcatalogdescriptionViewRow] = 
-    new Impl(None, identity, (_, x) => x)
+  lazy val structure: Relation[VproductmodelcatalogdescriptionViewFields, VproductmodelcatalogdescriptionViewRow] =
+    new Impl(Nil)
     
-  private final class Impl[Row](val prefix: Option[String], val extract: Row => VproductmodelcatalogdescriptionViewRow, val merge: (Row, VproductmodelcatalogdescriptionViewRow) => Row)
-    extends Relation[VproductmodelcatalogdescriptionViewFields, VproductmodelcatalogdescriptionViewRow, Row] { 
+  private final class Impl(val _path: List[Path])
+    extends Relation[VproductmodelcatalogdescriptionViewFields, VproductmodelcatalogdescriptionViewRow] {
   
-    override val fields: VproductmodelcatalogdescriptionViewFields[Row] = new VproductmodelcatalogdescriptionViewFields[Row] {
-      override val productmodelid = new Field[ProductmodelId, Row](prefix, "productmodelid", None, None)(x => extract(x).productmodelid, (row, value) => merge(row, extract(row).copy(productmodelid = value)))
-      override val name = new Field[Name, Row](prefix, "name", None, None)(x => extract(x).name, (row, value) => merge(row, extract(row).copy(name = value)))
-      override val Summary = new OptField[String, Row](prefix, "Summary", None, None)(x => extract(x).Summary, (row, value) => merge(row, extract(row).copy(Summary = value)))
-      override val manufacturer = new OptField[String, Row](prefix, "manufacturer", None, None)(x => extract(x).manufacturer, (row, value) => merge(row, extract(row).copy(manufacturer = value)))
-      override val copyright = new OptField[/* max 30 chars */ String, Row](prefix, "copyright", None, None)(x => extract(x).copyright, (row, value) => merge(row, extract(row).copy(copyright = value)))
-      override val producturl = new OptField[/* max 256 chars */ String, Row](prefix, "producturl", None, None)(x => extract(x).producturl, (row, value) => merge(row, extract(row).copy(producturl = value)))
-      override val warrantyperiod = new OptField[/* max 256 chars */ String, Row](prefix, "warrantyperiod", None, None)(x => extract(x).warrantyperiod, (row, value) => merge(row, extract(row).copy(warrantyperiod = value)))
-      override val warrantydescription = new OptField[/* max 256 chars */ String, Row](prefix, "warrantydescription", None, None)(x => extract(x).warrantydescription, (row, value) => merge(row, extract(row).copy(warrantydescription = value)))
-      override val noofyears = new OptField[/* max 256 chars */ String, Row](prefix, "noofyears", None, None)(x => extract(x).noofyears, (row, value) => merge(row, extract(row).copy(noofyears = value)))
-      override val maintenancedescription = new OptField[/* max 256 chars */ String, Row](prefix, "maintenancedescription", None, None)(x => extract(x).maintenancedescription, (row, value) => merge(row, extract(row).copy(maintenancedescription = value)))
-      override val wheel = new OptField[/* max 256 chars */ String, Row](prefix, "wheel", None, None)(x => extract(x).wheel, (row, value) => merge(row, extract(row).copy(wheel = value)))
-      override val saddle = new OptField[/* max 256 chars */ String, Row](prefix, "saddle", None, None)(x => extract(x).saddle, (row, value) => merge(row, extract(row).copy(saddle = value)))
-      override val pedal = new OptField[/* max 256 chars */ String, Row](prefix, "pedal", None, None)(x => extract(x).pedal, (row, value) => merge(row, extract(row).copy(pedal = value)))
-      override val bikeframe = new OptField[String, Row](prefix, "bikeframe", None, None)(x => extract(x).bikeframe, (row, value) => merge(row, extract(row).copy(bikeframe = value)))
-      override val crankset = new OptField[/* max 256 chars */ String, Row](prefix, "crankset", None, None)(x => extract(x).crankset, (row, value) => merge(row, extract(row).copy(crankset = value)))
-      override val pictureangle = new OptField[/* max 256 chars */ String, Row](prefix, "pictureangle", None, None)(x => extract(x).pictureangle, (row, value) => merge(row, extract(row).copy(pictureangle = value)))
-      override val picturesize = new OptField[/* max 256 chars */ String, Row](prefix, "picturesize", None, None)(x => extract(x).picturesize, (row, value) => merge(row, extract(row).copy(picturesize = value)))
-      override val productphotoid = new OptField[/* max 256 chars */ String, Row](prefix, "productphotoid", None, None)(x => extract(x).productphotoid, (row, value) => merge(row, extract(row).copy(productphotoid = value)))
-      override val material = new OptField[/* max 256 chars */ String, Row](prefix, "material", None, None)(x => extract(x).material, (row, value) => merge(row, extract(row).copy(material = value)))
-      override val color = new OptField[/* max 256 chars */ String, Row](prefix, "color", None, None)(x => extract(x).color, (row, value) => merge(row, extract(row).copy(color = value)))
-      override val productline = new OptField[/* max 256 chars */ String, Row](prefix, "productline", None, None)(x => extract(x).productline, (row, value) => merge(row, extract(row).copy(productline = value)))
-      override val style = new OptField[/* max 256 chars */ String, Row](prefix, "style", None, None)(x => extract(x).style, (row, value) => merge(row, extract(row).copy(style = value)))
-      override val riderexperience = new OptField[/* max 1024 chars */ String, Row](prefix, "riderexperience", None, None)(x => extract(x).riderexperience, (row, value) => merge(row, extract(row).copy(riderexperience = value)))
-      override val rowguid = new Field[TypoUUID, Row](prefix, "rowguid", None, None)(x => extract(x).rowguid, (row, value) => merge(row, extract(row).copy(rowguid = value)))
-      override val modifieddate = new Field[TypoLocalDateTime, Row](prefix, "modifieddate", Some("text"), None)(x => extract(x).modifieddate, (row, value) => merge(row, extract(row).copy(modifieddate = value)))
+    override lazy val fields: VproductmodelcatalogdescriptionViewFields = new VproductmodelcatalogdescriptionViewFields {
+      override def productmodelid = Field[ProductmodelId, VproductmodelcatalogdescriptionViewRow](_path, "productmodelid", None, None, x => x.productmodelid, (row, value) => row.copy(productmodelid = value))
+      override def name = Field[Name, VproductmodelcatalogdescriptionViewRow](_path, "name", None, None, x => x.name, (row, value) => row.copy(name = value))
+      override def Summary = OptField[String, VproductmodelcatalogdescriptionViewRow](_path, "Summary", None, None, x => x.Summary, (row, value) => row.copy(Summary = value))
+      override def manufacturer = OptField[String, VproductmodelcatalogdescriptionViewRow](_path, "manufacturer", None, None, x => x.manufacturer, (row, value) => row.copy(manufacturer = value))
+      override def copyright = OptField[/* max 30 chars */ String, VproductmodelcatalogdescriptionViewRow](_path, "copyright", None, None, x => x.copyright, (row, value) => row.copy(copyright = value))
+      override def producturl = OptField[/* max 256 chars */ String, VproductmodelcatalogdescriptionViewRow](_path, "producturl", None, None, x => x.producturl, (row, value) => row.copy(producturl = value))
+      override def warrantyperiod = OptField[/* max 256 chars */ String, VproductmodelcatalogdescriptionViewRow](_path, "warrantyperiod", None, None, x => x.warrantyperiod, (row, value) => row.copy(warrantyperiod = value))
+      override def warrantydescription = OptField[/* max 256 chars */ String, VproductmodelcatalogdescriptionViewRow](_path, "warrantydescription", None, None, x => x.warrantydescription, (row, value) => row.copy(warrantydescription = value))
+      override def noofyears = OptField[/* max 256 chars */ String, VproductmodelcatalogdescriptionViewRow](_path, "noofyears", None, None, x => x.noofyears, (row, value) => row.copy(noofyears = value))
+      override def maintenancedescription = OptField[/* max 256 chars */ String, VproductmodelcatalogdescriptionViewRow](_path, "maintenancedescription", None, None, x => x.maintenancedescription, (row, value) => row.copy(maintenancedescription = value))
+      override def wheel = OptField[/* max 256 chars */ String, VproductmodelcatalogdescriptionViewRow](_path, "wheel", None, None, x => x.wheel, (row, value) => row.copy(wheel = value))
+      override def saddle = OptField[/* max 256 chars */ String, VproductmodelcatalogdescriptionViewRow](_path, "saddle", None, None, x => x.saddle, (row, value) => row.copy(saddle = value))
+      override def pedal = OptField[/* max 256 chars */ String, VproductmodelcatalogdescriptionViewRow](_path, "pedal", None, None, x => x.pedal, (row, value) => row.copy(pedal = value))
+      override def bikeframe = OptField[String, VproductmodelcatalogdescriptionViewRow](_path, "bikeframe", None, None, x => x.bikeframe, (row, value) => row.copy(bikeframe = value))
+      override def crankset = OptField[/* max 256 chars */ String, VproductmodelcatalogdescriptionViewRow](_path, "crankset", None, None, x => x.crankset, (row, value) => row.copy(crankset = value))
+      override def pictureangle = OptField[/* max 256 chars */ String, VproductmodelcatalogdescriptionViewRow](_path, "pictureangle", None, None, x => x.pictureangle, (row, value) => row.copy(pictureangle = value))
+      override def picturesize = OptField[/* max 256 chars */ String, VproductmodelcatalogdescriptionViewRow](_path, "picturesize", None, None, x => x.picturesize, (row, value) => row.copy(picturesize = value))
+      override def productphotoid = OptField[/* max 256 chars */ String, VproductmodelcatalogdescriptionViewRow](_path, "productphotoid", None, None, x => x.productphotoid, (row, value) => row.copy(productphotoid = value))
+      override def material = OptField[/* max 256 chars */ String, VproductmodelcatalogdescriptionViewRow](_path, "material", None, None, x => x.material, (row, value) => row.copy(material = value))
+      override def color = OptField[/* max 256 chars */ String, VproductmodelcatalogdescriptionViewRow](_path, "color", None, None, x => x.color, (row, value) => row.copy(color = value))
+      override def productline = OptField[/* max 256 chars */ String, VproductmodelcatalogdescriptionViewRow](_path, "productline", None, None, x => x.productline, (row, value) => row.copy(productline = value))
+      override def style = OptField[/* max 256 chars */ String, VproductmodelcatalogdescriptionViewRow](_path, "style", None, None, x => x.style, (row, value) => row.copy(style = value))
+      override def riderexperience = OptField[/* max 1024 chars */ String, VproductmodelcatalogdescriptionViewRow](_path, "riderexperience", None, None, x => x.riderexperience, (row, value) => row.copy(riderexperience = value))
+      override def rowguid = Field[TypoUUID, VproductmodelcatalogdescriptionViewRow](_path, "rowguid", None, None, x => x.rowguid, (row, value) => row.copy(rowguid = value))
+      override def modifieddate = Field[TypoLocalDateTime, VproductmodelcatalogdescriptionViewRow](_path, "modifieddate", Some("text"), None, x => x.modifieddate, (row, value) => row.copy(modifieddate = value))
     }
   
-    override val columns: List[FieldLikeNoHkt[?, Row]] =
-      List[FieldLikeNoHkt[?, Row]](fields.productmodelid, fields.name, fields.Summary, fields.manufacturer, fields.copyright, fields.producturl, fields.warrantyperiod, fields.warrantydescription, fields.noofyears, fields.maintenancedescription, fields.wheel, fields.saddle, fields.pedal, fields.bikeframe, fields.crankset, fields.pictureangle, fields.picturesize, fields.productphotoid, fields.material, fields.color, fields.productline, fields.style, fields.riderexperience, fields.rowguid, fields.modifieddate)
+    override lazy val columns: List[FieldLikeNoHkt[?, VproductmodelcatalogdescriptionViewRow]] =
+      List[FieldLikeNoHkt[?, VproductmodelcatalogdescriptionViewRow]](fields.productmodelid, fields.name, fields.Summary, fields.manufacturer, fields.copyright, fields.producturl, fields.warrantyperiod, fields.warrantydescription, fields.noofyears, fields.maintenancedescription, fields.wheel, fields.saddle, fields.pedal, fields.bikeframe, fields.crankset, fields.pictureangle, fields.picturesize, fields.productphotoid, fields.material, fields.color, fields.productline, fields.style, fields.riderexperience, fields.rowguid, fields.modifieddate)
   
-    override def copy[NewRow](prefix: Option[String], extract: NewRow => VproductmodelcatalogdescriptionViewRow, merge: (NewRow, VproductmodelcatalogdescriptionViewRow) => NewRow): Impl[NewRow] =
-      new Impl(prefix, extract, merge)
+    override def copy(path: List[Path]): Impl =
+      new Impl(path)
   }
   
 }

--- a/typo-tester-doobie/generated-and-checked-in/adventureworks/production/vproductmodelinstructions/VproductmodelinstructionsViewFields.scala
+++ b/typo-tester-doobie/generated-and-checked-in/adventureworks/production/vproductmodelinstructions/VproductmodelinstructionsViewFields.scala
@@ -11,51 +11,52 @@ import adventureworks.customtypes.TypoLocalDateTime
 import adventureworks.customtypes.TypoUUID
 import adventureworks.production.productmodel.ProductmodelId
 import adventureworks.public.Name
+import typo.dsl.Path
 import typo.dsl.SqlExpr.Field
 import typo.dsl.SqlExpr.FieldLikeNoHkt
 import typo.dsl.SqlExpr.OptField
 import typo.dsl.Structure.Relation
 
-trait VproductmodelinstructionsViewFields[Row] {
-  val productmodelid: Field[ProductmodelId, Row]
-  val name: Field[Name, Row]
-  val instructions: OptField[String, Row]
-  val LocationID: OptField[Int, Row]
-  val SetupHours: OptField[BigDecimal, Row]
-  val MachineHours: OptField[BigDecimal, Row]
-  val LaborHours: OptField[BigDecimal, Row]
-  val LotSize: OptField[Int, Row]
-  val Step: OptField[/* max 1024 chars */ String, Row]
-  val rowguid: Field[TypoUUID, Row]
-  val modifieddate: Field[TypoLocalDateTime, Row]
+trait VproductmodelinstructionsViewFields {
+  def productmodelid: Field[ProductmodelId, VproductmodelinstructionsViewRow]
+  def name: Field[Name, VproductmodelinstructionsViewRow]
+  def instructions: OptField[String, VproductmodelinstructionsViewRow]
+  def LocationID: OptField[Int, VproductmodelinstructionsViewRow]
+  def SetupHours: OptField[BigDecimal, VproductmodelinstructionsViewRow]
+  def MachineHours: OptField[BigDecimal, VproductmodelinstructionsViewRow]
+  def LaborHours: OptField[BigDecimal, VproductmodelinstructionsViewRow]
+  def LotSize: OptField[Int, VproductmodelinstructionsViewRow]
+  def Step: OptField[/* max 1024 chars */ String, VproductmodelinstructionsViewRow]
+  def rowguid: Field[TypoUUID, VproductmodelinstructionsViewRow]
+  def modifieddate: Field[TypoLocalDateTime, VproductmodelinstructionsViewRow]
 }
 
 object VproductmodelinstructionsViewFields {
-  val structure: Relation[VproductmodelinstructionsViewFields, VproductmodelinstructionsViewRow, VproductmodelinstructionsViewRow] = 
-    new Impl(None, identity, (_, x) => x)
+  lazy val structure: Relation[VproductmodelinstructionsViewFields, VproductmodelinstructionsViewRow] =
+    new Impl(Nil)
     
-  private final class Impl[Row](val prefix: Option[String], val extract: Row => VproductmodelinstructionsViewRow, val merge: (Row, VproductmodelinstructionsViewRow) => Row)
-    extends Relation[VproductmodelinstructionsViewFields, VproductmodelinstructionsViewRow, Row] { 
+  private final class Impl(val _path: List[Path])
+    extends Relation[VproductmodelinstructionsViewFields, VproductmodelinstructionsViewRow] {
   
-    override val fields: VproductmodelinstructionsViewFields[Row] = new VproductmodelinstructionsViewFields[Row] {
-      override val productmodelid = new Field[ProductmodelId, Row](prefix, "productmodelid", None, None)(x => extract(x).productmodelid, (row, value) => merge(row, extract(row).copy(productmodelid = value)))
-      override val name = new Field[Name, Row](prefix, "name", None, None)(x => extract(x).name, (row, value) => merge(row, extract(row).copy(name = value)))
-      override val instructions = new OptField[String, Row](prefix, "instructions", None, None)(x => extract(x).instructions, (row, value) => merge(row, extract(row).copy(instructions = value)))
-      override val LocationID = new OptField[Int, Row](prefix, "LocationID", None, None)(x => extract(x).LocationID, (row, value) => merge(row, extract(row).copy(LocationID = value)))
-      override val SetupHours = new OptField[BigDecimal, Row](prefix, "SetupHours", None, None)(x => extract(x).SetupHours, (row, value) => merge(row, extract(row).copy(SetupHours = value)))
-      override val MachineHours = new OptField[BigDecimal, Row](prefix, "MachineHours", None, None)(x => extract(x).MachineHours, (row, value) => merge(row, extract(row).copy(MachineHours = value)))
-      override val LaborHours = new OptField[BigDecimal, Row](prefix, "LaborHours", None, None)(x => extract(x).LaborHours, (row, value) => merge(row, extract(row).copy(LaborHours = value)))
-      override val LotSize = new OptField[Int, Row](prefix, "LotSize", None, None)(x => extract(x).LotSize, (row, value) => merge(row, extract(row).copy(LotSize = value)))
-      override val Step = new OptField[/* max 1024 chars */ String, Row](prefix, "Step", None, None)(x => extract(x).Step, (row, value) => merge(row, extract(row).copy(Step = value)))
-      override val rowguid = new Field[TypoUUID, Row](prefix, "rowguid", None, None)(x => extract(x).rowguid, (row, value) => merge(row, extract(row).copy(rowguid = value)))
-      override val modifieddate = new Field[TypoLocalDateTime, Row](prefix, "modifieddate", Some("text"), None)(x => extract(x).modifieddate, (row, value) => merge(row, extract(row).copy(modifieddate = value)))
+    override lazy val fields: VproductmodelinstructionsViewFields = new VproductmodelinstructionsViewFields {
+      override def productmodelid = Field[ProductmodelId, VproductmodelinstructionsViewRow](_path, "productmodelid", None, None, x => x.productmodelid, (row, value) => row.copy(productmodelid = value))
+      override def name = Field[Name, VproductmodelinstructionsViewRow](_path, "name", None, None, x => x.name, (row, value) => row.copy(name = value))
+      override def instructions = OptField[String, VproductmodelinstructionsViewRow](_path, "instructions", None, None, x => x.instructions, (row, value) => row.copy(instructions = value))
+      override def LocationID = OptField[Int, VproductmodelinstructionsViewRow](_path, "LocationID", None, None, x => x.LocationID, (row, value) => row.copy(LocationID = value))
+      override def SetupHours = OptField[BigDecimal, VproductmodelinstructionsViewRow](_path, "SetupHours", None, None, x => x.SetupHours, (row, value) => row.copy(SetupHours = value))
+      override def MachineHours = OptField[BigDecimal, VproductmodelinstructionsViewRow](_path, "MachineHours", None, None, x => x.MachineHours, (row, value) => row.copy(MachineHours = value))
+      override def LaborHours = OptField[BigDecimal, VproductmodelinstructionsViewRow](_path, "LaborHours", None, None, x => x.LaborHours, (row, value) => row.copy(LaborHours = value))
+      override def LotSize = OptField[Int, VproductmodelinstructionsViewRow](_path, "LotSize", None, None, x => x.LotSize, (row, value) => row.copy(LotSize = value))
+      override def Step = OptField[/* max 1024 chars */ String, VproductmodelinstructionsViewRow](_path, "Step", None, None, x => x.Step, (row, value) => row.copy(Step = value))
+      override def rowguid = Field[TypoUUID, VproductmodelinstructionsViewRow](_path, "rowguid", None, None, x => x.rowguid, (row, value) => row.copy(rowguid = value))
+      override def modifieddate = Field[TypoLocalDateTime, VproductmodelinstructionsViewRow](_path, "modifieddate", Some("text"), None, x => x.modifieddate, (row, value) => row.copy(modifieddate = value))
     }
   
-    override val columns: List[FieldLikeNoHkt[?, Row]] =
-      List[FieldLikeNoHkt[?, Row]](fields.productmodelid, fields.name, fields.instructions, fields.LocationID, fields.SetupHours, fields.MachineHours, fields.LaborHours, fields.LotSize, fields.Step, fields.rowguid, fields.modifieddate)
+    override lazy val columns: List[FieldLikeNoHkt[?, VproductmodelinstructionsViewRow]] =
+      List[FieldLikeNoHkt[?, VproductmodelinstructionsViewRow]](fields.productmodelid, fields.name, fields.instructions, fields.LocationID, fields.SetupHours, fields.MachineHours, fields.LaborHours, fields.LotSize, fields.Step, fields.rowguid, fields.modifieddate)
   
-    override def copy[NewRow](prefix: Option[String], extract: NewRow => VproductmodelinstructionsViewRow, merge: (NewRow, VproductmodelinstructionsViewRow) => NewRow): Impl[NewRow] =
-      new Impl(prefix, extract, merge)
+    override def copy(path: List[Path]): Impl =
+      new Impl(path)
   }
   
 }

--- a/typo-tester-doobie/generated-and-checked-in/adventureworks/production/workorder/WorkorderFields.scala
+++ b/typo-tester-doobie/generated-and-checked-in/adventureworks/production/workorder/WorkorderFields.scala
@@ -11,48 +11,49 @@ import adventureworks.customtypes.TypoLocalDateTime
 import adventureworks.customtypes.TypoShort
 import adventureworks.production.product.ProductId
 import adventureworks.production.scrapreason.ScrapreasonId
+import typo.dsl.Path
 import typo.dsl.SqlExpr.Field
 import typo.dsl.SqlExpr.FieldLikeNoHkt
 import typo.dsl.SqlExpr.IdField
 import typo.dsl.SqlExpr.OptField
 import typo.dsl.Structure.Relation
 
-trait WorkorderFields[Row] {
-  val workorderid: IdField[WorkorderId, Row]
-  val productid: Field[ProductId, Row]
-  val orderqty: Field[Int, Row]
-  val scrappedqty: Field[TypoShort, Row]
-  val startdate: Field[TypoLocalDateTime, Row]
-  val enddate: OptField[TypoLocalDateTime, Row]
-  val duedate: Field[TypoLocalDateTime, Row]
-  val scrapreasonid: OptField[ScrapreasonId, Row]
-  val modifieddate: Field[TypoLocalDateTime, Row]
+trait WorkorderFields {
+  def workorderid: IdField[WorkorderId, WorkorderRow]
+  def productid: Field[ProductId, WorkorderRow]
+  def orderqty: Field[Int, WorkorderRow]
+  def scrappedqty: Field[TypoShort, WorkorderRow]
+  def startdate: Field[TypoLocalDateTime, WorkorderRow]
+  def enddate: OptField[TypoLocalDateTime, WorkorderRow]
+  def duedate: Field[TypoLocalDateTime, WorkorderRow]
+  def scrapreasonid: OptField[ScrapreasonId, WorkorderRow]
+  def modifieddate: Field[TypoLocalDateTime, WorkorderRow]
 }
 
 object WorkorderFields {
-  val structure: Relation[WorkorderFields, WorkorderRow, WorkorderRow] = 
-    new Impl(None, identity, (_, x) => x)
+  lazy val structure: Relation[WorkorderFields, WorkorderRow] =
+    new Impl(Nil)
     
-  private final class Impl[Row](val prefix: Option[String], val extract: Row => WorkorderRow, val merge: (Row, WorkorderRow) => Row)
-    extends Relation[WorkorderFields, WorkorderRow, Row] { 
+  private final class Impl(val _path: List[Path])
+    extends Relation[WorkorderFields, WorkorderRow] {
   
-    override val fields: WorkorderFields[Row] = new WorkorderFields[Row] {
-      override val workorderid = new IdField[WorkorderId, Row](prefix, "workorderid", None, Some("int4"))(x => extract(x).workorderid, (row, value) => merge(row, extract(row).copy(workorderid = value)))
-      override val productid = new Field[ProductId, Row](prefix, "productid", None, Some("int4"))(x => extract(x).productid, (row, value) => merge(row, extract(row).copy(productid = value)))
-      override val orderqty = new Field[Int, Row](prefix, "orderqty", None, Some("int4"))(x => extract(x).orderqty, (row, value) => merge(row, extract(row).copy(orderqty = value)))
-      override val scrappedqty = new Field[TypoShort, Row](prefix, "scrappedqty", None, Some("int2"))(x => extract(x).scrappedqty, (row, value) => merge(row, extract(row).copy(scrappedqty = value)))
-      override val startdate = new Field[TypoLocalDateTime, Row](prefix, "startdate", Some("text"), Some("timestamp"))(x => extract(x).startdate, (row, value) => merge(row, extract(row).copy(startdate = value)))
-      override val enddate = new OptField[TypoLocalDateTime, Row](prefix, "enddate", Some("text"), Some("timestamp"))(x => extract(x).enddate, (row, value) => merge(row, extract(row).copy(enddate = value)))
-      override val duedate = new Field[TypoLocalDateTime, Row](prefix, "duedate", Some("text"), Some("timestamp"))(x => extract(x).duedate, (row, value) => merge(row, extract(row).copy(duedate = value)))
-      override val scrapreasonid = new OptField[ScrapreasonId, Row](prefix, "scrapreasonid", None, Some("int2"))(x => extract(x).scrapreasonid, (row, value) => merge(row, extract(row).copy(scrapreasonid = value)))
-      override val modifieddate = new Field[TypoLocalDateTime, Row](prefix, "modifieddate", Some("text"), Some("timestamp"))(x => extract(x).modifieddate, (row, value) => merge(row, extract(row).copy(modifieddate = value)))
+    override lazy val fields: WorkorderFields = new WorkorderFields {
+      override def workorderid = IdField[WorkorderId, WorkorderRow](_path, "workorderid", None, Some("int4"), x => x.workorderid, (row, value) => row.copy(workorderid = value))
+      override def productid = Field[ProductId, WorkorderRow](_path, "productid", None, Some("int4"), x => x.productid, (row, value) => row.copy(productid = value))
+      override def orderqty = Field[Int, WorkorderRow](_path, "orderqty", None, Some("int4"), x => x.orderqty, (row, value) => row.copy(orderqty = value))
+      override def scrappedqty = Field[TypoShort, WorkorderRow](_path, "scrappedqty", None, Some("int2"), x => x.scrappedqty, (row, value) => row.copy(scrappedqty = value))
+      override def startdate = Field[TypoLocalDateTime, WorkorderRow](_path, "startdate", Some("text"), Some("timestamp"), x => x.startdate, (row, value) => row.copy(startdate = value))
+      override def enddate = OptField[TypoLocalDateTime, WorkorderRow](_path, "enddate", Some("text"), Some("timestamp"), x => x.enddate, (row, value) => row.copy(enddate = value))
+      override def duedate = Field[TypoLocalDateTime, WorkorderRow](_path, "duedate", Some("text"), Some("timestamp"), x => x.duedate, (row, value) => row.copy(duedate = value))
+      override def scrapreasonid = OptField[ScrapreasonId, WorkorderRow](_path, "scrapreasonid", None, Some("int2"), x => x.scrapreasonid, (row, value) => row.copy(scrapreasonid = value))
+      override def modifieddate = Field[TypoLocalDateTime, WorkorderRow](_path, "modifieddate", Some("text"), Some("timestamp"), x => x.modifieddate, (row, value) => row.copy(modifieddate = value))
     }
   
-    override val columns: List[FieldLikeNoHkt[?, Row]] =
-      List[FieldLikeNoHkt[?, Row]](fields.workorderid, fields.productid, fields.orderqty, fields.scrappedqty, fields.startdate, fields.enddate, fields.duedate, fields.scrapreasonid, fields.modifieddate)
+    override lazy val columns: List[FieldLikeNoHkt[?, WorkorderRow]] =
+      List[FieldLikeNoHkt[?, WorkorderRow]](fields.workorderid, fields.productid, fields.orderqty, fields.scrappedqty, fields.startdate, fields.enddate, fields.duedate, fields.scrapreasonid, fields.modifieddate)
   
-    override def copy[NewRow](prefix: Option[String], extract: NewRow => WorkorderRow, merge: (NewRow, WorkorderRow) => NewRow): Impl[NewRow] =
-      new Impl(prefix, extract, merge)
+    override def copy(path: List[Path]): Impl =
+      new Impl(path)
   }
   
 }

--- a/typo-tester-doobie/generated-and-checked-in/adventureworks/production/workorder/WorkorderRepoMock.scala
+++ b/typo-tester-doobie/generated-and-checked-in/adventureworks/production/workorder/WorkorderRepoMock.scala
@@ -24,7 +24,7 @@ import typo.dsl.UpdateParams
 class WorkorderRepoMock(toRow: Function1[WorkorderRowUnsaved, WorkorderRow],
                         map: scala.collection.mutable.Map[WorkorderId, WorkorderRow] = scala.collection.mutable.Map.empty) extends WorkorderRepo {
   override def delete: DeleteBuilder[WorkorderFields, WorkorderRow] = {
-    DeleteBuilderMock(DeleteParams.empty, WorkorderFields.structure.fields, map)
+    DeleteBuilderMock(DeleteParams.empty, WorkorderFields.structure, map)
   }
   override def deleteById(workorderid: WorkorderId): ConnectionIO[Boolean] = {
     delay(map.remove(workorderid).isDefined)
@@ -86,7 +86,7 @@ class WorkorderRepoMock(toRow: Function1[WorkorderRowUnsaved, WorkorderRow],
     }
   }
   override def update: UpdateBuilder[WorkorderFields, WorkorderRow] = {
-    UpdateBuilderMock(UpdateParams.empty, WorkorderFields.structure.fields, map)
+    UpdateBuilderMock(UpdateParams.empty, WorkorderFields.structure, map)
   }
   override def update(row: WorkorderRow): ConnectionIO[Boolean] = {
     delay {

--- a/typo-tester-doobie/generated-and-checked-in/adventureworks/production/workorderrouting/WorkorderroutingFields.scala
+++ b/typo-tester-doobie/generated-and-checked-in/adventureworks/production/workorderrouting/WorkorderroutingFields.scala
@@ -11,54 +11,55 @@ import adventureworks.customtypes.TypoLocalDateTime
 import adventureworks.customtypes.TypoShort
 import adventureworks.production.location.LocationId
 import adventureworks.production.workorder.WorkorderId
+import typo.dsl.Path
 import typo.dsl.SqlExpr.Field
 import typo.dsl.SqlExpr.FieldLikeNoHkt
 import typo.dsl.SqlExpr.IdField
 import typo.dsl.SqlExpr.OptField
 import typo.dsl.Structure.Relation
 
-trait WorkorderroutingFields[Row] {
-  val workorderid: IdField[WorkorderId, Row]
-  val productid: IdField[Int, Row]
-  val operationsequence: IdField[TypoShort, Row]
-  val locationid: Field[LocationId, Row]
-  val scheduledstartdate: Field[TypoLocalDateTime, Row]
-  val scheduledenddate: Field[TypoLocalDateTime, Row]
-  val actualstartdate: OptField[TypoLocalDateTime, Row]
-  val actualenddate: OptField[TypoLocalDateTime, Row]
-  val actualresourcehrs: OptField[BigDecimal, Row]
-  val plannedcost: Field[BigDecimal, Row]
-  val actualcost: OptField[BigDecimal, Row]
-  val modifieddate: Field[TypoLocalDateTime, Row]
+trait WorkorderroutingFields {
+  def workorderid: IdField[WorkorderId, WorkorderroutingRow]
+  def productid: IdField[Int, WorkorderroutingRow]
+  def operationsequence: IdField[TypoShort, WorkorderroutingRow]
+  def locationid: Field[LocationId, WorkorderroutingRow]
+  def scheduledstartdate: Field[TypoLocalDateTime, WorkorderroutingRow]
+  def scheduledenddate: Field[TypoLocalDateTime, WorkorderroutingRow]
+  def actualstartdate: OptField[TypoLocalDateTime, WorkorderroutingRow]
+  def actualenddate: OptField[TypoLocalDateTime, WorkorderroutingRow]
+  def actualresourcehrs: OptField[BigDecimal, WorkorderroutingRow]
+  def plannedcost: Field[BigDecimal, WorkorderroutingRow]
+  def actualcost: OptField[BigDecimal, WorkorderroutingRow]
+  def modifieddate: Field[TypoLocalDateTime, WorkorderroutingRow]
 }
 
 object WorkorderroutingFields {
-  val structure: Relation[WorkorderroutingFields, WorkorderroutingRow, WorkorderroutingRow] = 
-    new Impl(None, identity, (_, x) => x)
+  lazy val structure: Relation[WorkorderroutingFields, WorkorderroutingRow] =
+    new Impl(Nil)
     
-  private final class Impl[Row](val prefix: Option[String], val extract: Row => WorkorderroutingRow, val merge: (Row, WorkorderroutingRow) => Row)
-    extends Relation[WorkorderroutingFields, WorkorderroutingRow, Row] { 
+  private final class Impl(val _path: List[Path])
+    extends Relation[WorkorderroutingFields, WorkorderroutingRow] {
   
-    override val fields: WorkorderroutingFields[Row] = new WorkorderroutingFields[Row] {
-      override val workorderid = new IdField[WorkorderId, Row](prefix, "workorderid", None, Some("int4"))(x => extract(x).workorderid, (row, value) => merge(row, extract(row).copy(workorderid = value)))
-      override val productid = new IdField[Int, Row](prefix, "productid", None, Some("int4"))(x => extract(x).productid, (row, value) => merge(row, extract(row).copy(productid = value)))
-      override val operationsequence = new IdField[TypoShort, Row](prefix, "operationsequence", None, Some("int2"))(x => extract(x).operationsequence, (row, value) => merge(row, extract(row).copy(operationsequence = value)))
-      override val locationid = new Field[LocationId, Row](prefix, "locationid", None, Some("int2"))(x => extract(x).locationid, (row, value) => merge(row, extract(row).copy(locationid = value)))
-      override val scheduledstartdate = new Field[TypoLocalDateTime, Row](prefix, "scheduledstartdate", Some("text"), Some("timestamp"))(x => extract(x).scheduledstartdate, (row, value) => merge(row, extract(row).copy(scheduledstartdate = value)))
-      override val scheduledenddate = new Field[TypoLocalDateTime, Row](prefix, "scheduledenddate", Some("text"), Some("timestamp"))(x => extract(x).scheduledenddate, (row, value) => merge(row, extract(row).copy(scheduledenddate = value)))
-      override val actualstartdate = new OptField[TypoLocalDateTime, Row](prefix, "actualstartdate", Some("text"), Some("timestamp"))(x => extract(x).actualstartdate, (row, value) => merge(row, extract(row).copy(actualstartdate = value)))
-      override val actualenddate = new OptField[TypoLocalDateTime, Row](prefix, "actualenddate", Some("text"), Some("timestamp"))(x => extract(x).actualenddate, (row, value) => merge(row, extract(row).copy(actualenddate = value)))
-      override val actualresourcehrs = new OptField[BigDecimal, Row](prefix, "actualresourcehrs", None, Some("numeric"))(x => extract(x).actualresourcehrs, (row, value) => merge(row, extract(row).copy(actualresourcehrs = value)))
-      override val plannedcost = new Field[BigDecimal, Row](prefix, "plannedcost", None, Some("numeric"))(x => extract(x).plannedcost, (row, value) => merge(row, extract(row).copy(plannedcost = value)))
-      override val actualcost = new OptField[BigDecimal, Row](prefix, "actualcost", None, Some("numeric"))(x => extract(x).actualcost, (row, value) => merge(row, extract(row).copy(actualcost = value)))
-      override val modifieddate = new Field[TypoLocalDateTime, Row](prefix, "modifieddate", Some("text"), Some("timestamp"))(x => extract(x).modifieddate, (row, value) => merge(row, extract(row).copy(modifieddate = value)))
+    override lazy val fields: WorkorderroutingFields = new WorkorderroutingFields {
+      override def workorderid = IdField[WorkorderId, WorkorderroutingRow](_path, "workorderid", None, Some("int4"), x => x.workorderid, (row, value) => row.copy(workorderid = value))
+      override def productid = IdField[Int, WorkorderroutingRow](_path, "productid", None, Some("int4"), x => x.productid, (row, value) => row.copy(productid = value))
+      override def operationsequence = IdField[TypoShort, WorkorderroutingRow](_path, "operationsequence", None, Some("int2"), x => x.operationsequence, (row, value) => row.copy(operationsequence = value))
+      override def locationid = Field[LocationId, WorkorderroutingRow](_path, "locationid", None, Some("int2"), x => x.locationid, (row, value) => row.copy(locationid = value))
+      override def scheduledstartdate = Field[TypoLocalDateTime, WorkorderroutingRow](_path, "scheduledstartdate", Some("text"), Some("timestamp"), x => x.scheduledstartdate, (row, value) => row.copy(scheduledstartdate = value))
+      override def scheduledenddate = Field[TypoLocalDateTime, WorkorderroutingRow](_path, "scheduledenddate", Some("text"), Some("timestamp"), x => x.scheduledenddate, (row, value) => row.copy(scheduledenddate = value))
+      override def actualstartdate = OptField[TypoLocalDateTime, WorkorderroutingRow](_path, "actualstartdate", Some("text"), Some("timestamp"), x => x.actualstartdate, (row, value) => row.copy(actualstartdate = value))
+      override def actualenddate = OptField[TypoLocalDateTime, WorkorderroutingRow](_path, "actualenddate", Some("text"), Some("timestamp"), x => x.actualenddate, (row, value) => row.copy(actualenddate = value))
+      override def actualresourcehrs = OptField[BigDecimal, WorkorderroutingRow](_path, "actualresourcehrs", None, Some("numeric"), x => x.actualresourcehrs, (row, value) => row.copy(actualresourcehrs = value))
+      override def plannedcost = Field[BigDecimal, WorkorderroutingRow](_path, "plannedcost", None, Some("numeric"), x => x.plannedcost, (row, value) => row.copy(plannedcost = value))
+      override def actualcost = OptField[BigDecimal, WorkorderroutingRow](_path, "actualcost", None, Some("numeric"), x => x.actualcost, (row, value) => row.copy(actualcost = value))
+      override def modifieddate = Field[TypoLocalDateTime, WorkorderroutingRow](_path, "modifieddate", Some("text"), Some("timestamp"), x => x.modifieddate, (row, value) => row.copy(modifieddate = value))
     }
   
-    override val columns: List[FieldLikeNoHkt[?, Row]] =
-      List[FieldLikeNoHkt[?, Row]](fields.workorderid, fields.productid, fields.operationsequence, fields.locationid, fields.scheduledstartdate, fields.scheduledenddate, fields.actualstartdate, fields.actualenddate, fields.actualresourcehrs, fields.plannedcost, fields.actualcost, fields.modifieddate)
+    override lazy val columns: List[FieldLikeNoHkt[?, WorkorderroutingRow]] =
+      List[FieldLikeNoHkt[?, WorkorderroutingRow]](fields.workorderid, fields.productid, fields.operationsequence, fields.locationid, fields.scheduledstartdate, fields.scheduledenddate, fields.actualstartdate, fields.actualenddate, fields.actualresourcehrs, fields.plannedcost, fields.actualcost, fields.modifieddate)
   
-    override def copy[NewRow](prefix: Option[String], extract: NewRow => WorkorderroutingRow, merge: (NewRow, WorkorderroutingRow) => NewRow): Impl[NewRow] =
-      new Impl(prefix, extract, merge)
+    override def copy(path: List[Path]): Impl =
+      new Impl(path)
   }
   
 }

--- a/typo-tester-doobie/generated-and-checked-in/adventureworks/production/workorderrouting/WorkorderroutingRepoMock.scala
+++ b/typo-tester-doobie/generated-and-checked-in/adventureworks/production/workorderrouting/WorkorderroutingRepoMock.scala
@@ -24,7 +24,7 @@ import typo.dsl.UpdateParams
 class WorkorderroutingRepoMock(toRow: Function1[WorkorderroutingRowUnsaved, WorkorderroutingRow],
                                map: scala.collection.mutable.Map[WorkorderroutingId, WorkorderroutingRow] = scala.collection.mutable.Map.empty) extends WorkorderroutingRepo {
   override def delete: DeleteBuilder[WorkorderroutingFields, WorkorderroutingRow] = {
-    DeleteBuilderMock(DeleteParams.empty, WorkorderroutingFields.structure.fields, map)
+    DeleteBuilderMock(DeleteParams.empty, WorkorderroutingFields.structure, map)
   }
   override def deleteById(compositeId: WorkorderroutingId): ConnectionIO[Boolean] = {
     delay(map.remove(compositeId).isDefined)
@@ -86,7 +86,7 @@ class WorkorderroutingRepoMock(toRow: Function1[WorkorderroutingRowUnsaved, Work
     }
   }
   override def update: UpdateBuilder[WorkorderroutingFields, WorkorderroutingRow] = {
-    UpdateBuilderMock(UpdateParams.empty, WorkorderroutingFields.structure.fields, map)
+    UpdateBuilderMock(UpdateParams.empty, WorkorderroutingFields.structure, map)
   }
   override def update(row: WorkorderroutingRow): ConnectionIO[Boolean] = {
     delay {

--- a/typo-tester-doobie/generated-and-checked-in/adventureworks/pu/pod/PodViewFields.scala
+++ b/typo-tester-doobie/generated-and-checked-in/adventureworks/pu/pod/PodViewFields.scala
@@ -11,48 +11,49 @@ import adventureworks.customtypes.TypoLocalDateTime
 import adventureworks.customtypes.TypoShort
 import adventureworks.production.product.ProductId
 import adventureworks.purchasing.purchaseorderheader.PurchaseorderheaderId
+import typo.dsl.Path
 import typo.dsl.SqlExpr.Field
 import typo.dsl.SqlExpr.FieldLikeNoHkt
 import typo.dsl.Structure.Relation
 
-trait PodViewFields[Row] {
-  val id: Field[Int, Row]
-  val purchaseorderid: Field[PurchaseorderheaderId, Row]
-  val purchaseorderdetailid: Field[Int, Row]
-  val duedate: Field[TypoLocalDateTime, Row]
-  val orderqty: Field[TypoShort, Row]
-  val productid: Field[ProductId, Row]
-  val unitprice: Field[BigDecimal, Row]
-  val receivedqty: Field[BigDecimal, Row]
-  val rejectedqty: Field[BigDecimal, Row]
-  val modifieddate: Field[TypoLocalDateTime, Row]
+trait PodViewFields {
+  def id: Field[Int, PodViewRow]
+  def purchaseorderid: Field[PurchaseorderheaderId, PodViewRow]
+  def purchaseorderdetailid: Field[Int, PodViewRow]
+  def duedate: Field[TypoLocalDateTime, PodViewRow]
+  def orderqty: Field[TypoShort, PodViewRow]
+  def productid: Field[ProductId, PodViewRow]
+  def unitprice: Field[BigDecimal, PodViewRow]
+  def receivedqty: Field[BigDecimal, PodViewRow]
+  def rejectedqty: Field[BigDecimal, PodViewRow]
+  def modifieddate: Field[TypoLocalDateTime, PodViewRow]
 }
 
 object PodViewFields {
-  val structure: Relation[PodViewFields, PodViewRow, PodViewRow] = 
-    new Impl(None, identity, (_, x) => x)
+  lazy val structure: Relation[PodViewFields, PodViewRow] =
+    new Impl(Nil)
     
-  private final class Impl[Row](val prefix: Option[String], val extract: Row => PodViewRow, val merge: (Row, PodViewRow) => Row)
-    extends Relation[PodViewFields, PodViewRow, Row] { 
+  private final class Impl(val _path: List[Path])
+    extends Relation[PodViewFields, PodViewRow] {
   
-    override val fields: PodViewFields[Row] = new PodViewFields[Row] {
-      override val id = new Field[Int, Row](prefix, "id", None, None)(x => extract(x).id, (row, value) => merge(row, extract(row).copy(id = value)))
-      override val purchaseorderid = new Field[PurchaseorderheaderId, Row](prefix, "purchaseorderid", None, None)(x => extract(x).purchaseorderid, (row, value) => merge(row, extract(row).copy(purchaseorderid = value)))
-      override val purchaseorderdetailid = new Field[Int, Row](prefix, "purchaseorderdetailid", None, None)(x => extract(x).purchaseorderdetailid, (row, value) => merge(row, extract(row).copy(purchaseorderdetailid = value)))
-      override val duedate = new Field[TypoLocalDateTime, Row](prefix, "duedate", Some("text"), None)(x => extract(x).duedate, (row, value) => merge(row, extract(row).copy(duedate = value)))
-      override val orderqty = new Field[TypoShort, Row](prefix, "orderqty", None, None)(x => extract(x).orderqty, (row, value) => merge(row, extract(row).copy(orderqty = value)))
-      override val productid = new Field[ProductId, Row](prefix, "productid", None, None)(x => extract(x).productid, (row, value) => merge(row, extract(row).copy(productid = value)))
-      override val unitprice = new Field[BigDecimal, Row](prefix, "unitprice", None, None)(x => extract(x).unitprice, (row, value) => merge(row, extract(row).copy(unitprice = value)))
-      override val receivedqty = new Field[BigDecimal, Row](prefix, "receivedqty", None, None)(x => extract(x).receivedqty, (row, value) => merge(row, extract(row).copy(receivedqty = value)))
-      override val rejectedqty = new Field[BigDecimal, Row](prefix, "rejectedqty", None, None)(x => extract(x).rejectedqty, (row, value) => merge(row, extract(row).copy(rejectedqty = value)))
-      override val modifieddate = new Field[TypoLocalDateTime, Row](prefix, "modifieddate", Some("text"), None)(x => extract(x).modifieddate, (row, value) => merge(row, extract(row).copy(modifieddate = value)))
+    override lazy val fields: PodViewFields = new PodViewFields {
+      override def id = Field[Int, PodViewRow](_path, "id", None, None, x => x.id, (row, value) => row.copy(id = value))
+      override def purchaseorderid = Field[PurchaseorderheaderId, PodViewRow](_path, "purchaseorderid", None, None, x => x.purchaseorderid, (row, value) => row.copy(purchaseorderid = value))
+      override def purchaseorderdetailid = Field[Int, PodViewRow](_path, "purchaseorderdetailid", None, None, x => x.purchaseorderdetailid, (row, value) => row.copy(purchaseorderdetailid = value))
+      override def duedate = Field[TypoLocalDateTime, PodViewRow](_path, "duedate", Some("text"), None, x => x.duedate, (row, value) => row.copy(duedate = value))
+      override def orderqty = Field[TypoShort, PodViewRow](_path, "orderqty", None, None, x => x.orderqty, (row, value) => row.copy(orderqty = value))
+      override def productid = Field[ProductId, PodViewRow](_path, "productid", None, None, x => x.productid, (row, value) => row.copy(productid = value))
+      override def unitprice = Field[BigDecimal, PodViewRow](_path, "unitprice", None, None, x => x.unitprice, (row, value) => row.copy(unitprice = value))
+      override def receivedqty = Field[BigDecimal, PodViewRow](_path, "receivedqty", None, None, x => x.receivedqty, (row, value) => row.copy(receivedqty = value))
+      override def rejectedqty = Field[BigDecimal, PodViewRow](_path, "rejectedqty", None, None, x => x.rejectedqty, (row, value) => row.copy(rejectedqty = value))
+      override def modifieddate = Field[TypoLocalDateTime, PodViewRow](_path, "modifieddate", Some("text"), None, x => x.modifieddate, (row, value) => row.copy(modifieddate = value))
     }
   
-    override val columns: List[FieldLikeNoHkt[?, Row]] =
-      List[FieldLikeNoHkt[?, Row]](fields.id, fields.purchaseorderid, fields.purchaseorderdetailid, fields.duedate, fields.orderqty, fields.productid, fields.unitprice, fields.receivedqty, fields.rejectedqty, fields.modifieddate)
+    override lazy val columns: List[FieldLikeNoHkt[?, PodViewRow]] =
+      List[FieldLikeNoHkt[?, PodViewRow]](fields.id, fields.purchaseorderid, fields.purchaseorderdetailid, fields.duedate, fields.orderqty, fields.productid, fields.unitprice, fields.receivedqty, fields.rejectedqty, fields.modifieddate)
   
-    override def copy[NewRow](prefix: Option[String], extract: NewRow => PodViewRow, merge: (NewRow, PodViewRow) => NewRow): Impl[NewRow] =
-      new Impl(prefix, extract, merge)
+    override def copy(path: List[Path]): Impl =
+      new Impl(path)
   }
   
 }

--- a/typo-tester-doobie/generated-and-checked-in/adventureworks/pu/poh/PohViewFields.scala
+++ b/typo-tester-doobie/generated-and-checked-in/adventureworks/pu/poh/PohViewFields.scala
@@ -12,55 +12,56 @@ import adventureworks.customtypes.TypoShort
 import adventureworks.person.businessentity.BusinessentityId
 import adventureworks.purchasing.purchaseorderheader.PurchaseorderheaderId
 import adventureworks.purchasing.shipmethod.ShipmethodId
+import typo.dsl.Path
 import typo.dsl.SqlExpr.Field
 import typo.dsl.SqlExpr.FieldLikeNoHkt
 import typo.dsl.SqlExpr.OptField
 import typo.dsl.Structure.Relation
 
-trait PohViewFields[Row] {
-  val id: Field[PurchaseorderheaderId, Row]
-  val purchaseorderid: Field[PurchaseorderheaderId, Row]
-  val revisionnumber: Field[TypoShort, Row]
-  val status: Field[TypoShort, Row]
-  val employeeid: Field[BusinessentityId, Row]
-  val vendorid: Field[BusinessentityId, Row]
-  val shipmethodid: Field[ShipmethodId, Row]
-  val orderdate: Field[TypoLocalDateTime, Row]
-  val shipdate: OptField[TypoLocalDateTime, Row]
-  val subtotal: Field[BigDecimal, Row]
-  val taxamt: Field[BigDecimal, Row]
-  val freight: Field[BigDecimal, Row]
-  val modifieddate: Field[TypoLocalDateTime, Row]
+trait PohViewFields {
+  def id: Field[PurchaseorderheaderId, PohViewRow]
+  def purchaseorderid: Field[PurchaseorderheaderId, PohViewRow]
+  def revisionnumber: Field[TypoShort, PohViewRow]
+  def status: Field[TypoShort, PohViewRow]
+  def employeeid: Field[BusinessentityId, PohViewRow]
+  def vendorid: Field[BusinessentityId, PohViewRow]
+  def shipmethodid: Field[ShipmethodId, PohViewRow]
+  def orderdate: Field[TypoLocalDateTime, PohViewRow]
+  def shipdate: OptField[TypoLocalDateTime, PohViewRow]
+  def subtotal: Field[BigDecimal, PohViewRow]
+  def taxamt: Field[BigDecimal, PohViewRow]
+  def freight: Field[BigDecimal, PohViewRow]
+  def modifieddate: Field[TypoLocalDateTime, PohViewRow]
 }
 
 object PohViewFields {
-  val structure: Relation[PohViewFields, PohViewRow, PohViewRow] = 
-    new Impl(None, identity, (_, x) => x)
+  lazy val structure: Relation[PohViewFields, PohViewRow] =
+    new Impl(Nil)
     
-  private final class Impl[Row](val prefix: Option[String], val extract: Row => PohViewRow, val merge: (Row, PohViewRow) => Row)
-    extends Relation[PohViewFields, PohViewRow, Row] { 
+  private final class Impl(val _path: List[Path])
+    extends Relation[PohViewFields, PohViewRow] {
   
-    override val fields: PohViewFields[Row] = new PohViewFields[Row] {
-      override val id = new Field[PurchaseorderheaderId, Row](prefix, "id", None, None)(x => extract(x).id, (row, value) => merge(row, extract(row).copy(id = value)))
-      override val purchaseorderid = new Field[PurchaseorderheaderId, Row](prefix, "purchaseorderid", None, None)(x => extract(x).purchaseorderid, (row, value) => merge(row, extract(row).copy(purchaseorderid = value)))
-      override val revisionnumber = new Field[TypoShort, Row](prefix, "revisionnumber", None, None)(x => extract(x).revisionnumber, (row, value) => merge(row, extract(row).copy(revisionnumber = value)))
-      override val status = new Field[TypoShort, Row](prefix, "status", None, None)(x => extract(x).status, (row, value) => merge(row, extract(row).copy(status = value)))
-      override val employeeid = new Field[BusinessentityId, Row](prefix, "employeeid", None, None)(x => extract(x).employeeid, (row, value) => merge(row, extract(row).copy(employeeid = value)))
-      override val vendorid = new Field[BusinessentityId, Row](prefix, "vendorid", None, None)(x => extract(x).vendorid, (row, value) => merge(row, extract(row).copy(vendorid = value)))
-      override val shipmethodid = new Field[ShipmethodId, Row](prefix, "shipmethodid", None, None)(x => extract(x).shipmethodid, (row, value) => merge(row, extract(row).copy(shipmethodid = value)))
-      override val orderdate = new Field[TypoLocalDateTime, Row](prefix, "orderdate", Some("text"), None)(x => extract(x).orderdate, (row, value) => merge(row, extract(row).copy(orderdate = value)))
-      override val shipdate = new OptField[TypoLocalDateTime, Row](prefix, "shipdate", Some("text"), None)(x => extract(x).shipdate, (row, value) => merge(row, extract(row).copy(shipdate = value)))
-      override val subtotal = new Field[BigDecimal, Row](prefix, "subtotal", None, None)(x => extract(x).subtotal, (row, value) => merge(row, extract(row).copy(subtotal = value)))
-      override val taxamt = new Field[BigDecimal, Row](prefix, "taxamt", None, None)(x => extract(x).taxamt, (row, value) => merge(row, extract(row).copy(taxamt = value)))
-      override val freight = new Field[BigDecimal, Row](prefix, "freight", None, None)(x => extract(x).freight, (row, value) => merge(row, extract(row).copy(freight = value)))
-      override val modifieddate = new Field[TypoLocalDateTime, Row](prefix, "modifieddate", Some("text"), None)(x => extract(x).modifieddate, (row, value) => merge(row, extract(row).copy(modifieddate = value)))
+    override lazy val fields: PohViewFields = new PohViewFields {
+      override def id = Field[PurchaseorderheaderId, PohViewRow](_path, "id", None, None, x => x.id, (row, value) => row.copy(id = value))
+      override def purchaseorderid = Field[PurchaseorderheaderId, PohViewRow](_path, "purchaseorderid", None, None, x => x.purchaseorderid, (row, value) => row.copy(purchaseorderid = value))
+      override def revisionnumber = Field[TypoShort, PohViewRow](_path, "revisionnumber", None, None, x => x.revisionnumber, (row, value) => row.copy(revisionnumber = value))
+      override def status = Field[TypoShort, PohViewRow](_path, "status", None, None, x => x.status, (row, value) => row.copy(status = value))
+      override def employeeid = Field[BusinessentityId, PohViewRow](_path, "employeeid", None, None, x => x.employeeid, (row, value) => row.copy(employeeid = value))
+      override def vendorid = Field[BusinessentityId, PohViewRow](_path, "vendorid", None, None, x => x.vendorid, (row, value) => row.copy(vendorid = value))
+      override def shipmethodid = Field[ShipmethodId, PohViewRow](_path, "shipmethodid", None, None, x => x.shipmethodid, (row, value) => row.copy(shipmethodid = value))
+      override def orderdate = Field[TypoLocalDateTime, PohViewRow](_path, "orderdate", Some("text"), None, x => x.orderdate, (row, value) => row.copy(orderdate = value))
+      override def shipdate = OptField[TypoLocalDateTime, PohViewRow](_path, "shipdate", Some("text"), None, x => x.shipdate, (row, value) => row.copy(shipdate = value))
+      override def subtotal = Field[BigDecimal, PohViewRow](_path, "subtotal", None, None, x => x.subtotal, (row, value) => row.copy(subtotal = value))
+      override def taxamt = Field[BigDecimal, PohViewRow](_path, "taxamt", None, None, x => x.taxamt, (row, value) => row.copy(taxamt = value))
+      override def freight = Field[BigDecimal, PohViewRow](_path, "freight", None, None, x => x.freight, (row, value) => row.copy(freight = value))
+      override def modifieddate = Field[TypoLocalDateTime, PohViewRow](_path, "modifieddate", Some("text"), None, x => x.modifieddate, (row, value) => row.copy(modifieddate = value))
     }
   
-    override val columns: List[FieldLikeNoHkt[?, Row]] =
-      List[FieldLikeNoHkt[?, Row]](fields.id, fields.purchaseorderid, fields.revisionnumber, fields.status, fields.employeeid, fields.vendorid, fields.shipmethodid, fields.orderdate, fields.shipdate, fields.subtotal, fields.taxamt, fields.freight, fields.modifieddate)
+    override lazy val columns: List[FieldLikeNoHkt[?, PohViewRow]] =
+      List[FieldLikeNoHkt[?, PohViewRow]](fields.id, fields.purchaseorderid, fields.revisionnumber, fields.status, fields.employeeid, fields.vendorid, fields.shipmethodid, fields.orderdate, fields.shipdate, fields.subtotal, fields.taxamt, fields.freight, fields.modifieddate)
   
-    override def copy[NewRow](prefix: Option[String], extract: NewRow => PohViewRow, merge: (NewRow, PohViewRow) => NewRow): Impl[NewRow] =
-      new Impl(prefix, extract, merge)
+    override def copy(path: List[Path]): Impl =
+      new Impl(path)
   }
   
 }

--- a/typo-tester-doobie/generated-and-checked-in/adventureworks/pu/pv/PvViewFields.scala
+++ b/typo-tester-doobie/generated-and-checked-in/adventureworks/pu/pv/PvViewFields.scala
@@ -11,53 +11,54 @@ import adventureworks.customtypes.TypoLocalDateTime
 import adventureworks.person.businessentity.BusinessentityId
 import adventureworks.production.product.ProductId
 import adventureworks.production.unitmeasure.UnitmeasureId
+import typo.dsl.Path
 import typo.dsl.SqlExpr.Field
 import typo.dsl.SqlExpr.FieldLikeNoHkt
 import typo.dsl.SqlExpr.OptField
 import typo.dsl.Structure.Relation
 
-trait PvViewFields[Row] {
-  val id: Field[ProductId, Row]
-  val productid: Field[ProductId, Row]
-  val businessentityid: Field[BusinessentityId, Row]
-  val averageleadtime: Field[Int, Row]
-  val standardprice: Field[BigDecimal, Row]
-  val lastreceiptcost: OptField[BigDecimal, Row]
-  val lastreceiptdate: OptField[TypoLocalDateTime, Row]
-  val minorderqty: Field[Int, Row]
-  val maxorderqty: Field[Int, Row]
-  val onorderqty: OptField[Int, Row]
-  val unitmeasurecode: Field[UnitmeasureId, Row]
-  val modifieddate: Field[TypoLocalDateTime, Row]
+trait PvViewFields {
+  def id: Field[ProductId, PvViewRow]
+  def productid: Field[ProductId, PvViewRow]
+  def businessentityid: Field[BusinessentityId, PvViewRow]
+  def averageleadtime: Field[Int, PvViewRow]
+  def standardprice: Field[BigDecimal, PvViewRow]
+  def lastreceiptcost: OptField[BigDecimal, PvViewRow]
+  def lastreceiptdate: OptField[TypoLocalDateTime, PvViewRow]
+  def minorderqty: Field[Int, PvViewRow]
+  def maxorderqty: Field[Int, PvViewRow]
+  def onorderqty: OptField[Int, PvViewRow]
+  def unitmeasurecode: Field[UnitmeasureId, PvViewRow]
+  def modifieddate: Field[TypoLocalDateTime, PvViewRow]
 }
 
 object PvViewFields {
-  val structure: Relation[PvViewFields, PvViewRow, PvViewRow] = 
-    new Impl(None, identity, (_, x) => x)
+  lazy val structure: Relation[PvViewFields, PvViewRow] =
+    new Impl(Nil)
     
-  private final class Impl[Row](val prefix: Option[String], val extract: Row => PvViewRow, val merge: (Row, PvViewRow) => Row)
-    extends Relation[PvViewFields, PvViewRow, Row] { 
+  private final class Impl(val _path: List[Path])
+    extends Relation[PvViewFields, PvViewRow] {
   
-    override val fields: PvViewFields[Row] = new PvViewFields[Row] {
-      override val id = new Field[ProductId, Row](prefix, "id", None, None)(x => extract(x).id, (row, value) => merge(row, extract(row).copy(id = value)))
-      override val productid = new Field[ProductId, Row](prefix, "productid", None, None)(x => extract(x).productid, (row, value) => merge(row, extract(row).copy(productid = value)))
-      override val businessentityid = new Field[BusinessentityId, Row](prefix, "businessentityid", None, None)(x => extract(x).businessentityid, (row, value) => merge(row, extract(row).copy(businessentityid = value)))
-      override val averageleadtime = new Field[Int, Row](prefix, "averageleadtime", None, None)(x => extract(x).averageleadtime, (row, value) => merge(row, extract(row).copy(averageleadtime = value)))
-      override val standardprice = new Field[BigDecimal, Row](prefix, "standardprice", None, None)(x => extract(x).standardprice, (row, value) => merge(row, extract(row).copy(standardprice = value)))
-      override val lastreceiptcost = new OptField[BigDecimal, Row](prefix, "lastreceiptcost", None, None)(x => extract(x).lastreceiptcost, (row, value) => merge(row, extract(row).copy(lastreceiptcost = value)))
-      override val lastreceiptdate = new OptField[TypoLocalDateTime, Row](prefix, "lastreceiptdate", Some("text"), None)(x => extract(x).lastreceiptdate, (row, value) => merge(row, extract(row).copy(lastreceiptdate = value)))
-      override val minorderqty = new Field[Int, Row](prefix, "minorderqty", None, None)(x => extract(x).minorderqty, (row, value) => merge(row, extract(row).copy(minorderqty = value)))
-      override val maxorderqty = new Field[Int, Row](prefix, "maxorderqty", None, None)(x => extract(x).maxorderqty, (row, value) => merge(row, extract(row).copy(maxorderqty = value)))
-      override val onorderqty = new OptField[Int, Row](prefix, "onorderqty", None, None)(x => extract(x).onorderqty, (row, value) => merge(row, extract(row).copy(onorderqty = value)))
-      override val unitmeasurecode = new Field[UnitmeasureId, Row](prefix, "unitmeasurecode", None, None)(x => extract(x).unitmeasurecode, (row, value) => merge(row, extract(row).copy(unitmeasurecode = value)))
-      override val modifieddate = new Field[TypoLocalDateTime, Row](prefix, "modifieddate", Some("text"), None)(x => extract(x).modifieddate, (row, value) => merge(row, extract(row).copy(modifieddate = value)))
+    override lazy val fields: PvViewFields = new PvViewFields {
+      override def id = Field[ProductId, PvViewRow](_path, "id", None, None, x => x.id, (row, value) => row.copy(id = value))
+      override def productid = Field[ProductId, PvViewRow](_path, "productid", None, None, x => x.productid, (row, value) => row.copy(productid = value))
+      override def businessentityid = Field[BusinessentityId, PvViewRow](_path, "businessentityid", None, None, x => x.businessentityid, (row, value) => row.copy(businessentityid = value))
+      override def averageleadtime = Field[Int, PvViewRow](_path, "averageleadtime", None, None, x => x.averageleadtime, (row, value) => row.copy(averageleadtime = value))
+      override def standardprice = Field[BigDecimal, PvViewRow](_path, "standardprice", None, None, x => x.standardprice, (row, value) => row.copy(standardprice = value))
+      override def lastreceiptcost = OptField[BigDecimal, PvViewRow](_path, "lastreceiptcost", None, None, x => x.lastreceiptcost, (row, value) => row.copy(lastreceiptcost = value))
+      override def lastreceiptdate = OptField[TypoLocalDateTime, PvViewRow](_path, "lastreceiptdate", Some("text"), None, x => x.lastreceiptdate, (row, value) => row.copy(lastreceiptdate = value))
+      override def minorderqty = Field[Int, PvViewRow](_path, "minorderqty", None, None, x => x.minorderqty, (row, value) => row.copy(minorderqty = value))
+      override def maxorderqty = Field[Int, PvViewRow](_path, "maxorderqty", None, None, x => x.maxorderqty, (row, value) => row.copy(maxorderqty = value))
+      override def onorderqty = OptField[Int, PvViewRow](_path, "onorderqty", None, None, x => x.onorderqty, (row, value) => row.copy(onorderqty = value))
+      override def unitmeasurecode = Field[UnitmeasureId, PvViewRow](_path, "unitmeasurecode", None, None, x => x.unitmeasurecode, (row, value) => row.copy(unitmeasurecode = value))
+      override def modifieddate = Field[TypoLocalDateTime, PvViewRow](_path, "modifieddate", Some("text"), None, x => x.modifieddate, (row, value) => row.copy(modifieddate = value))
     }
   
-    override val columns: List[FieldLikeNoHkt[?, Row]] =
-      List[FieldLikeNoHkt[?, Row]](fields.id, fields.productid, fields.businessentityid, fields.averageleadtime, fields.standardprice, fields.lastreceiptcost, fields.lastreceiptdate, fields.minorderqty, fields.maxorderqty, fields.onorderqty, fields.unitmeasurecode, fields.modifieddate)
+    override lazy val columns: List[FieldLikeNoHkt[?, PvViewRow]] =
+      List[FieldLikeNoHkt[?, PvViewRow]](fields.id, fields.productid, fields.businessentityid, fields.averageleadtime, fields.standardprice, fields.lastreceiptcost, fields.lastreceiptdate, fields.minorderqty, fields.maxorderqty, fields.onorderqty, fields.unitmeasurecode, fields.modifieddate)
   
-    override def copy[NewRow](prefix: Option[String], extract: NewRow => PvViewRow, merge: (NewRow, PvViewRow) => NewRow): Impl[NewRow] =
-      new Impl(prefix, extract, merge)
+    override def copy(path: List[Path]): Impl =
+      new Impl(path)
   }
   
 }

--- a/typo-tester-doobie/generated-and-checked-in/adventureworks/pu/sm/SmViewFields.scala
+++ b/typo-tester-doobie/generated-and-checked-in/adventureworks/pu/sm/SmViewFields.scala
@@ -11,42 +11,43 @@ import adventureworks.customtypes.TypoLocalDateTime
 import adventureworks.customtypes.TypoUUID
 import adventureworks.public.Name
 import adventureworks.purchasing.shipmethod.ShipmethodId
+import typo.dsl.Path
 import typo.dsl.SqlExpr.Field
 import typo.dsl.SqlExpr.FieldLikeNoHkt
 import typo.dsl.Structure.Relation
 
-trait SmViewFields[Row] {
-  val id: Field[ShipmethodId, Row]
-  val shipmethodid: Field[ShipmethodId, Row]
-  val name: Field[Name, Row]
-  val shipbase: Field[BigDecimal, Row]
-  val shiprate: Field[BigDecimal, Row]
-  val rowguid: Field[TypoUUID, Row]
-  val modifieddate: Field[TypoLocalDateTime, Row]
+trait SmViewFields {
+  def id: Field[ShipmethodId, SmViewRow]
+  def shipmethodid: Field[ShipmethodId, SmViewRow]
+  def name: Field[Name, SmViewRow]
+  def shipbase: Field[BigDecimal, SmViewRow]
+  def shiprate: Field[BigDecimal, SmViewRow]
+  def rowguid: Field[TypoUUID, SmViewRow]
+  def modifieddate: Field[TypoLocalDateTime, SmViewRow]
 }
 
 object SmViewFields {
-  val structure: Relation[SmViewFields, SmViewRow, SmViewRow] = 
-    new Impl(None, identity, (_, x) => x)
+  lazy val structure: Relation[SmViewFields, SmViewRow] =
+    new Impl(Nil)
     
-  private final class Impl[Row](val prefix: Option[String], val extract: Row => SmViewRow, val merge: (Row, SmViewRow) => Row)
-    extends Relation[SmViewFields, SmViewRow, Row] { 
+  private final class Impl(val _path: List[Path])
+    extends Relation[SmViewFields, SmViewRow] {
   
-    override val fields: SmViewFields[Row] = new SmViewFields[Row] {
-      override val id = new Field[ShipmethodId, Row](prefix, "id", None, None)(x => extract(x).id, (row, value) => merge(row, extract(row).copy(id = value)))
-      override val shipmethodid = new Field[ShipmethodId, Row](prefix, "shipmethodid", None, None)(x => extract(x).shipmethodid, (row, value) => merge(row, extract(row).copy(shipmethodid = value)))
-      override val name = new Field[Name, Row](prefix, "name", None, None)(x => extract(x).name, (row, value) => merge(row, extract(row).copy(name = value)))
-      override val shipbase = new Field[BigDecimal, Row](prefix, "shipbase", None, None)(x => extract(x).shipbase, (row, value) => merge(row, extract(row).copy(shipbase = value)))
-      override val shiprate = new Field[BigDecimal, Row](prefix, "shiprate", None, None)(x => extract(x).shiprate, (row, value) => merge(row, extract(row).copy(shiprate = value)))
-      override val rowguid = new Field[TypoUUID, Row](prefix, "rowguid", None, None)(x => extract(x).rowguid, (row, value) => merge(row, extract(row).copy(rowguid = value)))
-      override val modifieddate = new Field[TypoLocalDateTime, Row](prefix, "modifieddate", Some("text"), None)(x => extract(x).modifieddate, (row, value) => merge(row, extract(row).copy(modifieddate = value)))
+    override lazy val fields: SmViewFields = new SmViewFields {
+      override def id = Field[ShipmethodId, SmViewRow](_path, "id", None, None, x => x.id, (row, value) => row.copy(id = value))
+      override def shipmethodid = Field[ShipmethodId, SmViewRow](_path, "shipmethodid", None, None, x => x.shipmethodid, (row, value) => row.copy(shipmethodid = value))
+      override def name = Field[Name, SmViewRow](_path, "name", None, None, x => x.name, (row, value) => row.copy(name = value))
+      override def shipbase = Field[BigDecimal, SmViewRow](_path, "shipbase", None, None, x => x.shipbase, (row, value) => row.copy(shipbase = value))
+      override def shiprate = Field[BigDecimal, SmViewRow](_path, "shiprate", None, None, x => x.shiprate, (row, value) => row.copy(shiprate = value))
+      override def rowguid = Field[TypoUUID, SmViewRow](_path, "rowguid", None, None, x => x.rowguid, (row, value) => row.copy(rowguid = value))
+      override def modifieddate = Field[TypoLocalDateTime, SmViewRow](_path, "modifieddate", Some("text"), None, x => x.modifieddate, (row, value) => row.copy(modifieddate = value))
     }
   
-    override val columns: List[FieldLikeNoHkt[?, Row]] =
-      List[FieldLikeNoHkt[?, Row]](fields.id, fields.shipmethodid, fields.name, fields.shipbase, fields.shiprate, fields.rowguid, fields.modifieddate)
+    override lazy val columns: List[FieldLikeNoHkt[?, SmViewRow]] =
+      List[FieldLikeNoHkt[?, SmViewRow]](fields.id, fields.shipmethodid, fields.name, fields.shipbase, fields.shiprate, fields.rowguid, fields.modifieddate)
   
-    override def copy[NewRow](prefix: Option[String], extract: NewRow => SmViewRow, merge: (NewRow, SmViewRow) => NewRow): Impl[NewRow] =
-      new Impl(prefix, extract, merge)
+    override def copy(path: List[Path]): Impl =
+      new Impl(path)
   }
   
 }

--- a/typo-tester-doobie/generated-and-checked-in/adventureworks/pu/v/VViewFields.scala
+++ b/typo-tester-doobie/generated-and-checked-in/adventureworks/pu/v/VViewFields.scala
@@ -13,47 +13,48 @@ import adventureworks.person.businessentity.BusinessentityId
 import adventureworks.public.AccountNumber
 import adventureworks.public.Flag
 import adventureworks.public.Name
+import typo.dsl.Path
 import typo.dsl.SqlExpr.Field
 import typo.dsl.SqlExpr.FieldLikeNoHkt
 import typo.dsl.SqlExpr.OptField
 import typo.dsl.Structure.Relation
 
-trait VViewFields[Row] {
-  val id: Field[BusinessentityId, Row]
-  val businessentityid: Field[BusinessentityId, Row]
-  val accountnumber: Field[AccountNumber, Row]
-  val name: Field[Name, Row]
-  val creditrating: Field[TypoShort, Row]
-  val preferredvendorstatus: Field[Flag, Row]
-  val activeflag: Field[Flag, Row]
-  val purchasingwebserviceurl: OptField[/* max 1024 chars */ String, Row]
-  val modifieddate: Field[TypoLocalDateTime, Row]
+trait VViewFields {
+  def id: Field[BusinessentityId, VViewRow]
+  def businessentityid: Field[BusinessentityId, VViewRow]
+  def accountnumber: Field[AccountNumber, VViewRow]
+  def name: Field[Name, VViewRow]
+  def creditrating: Field[TypoShort, VViewRow]
+  def preferredvendorstatus: Field[Flag, VViewRow]
+  def activeflag: Field[Flag, VViewRow]
+  def purchasingwebserviceurl: OptField[/* max 1024 chars */ String, VViewRow]
+  def modifieddate: Field[TypoLocalDateTime, VViewRow]
 }
 
 object VViewFields {
-  val structure: Relation[VViewFields, VViewRow, VViewRow] = 
-    new Impl(None, identity, (_, x) => x)
+  lazy val structure: Relation[VViewFields, VViewRow] =
+    new Impl(Nil)
     
-  private final class Impl[Row](val prefix: Option[String], val extract: Row => VViewRow, val merge: (Row, VViewRow) => Row)
-    extends Relation[VViewFields, VViewRow, Row] { 
+  private final class Impl(val _path: List[Path])
+    extends Relation[VViewFields, VViewRow] {
   
-    override val fields: VViewFields[Row] = new VViewFields[Row] {
-      override val id = new Field[BusinessentityId, Row](prefix, "id", None, None)(x => extract(x).id, (row, value) => merge(row, extract(row).copy(id = value)))
-      override val businessentityid = new Field[BusinessentityId, Row](prefix, "businessentityid", None, None)(x => extract(x).businessentityid, (row, value) => merge(row, extract(row).copy(businessentityid = value)))
-      override val accountnumber = new Field[AccountNumber, Row](prefix, "accountnumber", None, None)(x => extract(x).accountnumber, (row, value) => merge(row, extract(row).copy(accountnumber = value)))
-      override val name = new Field[Name, Row](prefix, "name", None, None)(x => extract(x).name, (row, value) => merge(row, extract(row).copy(name = value)))
-      override val creditrating = new Field[TypoShort, Row](prefix, "creditrating", None, None)(x => extract(x).creditrating, (row, value) => merge(row, extract(row).copy(creditrating = value)))
-      override val preferredvendorstatus = new Field[Flag, Row](prefix, "preferredvendorstatus", None, None)(x => extract(x).preferredvendorstatus, (row, value) => merge(row, extract(row).copy(preferredvendorstatus = value)))
-      override val activeflag = new Field[Flag, Row](prefix, "activeflag", None, None)(x => extract(x).activeflag, (row, value) => merge(row, extract(row).copy(activeflag = value)))
-      override val purchasingwebserviceurl = new OptField[/* max 1024 chars */ String, Row](prefix, "purchasingwebserviceurl", None, None)(x => extract(x).purchasingwebserviceurl, (row, value) => merge(row, extract(row).copy(purchasingwebserviceurl = value)))
-      override val modifieddate = new Field[TypoLocalDateTime, Row](prefix, "modifieddate", Some("text"), None)(x => extract(x).modifieddate, (row, value) => merge(row, extract(row).copy(modifieddate = value)))
+    override lazy val fields: VViewFields = new VViewFields {
+      override def id = Field[BusinessentityId, VViewRow](_path, "id", None, None, x => x.id, (row, value) => row.copy(id = value))
+      override def businessentityid = Field[BusinessentityId, VViewRow](_path, "businessentityid", None, None, x => x.businessentityid, (row, value) => row.copy(businessentityid = value))
+      override def accountnumber = Field[AccountNumber, VViewRow](_path, "accountnumber", None, None, x => x.accountnumber, (row, value) => row.copy(accountnumber = value))
+      override def name = Field[Name, VViewRow](_path, "name", None, None, x => x.name, (row, value) => row.copy(name = value))
+      override def creditrating = Field[TypoShort, VViewRow](_path, "creditrating", None, None, x => x.creditrating, (row, value) => row.copy(creditrating = value))
+      override def preferredvendorstatus = Field[Flag, VViewRow](_path, "preferredvendorstatus", None, None, x => x.preferredvendorstatus, (row, value) => row.copy(preferredvendorstatus = value))
+      override def activeflag = Field[Flag, VViewRow](_path, "activeflag", None, None, x => x.activeflag, (row, value) => row.copy(activeflag = value))
+      override def purchasingwebserviceurl = OptField[/* max 1024 chars */ String, VViewRow](_path, "purchasingwebserviceurl", None, None, x => x.purchasingwebserviceurl, (row, value) => row.copy(purchasingwebserviceurl = value))
+      override def modifieddate = Field[TypoLocalDateTime, VViewRow](_path, "modifieddate", Some("text"), None, x => x.modifieddate, (row, value) => row.copy(modifieddate = value))
     }
   
-    override val columns: List[FieldLikeNoHkt[?, Row]] =
-      List[FieldLikeNoHkt[?, Row]](fields.id, fields.businessentityid, fields.accountnumber, fields.name, fields.creditrating, fields.preferredvendorstatus, fields.activeflag, fields.purchasingwebserviceurl, fields.modifieddate)
+    override lazy val columns: List[FieldLikeNoHkt[?, VViewRow]] =
+      List[FieldLikeNoHkt[?, VViewRow]](fields.id, fields.businessentityid, fields.accountnumber, fields.name, fields.creditrating, fields.preferredvendorstatus, fields.activeflag, fields.purchasingwebserviceurl, fields.modifieddate)
   
-    override def copy[NewRow](prefix: Option[String], extract: NewRow => VViewRow, merge: (NewRow, VViewRow) => NewRow): Impl[NewRow] =
-      new Impl(prefix, extract, merge)
+    override def copy(path: List[Path]): Impl =
+      new Impl(path)
   }
   
 }

--- a/typo-tester-doobie/generated-and-checked-in/adventureworks/public/flaff/FlaffFields.scala
+++ b/typo-tester-doobie/generated-and-checked-in/adventureworks/public/flaff/FlaffFields.scala
@@ -8,39 +8,40 @@ package public
 package flaff
 
 import adventureworks.public.ShortText
+import typo.dsl.Path
 import typo.dsl.SqlExpr.FieldLikeNoHkt
 import typo.dsl.SqlExpr.IdField
 import typo.dsl.SqlExpr.OptField
 import typo.dsl.Structure.Relation
 
-trait FlaffFields[Row] {
-  val code: IdField[ShortText, Row]
-  val anotherCode: IdField[/* max 20 chars */ String, Row]
-  val someNumber: IdField[Int, Row]
-  val specifier: IdField[ShortText, Row]
-  val parentspecifier: OptField[ShortText, Row]
+trait FlaffFields {
+  def code: IdField[ShortText, FlaffRow]
+  def anotherCode: IdField[/* max 20 chars */ String, FlaffRow]
+  def someNumber: IdField[Int, FlaffRow]
+  def specifier: IdField[ShortText, FlaffRow]
+  def parentspecifier: OptField[ShortText, FlaffRow]
 }
 
 object FlaffFields {
-  val structure: Relation[FlaffFields, FlaffRow, FlaffRow] = 
-    new Impl(None, identity, (_, x) => x)
+  lazy val structure: Relation[FlaffFields, FlaffRow] =
+    new Impl(Nil)
     
-  private final class Impl[Row](val prefix: Option[String], val extract: Row => FlaffRow, val merge: (Row, FlaffRow) => Row)
-    extends Relation[FlaffFields, FlaffRow, Row] { 
+  private final class Impl(val _path: List[Path])
+    extends Relation[FlaffFields, FlaffRow] {
   
-    override val fields: FlaffFields[Row] = new FlaffFields[Row] {
-      override val code = new IdField[ShortText, Row](prefix, "code", None, Some("text"))(x => extract(x).code, (row, value) => merge(row, extract(row).copy(code = value)))
-      override val anotherCode = new IdField[/* max 20 chars */ String, Row](prefix, "another_code", None, None)(x => extract(x).anotherCode, (row, value) => merge(row, extract(row).copy(anotherCode = value)))
-      override val someNumber = new IdField[Int, Row](prefix, "some_number", None, Some("int4"))(x => extract(x).someNumber, (row, value) => merge(row, extract(row).copy(someNumber = value)))
-      override val specifier = new IdField[ShortText, Row](prefix, "specifier", None, Some("text"))(x => extract(x).specifier, (row, value) => merge(row, extract(row).copy(specifier = value)))
-      override val parentspecifier = new OptField[ShortText, Row](prefix, "parentspecifier", None, Some("text"))(x => extract(x).parentspecifier, (row, value) => merge(row, extract(row).copy(parentspecifier = value)))
+    override lazy val fields: FlaffFields = new FlaffFields {
+      override def code = IdField[ShortText, FlaffRow](_path, "code", None, Some("text"), x => x.code, (row, value) => row.copy(code = value))
+      override def anotherCode = IdField[/* max 20 chars */ String, FlaffRow](_path, "another_code", None, None, x => x.anotherCode, (row, value) => row.copy(anotherCode = value))
+      override def someNumber = IdField[Int, FlaffRow](_path, "some_number", None, Some("int4"), x => x.someNumber, (row, value) => row.copy(someNumber = value))
+      override def specifier = IdField[ShortText, FlaffRow](_path, "specifier", None, Some("text"), x => x.specifier, (row, value) => row.copy(specifier = value))
+      override def parentspecifier = OptField[ShortText, FlaffRow](_path, "parentspecifier", None, Some("text"), x => x.parentspecifier, (row, value) => row.copy(parentspecifier = value))
     }
   
-    override val columns: List[FieldLikeNoHkt[?, Row]] =
-      List[FieldLikeNoHkt[?, Row]](fields.code, fields.anotherCode, fields.someNumber, fields.specifier, fields.parentspecifier)
+    override lazy val columns: List[FieldLikeNoHkt[?, FlaffRow]] =
+      List[FieldLikeNoHkt[?, FlaffRow]](fields.code, fields.anotherCode, fields.someNumber, fields.specifier, fields.parentspecifier)
   
-    override def copy[NewRow](prefix: Option[String], extract: NewRow => FlaffRow, merge: (NewRow, FlaffRow) => NewRow): Impl[NewRow] =
-      new Impl(prefix, extract, merge)
+    override def copy(path: List[Path]): Impl =
+      new Impl(path)
   }
   
 }

--- a/typo-tester-doobie/generated-and-checked-in/adventureworks/public/flaff/FlaffRepoMock.scala
+++ b/typo-tester-doobie/generated-and-checked-in/adventureworks/public/flaff/FlaffRepoMock.scala
@@ -23,7 +23,7 @@ import typo.dsl.UpdateParams
 
 class FlaffRepoMock(map: scala.collection.mutable.Map[FlaffId, FlaffRow] = scala.collection.mutable.Map.empty) extends FlaffRepo {
   override def delete: DeleteBuilder[FlaffFields, FlaffRow] = {
-    DeleteBuilderMock(DeleteParams.empty, FlaffFields.structure.fields, map)
+    DeleteBuilderMock(DeleteParams.empty, FlaffFields.structure, map)
   }
   override def deleteById(compositeId: FlaffId): ConnectionIO[Boolean] = {
     delay(map.remove(compositeId).isDefined)
@@ -70,7 +70,7 @@ class FlaffRepoMock(map: scala.collection.mutable.Map[FlaffId, FlaffRow] = scala
     }
   }
   override def update: UpdateBuilder[FlaffFields, FlaffRow] = {
-    UpdateBuilderMock(UpdateParams.empty, FlaffFields.structure.fields, map)
+    UpdateBuilderMock(UpdateParams.empty, FlaffFields.structure, map)
   }
   override def update(row: FlaffRow): ConnectionIO[Boolean] = {
     delay {

--- a/typo-tester-doobie/generated-and-checked-in/adventureworks/public/identity_test/IdentityTestRepoMock.scala
+++ b/typo-tester-doobie/generated-and-checked-in/adventureworks/public/identity_test/IdentityTestRepoMock.scala
@@ -24,7 +24,7 @@ import typo.dsl.UpdateParams
 class IdentityTestRepoMock(toRow: Function1[IdentityTestRowUnsaved, IdentityTestRow],
                            map: scala.collection.mutable.Map[IdentityTestId, IdentityTestRow] = scala.collection.mutable.Map.empty) extends IdentityTestRepo {
   override def delete: DeleteBuilder[IdentityTestFields, IdentityTestRow] = {
-    DeleteBuilderMock(DeleteParams.empty, IdentityTestFields.structure.fields, map)
+    DeleteBuilderMock(DeleteParams.empty, IdentityTestFields.structure, map)
   }
   override def deleteById(name: IdentityTestId): ConnectionIO[Boolean] = {
     delay(map.remove(name).isDefined)
@@ -86,7 +86,7 @@ class IdentityTestRepoMock(toRow: Function1[IdentityTestRowUnsaved, IdentityTest
     }
   }
   override def update: UpdateBuilder[IdentityTestFields, IdentityTestRow] = {
-    UpdateBuilderMock(UpdateParams.empty, IdentityTestFields.structure.fields, map)
+    UpdateBuilderMock(UpdateParams.empty, IdentityTestFields.structure, map)
   }
   override def update(row: IdentityTestRow): ConnectionIO[Boolean] = {
     delay {

--- a/typo-tester-doobie/generated-and-checked-in/adventureworks/public/pgtest/PgtestFields.scala
+++ b/typo-tester-doobie/generated-and-checked-in/adventureworks/public/pgtest/PgtestFields.scala
@@ -33,166 +33,167 @@ import adventureworks.customtypes.TypoVector
 import adventureworks.customtypes.TypoXml
 import adventureworks.public.Mydomain
 import adventureworks.public.Myenum
+import typo.dsl.Path
 import typo.dsl.SqlExpr.Field
 import typo.dsl.SqlExpr.FieldLikeNoHkt
 import typo.dsl.Structure.Relation
 
-trait PgtestFields[Row] {
-  val bool: Field[Boolean, Row]
-  val box: Field[TypoBox, Row]
-  val bpchar: Field[/* bpchar, max 3 chars */ String, Row]
-  val bytea: Field[TypoBytea, Row]
-  val char: Field[/* bpchar, max 1 chars */ String, Row]
-  val circle: Field[TypoCircle, Row]
-  val date: Field[TypoLocalDate, Row]
-  val float4: Field[Float, Row]
-  val float8: Field[Double, Row]
-  val hstore: Field[TypoHStore, Row]
-  val inet: Field[TypoInet, Row]
-  val int2: Field[TypoShort, Row]
-  val int2vector: Field[TypoInt2Vector, Row]
-  val int4: Field[Int, Row]
-  val int8: Field[Long, Row]
-  val interval: Field[TypoInterval, Row]
-  val json: Field[TypoJson, Row]
-  val jsonb: Field[TypoJsonb, Row]
-  val line: Field[TypoLine, Row]
-  val lseg: Field[TypoLineSegment, Row]
-  val money: Field[TypoMoney, Row]
-  val mydomain: Field[Mydomain, Row]
-  val myenum: Field[Myenum, Row]
-  val name: Field[String, Row]
-  val numeric: Field[BigDecimal, Row]
-  val path: Field[TypoPath, Row]
-  val point: Field[TypoPoint, Row]
-  val polygon: Field[TypoPolygon, Row]
-  val text: Field[String, Row]
-  val time: Field[TypoLocalTime, Row]
-  val timestamp: Field[TypoLocalDateTime, Row]
-  val timestampz: Field[TypoInstant, Row]
-  val timez: Field[TypoOffsetTime, Row]
-  val uuid: Field[TypoUUID, Row]
-  val varchar: Field[String, Row]
-  val vector: Field[TypoVector, Row]
-  val xml: Field[TypoXml, Row]
-  val boxes: Field[Array[TypoBox], Row]
-  val bpchares: Field[Array[/* bpchar */ String], Row]
-  val chares: Field[Array[/* bpchar */ String], Row]
-  val circlees: Field[Array[TypoCircle], Row]
-  val datees: Field[Array[TypoLocalDate], Row]
-  val float4es: Field[Array[Float], Row]
-  val float8es: Field[Array[Double], Row]
-  val inetes: Field[Array[TypoInet], Row]
-  val int2es: Field[Array[TypoShort], Row]
-  val int2vectores: Field[Array[TypoInt2Vector], Row]
-  val int4es: Field[Array[Int], Row]
-  val int8es: Field[Array[Long], Row]
-  val intervales: Field[Array[TypoInterval], Row]
-  val jsones: Field[Array[TypoJson], Row]
-  val jsonbes: Field[Array[TypoJsonb], Row]
-  val linees: Field[Array[TypoLine], Row]
-  val lseges: Field[Array[TypoLineSegment], Row]
-  val moneyes: Field[Array[TypoMoney], Row]
-  val myenumes: Field[Array[Myenum], Row]
-  val namees: Field[Array[String], Row]
-  val numerices: Field[Array[BigDecimal], Row]
-  val pathes: Field[Array[TypoPath], Row]
-  val pointes: Field[Array[TypoPoint], Row]
-  val polygones: Field[Array[TypoPolygon], Row]
-  val textes: Field[Array[String], Row]
-  val timees: Field[Array[TypoLocalTime], Row]
-  val timestampes: Field[Array[TypoLocalDateTime], Row]
-  val timestampzes: Field[Array[TypoInstant], Row]
-  val timezes: Field[Array[TypoOffsetTime], Row]
-  val uuides: Field[Array[TypoUUID], Row]
-  val varchares: Field[Array[String], Row]
-  val xmles: Field[Array[TypoXml], Row]
+trait PgtestFields {
+  def bool: Field[Boolean, PgtestRow]
+  def box: Field[TypoBox, PgtestRow]
+  def bpchar: Field[/* bpchar, max 3 chars */ String, PgtestRow]
+  def bytea: Field[TypoBytea, PgtestRow]
+  def char: Field[/* bpchar, max 1 chars */ String, PgtestRow]
+  def circle: Field[TypoCircle, PgtestRow]
+  def date: Field[TypoLocalDate, PgtestRow]
+  def float4: Field[Float, PgtestRow]
+  def float8: Field[Double, PgtestRow]
+  def hstore: Field[TypoHStore, PgtestRow]
+  def inet: Field[TypoInet, PgtestRow]
+  def int2: Field[TypoShort, PgtestRow]
+  def int2vector: Field[TypoInt2Vector, PgtestRow]
+  def int4: Field[Int, PgtestRow]
+  def int8: Field[Long, PgtestRow]
+  def interval: Field[TypoInterval, PgtestRow]
+  def json: Field[TypoJson, PgtestRow]
+  def jsonb: Field[TypoJsonb, PgtestRow]
+  def line: Field[TypoLine, PgtestRow]
+  def lseg: Field[TypoLineSegment, PgtestRow]
+  def money: Field[TypoMoney, PgtestRow]
+  def mydomain: Field[Mydomain, PgtestRow]
+  def myenum: Field[Myenum, PgtestRow]
+  def name: Field[String, PgtestRow]
+  def numeric: Field[BigDecimal, PgtestRow]
+  def path: Field[TypoPath, PgtestRow]
+  def point: Field[TypoPoint, PgtestRow]
+  def polygon: Field[TypoPolygon, PgtestRow]
+  def text: Field[String, PgtestRow]
+  def time: Field[TypoLocalTime, PgtestRow]
+  def timestamp: Field[TypoLocalDateTime, PgtestRow]
+  def timestampz: Field[TypoInstant, PgtestRow]
+  def timez: Field[TypoOffsetTime, PgtestRow]
+  def uuid: Field[TypoUUID, PgtestRow]
+  def varchar: Field[String, PgtestRow]
+  def vector: Field[TypoVector, PgtestRow]
+  def xml: Field[TypoXml, PgtestRow]
+  def boxes: Field[Array[TypoBox], PgtestRow]
+  def bpchares: Field[Array[/* bpchar */ String], PgtestRow]
+  def chares: Field[Array[/* bpchar */ String], PgtestRow]
+  def circlees: Field[Array[TypoCircle], PgtestRow]
+  def datees: Field[Array[TypoLocalDate], PgtestRow]
+  def float4es: Field[Array[Float], PgtestRow]
+  def float8es: Field[Array[Double], PgtestRow]
+  def inetes: Field[Array[TypoInet], PgtestRow]
+  def int2es: Field[Array[TypoShort], PgtestRow]
+  def int2vectores: Field[Array[TypoInt2Vector], PgtestRow]
+  def int4es: Field[Array[Int], PgtestRow]
+  def int8es: Field[Array[Long], PgtestRow]
+  def intervales: Field[Array[TypoInterval], PgtestRow]
+  def jsones: Field[Array[TypoJson], PgtestRow]
+  def jsonbes: Field[Array[TypoJsonb], PgtestRow]
+  def linees: Field[Array[TypoLine], PgtestRow]
+  def lseges: Field[Array[TypoLineSegment], PgtestRow]
+  def moneyes: Field[Array[TypoMoney], PgtestRow]
+  def myenumes: Field[Array[Myenum], PgtestRow]
+  def namees: Field[Array[String], PgtestRow]
+  def numerices: Field[Array[BigDecimal], PgtestRow]
+  def pathes: Field[Array[TypoPath], PgtestRow]
+  def pointes: Field[Array[TypoPoint], PgtestRow]
+  def polygones: Field[Array[TypoPolygon], PgtestRow]
+  def textes: Field[Array[String], PgtestRow]
+  def timees: Field[Array[TypoLocalTime], PgtestRow]
+  def timestampes: Field[Array[TypoLocalDateTime], PgtestRow]
+  def timestampzes: Field[Array[TypoInstant], PgtestRow]
+  def timezes: Field[Array[TypoOffsetTime], PgtestRow]
+  def uuides: Field[Array[TypoUUID], PgtestRow]
+  def varchares: Field[Array[String], PgtestRow]
+  def xmles: Field[Array[TypoXml], PgtestRow]
 }
 
 object PgtestFields {
-  val structure: Relation[PgtestFields, PgtestRow, PgtestRow] = 
-    new Impl(None, identity, (_, x) => x)
+  lazy val structure: Relation[PgtestFields, PgtestRow] =
+    new Impl(Nil)
     
-  private final class Impl[Row](val prefix: Option[String], val extract: Row => PgtestRow, val merge: (Row, PgtestRow) => Row)
-    extends Relation[PgtestFields, PgtestRow, Row] { 
+  private final class Impl(val _path: List[Path])
+    extends Relation[PgtestFields, PgtestRow] {
   
-    override val fields: PgtestFields[Row] = new PgtestFields[Row] {
-      override val bool = new Field[Boolean, Row](prefix, "bool", None, None)(x => extract(x).bool, (row, value) => merge(row, extract(row).copy(bool = value)))
-      override val box = new Field[TypoBox, Row](prefix, "box", None, Some("box"))(x => extract(x).box, (row, value) => merge(row, extract(row).copy(box = value)))
-      override val bpchar = new Field[/* bpchar, max 3 chars */ String, Row](prefix, "bpchar", None, Some("bpchar"))(x => extract(x).bpchar, (row, value) => merge(row, extract(row).copy(bpchar = value)))
-      override val bytea = new Field[TypoBytea, Row](prefix, "bytea", None, Some("bytea"))(x => extract(x).bytea, (row, value) => merge(row, extract(row).copy(bytea = value)))
-      override val char = new Field[/* bpchar, max 1 chars */ String, Row](prefix, "char", None, Some("bpchar"))(x => extract(x).char, (row, value) => merge(row, extract(row).copy(char = value)))
-      override val circle = new Field[TypoCircle, Row](prefix, "circle", None, Some("circle"))(x => extract(x).circle, (row, value) => merge(row, extract(row).copy(circle = value)))
-      override val date = new Field[TypoLocalDate, Row](prefix, "date", Some("text"), Some("date"))(x => extract(x).date, (row, value) => merge(row, extract(row).copy(date = value)))
-      override val float4 = new Field[Float, Row](prefix, "float4", None, Some("float4"))(x => extract(x).float4, (row, value) => merge(row, extract(row).copy(float4 = value)))
-      override val float8 = new Field[Double, Row](prefix, "float8", None, Some("float8"))(x => extract(x).float8, (row, value) => merge(row, extract(row).copy(float8 = value)))
-      override val hstore = new Field[TypoHStore, Row](prefix, "hstore", None, Some("hstore"))(x => extract(x).hstore, (row, value) => merge(row, extract(row).copy(hstore = value)))
-      override val inet = new Field[TypoInet, Row](prefix, "inet", None, Some("inet"))(x => extract(x).inet, (row, value) => merge(row, extract(row).copy(inet = value)))
-      override val int2 = new Field[TypoShort, Row](prefix, "int2", None, Some("int2"))(x => extract(x).int2, (row, value) => merge(row, extract(row).copy(int2 = value)))
-      override val int2vector = new Field[TypoInt2Vector, Row](prefix, "int2vector", None, Some("int2vector"))(x => extract(x).int2vector, (row, value) => merge(row, extract(row).copy(int2vector = value)))
-      override val int4 = new Field[Int, Row](prefix, "int4", None, Some("int4"))(x => extract(x).int4, (row, value) => merge(row, extract(row).copy(int4 = value)))
-      override val int8 = new Field[Long, Row](prefix, "int8", None, Some("int8"))(x => extract(x).int8, (row, value) => merge(row, extract(row).copy(int8 = value)))
-      override val interval = new Field[TypoInterval, Row](prefix, "interval", None, Some("interval"))(x => extract(x).interval, (row, value) => merge(row, extract(row).copy(interval = value)))
-      override val json = new Field[TypoJson, Row](prefix, "json", None, Some("json"))(x => extract(x).json, (row, value) => merge(row, extract(row).copy(json = value)))
-      override val jsonb = new Field[TypoJsonb, Row](prefix, "jsonb", None, Some("jsonb"))(x => extract(x).jsonb, (row, value) => merge(row, extract(row).copy(jsonb = value)))
-      override val line = new Field[TypoLine, Row](prefix, "line", None, Some("line"))(x => extract(x).line, (row, value) => merge(row, extract(row).copy(line = value)))
-      override val lseg = new Field[TypoLineSegment, Row](prefix, "lseg", None, Some("lseg"))(x => extract(x).lseg, (row, value) => merge(row, extract(row).copy(lseg = value)))
-      override val money = new Field[TypoMoney, Row](prefix, "money", Some("numeric"), Some("money"))(x => extract(x).money, (row, value) => merge(row, extract(row).copy(money = value)))
-      override val mydomain = new Field[Mydomain, Row](prefix, "mydomain", None, Some("text"))(x => extract(x).mydomain, (row, value) => merge(row, extract(row).copy(mydomain = value)))
-      override val myenum = new Field[Myenum, Row](prefix, "myenum", None, Some("public.myenum"))(x => extract(x).myenum, (row, value) => merge(row, extract(row).copy(myenum = value)))
-      override val name = new Field[String, Row](prefix, "name", None, Some("name"))(x => extract(x).name, (row, value) => merge(row, extract(row).copy(name = value)))
-      override val numeric = new Field[BigDecimal, Row](prefix, "numeric", None, Some("numeric"))(x => extract(x).numeric, (row, value) => merge(row, extract(row).copy(numeric = value)))
-      override val path = new Field[TypoPath, Row](prefix, "path", None, Some("path"))(x => extract(x).path, (row, value) => merge(row, extract(row).copy(path = value)))
-      override val point = new Field[TypoPoint, Row](prefix, "point", None, Some("point"))(x => extract(x).point, (row, value) => merge(row, extract(row).copy(point = value)))
-      override val polygon = new Field[TypoPolygon, Row](prefix, "polygon", None, Some("polygon"))(x => extract(x).polygon, (row, value) => merge(row, extract(row).copy(polygon = value)))
-      override val text = new Field[String, Row](prefix, "text", None, None)(x => extract(x).text, (row, value) => merge(row, extract(row).copy(text = value)))
-      override val time = new Field[TypoLocalTime, Row](prefix, "time", Some("text"), Some("time"))(x => extract(x).time, (row, value) => merge(row, extract(row).copy(time = value)))
-      override val timestamp = new Field[TypoLocalDateTime, Row](prefix, "timestamp", Some("text"), Some("timestamp"))(x => extract(x).timestamp, (row, value) => merge(row, extract(row).copy(timestamp = value)))
-      override val timestampz = new Field[TypoInstant, Row](prefix, "timestampz", Some("text"), Some("timestamptz"))(x => extract(x).timestampz, (row, value) => merge(row, extract(row).copy(timestampz = value)))
-      override val timez = new Field[TypoOffsetTime, Row](prefix, "timez", Some("text"), Some("timetz"))(x => extract(x).timez, (row, value) => merge(row, extract(row).copy(timez = value)))
-      override val uuid = new Field[TypoUUID, Row](prefix, "uuid", None, Some("uuid"))(x => extract(x).uuid, (row, value) => merge(row, extract(row).copy(uuid = value)))
-      override val varchar = new Field[String, Row](prefix, "varchar", None, None)(x => extract(x).varchar, (row, value) => merge(row, extract(row).copy(varchar = value)))
-      override val vector = new Field[TypoVector, Row](prefix, "vector", Some("float4[]"), Some("vector"))(x => extract(x).vector, (row, value) => merge(row, extract(row).copy(vector = value)))
-      override val xml = new Field[TypoXml, Row](prefix, "xml", None, Some("xml"))(x => extract(x).xml, (row, value) => merge(row, extract(row).copy(xml = value)))
-      override val boxes = new Field[Array[TypoBox], Row](prefix, "boxes", None, Some("_box"))(x => extract(x).boxes, (row, value) => merge(row, extract(row).copy(boxes = value)))
-      override val bpchares = new Field[Array[/* bpchar */ String], Row](prefix, "bpchares", None, Some("_bpchar"))(x => extract(x).bpchares, (row, value) => merge(row, extract(row).copy(bpchares = value)))
-      override val chares = new Field[Array[/* bpchar */ String], Row](prefix, "chares", None, Some("_bpchar"))(x => extract(x).chares, (row, value) => merge(row, extract(row).copy(chares = value)))
-      override val circlees = new Field[Array[TypoCircle], Row](prefix, "circlees", None, Some("_circle"))(x => extract(x).circlees, (row, value) => merge(row, extract(row).copy(circlees = value)))
-      override val datees = new Field[Array[TypoLocalDate], Row](prefix, "datees", Some("text[]"), Some("_date"))(x => extract(x).datees, (row, value) => merge(row, extract(row).copy(datees = value)))
-      override val float4es = new Field[Array[Float], Row](prefix, "float4es", None, Some("_float4"))(x => extract(x).float4es, (row, value) => merge(row, extract(row).copy(float4es = value)))
-      override val float8es = new Field[Array[Double], Row](prefix, "float8es", None, Some("_float8"))(x => extract(x).float8es, (row, value) => merge(row, extract(row).copy(float8es = value)))
-      override val inetes = new Field[Array[TypoInet], Row](prefix, "inetes", None, Some("_inet"))(x => extract(x).inetes, (row, value) => merge(row, extract(row).copy(inetes = value)))
-      override val int2es = new Field[Array[TypoShort], Row](prefix, "int2es", None, Some("_int2"))(x => extract(x).int2es, (row, value) => merge(row, extract(row).copy(int2es = value)))
-      override val int2vectores = new Field[Array[TypoInt2Vector], Row](prefix, "int2vectores", None, Some("_int2vector"))(x => extract(x).int2vectores, (row, value) => merge(row, extract(row).copy(int2vectores = value)))
-      override val int4es = new Field[Array[Int], Row](prefix, "int4es", None, Some("_int4"))(x => extract(x).int4es, (row, value) => merge(row, extract(row).copy(int4es = value)))
-      override val int8es = new Field[Array[Long], Row](prefix, "int8es", None, Some("_int8"))(x => extract(x).int8es, (row, value) => merge(row, extract(row).copy(int8es = value)))
-      override val intervales = new Field[Array[TypoInterval], Row](prefix, "intervales", None, Some("_interval"))(x => extract(x).intervales, (row, value) => merge(row, extract(row).copy(intervales = value)))
-      override val jsones = new Field[Array[TypoJson], Row](prefix, "jsones", None, Some("_json"))(x => extract(x).jsones, (row, value) => merge(row, extract(row).copy(jsones = value)))
-      override val jsonbes = new Field[Array[TypoJsonb], Row](prefix, "jsonbes", None, Some("_jsonb"))(x => extract(x).jsonbes, (row, value) => merge(row, extract(row).copy(jsonbes = value)))
-      override val linees = new Field[Array[TypoLine], Row](prefix, "linees", None, Some("_line"))(x => extract(x).linees, (row, value) => merge(row, extract(row).copy(linees = value)))
-      override val lseges = new Field[Array[TypoLineSegment], Row](prefix, "lseges", None, Some("_lseg"))(x => extract(x).lseges, (row, value) => merge(row, extract(row).copy(lseges = value)))
-      override val moneyes = new Field[Array[TypoMoney], Row](prefix, "moneyes", Some("numeric[]"), Some("_money"))(x => extract(x).moneyes, (row, value) => merge(row, extract(row).copy(moneyes = value)))
-      override val myenumes = new Field[Array[Myenum], Row](prefix, "myenumes", None, Some("_myenum"))(x => extract(x).myenumes, (row, value) => merge(row, extract(row).copy(myenumes = value)))
-      override val namees = new Field[Array[String], Row](prefix, "namees", None, Some("_name"))(x => extract(x).namees, (row, value) => merge(row, extract(row).copy(namees = value)))
-      override val numerices = new Field[Array[BigDecimal], Row](prefix, "numerices", None, Some("_numeric"))(x => extract(x).numerices, (row, value) => merge(row, extract(row).copy(numerices = value)))
-      override val pathes = new Field[Array[TypoPath], Row](prefix, "pathes", None, Some("_path"))(x => extract(x).pathes, (row, value) => merge(row, extract(row).copy(pathes = value)))
-      override val pointes = new Field[Array[TypoPoint], Row](prefix, "pointes", None, Some("_point"))(x => extract(x).pointes, (row, value) => merge(row, extract(row).copy(pointes = value)))
-      override val polygones = new Field[Array[TypoPolygon], Row](prefix, "polygones", None, Some("_polygon"))(x => extract(x).polygones, (row, value) => merge(row, extract(row).copy(polygones = value)))
-      override val textes = new Field[Array[String], Row](prefix, "textes", None, Some("_text"))(x => extract(x).textes, (row, value) => merge(row, extract(row).copy(textes = value)))
-      override val timees = new Field[Array[TypoLocalTime], Row](prefix, "timees", Some("text[]"), Some("_time"))(x => extract(x).timees, (row, value) => merge(row, extract(row).copy(timees = value)))
-      override val timestampes = new Field[Array[TypoLocalDateTime], Row](prefix, "timestampes", Some("text[]"), Some("_timestamp"))(x => extract(x).timestampes, (row, value) => merge(row, extract(row).copy(timestampes = value)))
-      override val timestampzes = new Field[Array[TypoInstant], Row](prefix, "timestampzes", Some("text[]"), Some("_timestamptz"))(x => extract(x).timestampzes, (row, value) => merge(row, extract(row).copy(timestampzes = value)))
-      override val timezes = new Field[Array[TypoOffsetTime], Row](prefix, "timezes", Some("text[]"), Some("_timetz"))(x => extract(x).timezes, (row, value) => merge(row, extract(row).copy(timezes = value)))
-      override val uuides = new Field[Array[TypoUUID], Row](prefix, "uuides", None, Some("_uuid"))(x => extract(x).uuides, (row, value) => merge(row, extract(row).copy(uuides = value)))
-      override val varchares = new Field[Array[String], Row](prefix, "varchares", None, Some("_varchar"))(x => extract(x).varchares, (row, value) => merge(row, extract(row).copy(varchares = value)))
-      override val xmles = new Field[Array[TypoXml], Row](prefix, "xmles", None, Some("_xml"))(x => extract(x).xmles, (row, value) => merge(row, extract(row).copy(xmles = value)))
+    override lazy val fields: PgtestFields = new PgtestFields {
+      override def bool = Field[Boolean, PgtestRow](_path, "bool", None, None, x => x.bool, (row, value) => row.copy(bool = value))
+      override def box = Field[TypoBox, PgtestRow](_path, "box", None, Some("box"), x => x.box, (row, value) => row.copy(box = value))
+      override def bpchar = Field[/* bpchar, max 3 chars */ String, PgtestRow](_path, "bpchar", None, Some("bpchar"), x => x.bpchar, (row, value) => row.copy(bpchar = value))
+      override def bytea = Field[TypoBytea, PgtestRow](_path, "bytea", None, Some("bytea"), x => x.bytea, (row, value) => row.copy(bytea = value))
+      override def char = Field[/* bpchar, max 1 chars */ String, PgtestRow](_path, "char", None, Some("bpchar"), x => x.char, (row, value) => row.copy(char = value))
+      override def circle = Field[TypoCircle, PgtestRow](_path, "circle", None, Some("circle"), x => x.circle, (row, value) => row.copy(circle = value))
+      override def date = Field[TypoLocalDate, PgtestRow](_path, "date", Some("text"), Some("date"), x => x.date, (row, value) => row.copy(date = value))
+      override def float4 = Field[Float, PgtestRow](_path, "float4", None, Some("float4"), x => x.float4, (row, value) => row.copy(float4 = value))
+      override def float8 = Field[Double, PgtestRow](_path, "float8", None, Some("float8"), x => x.float8, (row, value) => row.copy(float8 = value))
+      override def hstore = Field[TypoHStore, PgtestRow](_path, "hstore", None, Some("hstore"), x => x.hstore, (row, value) => row.copy(hstore = value))
+      override def inet = Field[TypoInet, PgtestRow](_path, "inet", None, Some("inet"), x => x.inet, (row, value) => row.copy(inet = value))
+      override def int2 = Field[TypoShort, PgtestRow](_path, "int2", None, Some("int2"), x => x.int2, (row, value) => row.copy(int2 = value))
+      override def int2vector = Field[TypoInt2Vector, PgtestRow](_path, "int2vector", None, Some("int2vector"), x => x.int2vector, (row, value) => row.copy(int2vector = value))
+      override def int4 = Field[Int, PgtestRow](_path, "int4", None, Some("int4"), x => x.int4, (row, value) => row.copy(int4 = value))
+      override def int8 = Field[Long, PgtestRow](_path, "int8", None, Some("int8"), x => x.int8, (row, value) => row.copy(int8 = value))
+      override def interval = Field[TypoInterval, PgtestRow](_path, "interval", None, Some("interval"), x => x.interval, (row, value) => row.copy(interval = value))
+      override def json = Field[TypoJson, PgtestRow](_path, "json", None, Some("json"), x => x.json, (row, value) => row.copy(json = value))
+      override def jsonb = Field[TypoJsonb, PgtestRow](_path, "jsonb", None, Some("jsonb"), x => x.jsonb, (row, value) => row.copy(jsonb = value))
+      override def line = Field[TypoLine, PgtestRow](_path, "line", None, Some("line"), x => x.line, (row, value) => row.copy(line = value))
+      override def lseg = Field[TypoLineSegment, PgtestRow](_path, "lseg", None, Some("lseg"), x => x.lseg, (row, value) => row.copy(lseg = value))
+      override def money = Field[TypoMoney, PgtestRow](_path, "money", Some("numeric"), Some("money"), x => x.money, (row, value) => row.copy(money = value))
+      override def mydomain = Field[Mydomain, PgtestRow](_path, "mydomain", None, Some("text"), x => x.mydomain, (row, value) => row.copy(mydomain = value))
+      override def myenum = Field[Myenum, PgtestRow](_path, "myenum", None, Some("public.myenum"), x => x.myenum, (row, value) => row.copy(myenum = value))
+      override def name = Field[String, PgtestRow](_path, "name", None, Some("name"), x => x.name, (row, value) => row.copy(name = value))
+      override def numeric = Field[BigDecimal, PgtestRow](_path, "numeric", None, Some("numeric"), x => x.numeric, (row, value) => row.copy(numeric = value))
+      override def path = Field[TypoPath, PgtestRow](_path, "path", None, Some("path"), x => x.path, (row, value) => row.copy(path = value))
+      override def point = Field[TypoPoint, PgtestRow](_path, "point", None, Some("point"), x => x.point, (row, value) => row.copy(point = value))
+      override def polygon = Field[TypoPolygon, PgtestRow](_path, "polygon", None, Some("polygon"), x => x.polygon, (row, value) => row.copy(polygon = value))
+      override def text = Field[String, PgtestRow](_path, "text", None, None, x => x.text, (row, value) => row.copy(text = value))
+      override def time = Field[TypoLocalTime, PgtestRow](_path, "time", Some("text"), Some("time"), x => x.time, (row, value) => row.copy(time = value))
+      override def timestamp = Field[TypoLocalDateTime, PgtestRow](_path, "timestamp", Some("text"), Some("timestamp"), x => x.timestamp, (row, value) => row.copy(timestamp = value))
+      override def timestampz = Field[TypoInstant, PgtestRow](_path, "timestampz", Some("text"), Some("timestamptz"), x => x.timestampz, (row, value) => row.copy(timestampz = value))
+      override def timez = Field[TypoOffsetTime, PgtestRow](_path, "timez", Some("text"), Some("timetz"), x => x.timez, (row, value) => row.copy(timez = value))
+      override def uuid = Field[TypoUUID, PgtestRow](_path, "uuid", None, Some("uuid"), x => x.uuid, (row, value) => row.copy(uuid = value))
+      override def varchar = Field[String, PgtestRow](_path, "varchar", None, None, x => x.varchar, (row, value) => row.copy(varchar = value))
+      override def vector = Field[TypoVector, PgtestRow](_path, "vector", Some("float4[]"), Some("vector"), x => x.vector, (row, value) => row.copy(vector = value))
+      override def xml = Field[TypoXml, PgtestRow](_path, "xml", None, Some("xml"), x => x.xml, (row, value) => row.copy(xml = value))
+      override def boxes = Field[Array[TypoBox], PgtestRow](_path, "boxes", None, Some("_box"), x => x.boxes, (row, value) => row.copy(boxes = value))
+      override def bpchares = Field[Array[/* bpchar */ String], PgtestRow](_path, "bpchares", None, Some("_bpchar"), x => x.bpchares, (row, value) => row.copy(bpchares = value))
+      override def chares = Field[Array[/* bpchar */ String], PgtestRow](_path, "chares", None, Some("_bpchar"), x => x.chares, (row, value) => row.copy(chares = value))
+      override def circlees = Field[Array[TypoCircle], PgtestRow](_path, "circlees", None, Some("_circle"), x => x.circlees, (row, value) => row.copy(circlees = value))
+      override def datees = Field[Array[TypoLocalDate], PgtestRow](_path, "datees", Some("text[]"), Some("_date"), x => x.datees, (row, value) => row.copy(datees = value))
+      override def float4es = Field[Array[Float], PgtestRow](_path, "float4es", None, Some("_float4"), x => x.float4es, (row, value) => row.copy(float4es = value))
+      override def float8es = Field[Array[Double], PgtestRow](_path, "float8es", None, Some("_float8"), x => x.float8es, (row, value) => row.copy(float8es = value))
+      override def inetes = Field[Array[TypoInet], PgtestRow](_path, "inetes", None, Some("_inet"), x => x.inetes, (row, value) => row.copy(inetes = value))
+      override def int2es = Field[Array[TypoShort], PgtestRow](_path, "int2es", None, Some("_int2"), x => x.int2es, (row, value) => row.copy(int2es = value))
+      override def int2vectores = Field[Array[TypoInt2Vector], PgtestRow](_path, "int2vectores", None, Some("_int2vector"), x => x.int2vectores, (row, value) => row.copy(int2vectores = value))
+      override def int4es = Field[Array[Int], PgtestRow](_path, "int4es", None, Some("_int4"), x => x.int4es, (row, value) => row.copy(int4es = value))
+      override def int8es = Field[Array[Long], PgtestRow](_path, "int8es", None, Some("_int8"), x => x.int8es, (row, value) => row.copy(int8es = value))
+      override def intervales = Field[Array[TypoInterval], PgtestRow](_path, "intervales", None, Some("_interval"), x => x.intervales, (row, value) => row.copy(intervales = value))
+      override def jsones = Field[Array[TypoJson], PgtestRow](_path, "jsones", None, Some("_json"), x => x.jsones, (row, value) => row.copy(jsones = value))
+      override def jsonbes = Field[Array[TypoJsonb], PgtestRow](_path, "jsonbes", None, Some("_jsonb"), x => x.jsonbes, (row, value) => row.copy(jsonbes = value))
+      override def linees = Field[Array[TypoLine], PgtestRow](_path, "linees", None, Some("_line"), x => x.linees, (row, value) => row.copy(linees = value))
+      override def lseges = Field[Array[TypoLineSegment], PgtestRow](_path, "lseges", None, Some("_lseg"), x => x.lseges, (row, value) => row.copy(lseges = value))
+      override def moneyes = Field[Array[TypoMoney], PgtestRow](_path, "moneyes", Some("numeric[]"), Some("_money"), x => x.moneyes, (row, value) => row.copy(moneyes = value))
+      override def myenumes = Field[Array[Myenum], PgtestRow](_path, "myenumes", None, Some("_myenum"), x => x.myenumes, (row, value) => row.copy(myenumes = value))
+      override def namees = Field[Array[String], PgtestRow](_path, "namees", None, Some("_name"), x => x.namees, (row, value) => row.copy(namees = value))
+      override def numerices = Field[Array[BigDecimal], PgtestRow](_path, "numerices", None, Some("_numeric"), x => x.numerices, (row, value) => row.copy(numerices = value))
+      override def pathes = Field[Array[TypoPath], PgtestRow](_path, "pathes", None, Some("_path"), x => x.pathes, (row, value) => row.copy(pathes = value))
+      override def pointes = Field[Array[TypoPoint], PgtestRow](_path, "pointes", None, Some("_point"), x => x.pointes, (row, value) => row.copy(pointes = value))
+      override def polygones = Field[Array[TypoPolygon], PgtestRow](_path, "polygones", None, Some("_polygon"), x => x.polygones, (row, value) => row.copy(polygones = value))
+      override def textes = Field[Array[String], PgtestRow](_path, "textes", None, Some("_text"), x => x.textes, (row, value) => row.copy(textes = value))
+      override def timees = Field[Array[TypoLocalTime], PgtestRow](_path, "timees", Some("text[]"), Some("_time"), x => x.timees, (row, value) => row.copy(timees = value))
+      override def timestampes = Field[Array[TypoLocalDateTime], PgtestRow](_path, "timestampes", Some("text[]"), Some("_timestamp"), x => x.timestampes, (row, value) => row.copy(timestampes = value))
+      override def timestampzes = Field[Array[TypoInstant], PgtestRow](_path, "timestampzes", Some("text[]"), Some("_timestamptz"), x => x.timestampzes, (row, value) => row.copy(timestampzes = value))
+      override def timezes = Field[Array[TypoOffsetTime], PgtestRow](_path, "timezes", Some("text[]"), Some("_timetz"), x => x.timezes, (row, value) => row.copy(timezes = value))
+      override def uuides = Field[Array[TypoUUID], PgtestRow](_path, "uuides", None, Some("_uuid"), x => x.uuides, (row, value) => row.copy(uuides = value))
+      override def varchares = Field[Array[String], PgtestRow](_path, "varchares", None, Some("_varchar"), x => x.varchares, (row, value) => row.copy(varchares = value))
+      override def xmles = Field[Array[TypoXml], PgtestRow](_path, "xmles", None, Some("_xml"), x => x.xmles, (row, value) => row.copy(xmles = value))
     }
   
-    override val columns: List[FieldLikeNoHkt[?, Row]] =
-      List[FieldLikeNoHkt[?, Row]](fields.bool, fields.box, fields.bpchar, fields.bytea, fields.char, fields.circle, fields.date, fields.float4, fields.float8, fields.hstore, fields.inet, fields.int2, fields.int2vector, fields.int4, fields.int8, fields.interval, fields.json, fields.jsonb, fields.line, fields.lseg, fields.money, fields.mydomain, fields.myenum, fields.name, fields.numeric, fields.path, fields.point, fields.polygon, fields.text, fields.time, fields.timestamp, fields.timestampz, fields.timez, fields.uuid, fields.varchar, fields.vector, fields.xml, fields.boxes, fields.bpchares, fields.chares, fields.circlees, fields.datees, fields.float4es, fields.float8es, fields.inetes, fields.int2es, fields.int2vectores, fields.int4es, fields.int8es, fields.intervales, fields.jsones, fields.jsonbes, fields.linees, fields.lseges, fields.moneyes, fields.myenumes, fields.namees, fields.numerices, fields.pathes, fields.pointes, fields.polygones, fields.textes, fields.timees, fields.timestampes, fields.timestampzes, fields.timezes, fields.uuides, fields.varchares, fields.xmles)
+    override lazy val columns: List[FieldLikeNoHkt[?, PgtestRow]] =
+      List[FieldLikeNoHkt[?, PgtestRow]](fields.bool, fields.box, fields.bpchar, fields.bytea, fields.char, fields.circle, fields.date, fields.float4, fields.float8, fields.hstore, fields.inet, fields.int2, fields.int2vector, fields.int4, fields.int8, fields.interval, fields.json, fields.jsonb, fields.line, fields.lseg, fields.money, fields.mydomain, fields.myenum, fields.name, fields.numeric, fields.path, fields.point, fields.polygon, fields.text, fields.time, fields.timestamp, fields.timestampz, fields.timez, fields.uuid, fields.varchar, fields.vector, fields.xml, fields.boxes, fields.bpchares, fields.chares, fields.circlees, fields.datees, fields.float4es, fields.float8es, fields.inetes, fields.int2es, fields.int2vectores, fields.int4es, fields.int8es, fields.intervales, fields.jsones, fields.jsonbes, fields.linees, fields.lseges, fields.moneyes, fields.myenumes, fields.namees, fields.numerices, fields.pathes, fields.pointes, fields.polygones, fields.textes, fields.timees, fields.timestampes, fields.timestampzes, fields.timezes, fields.uuides, fields.varchares, fields.xmles)
   
-    override def copy[NewRow](prefix: Option[String], extract: NewRow => PgtestRow, merge: (NewRow, PgtestRow) => NewRow): Impl[NewRow] =
-      new Impl(prefix, extract, merge)
+    override def copy(path: List[Path]): Impl =
+      new Impl(path)
   }
   
 }

--- a/typo-tester-doobie/generated-and-checked-in/adventureworks/public/pgtestnull/PgtestnullFields.scala
+++ b/typo-tester-doobie/generated-and-checked-in/adventureworks/public/pgtestnull/PgtestnullFields.scala
@@ -33,166 +33,167 @@ import adventureworks.customtypes.TypoVector
 import adventureworks.customtypes.TypoXml
 import adventureworks.public.Mydomain
 import adventureworks.public.Myenum
+import typo.dsl.Path
 import typo.dsl.SqlExpr.FieldLikeNoHkt
 import typo.dsl.SqlExpr.OptField
 import typo.dsl.Structure.Relation
 
-trait PgtestnullFields[Row] {
-  val bool: OptField[Boolean, Row]
-  val box: OptField[TypoBox, Row]
-  val bpchar: OptField[/* bpchar, max 3 chars */ String, Row]
-  val bytea: OptField[TypoBytea, Row]
-  val char: OptField[/* bpchar, max 1 chars */ String, Row]
-  val circle: OptField[TypoCircle, Row]
-  val date: OptField[TypoLocalDate, Row]
-  val float4: OptField[Float, Row]
-  val float8: OptField[Double, Row]
-  val hstore: OptField[TypoHStore, Row]
-  val inet: OptField[TypoInet, Row]
-  val int2: OptField[TypoShort, Row]
-  val int2vector: OptField[TypoInt2Vector, Row]
-  val int4: OptField[Int, Row]
-  val int8: OptField[Long, Row]
-  val interval: OptField[TypoInterval, Row]
-  val json: OptField[TypoJson, Row]
-  val jsonb: OptField[TypoJsonb, Row]
-  val line: OptField[TypoLine, Row]
-  val lseg: OptField[TypoLineSegment, Row]
-  val money: OptField[TypoMoney, Row]
-  val mydomain: OptField[Mydomain, Row]
-  val myenum: OptField[Myenum, Row]
-  val name: OptField[String, Row]
-  val numeric: OptField[BigDecimal, Row]
-  val path: OptField[TypoPath, Row]
-  val point: OptField[TypoPoint, Row]
-  val polygon: OptField[TypoPolygon, Row]
-  val text: OptField[String, Row]
-  val time: OptField[TypoLocalTime, Row]
-  val timestamp: OptField[TypoLocalDateTime, Row]
-  val timestampz: OptField[TypoInstant, Row]
-  val timez: OptField[TypoOffsetTime, Row]
-  val uuid: OptField[TypoUUID, Row]
-  val varchar: OptField[String, Row]
-  val vector: OptField[TypoVector, Row]
-  val xml: OptField[TypoXml, Row]
-  val boxes: OptField[Array[TypoBox], Row]
-  val bpchares: OptField[Array[/* bpchar */ String], Row]
-  val chares: OptField[Array[/* bpchar */ String], Row]
-  val circlees: OptField[Array[TypoCircle], Row]
-  val datees: OptField[Array[TypoLocalDate], Row]
-  val float4es: OptField[Array[Float], Row]
-  val float8es: OptField[Array[Double], Row]
-  val inetes: OptField[Array[TypoInet], Row]
-  val int2es: OptField[Array[TypoShort], Row]
-  val int2vectores: OptField[Array[TypoInt2Vector], Row]
-  val int4es: OptField[Array[Int], Row]
-  val int8es: OptField[Array[Long], Row]
-  val intervales: OptField[Array[TypoInterval], Row]
-  val jsones: OptField[Array[TypoJson], Row]
-  val jsonbes: OptField[Array[TypoJsonb], Row]
-  val linees: OptField[Array[TypoLine], Row]
-  val lseges: OptField[Array[TypoLineSegment], Row]
-  val moneyes: OptField[Array[TypoMoney], Row]
-  val myenumes: OptField[Array[Myenum], Row]
-  val namees: OptField[Array[String], Row]
-  val numerices: OptField[Array[BigDecimal], Row]
-  val pathes: OptField[Array[TypoPath], Row]
-  val pointes: OptField[Array[TypoPoint], Row]
-  val polygones: OptField[Array[TypoPolygon], Row]
-  val textes: OptField[Array[String], Row]
-  val timees: OptField[Array[TypoLocalTime], Row]
-  val timestampes: OptField[Array[TypoLocalDateTime], Row]
-  val timestampzes: OptField[Array[TypoInstant], Row]
-  val timezes: OptField[Array[TypoOffsetTime], Row]
-  val uuides: OptField[Array[TypoUUID], Row]
-  val varchares: OptField[Array[String], Row]
-  val xmles: OptField[Array[TypoXml], Row]
+trait PgtestnullFields {
+  def bool: OptField[Boolean, PgtestnullRow]
+  def box: OptField[TypoBox, PgtestnullRow]
+  def bpchar: OptField[/* bpchar, max 3 chars */ String, PgtestnullRow]
+  def bytea: OptField[TypoBytea, PgtestnullRow]
+  def char: OptField[/* bpchar, max 1 chars */ String, PgtestnullRow]
+  def circle: OptField[TypoCircle, PgtestnullRow]
+  def date: OptField[TypoLocalDate, PgtestnullRow]
+  def float4: OptField[Float, PgtestnullRow]
+  def float8: OptField[Double, PgtestnullRow]
+  def hstore: OptField[TypoHStore, PgtestnullRow]
+  def inet: OptField[TypoInet, PgtestnullRow]
+  def int2: OptField[TypoShort, PgtestnullRow]
+  def int2vector: OptField[TypoInt2Vector, PgtestnullRow]
+  def int4: OptField[Int, PgtestnullRow]
+  def int8: OptField[Long, PgtestnullRow]
+  def interval: OptField[TypoInterval, PgtestnullRow]
+  def json: OptField[TypoJson, PgtestnullRow]
+  def jsonb: OptField[TypoJsonb, PgtestnullRow]
+  def line: OptField[TypoLine, PgtestnullRow]
+  def lseg: OptField[TypoLineSegment, PgtestnullRow]
+  def money: OptField[TypoMoney, PgtestnullRow]
+  def mydomain: OptField[Mydomain, PgtestnullRow]
+  def myenum: OptField[Myenum, PgtestnullRow]
+  def name: OptField[String, PgtestnullRow]
+  def numeric: OptField[BigDecimal, PgtestnullRow]
+  def path: OptField[TypoPath, PgtestnullRow]
+  def point: OptField[TypoPoint, PgtestnullRow]
+  def polygon: OptField[TypoPolygon, PgtestnullRow]
+  def text: OptField[String, PgtestnullRow]
+  def time: OptField[TypoLocalTime, PgtestnullRow]
+  def timestamp: OptField[TypoLocalDateTime, PgtestnullRow]
+  def timestampz: OptField[TypoInstant, PgtestnullRow]
+  def timez: OptField[TypoOffsetTime, PgtestnullRow]
+  def uuid: OptField[TypoUUID, PgtestnullRow]
+  def varchar: OptField[String, PgtestnullRow]
+  def vector: OptField[TypoVector, PgtestnullRow]
+  def xml: OptField[TypoXml, PgtestnullRow]
+  def boxes: OptField[Array[TypoBox], PgtestnullRow]
+  def bpchares: OptField[Array[/* bpchar */ String], PgtestnullRow]
+  def chares: OptField[Array[/* bpchar */ String], PgtestnullRow]
+  def circlees: OptField[Array[TypoCircle], PgtestnullRow]
+  def datees: OptField[Array[TypoLocalDate], PgtestnullRow]
+  def float4es: OptField[Array[Float], PgtestnullRow]
+  def float8es: OptField[Array[Double], PgtestnullRow]
+  def inetes: OptField[Array[TypoInet], PgtestnullRow]
+  def int2es: OptField[Array[TypoShort], PgtestnullRow]
+  def int2vectores: OptField[Array[TypoInt2Vector], PgtestnullRow]
+  def int4es: OptField[Array[Int], PgtestnullRow]
+  def int8es: OptField[Array[Long], PgtestnullRow]
+  def intervales: OptField[Array[TypoInterval], PgtestnullRow]
+  def jsones: OptField[Array[TypoJson], PgtestnullRow]
+  def jsonbes: OptField[Array[TypoJsonb], PgtestnullRow]
+  def linees: OptField[Array[TypoLine], PgtestnullRow]
+  def lseges: OptField[Array[TypoLineSegment], PgtestnullRow]
+  def moneyes: OptField[Array[TypoMoney], PgtestnullRow]
+  def myenumes: OptField[Array[Myenum], PgtestnullRow]
+  def namees: OptField[Array[String], PgtestnullRow]
+  def numerices: OptField[Array[BigDecimal], PgtestnullRow]
+  def pathes: OptField[Array[TypoPath], PgtestnullRow]
+  def pointes: OptField[Array[TypoPoint], PgtestnullRow]
+  def polygones: OptField[Array[TypoPolygon], PgtestnullRow]
+  def textes: OptField[Array[String], PgtestnullRow]
+  def timees: OptField[Array[TypoLocalTime], PgtestnullRow]
+  def timestampes: OptField[Array[TypoLocalDateTime], PgtestnullRow]
+  def timestampzes: OptField[Array[TypoInstant], PgtestnullRow]
+  def timezes: OptField[Array[TypoOffsetTime], PgtestnullRow]
+  def uuides: OptField[Array[TypoUUID], PgtestnullRow]
+  def varchares: OptField[Array[String], PgtestnullRow]
+  def xmles: OptField[Array[TypoXml], PgtestnullRow]
 }
 
 object PgtestnullFields {
-  val structure: Relation[PgtestnullFields, PgtestnullRow, PgtestnullRow] = 
-    new Impl(None, identity, (_, x) => x)
+  lazy val structure: Relation[PgtestnullFields, PgtestnullRow] =
+    new Impl(Nil)
     
-  private final class Impl[Row](val prefix: Option[String], val extract: Row => PgtestnullRow, val merge: (Row, PgtestnullRow) => Row)
-    extends Relation[PgtestnullFields, PgtestnullRow, Row] { 
+  private final class Impl(val _path: List[Path])
+    extends Relation[PgtestnullFields, PgtestnullRow] {
   
-    override val fields: PgtestnullFields[Row] = new PgtestnullFields[Row] {
-      override val bool = new OptField[Boolean, Row](prefix, "bool", None, None)(x => extract(x).bool, (row, value) => merge(row, extract(row).copy(bool = value)))
-      override val box = new OptField[TypoBox, Row](prefix, "box", None, Some("box"))(x => extract(x).box, (row, value) => merge(row, extract(row).copy(box = value)))
-      override val bpchar = new OptField[/* bpchar, max 3 chars */ String, Row](prefix, "bpchar", None, Some("bpchar"))(x => extract(x).bpchar, (row, value) => merge(row, extract(row).copy(bpchar = value)))
-      override val bytea = new OptField[TypoBytea, Row](prefix, "bytea", None, Some("bytea"))(x => extract(x).bytea, (row, value) => merge(row, extract(row).copy(bytea = value)))
-      override val char = new OptField[/* bpchar, max 1 chars */ String, Row](prefix, "char", None, Some("bpchar"))(x => extract(x).char, (row, value) => merge(row, extract(row).copy(char = value)))
-      override val circle = new OptField[TypoCircle, Row](prefix, "circle", None, Some("circle"))(x => extract(x).circle, (row, value) => merge(row, extract(row).copy(circle = value)))
-      override val date = new OptField[TypoLocalDate, Row](prefix, "date", Some("text"), Some("date"))(x => extract(x).date, (row, value) => merge(row, extract(row).copy(date = value)))
-      override val float4 = new OptField[Float, Row](prefix, "float4", None, Some("float4"))(x => extract(x).float4, (row, value) => merge(row, extract(row).copy(float4 = value)))
-      override val float8 = new OptField[Double, Row](prefix, "float8", None, Some("float8"))(x => extract(x).float8, (row, value) => merge(row, extract(row).copy(float8 = value)))
-      override val hstore = new OptField[TypoHStore, Row](prefix, "hstore", None, Some("hstore"))(x => extract(x).hstore, (row, value) => merge(row, extract(row).copy(hstore = value)))
-      override val inet = new OptField[TypoInet, Row](prefix, "inet", None, Some("inet"))(x => extract(x).inet, (row, value) => merge(row, extract(row).copy(inet = value)))
-      override val int2 = new OptField[TypoShort, Row](prefix, "int2", None, Some("int2"))(x => extract(x).int2, (row, value) => merge(row, extract(row).copy(int2 = value)))
-      override val int2vector = new OptField[TypoInt2Vector, Row](prefix, "int2vector", None, Some("int2vector"))(x => extract(x).int2vector, (row, value) => merge(row, extract(row).copy(int2vector = value)))
-      override val int4 = new OptField[Int, Row](prefix, "int4", None, Some("int4"))(x => extract(x).int4, (row, value) => merge(row, extract(row).copy(int4 = value)))
-      override val int8 = new OptField[Long, Row](prefix, "int8", None, Some("int8"))(x => extract(x).int8, (row, value) => merge(row, extract(row).copy(int8 = value)))
-      override val interval = new OptField[TypoInterval, Row](prefix, "interval", None, Some("interval"))(x => extract(x).interval, (row, value) => merge(row, extract(row).copy(interval = value)))
-      override val json = new OptField[TypoJson, Row](prefix, "json", None, Some("json"))(x => extract(x).json, (row, value) => merge(row, extract(row).copy(json = value)))
-      override val jsonb = new OptField[TypoJsonb, Row](prefix, "jsonb", None, Some("jsonb"))(x => extract(x).jsonb, (row, value) => merge(row, extract(row).copy(jsonb = value)))
-      override val line = new OptField[TypoLine, Row](prefix, "line", None, Some("line"))(x => extract(x).line, (row, value) => merge(row, extract(row).copy(line = value)))
-      override val lseg = new OptField[TypoLineSegment, Row](prefix, "lseg", None, Some("lseg"))(x => extract(x).lseg, (row, value) => merge(row, extract(row).copy(lseg = value)))
-      override val money = new OptField[TypoMoney, Row](prefix, "money", Some("numeric"), Some("money"))(x => extract(x).money, (row, value) => merge(row, extract(row).copy(money = value)))
-      override val mydomain = new OptField[Mydomain, Row](prefix, "mydomain", None, Some("text"))(x => extract(x).mydomain, (row, value) => merge(row, extract(row).copy(mydomain = value)))
-      override val myenum = new OptField[Myenum, Row](prefix, "myenum", None, Some("public.myenum"))(x => extract(x).myenum, (row, value) => merge(row, extract(row).copy(myenum = value)))
-      override val name = new OptField[String, Row](prefix, "name", None, Some("name"))(x => extract(x).name, (row, value) => merge(row, extract(row).copy(name = value)))
-      override val numeric = new OptField[BigDecimal, Row](prefix, "numeric", None, Some("numeric"))(x => extract(x).numeric, (row, value) => merge(row, extract(row).copy(numeric = value)))
-      override val path = new OptField[TypoPath, Row](prefix, "path", None, Some("path"))(x => extract(x).path, (row, value) => merge(row, extract(row).copy(path = value)))
-      override val point = new OptField[TypoPoint, Row](prefix, "point", None, Some("point"))(x => extract(x).point, (row, value) => merge(row, extract(row).copy(point = value)))
-      override val polygon = new OptField[TypoPolygon, Row](prefix, "polygon", None, Some("polygon"))(x => extract(x).polygon, (row, value) => merge(row, extract(row).copy(polygon = value)))
-      override val text = new OptField[String, Row](prefix, "text", None, None)(x => extract(x).text, (row, value) => merge(row, extract(row).copy(text = value)))
-      override val time = new OptField[TypoLocalTime, Row](prefix, "time", Some("text"), Some("time"))(x => extract(x).time, (row, value) => merge(row, extract(row).copy(time = value)))
-      override val timestamp = new OptField[TypoLocalDateTime, Row](prefix, "timestamp", Some("text"), Some("timestamp"))(x => extract(x).timestamp, (row, value) => merge(row, extract(row).copy(timestamp = value)))
-      override val timestampz = new OptField[TypoInstant, Row](prefix, "timestampz", Some("text"), Some("timestamptz"))(x => extract(x).timestampz, (row, value) => merge(row, extract(row).copy(timestampz = value)))
-      override val timez = new OptField[TypoOffsetTime, Row](prefix, "timez", Some("text"), Some("timetz"))(x => extract(x).timez, (row, value) => merge(row, extract(row).copy(timez = value)))
-      override val uuid = new OptField[TypoUUID, Row](prefix, "uuid", None, Some("uuid"))(x => extract(x).uuid, (row, value) => merge(row, extract(row).copy(uuid = value)))
-      override val varchar = new OptField[String, Row](prefix, "varchar", None, None)(x => extract(x).varchar, (row, value) => merge(row, extract(row).copy(varchar = value)))
-      override val vector = new OptField[TypoVector, Row](prefix, "vector", Some("float4[]"), Some("vector"))(x => extract(x).vector, (row, value) => merge(row, extract(row).copy(vector = value)))
-      override val xml = new OptField[TypoXml, Row](prefix, "xml", None, Some("xml"))(x => extract(x).xml, (row, value) => merge(row, extract(row).copy(xml = value)))
-      override val boxes = new OptField[Array[TypoBox], Row](prefix, "boxes", None, Some("_box"))(x => extract(x).boxes, (row, value) => merge(row, extract(row).copy(boxes = value)))
-      override val bpchares = new OptField[Array[/* bpchar */ String], Row](prefix, "bpchares", None, Some("_bpchar"))(x => extract(x).bpchares, (row, value) => merge(row, extract(row).copy(bpchares = value)))
-      override val chares = new OptField[Array[/* bpchar */ String], Row](prefix, "chares", None, Some("_bpchar"))(x => extract(x).chares, (row, value) => merge(row, extract(row).copy(chares = value)))
-      override val circlees = new OptField[Array[TypoCircle], Row](prefix, "circlees", None, Some("_circle"))(x => extract(x).circlees, (row, value) => merge(row, extract(row).copy(circlees = value)))
-      override val datees = new OptField[Array[TypoLocalDate], Row](prefix, "datees", Some("text[]"), Some("_date"))(x => extract(x).datees, (row, value) => merge(row, extract(row).copy(datees = value)))
-      override val float4es = new OptField[Array[Float], Row](prefix, "float4es", None, Some("_float4"))(x => extract(x).float4es, (row, value) => merge(row, extract(row).copy(float4es = value)))
-      override val float8es = new OptField[Array[Double], Row](prefix, "float8es", None, Some("_float8"))(x => extract(x).float8es, (row, value) => merge(row, extract(row).copy(float8es = value)))
-      override val inetes = new OptField[Array[TypoInet], Row](prefix, "inetes", None, Some("_inet"))(x => extract(x).inetes, (row, value) => merge(row, extract(row).copy(inetes = value)))
-      override val int2es = new OptField[Array[TypoShort], Row](prefix, "int2es", None, Some("_int2"))(x => extract(x).int2es, (row, value) => merge(row, extract(row).copy(int2es = value)))
-      override val int2vectores = new OptField[Array[TypoInt2Vector], Row](prefix, "int2vectores", None, Some("_int2vector"))(x => extract(x).int2vectores, (row, value) => merge(row, extract(row).copy(int2vectores = value)))
-      override val int4es = new OptField[Array[Int], Row](prefix, "int4es", None, Some("_int4"))(x => extract(x).int4es, (row, value) => merge(row, extract(row).copy(int4es = value)))
-      override val int8es = new OptField[Array[Long], Row](prefix, "int8es", None, Some("_int8"))(x => extract(x).int8es, (row, value) => merge(row, extract(row).copy(int8es = value)))
-      override val intervales = new OptField[Array[TypoInterval], Row](prefix, "intervales", None, Some("_interval"))(x => extract(x).intervales, (row, value) => merge(row, extract(row).copy(intervales = value)))
-      override val jsones = new OptField[Array[TypoJson], Row](prefix, "jsones", None, Some("_json"))(x => extract(x).jsones, (row, value) => merge(row, extract(row).copy(jsones = value)))
-      override val jsonbes = new OptField[Array[TypoJsonb], Row](prefix, "jsonbes", None, Some("_jsonb"))(x => extract(x).jsonbes, (row, value) => merge(row, extract(row).copy(jsonbes = value)))
-      override val linees = new OptField[Array[TypoLine], Row](prefix, "linees", None, Some("_line"))(x => extract(x).linees, (row, value) => merge(row, extract(row).copy(linees = value)))
-      override val lseges = new OptField[Array[TypoLineSegment], Row](prefix, "lseges", None, Some("_lseg"))(x => extract(x).lseges, (row, value) => merge(row, extract(row).copy(lseges = value)))
-      override val moneyes = new OptField[Array[TypoMoney], Row](prefix, "moneyes", Some("numeric[]"), Some("_money"))(x => extract(x).moneyes, (row, value) => merge(row, extract(row).copy(moneyes = value)))
-      override val myenumes = new OptField[Array[Myenum], Row](prefix, "myenumes", None, Some("_myenum"))(x => extract(x).myenumes, (row, value) => merge(row, extract(row).copy(myenumes = value)))
-      override val namees = new OptField[Array[String], Row](prefix, "namees", None, Some("_name"))(x => extract(x).namees, (row, value) => merge(row, extract(row).copy(namees = value)))
-      override val numerices = new OptField[Array[BigDecimal], Row](prefix, "numerices", None, Some("_numeric"))(x => extract(x).numerices, (row, value) => merge(row, extract(row).copy(numerices = value)))
-      override val pathes = new OptField[Array[TypoPath], Row](prefix, "pathes", None, Some("_path"))(x => extract(x).pathes, (row, value) => merge(row, extract(row).copy(pathes = value)))
-      override val pointes = new OptField[Array[TypoPoint], Row](prefix, "pointes", None, Some("_point"))(x => extract(x).pointes, (row, value) => merge(row, extract(row).copy(pointes = value)))
-      override val polygones = new OptField[Array[TypoPolygon], Row](prefix, "polygones", None, Some("_polygon"))(x => extract(x).polygones, (row, value) => merge(row, extract(row).copy(polygones = value)))
-      override val textes = new OptField[Array[String], Row](prefix, "textes", None, Some("_text"))(x => extract(x).textes, (row, value) => merge(row, extract(row).copy(textes = value)))
-      override val timees = new OptField[Array[TypoLocalTime], Row](prefix, "timees", Some("text[]"), Some("_time"))(x => extract(x).timees, (row, value) => merge(row, extract(row).copy(timees = value)))
-      override val timestampes = new OptField[Array[TypoLocalDateTime], Row](prefix, "timestampes", Some("text[]"), Some("_timestamp"))(x => extract(x).timestampes, (row, value) => merge(row, extract(row).copy(timestampes = value)))
-      override val timestampzes = new OptField[Array[TypoInstant], Row](prefix, "timestampzes", Some("text[]"), Some("_timestamptz"))(x => extract(x).timestampzes, (row, value) => merge(row, extract(row).copy(timestampzes = value)))
-      override val timezes = new OptField[Array[TypoOffsetTime], Row](prefix, "timezes", Some("text[]"), Some("_timetz"))(x => extract(x).timezes, (row, value) => merge(row, extract(row).copy(timezes = value)))
-      override val uuides = new OptField[Array[TypoUUID], Row](prefix, "uuides", None, Some("_uuid"))(x => extract(x).uuides, (row, value) => merge(row, extract(row).copy(uuides = value)))
-      override val varchares = new OptField[Array[String], Row](prefix, "varchares", None, Some("_varchar"))(x => extract(x).varchares, (row, value) => merge(row, extract(row).copy(varchares = value)))
-      override val xmles = new OptField[Array[TypoXml], Row](prefix, "xmles", None, Some("_xml"))(x => extract(x).xmles, (row, value) => merge(row, extract(row).copy(xmles = value)))
+    override lazy val fields: PgtestnullFields = new PgtestnullFields {
+      override def bool = OptField[Boolean, PgtestnullRow](_path, "bool", None, None, x => x.bool, (row, value) => row.copy(bool = value))
+      override def box = OptField[TypoBox, PgtestnullRow](_path, "box", None, Some("box"), x => x.box, (row, value) => row.copy(box = value))
+      override def bpchar = OptField[/* bpchar, max 3 chars */ String, PgtestnullRow](_path, "bpchar", None, Some("bpchar"), x => x.bpchar, (row, value) => row.copy(bpchar = value))
+      override def bytea = OptField[TypoBytea, PgtestnullRow](_path, "bytea", None, Some("bytea"), x => x.bytea, (row, value) => row.copy(bytea = value))
+      override def char = OptField[/* bpchar, max 1 chars */ String, PgtestnullRow](_path, "char", None, Some("bpchar"), x => x.char, (row, value) => row.copy(char = value))
+      override def circle = OptField[TypoCircle, PgtestnullRow](_path, "circle", None, Some("circle"), x => x.circle, (row, value) => row.copy(circle = value))
+      override def date = OptField[TypoLocalDate, PgtestnullRow](_path, "date", Some("text"), Some("date"), x => x.date, (row, value) => row.copy(date = value))
+      override def float4 = OptField[Float, PgtestnullRow](_path, "float4", None, Some("float4"), x => x.float4, (row, value) => row.copy(float4 = value))
+      override def float8 = OptField[Double, PgtestnullRow](_path, "float8", None, Some("float8"), x => x.float8, (row, value) => row.copy(float8 = value))
+      override def hstore = OptField[TypoHStore, PgtestnullRow](_path, "hstore", None, Some("hstore"), x => x.hstore, (row, value) => row.copy(hstore = value))
+      override def inet = OptField[TypoInet, PgtestnullRow](_path, "inet", None, Some("inet"), x => x.inet, (row, value) => row.copy(inet = value))
+      override def int2 = OptField[TypoShort, PgtestnullRow](_path, "int2", None, Some("int2"), x => x.int2, (row, value) => row.copy(int2 = value))
+      override def int2vector = OptField[TypoInt2Vector, PgtestnullRow](_path, "int2vector", None, Some("int2vector"), x => x.int2vector, (row, value) => row.copy(int2vector = value))
+      override def int4 = OptField[Int, PgtestnullRow](_path, "int4", None, Some("int4"), x => x.int4, (row, value) => row.copy(int4 = value))
+      override def int8 = OptField[Long, PgtestnullRow](_path, "int8", None, Some("int8"), x => x.int8, (row, value) => row.copy(int8 = value))
+      override def interval = OptField[TypoInterval, PgtestnullRow](_path, "interval", None, Some("interval"), x => x.interval, (row, value) => row.copy(interval = value))
+      override def json = OptField[TypoJson, PgtestnullRow](_path, "json", None, Some("json"), x => x.json, (row, value) => row.copy(json = value))
+      override def jsonb = OptField[TypoJsonb, PgtestnullRow](_path, "jsonb", None, Some("jsonb"), x => x.jsonb, (row, value) => row.copy(jsonb = value))
+      override def line = OptField[TypoLine, PgtestnullRow](_path, "line", None, Some("line"), x => x.line, (row, value) => row.copy(line = value))
+      override def lseg = OptField[TypoLineSegment, PgtestnullRow](_path, "lseg", None, Some("lseg"), x => x.lseg, (row, value) => row.copy(lseg = value))
+      override def money = OptField[TypoMoney, PgtestnullRow](_path, "money", Some("numeric"), Some("money"), x => x.money, (row, value) => row.copy(money = value))
+      override def mydomain = OptField[Mydomain, PgtestnullRow](_path, "mydomain", None, Some("text"), x => x.mydomain, (row, value) => row.copy(mydomain = value))
+      override def myenum = OptField[Myenum, PgtestnullRow](_path, "myenum", None, Some("public.myenum"), x => x.myenum, (row, value) => row.copy(myenum = value))
+      override def name = OptField[String, PgtestnullRow](_path, "name", None, Some("name"), x => x.name, (row, value) => row.copy(name = value))
+      override def numeric = OptField[BigDecimal, PgtestnullRow](_path, "numeric", None, Some("numeric"), x => x.numeric, (row, value) => row.copy(numeric = value))
+      override def path = OptField[TypoPath, PgtestnullRow](_path, "path", None, Some("path"), x => x.path, (row, value) => row.copy(path = value))
+      override def point = OptField[TypoPoint, PgtestnullRow](_path, "point", None, Some("point"), x => x.point, (row, value) => row.copy(point = value))
+      override def polygon = OptField[TypoPolygon, PgtestnullRow](_path, "polygon", None, Some("polygon"), x => x.polygon, (row, value) => row.copy(polygon = value))
+      override def text = OptField[String, PgtestnullRow](_path, "text", None, None, x => x.text, (row, value) => row.copy(text = value))
+      override def time = OptField[TypoLocalTime, PgtestnullRow](_path, "time", Some("text"), Some("time"), x => x.time, (row, value) => row.copy(time = value))
+      override def timestamp = OptField[TypoLocalDateTime, PgtestnullRow](_path, "timestamp", Some("text"), Some("timestamp"), x => x.timestamp, (row, value) => row.copy(timestamp = value))
+      override def timestampz = OptField[TypoInstant, PgtestnullRow](_path, "timestampz", Some("text"), Some("timestamptz"), x => x.timestampz, (row, value) => row.copy(timestampz = value))
+      override def timez = OptField[TypoOffsetTime, PgtestnullRow](_path, "timez", Some("text"), Some("timetz"), x => x.timez, (row, value) => row.copy(timez = value))
+      override def uuid = OptField[TypoUUID, PgtestnullRow](_path, "uuid", None, Some("uuid"), x => x.uuid, (row, value) => row.copy(uuid = value))
+      override def varchar = OptField[String, PgtestnullRow](_path, "varchar", None, None, x => x.varchar, (row, value) => row.copy(varchar = value))
+      override def vector = OptField[TypoVector, PgtestnullRow](_path, "vector", Some("float4[]"), Some("vector"), x => x.vector, (row, value) => row.copy(vector = value))
+      override def xml = OptField[TypoXml, PgtestnullRow](_path, "xml", None, Some("xml"), x => x.xml, (row, value) => row.copy(xml = value))
+      override def boxes = OptField[Array[TypoBox], PgtestnullRow](_path, "boxes", None, Some("_box"), x => x.boxes, (row, value) => row.copy(boxes = value))
+      override def bpchares = OptField[Array[/* bpchar */ String], PgtestnullRow](_path, "bpchares", None, Some("_bpchar"), x => x.bpchares, (row, value) => row.copy(bpchares = value))
+      override def chares = OptField[Array[/* bpchar */ String], PgtestnullRow](_path, "chares", None, Some("_bpchar"), x => x.chares, (row, value) => row.copy(chares = value))
+      override def circlees = OptField[Array[TypoCircle], PgtestnullRow](_path, "circlees", None, Some("_circle"), x => x.circlees, (row, value) => row.copy(circlees = value))
+      override def datees = OptField[Array[TypoLocalDate], PgtestnullRow](_path, "datees", Some("text[]"), Some("_date"), x => x.datees, (row, value) => row.copy(datees = value))
+      override def float4es = OptField[Array[Float], PgtestnullRow](_path, "float4es", None, Some("_float4"), x => x.float4es, (row, value) => row.copy(float4es = value))
+      override def float8es = OptField[Array[Double], PgtestnullRow](_path, "float8es", None, Some("_float8"), x => x.float8es, (row, value) => row.copy(float8es = value))
+      override def inetes = OptField[Array[TypoInet], PgtestnullRow](_path, "inetes", None, Some("_inet"), x => x.inetes, (row, value) => row.copy(inetes = value))
+      override def int2es = OptField[Array[TypoShort], PgtestnullRow](_path, "int2es", None, Some("_int2"), x => x.int2es, (row, value) => row.copy(int2es = value))
+      override def int2vectores = OptField[Array[TypoInt2Vector], PgtestnullRow](_path, "int2vectores", None, Some("_int2vector"), x => x.int2vectores, (row, value) => row.copy(int2vectores = value))
+      override def int4es = OptField[Array[Int], PgtestnullRow](_path, "int4es", None, Some("_int4"), x => x.int4es, (row, value) => row.copy(int4es = value))
+      override def int8es = OptField[Array[Long], PgtestnullRow](_path, "int8es", None, Some("_int8"), x => x.int8es, (row, value) => row.copy(int8es = value))
+      override def intervales = OptField[Array[TypoInterval], PgtestnullRow](_path, "intervales", None, Some("_interval"), x => x.intervales, (row, value) => row.copy(intervales = value))
+      override def jsones = OptField[Array[TypoJson], PgtestnullRow](_path, "jsones", None, Some("_json"), x => x.jsones, (row, value) => row.copy(jsones = value))
+      override def jsonbes = OptField[Array[TypoJsonb], PgtestnullRow](_path, "jsonbes", None, Some("_jsonb"), x => x.jsonbes, (row, value) => row.copy(jsonbes = value))
+      override def linees = OptField[Array[TypoLine], PgtestnullRow](_path, "linees", None, Some("_line"), x => x.linees, (row, value) => row.copy(linees = value))
+      override def lseges = OptField[Array[TypoLineSegment], PgtestnullRow](_path, "lseges", None, Some("_lseg"), x => x.lseges, (row, value) => row.copy(lseges = value))
+      override def moneyes = OptField[Array[TypoMoney], PgtestnullRow](_path, "moneyes", Some("numeric[]"), Some("_money"), x => x.moneyes, (row, value) => row.copy(moneyes = value))
+      override def myenumes = OptField[Array[Myenum], PgtestnullRow](_path, "myenumes", None, Some("_myenum"), x => x.myenumes, (row, value) => row.copy(myenumes = value))
+      override def namees = OptField[Array[String], PgtestnullRow](_path, "namees", None, Some("_name"), x => x.namees, (row, value) => row.copy(namees = value))
+      override def numerices = OptField[Array[BigDecimal], PgtestnullRow](_path, "numerices", None, Some("_numeric"), x => x.numerices, (row, value) => row.copy(numerices = value))
+      override def pathes = OptField[Array[TypoPath], PgtestnullRow](_path, "pathes", None, Some("_path"), x => x.pathes, (row, value) => row.copy(pathes = value))
+      override def pointes = OptField[Array[TypoPoint], PgtestnullRow](_path, "pointes", None, Some("_point"), x => x.pointes, (row, value) => row.copy(pointes = value))
+      override def polygones = OptField[Array[TypoPolygon], PgtestnullRow](_path, "polygones", None, Some("_polygon"), x => x.polygones, (row, value) => row.copy(polygones = value))
+      override def textes = OptField[Array[String], PgtestnullRow](_path, "textes", None, Some("_text"), x => x.textes, (row, value) => row.copy(textes = value))
+      override def timees = OptField[Array[TypoLocalTime], PgtestnullRow](_path, "timees", Some("text[]"), Some("_time"), x => x.timees, (row, value) => row.copy(timees = value))
+      override def timestampes = OptField[Array[TypoLocalDateTime], PgtestnullRow](_path, "timestampes", Some("text[]"), Some("_timestamp"), x => x.timestampes, (row, value) => row.copy(timestampes = value))
+      override def timestampzes = OptField[Array[TypoInstant], PgtestnullRow](_path, "timestampzes", Some("text[]"), Some("_timestamptz"), x => x.timestampzes, (row, value) => row.copy(timestampzes = value))
+      override def timezes = OptField[Array[TypoOffsetTime], PgtestnullRow](_path, "timezes", Some("text[]"), Some("_timetz"), x => x.timezes, (row, value) => row.copy(timezes = value))
+      override def uuides = OptField[Array[TypoUUID], PgtestnullRow](_path, "uuides", None, Some("_uuid"), x => x.uuides, (row, value) => row.copy(uuides = value))
+      override def varchares = OptField[Array[String], PgtestnullRow](_path, "varchares", None, Some("_varchar"), x => x.varchares, (row, value) => row.copy(varchares = value))
+      override def xmles = OptField[Array[TypoXml], PgtestnullRow](_path, "xmles", None, Some("_xml"), x => x.xmles, (row, value) => row.copy(xmles = value))
     }
   
-    override val columns: List[FieldLikeNoHkt[?, Row]] =
-      List[FieldLikeNoHkt[?, Row]](fields.bool, fields.box, fields.bpchar, fields.bytea, fields.char, fields.circle, fields.date, fields.float4, fields.float8, fields.hstore, fields.inet, fields.int2, fields.int2vector, fields.int4, fields.int8, fields.interval, fields.json, fields.jsonb, fields.line, fields.lseg, fields.money, fields.mydomain, fields.myenum, fields.name, fields.numeric, fields.path, fields.point, fields.polygon, fields.text, fields.time, fields.timestamp, fields.timestampz, fields.timez, fields.uuid, fields.varchar, fields.vector, fields.xml, fields.boxes, fields.bpchares, fields.chares, fields.circlees, fields.datees, fields.float4es, fields.float8es, fields.inetes, fields.int2es, fields.int2vectores, fields.int4es, fields.int8es, fields.intervales, fields.jsones, fields.jsonbes, fields.linees, fields.lseges, fields.moneyes, fields.myenumes, fields.namees, fields.numerices, fields.pathes, fields.pointes, fields.polygones, fields.textes, fields.timees, fields.timestampes, fields.timestampzes, fields.timezes, fields.uuides, fields.varchares, fields.xmles)
+    override lazy val columns: List[FieldLikeNoHkt[?, PgtestnullRow]] =
+      List[FieldLikeNoHkt[?, PgtestnullRow]](fields.bool, fields.box, fields.bpchar, fields.bytea, fields.char, fields.circle, fields.date, fields.float4, fields.float8, fields.hstore, fields.inet, fields.int2, fields.int2vector, fields.int4, fields.int8, fields.interval, fields.json, fields.jsonb, fields.line, fields.lseg, fields.money, fields.mydomain, fields.myenum, fields.name, fields.numeric, fields.path, fields.point, fields.polygon, fields.text, fields.time, fields.timestamp, fields.timestampz, fields.timez, fields.uuid, fields.varchar, fields.vector, fields.xml, fields.boxes, fields.bpchares, fields.chares, fields.circlees, fields.datees, fields.float4es, fields.float8es, fields.inetes, fields.int2es, fields.int2vectores, fields.int4es, fields.int8es, fields.intervales, fields.jsones, fields.jsonbes, fields.linees, fields.lseges, fields.moneyes, fields.myenumes, fields.namees, fields.numerices, fields.pathes, fields.pointes, fields.polygones, fields.textes, fields.timees, fields.timestampes, fields.timestampzes, fields.timezes, fields.uuides, fields.varchares, fields.xmles)
   
-    override def copy[NewRow](prefix: Option[String], extract: NewRow => PgtestnullRow, merge: (NewRow, PgtestnullRow) => NewRow): Impl[NewRow] =
-      new Impl(prefix, extract, merge)
+    override def copy(path: List[Path]): Impl =
+      new Impl(path)
   }
   
 }

--- a/typo-tester-doobie/generated-and-checked-in/adventureworks/public/users/UsersFields.scala
+++ b/typo-tester-doobie/generated-and-checked-in/adventureworks/public/users/UsersFields.scala
@@ -9,44 +9,45 @@ package users
 
 import adventureworks.customtypes.TypoInstant
 import adventureworks.customtypes.TypoUnknownCitext
+import typo.dsl.Path
 import typo.dsl.SqlExpr.Field
 import typo.dsl.SqlExpr.FieldLikeNoHkt
 import typo.dsl.SqlExpr.IdField
 import typo.dsl.SqlExpr.OptField
 import typo.dsl.Structure.Relation
 
-trait UsersFields[Row] {
-  val userId: IdField[UsersId, Row]
-  val name: Field[String, Row]
-  val lastName: OptField[String, Row]
-  val email: Field[TypoUnknownCitext, Row]
-  val password: Field[String, Row]
-  val createdAt: Field[TypoInstant, Row]
-  val verifiedOn: OptField[TypoInstant, Row]
+trait UsersFields {
+  def userId: IdField[UsersId, UsersRow]
+  def name: Field[String, UsersRow]
+  def lastName: OptField[String, UsersRow]
+  def email: Field[TypoUnknownCitext, UsersRow]
+  def password: Field[String, UsersRow]
+  def createdAt: Field[TypoInstant, UsersRow]
+  def verifiedOn: OptField[TypoInstant, UsersRow]
 }
 
 object UsersFields {
-  val structure: Relation[UsersFields, UsersRow, UsersRow] = 
-    new Impl(None, identity, (_, x) => x)
+  lazy val structure: Relation[UsersFields, UsersRow] =
+    new Impl(Nil)
     
-  private final class Impl[Row](val prefix: Option[String], val extract: Row => UsersRow, val merge: (Row, UsersRow) => Row)
-    extends Relation[UsersFields, UsersRow, Row] { 
+  private final class Impl(val _path: List[Path])
+    extends Relation[UsersFields, UsersRow] {
   
-    override val fields: UsersFields[Row] = new UsersFields[Row] {
-      override val userId = new IdField[UsersId, Row](prefix, "user_id", None, Some("uuid"))(x => extract(x).userId, (row, value) => merge(row, extract(row).copy(userId = value)))
-      override val name = new Field[String, Row](prefix, "name", None, None)(x => extract(x).name, (row, value) => merge(row, extract(row).copy(name = value)))
-      override val lastName = new OptField[String, Row](prefix, "last_name", None, None)(x => extract(x).lastName, (row, value) => merge(row, extract(row).copy(lastName = value)))
-      override val email = new Field[TypoUnknownCitext, Row](prefix, "email", Some("text"), Some("citext"))(x => extract(x).email, (row, value) => merge(row, extract(row).copy(email = value)))
-      override val password = new Field[String, Row](prefix, "password", None, None)(x => extract(x).password, (row, value) => merge(row, extract(row).copy(password = value)))
-      override val createdAt = new Field[TypoInstant, Row](prefix, "created_at", Some("text"), Some("timestamptz"))(x => extract(x).createdAt, (row, value) => merge(row, extract(row).copy(createdAt = value)))
-      override val verifiedOn = new OptField[TypoInstant, Row](prefix, "verified_on", Some("text"), Some("timestamptz"))(x => extract(x).verifiedOn, (row, value) => merge(row, extract(row).copy(verifiedOn = value)))
+    override lazy val fields: UsersFields = new UsersFields {
+      override def userId = IdField[UsersId, UsersRow](_path, "user_id", None, Some("uuid"), x => x.userId, (row, value) => row.copy(userId = value))
+      override def name = Field[String, UsersRow](_path, "name", None, None, x => x.name, (row, value) => row.copy(name = value))
+      override def lastName = OptField[String, UsersRow](_path, "last_name", None, None, x => x.lastName, (row, value) => row.copy(lastName = value))
+      override def email = Field[TypoUnknownCitext, UsersRow](_path, "email", Some("text"), Some("citext"), x => x.email, (row, value) => row.copy(email = value))
+      override def password = Field[String, UsersRow](_path, "password", None, None, x => x.password, (row, value) => row.copy(password = value))
+      override def createdAt = Field[TypoInstant, UsersRow](_path, "created_at", Some("text"), Some("timestamptz"), x => x.createdAt, (row, value) => row.copy(createdAt = value))
+      override def verifiedOn = OptField[TypoInstant, UsersRow](_path, "verified_on", Some("text"), Some("timestamptz"), x => x.verifiedOn, (row, value) => row.copy(verifiedOn = value))
     }
   
-    override val columns: List[FieldLikeNoHkt[?, Row]] =
-      List[FieldLikeNoHkt[?, Row]](fields.userId, fields.name, fields.lastName, fields.email, fields.password, fields.createdAt, fields.verifiedOn)
+    override lazy val columns: List[FieldLikeNoHkt[?, UsersRow]] =
+      List[FieldLikeNoHkt[?, UsersRow]](fields.userId, fields.name, fields.lastName, fields.email, fields.password, fields.createdAt, fields.verifiedOn)
   
-    override def copy[NewRow](prefix: Option[String], extract: NewRow => UsersRow, merge: (NewRow, UsersRow) => NewRow): Impl[NewRow] =
-      new Impl(prefix, extract, merge)
+    override def copy(path: List[Path]): Impl =
+      new Impl(path)
   }
   
 }

--- a/typo-tester-doobie/generated-and-checked-in/adventureworks/public/users/UsersRepoMock.scala
+++ b/typo-tester-doobie/generated-and-checked-in/adventureworks/public/users/UsersRepoMock.scala
@@ -25,7 +25,7 @@ import typo.dsl.UpdateParams
 class UsersRepoMock(toRow: Function1[UsersRowUnsaved, UsersRow],
                     map: scala.collection.mutable.Map[UsersId, UsersRow] = scala.collection.mutable.Map.empty) extends UsersRepo {
   override def delete: DeleteBuilder[UsersFields, UsersRow] = {
-    DeleteBuilderMock(DeleteParams.empty, UsersFields.structure.fields, map)
+    DeleteBuilderMock(DeleteParams.empty, UsersFields.structure, map)
   }
   override def deleteById(userId: UsersId): ConnectionIO[Boolean] = {
     delay(map.remove(userId).isDefined)
@@ -90,7 +90,7 @@ class UsersRepoMock(toRow: Function1[UsersRowUnsaved, UsersRow],
     delay(map.values.find(v => email == v.email))
   }
   override def update: UpdateBuilder[UsersFields, UsersRow] = {
-    UpdateBuilderMock(UpdateParams.empty, UsersFields.structure.fields, map)
+    UpdateBuilderMock(UpdateParams.empty, UsersFields.structure, map)
   }
   override def update(row: UsersRow): ConnectionIO[Boolean] = {
     delay {

--- a/typo-tester-doobie/generated-and-checked-in/adventureworks/purchasing/productvendor/ProductvendorFields.scala
+++ b/typo-tester-doobie/generated-and-checked-in/adventureworks/purchasing/productvendor/ProductvendorFields.scala
@@ -11,52 +11,53 @@ import adventureworks.customtypes.TypoLocalDateTime
 import adventureworks.person.businessentity.BusinessentityId
 import adventureworks.production.product.ProductId
 import adventureworks.production.unitmeasure.UnitmeasureId
+import typo.dsl.Path
 import typo.dsl.SqlExpr.Field
 import typo.dsl.SqlExpr.FieldLikeNoHkt
 import typo.dsl.SqlExpr.IdField
 import typo.dsl.SqlExpr.OptField
 import typo.dsl.Structure.Relation
 
-trait ProductvendorFields[Row] {
-  val productid: IdField[ProductId, Row]
-  val businessentityid: IdField[BusinessentityId, Row]
-  val averageleadtime: Field[Int, Row]
-  val standardprice: Field[BigDecimal, Row]
-  val lastreceiptcost: OptField[BigDecimal, Row]
-  val lastreceiptdate: OptField[TypoLocalDateTime, Row]
-  val minorderqty: Field[Int, Row]
-  val maxorderqty: Field[Int, Row]
-  val onorderqty: OptField[Int, Row]
-  val unitmeasurecode: Field[UnitmeasureId, Row]
-  val modifieddate: Field[TypoLocalDateTime, Row]
+trait ProductvendorFields {
+  def productid: IdField[ProductId, ProductvendorRow]
+  def businessentityid: IdField[BusinessentityId, ProductvendorRow]
+  def averageleadtime: Field[Int, ProductvendorRow]
+  def standardprice: Field[BigDecimal, ProductvendorRow]
+  def lastreceiptcost: OptField[BigDecimal, ProductvendorRow]
+  def lastreceiptdate: OptField[TypoLocalDateTime, ProductvendorRow]
+  def minorderqty: Field[Int, ProductvendorRow]
+  def maxorderqty: Field[Int, ProductvendorRow]
+  def onorderqty: OptField[Int, ProductvendorRow]
+  def unitmeasurecode: Field[UnitmeasureId, ProductvendorRow]
+  def modifieddate: Field[TypoLocalDateTime, ProductvendorRow]
 }
 
 object ProductvendorFields {
-  val structure: Relation[ProductvendorFields, ProductvendorRow, ProductvendorRow] = 
-    new Impl(None, identity, (_, x) => x)
+  lazy val structure: Relation[ProductvendorFields, ProductvendorRow] =
+    new Impl(Nil)
     
-  private final class Impl[Row](val prefix: Option[String], val extract: Row => ProductvendorRow, val merge: (Row, ProductvendorRow) => Row)
-    extends Relation[ProductvendorFields, ProductvendorRow, Row] { 
+  private final class Impl(val _path: List[Path])
+    extends Relation[ProductvendorFields, ProductvendorRow] {
   
-    override val fields: ProductvendorFields[Row] = new ProductvendorFields[Row] {
-      override val productid = new IdField[ProductId, Row](prefix, "productid", None, Some("int4"))(x => extract(x).productid, (row, value) => merge(row, extract(row).copy(productid = value)))
-      override val businessentityid = new IdField[BusinessentityId, Row](prefix, "businessentityid", None, Some("int4"))(x => extract(x).businessentityid, (row, value) => merge(row, extract(row).copy(businessentityid = value)))
-      override val averageleadtime = new Field[Int, Row](prefix, "averageleadtime", None, Some("int4"))(x => extract(x).averageleadtime, (row, value) => merge(row, extract(row).copy(averageleadtime = value)))
-      override val standardprice = new Field[BigDecimal, Row](prefix, "standardprice", None, Some("numeric"))(x => extract(x).standardprice, (row, value) => merge(row, extract(row).copy(standardprice = value)))
-      override val lastreceiptcost = new OptField[BigDecimal, Row](prefix, "lastreceiptcost", None, Some("numeric"))(x => extract(x).lastreceiptcost, (row, value) => merge(row, extract(row).copy(lastreceiptcost = value)))
-      override val lastreceiptdate = new OptField[TypoLocalDateTime, Row](prefix, "lastreceiptdate", Some("text"), Some("timestamp"))(x => extract(x).lastreceiptdate, (row, value) => merge(row, extract(row).copy(lastreceiptdate = value)))
-      override val minorderqty = new Field[Int, Row](prefix, "minorderqty", None, Some("int4"))(x => extract(x).minorderqty, (row, value) => merge(row, extract(row).copy(minorderqty = value)))
-      override val maxorderqty = new Field[Int, Row](prefix, "maxorderqty", None, Some("int4"))(x => extract(x).maxorderqty, (row, value) => merge(row, extract(row).copy(maxorderqty = value)))
-      override val onorderqty = new OptField[Int, Row](prefix, "onorderqty", None, Some("int4"))(x => extract(x).onorderqty, (row, value) => merge(row, extract(row).copy(onorderqty = value)))
-      override val unitmeasurecode = new Field[UnitmeasureId, Row](prefix, "unitmeasurecode", None, Some("bpchar"))(x => extract(x).unitmeasurecode, (row, value) => merge(row, extract(row).copy(unitmeasurecode = value)))
-      override val modifieddate = new Field[TypoLocalDateTime, Row](prefix, "modifieddate", Some("text"), Some("timestamp"))(x => extract(x).modifieddate, (row, value) => merge(row, extract(row).copy(modifieddate = value)))
+    override lazy val fields: ProductvendorFields = new ProductvendorFields {
+      override def productid = IdField[ProductId, ProductvendorRow](_path, "productid", None, Some("int4"), x => x.productid, (row, value) => row.copy(productid = value))
+      override def businessentityid = IdField[BusinessentityId, ProductvendorRow](_path, "businessentityid", None, Some("int4"), x => x.businessentityid, (row, value) => row.copy(businessentityid = value))
+      override def averageleadtime = Field[Int, ProductvendorRow](_path, "averageleadtime", None, Some("int4"), x => x.averageleadtime, (row, value) => row.copy(averageleadtime = value))
+      override def standardprice = Field[BigDecimal, ProductvendorRow](_path, "standardprice", None, Some("numeric"), x => x.standardprice, (row, value) => row.copy(standardprice = value))
+      override def lastreceiptcost = OptField[BigDecimal, ProductvendorRow](_path, "lastreceiptcost", None, Some("numeric"), x => x.lastreceiptcost, (row, value) => row.copy(lastreceiptcost = value))
+      override def lastreceiptdate = OptField[TypoLocalDateTime, ProductvendorRow](_path, "lastreceiptdate", Some("text"), Some("timestamp"), x => x.lastreceiptdate, (row, value) => row.copy(lastreceiptdate = value))
+      override def minorderqty = Field[Int, ProductvendorRow](_path, "minorderqty", None, Some("int4"), x => x.minorderqty, (row, value) => row.copy(minorderqty = value))
+      override def maxorderqty = Field[Int, ProductvendorRow](_path, "maxorderqty", None, Some("int4"), x => x.maxorderqty, (row, value) => row.copy(maxorderqty = value))
+      override def onorderqty = OptField[Int, ProductvendorRow](_path, "onorderqty", None, Some("int4"), x => x.onorderqty, (row, value) => row.copy(onorderqty = value))
+      override def unitmeasurecode = Field[UnitmeasureId, ProductvendorRow](_path, "unitmeasurecode", None, Some("bpchar"), x => x.unitmeasurecode, (row, value) => row.copy(unitmeasurecode = value))
+      override def modifieddate = Field[TypoLocalDateTime, ProductvendorRow](_path, "modifieddate", Some("text"), Some("timestamp"), x => x.modifieddate, (row, value) => row.copy(modifieddate = value))
     }
   
-    override val columns: List[FieldLikeNoHkt[?, Row]] =
-      List[FieldLikeNoHkt[?, Row]](fields.productid, fields.businessentityid, fields.averageleadtime, fields.standardprice, fields.lastreceiptcost, fields.lastreceiptdate, fields.minorderqty, fields.maxorderqty, fields.onorderqty, fields.unitmeasurecode, fields.modifieddate)
+    override lazy val columns: List[FieldLikeNoHkt[?, ProductvendorRow]] =
+      List[FieldLikeNoHkt[?, ProductvendorRow]](fields.productid, fields.businessentityid, fields.averageleadtime, fields.standardprice, fields.lastreceiptcost, fields.lastreceiptdate, fields.minorderqty, fields.maxorderqty, fields.onorderqty, fields.unitmeasurecode, fields.modifieddate)
   
-    override def copy[NewRow](prefix: Option[String], extract: NewRow => ProductvendorRow, merge: (NewRow, ProductvendorRow) => NewRow): Impl[NewRow] =
-      new Impl(prefix, extract, merge)
+    override def copy(path: List[Path]): Impl =
+      new Impl(path)
   }
   
 }

--- a/typo-tester-doobie/generated-and-checked-in/adventureworks/purchasing/productvendor/ProductvendorRepoMock.scala
+++ b/typo-tester-doobie/generated-and-checked-in/adventureworks/purchasing/productvendor/ProductvendorRepoMock.scala
@@ -24,7 +24,7 @@ import typo.dsl.UpdateParams
 class ProductvendorRepoMock(toRow: Function1[ProductvendorRowUnsaved, ProductvendorRow],
                             map: scala.collection.mutable.Map[ProductvendorId, ProductvendorRow] = scala.collection.mutable.Map.empty) extends ProductvendorRepo {
   override def delete: DeleteBuilder[ProductvendorFields, ProductvendorRow] = {
-    DeleteBuilderMock(DeleteParams.empty, ProductvendorFields.structure.fields, map)
+    DeleteBuilderMock(DeleteParams.empty, ProductvendorFields.structure, map)
   }
   override def deleteById(compositeId: ProductvendorId): ConnectionIO[Boolean] = {
     delay(map.remove(compositeId).isDefined)
@@ -86,7 +86,7 @@ class ProductvendorRepoMock(toRow: Function1[ProductvendorRowUnsaved, Productven
     }
   }
   override def update: UpdateBuilder[ProductvendorFields, ProductvendorRow] = {
-    UpdateBuilderMock(UpdateParams.empty, ProductvendorFields.structure.fields, map)
+    UpdateBuilderMock(UpdateParams.empty, ProductvendorFields.structure, map)
   }
   override def update(row: ProductvendorRow): ConnectionIO[Boolean] = {
     delay {

--- a/typo-tester-doobie/generated-and-checked-in/adventureworks/purchasing/purchaseorderdetail/PurchaseorderdetailFields.scala
+++ b/typo-tester-doobie/generated-and-checked-in/adventureworks/purchasing/purchaseorderdetail/PurchaseorderdetailFields.scala
@@ -11,47 +11,48 @@ import adventureworks.customtypes.TypoLocalDateTime
 import adventureworks.customtypes.TypoShort
 import adventureworks.production.product.ProductId
 import adventureworks.purchasing.purchaseorderheader.PurchaseorderheaderId
+import typo.dsl.Path
 import typo.dsl.SqlExpr.Field
 import typo.dsl.SqlExpr.FieldLikeNoHkt
 import typo.dsl.SqlExpr.IdField
 import typo.dsl.Structure.Relation
 
-trait PurchaseorderdetailFields[Row] {
-  val purchaseorderid: IdField[PurchaseorderheaderId, Row]
-  val purchaseorderdetailid: IdField[Int, Row]
-  val duedate: Field[TypoLocalDateTime, Row]
-  val orderqty: Field[TypoShort, Row]
-  val productid: Field[ProductId, Row]
-  val unitprice: Field[BigDecimal, Row]
-  val receivedqty: Field[BigDecimal, Row]
-  val rejectedqty: Field[BigDecimal, Row]
-  val modifieddate: Field[TypoLocalDateTime, Row]
+trait PurchaseorderdetailFields {
+  def purchaseorderid: IdField[PurchaseorderheaderId, PurchaseorderdetailRow]
+  def purchaseorderdetailid: IdField[Int, PurchaseorderdetailRow]
+  def duedate: Field[TypoLocalDateTime, PurchaseorderdetailRow]
+  def orderqty: Field[TypoShort, PurchaseorderdetailRow]
+  def productid: Field[ProductId, PurchaseorderdetailRow]
+  def unitprice: Field[BigDecimal, PurchaseorderdetailRow]
+  def receivedqty: Field[BigDecimal, PurchaseorderdetailRow]
+  def rejectedqty: Field[BigDecimal, PurchaseorderdetailRow]
+  def modifieddate: Field[TypoLocalDateTime, PurchaseorderdetailRow]
 }
 
 object PurchaseorderdetailFields {
-  val structure: Relation[PurchaseorderdetailFields, PurchaseorderdetailRow, PurchaseorderdetailRow] = 
-    new Impl(None, identity, (_, x) => x)
+  lazy val structure: Relation[PurchaseorderdetailFields, PurchaseorderdetailRow] =
+    new Impl(Nil)
     
-  private final class Impl[Row](val prefix: Option[String], val extract: Row => PurchaseorderdetailRow, val merge: (Row, PurchaseorderdetailRow) => Row)
-    extends Relation[PurchaseorderdetailFields, PurchaseorderdetailRow, Row] { 
+  private final class Impl(val _path: List[Path])
+    extends Relation[PurchaseorderdetailFields, PurchaseorderdetailRow] {
   
-    override val fields: PurchaseorderdetailFields[Row] = new PurchaseorderdetailFields[Row] {
-      override val purchaseorderid = new IdField[PurchaseorderheaderId, Row](prefix, "purchaseorderid", None, Some("int4"))(x => extract(x).purchaseorderid, (row, value) => merge(row, extract(row).copy(purchaseorderid = value)))
-      override val purchaseorderdetailid = new IdField[Int, Row](prefix, "purchaseorderdetailid", None, Some("int4"))(x => extract(x).purchaseorderdetailid, (row, value) => merge(row, extract(row).copy(purchaseorderdetailid = value)))
-      override val duedate = new Field[TypoLocalDateTime, Row](prefix, "duedate", Some("text"), Some("timestamp"))(x => extract(x).duedate, (row, value) => merge(row, extract(row).copy(duedate = value)))
-      override val orderqty = new Field[TypoShort, Row](prefix, "orderqty", None, Some("int2"))(x => extract(x).orderqty, (row, value) => merge(row, extract(row).copy(orderqty = value)))
-      override val productid = new Field[ProductId, Row](prefix, "productid", None, Some("int4"))(x => extract(x).productid, (row, value) => merge(row, extract(row).copy(productid = value)))
-      override val unitprice = new Field[BigDecimal, Row](prefix, "unitprice", None, Some("numeric"))(x => extract(x).unitprice, (row, value) => merge(row, extract(row).copy(unitprice = value)))
-      override val receivedqty = new Field[BigDecimal, Row](prefix, "receivedqty", None, Some("numeric"))(x => extract(x).receivedqty, (row, value) => merge(row, extract(row).copy(receivedqty = value)))
-      override val rejectedqty = new Field[BigDecimal, Row](prefix, "rejectedqty", None, Some("numeric"))(x => extract(x).rejectedqty, (row, value) => merge(row, extract(row).copy(rejectedqty = value)))
-      override val modifieddate = new Field[TypoLocalDateTime, Row](prefix, "modifieddate", Some("text"), Some("timestamp"))(x => extract(x).modifieddate, (row, value) => merge(row, extract(row).copy(modifieddate = value)))
+    override lazy val fields: PurchaseorderdetailFields = new PurchaseorderdetailFields {
+      override def purchaseorderid = IdField[PurchaseorderheaderId, PurchaseorderdetailRow](_path, "purchaseorderid", None, Some("int4"), x => x.purchaseorderid, (row, value) => row.copy(purchaseorderid = value))
+      override def purchaseorderdetailid = IdField[Int, PurchaseorderdetailRow](_path, "purchaseorderdetailid", None, Some("int4"), x => x.purchaseorderdetailid, (row, value) => row.copy(purchaseorderdetailid = value))
+      override def duedate = Field[TypoLocalDateTime, PurchaseorderdetailRow](_path, "duedate", Some("text"), Some("timestamp"), x => x.duedate, (row, value) => row.copy(duedate = value))
+      override def orderqty = Field[TypoShort, PurchaseorderdetailRow](_path, "orderqty", None, Some("int2"), x => x.orderqty, (row, value) => row.copy(orderqty = value))
+      override def productid = Field[ProductId, PurchaseorderdetailRow](_path, "productid", None, Some("int4"), x => x.productid, (row, value) => row.copy(productid = value))
+      override def unitprice = Field[BigDecimal, PurchaseorderdetailRow](_path, "unitprice", None, Some("numeric"), x => x.unitprice, (row, value) => row.copy(unitprice = value))
+      override def receivedqty = Field[BigDecimal, PurchaseorderdetailRow](_path, "receivedqty", None, Some("numeric"), x => x.receivedqty, (row, value) => row.copy(receivedqty = value))
+      override def rejectedqty = Field[BigDecimal, PurchaseorderdetailRow](_path, "rejectedqty", None, Some("numeric"), x => x.rejectedqty, (row, value) => row.copy(rejectedqty = value))
+      override def modifieddate = Field[TypoLocalDateTime, PurchaseorderdetailRow](_path, "modifieddate", Some("text"), Some("timestamp"), x => x.modifieddate, (row, value) => row.copy(modifieddate = value))
     }
   
-    override val columns: List[FieldLikeNoHkt[?, Row]] =
-      List[FieldLikeNoHkt[?, Row]](fields.purchaseorderid, fields.purchaseorderdetailid, fields.duedate, fields.orderqty, fields.productid, fields.unitprice, fields.receivedqty, fields.rejectedqty, fields.modifieddate)
+    override lazy val columns: List[FieldLikeNoHkt[?, PurchaseorderdetailRow]] =
+      List[FieldLikeNoHkt[?, PurchaseorderdetailRow]](fields.purchaseorderid, fields.purchaseorderdetailid, fields.duedate, fields.orderqty, fields.productid, fields.unitprice, fields.receivedqty, fields.rejectedqty, fields.modifieddate)
   
-    override def copy[NewRow](prefix: Option[String], extract: NewRow => PurchaseorderdetailRow, merge: (NewRow, PurchaseorderdetailRow) => NewRow): Impl[NewRow] =
-      new Impl(prefix, extract, merge)
+    override def copy(path: List[Path]): Impl =
+      new Impl(path)
   }
   
 }

--- a/typo-tester-doobie/generated-and-checked-in/adventureworks/purchasing/purchaseorderheader/PurchaseorderheaderFields.scala
+++ b/typo-tester-doobie/generated-and-checked-in/adventureworks/purchasing/purchaseorderheader/PurchaseorderheaderFields.scala
@@ -11,54 +11,55 @@ import adventureworks.customtypes.TypoLocalDateTime
 import adventureworks.customtypes.TypoShort
 import adventureworks.person.businessentity.BusinessentityId
 import adventureworks.purchasing.shipmethod.ShipmethodId
+import typo.dsl.Path
 import typo.dsl.SqlExpr.Field
 import typo.dsl.SqlExpr.FieldLikeNoHkt
 import typo.dsl.SqlExpr.IdField
 import typo.dsl.SqlExpr.OptField
 import typo.dsl.Structure.Relation
 
-trait PurchaseorderheaderFields[Row] {
-  val purchaseorderid: IdField[PurchaseorderheaderId, Row]
-  val revisionnumber: Field[TypoShort, Row]
-  val status: Field[TypoShort, Row]
-  val employeeid: Field[BusinessentityId, Row]
-  val vendorid: Field[BusinessentityId, Row]
-  val shipmethodid: Field[ShipmethodId, Row]
-  val orderdate: Field[TypoLocalDateTime, Row]
-  val shipdate: OptField[TypoLocalDateTime, Row]
-  val subtotal: Field[BigDecimal, Row]
-  val taxamt: Field[BigDecimal, Row]
-  val freight: Field[BigDecimal, Row]
-  val modifieddate: Field[TypoLocalDateTime, Row]
+trait PurchaseorderheaderFields {
+  def purchaseorderid: IdField[PurchaseorderheaderId, PurchaseorderheaderRow]
+  def revisionnumber: Field[TypoShort, PurchaseorderheaderRow]
+  def status: Field[TypoShort, PurchaseorderheaderRow]
+  def employeeid: Field[BusinessentityId, PurchaseorderheaderRow]
+  def vendorid: Field[BusinessentityId, PurchaseorderheaderRow]
+  def shipmethodid: Field[ShipmethodId, PurchaseorderheaderRow]
+  def orderdate: Field[TypoLocalDateTime, PurchaseorderheaderRow]
+  def shipdate: OptField[TypoLocalDateTime, PurchaseorderheaderRow]
+  def subtotal: Field[BigDecimal, PurchaseorderheaderRow]
+  def taxamt: Field[BigDecimal, PurchaseorderheaderRow]
+  def freight: Field[BigDecimal, PurchaseorderheaderRow]
+  def modifieddate: Field[TypoLocalDateTime, PurchaseorderheaderRow]
 }
 
 object PurchaseorderheaderFields {
-  val structure: Relation[PurchaseorderheaderFields, PurchaseorderheaderRow, PurchaseorderheaderRow] = 
-    new Impl(None, identity, (_, x) => x)
+  lazy val structure: Relation[PurchaseorderheaderFields, PurchaseorderheaderRow] =
+    new Impl(Nil)
     
-  private final class Impl[Row](val prefix: Option[String], val extract: Row => PurchaseorderheaderRow, val merge: (Row, PurchaseorderheaderRow) => Row)
-    extends Relation[PurchaseorderheaderFields, PurchaseorderheaderRow, Row] { 
+  private final class Impl(val _path: List[Path])
+    extends Relation[PurchaseorderheaderFields, PurchaseorderheaderRow] {
   
-    override val fields: PurchaseorderheaderFields[Row] = new PurchaseorderheaderFields[Row] {
-      override val purchaseorderid = new IdField[PurchaseorderheaderId, Row](prefix, "purchaseorderid", None, Some("int4"))(x => extract(x).purchaseorderid, (row, value) => merge(row, extract(row).copy(purchaseorderid = value)))
-      override val revisionnumber = new Field[TypoShort, Row](prefix, "revisionnumber", None, Some("int2"))(x => extract(x).revisionnumber, (row, value) => merge(row, extract(row).copy(revisionnumber = value)))
-      override val status = new Field[TypoShort, Row](prefix, "status", None, Some("int2"))(x => extract(x).status, (row, value) => merge(row, extract(row).copy(status = value)))
-      override val employeeid = new Field[BusinessentityId, Row](prefix, "employeeid", None, Some("int4"))(x => extract(x).employeeid, (row, value) => merge(row, extract(row).copy(employeeid = value)))
-      override val vendorid = new Field[BusinessentityId, Row](prefix, "vendorid", None, Some("int4"))(x => extract(x).vendorid, (row, value) => merge(row, extract(row).copy(vendorid = value)))
-      override val shipmethodid = new Field[ShipmethodId, Row](prefix, "shipmethodid", None, Some("int4"))(x => extract(x).shipmethodid, (row, value) => merge(row, extract(row).copy(shipmethodid = value)))
-      override val orderdate = new Field[TypoLocalDateTime, Row](prefix, "orderdate", Some("text"), Some("timestamp"))(x => extract(x).orderdate, (row, value) => merge(row, extract(row).copy(orderdate = value)))
-      override val shipdate = new OptField[TypoLocalDateTime, Row](prefix, "shipdate", Some("text"), Some("timestamp"))(x => extract(x).shipdate, (row, value) => merge(row, extract(row).copy(shipdate = value)))
-      override val subtotal = new Field[BigDecimal, Row](prefix, "subtotal", None, Some("numeric"))(x => extract(x).subtotal, (row, value) => merge(row, extract(row).copy(subtotal = value)))
-      override val taxamt = new Field[BigDecimal, Row](prefix, "taxamt", None, Some("numeric"))(x => extract(x).taxamt, (row, value) => merge(row, extract(row).copy(taxamt = value)))
-      override val freight = new Field[BigDecimal, Row](prefix, "freight", None, Some("numeric"))(x => extract(x).freight, (row, value) => merge(row, extract(row).copy(freight = value)))
-      override val modifieddate = new Field[TypoLocalDateTime, Row](prefix, "modifieddate", Some("text"), Some("timestamp"))(x => extract(x).modifieddate, (row, value) => merge(row, extract(row).copy(modifieddate = value)))
+    override lazy val fields: PurchaseorderheaderFields = new PurchaseorderheaderFields {
+      override def purchaseorderid = IdField[PurchaseorderheaderId, PurchaseorderheaderRow](_path, "purchaseorderid", None, Some("int4"), x => x.purchaseorderid, (row, value) => row.copy(purchaseorderid = value))
+      override def revisionnumber = Field[TypoShort, PurchaseorderheaderRow](_path, "revisionnumber", None, Some("int2"), x => x.revisionnumber, (row, value) => row.copy(revisionnumber = value))
+      override def status = Field[TypoShort, PurchaseorderheaderRow](_path, "status", None, Some("int2"), x => x.status, (row, value) => row.copy(status = value))
+      override def employeeid = Field[BusinessentityId, PurchaseorderheaderRow](_path, "employeeid", None, Some("int4"), x => x.employeeid, (row, value) => row.copy(employeeid = value))
+      override def vendorid = Field[BusinessentityId, PurchaseorderheaderRow](_path, "vendorid", None, Some("int4"), x => x.vendorid, (row, value) => row.copy(vendorid = value))
+      override def shipmethodid = Field[ShipmethodId, PurchaseorderheaderRow](_path, "shipmethodid", None, Some("int4"), x => x.shipmethodid, (row, value) => row.copy(shipmethodid = value))
+      override def orderdate = Field[TypoLocalDateTime, PurchaseorderheaderRow](_path, "orderdate", Some("text"), Some("timestamp"), x => x.orderdate, (row, value) => row.copy(orderdate = value))
+      override def shipdate = OptField[TypoLocalDateTime, PurchaseorderheaderRow](_path, "shipdate", Some("text"), Some("timestamp"), x => x.shipdate, (row, value) => row.copy(shipdate = value))
+      override def subtotal = Field[BigDecimal, PurchaseorderheaderRow](_path, "subtotal", None, Some("numeric"), x => x.subtotal, (row, value) => row.copy(subtotal = value))
+      override def taxamt = Field[BigDecimal, PurchaseorderheaderRow](_path, "taxamt", None, Some("numeric"), x => x.taxamt, (row, value) => row.copy(taxamt = value))
+      override def freight = Field[BigDecimal, PurchaseorderheaderRow](_path, "freight", None, Some("numeric"), x => x.freight, (row, value) => row.copy(freight = value))
+      override def modifieddate = Field[TypoLocalDateTime, PurchaseorderheaderRow](_path, "modifieddate", Some("text"), Some("timestamp"), x => x.modifieddate, (row, value) => row.copy(modifieddate = value))
     }
   
-    override val columns: List[FieldLikeNoHkt[?, Row]] =
-      List[FieldLikeNoHkt[?, Row]](fields.purchaseorderid, fields.revisionnumber, fields.status, fields.employeeid, fields.vendorid, fields.shipmethodid, fields.orderdate, fields.shipdate, fields.subtotal, fields.taxamt, fields.freight, fields.modifieddate)
+    override lazy val columns: List[FieldLikeNoHkt[?, PurchaseorderheaderRow]] =
+      List[FieldLikeNoHkt[?, PurchaseorderheaderRow]](fields.purchaseorderid, fields.revisionnumber, fields.status, fields.employeeid, fields.vendorid, fields.shipmethodid, fields.orderdate, fields.shipdate, fields.subtotal, fields.taxamt, fields.freight, fields.modifieddate)
   
-    override def copy[NewRow](prefix: Option[String], extract: NewRow => PurchaseorderheaderRow, merge: (NewRow, PurchaseorderheaderRow) => NewRow): Impl[NewRow] =
-      new Impl(prefix, extract, merge)
+    override def copy(path: List[Path]): Impl =
+      new Impl(path)
   }
   
 }

--- a/typo-tester-doobie/generated-and-checked-in/adventureworks/purchasing/purchaseorderheader/PurchaseorderheaderRepoMock.scala
+++ b/typo-tester-doobie/generated-and-checked-in/adventureworks/purchasing/purchaseorderheader/PurchaseorderheaderRepoMock.scala
@@ -24,7 +24,7 @@ import typo.dsl.UpdateParams
 class PurchaseorderheaderRepoMock(toRow: Function1[PurchaseorderheaderRowUnsaved, PurchaseorderheaderRow],
                                   map: scala.collection.mutable.Map[PurchaseorderheaderId, PurchaseorderheaderRow] = scala.collection.mutable.Map.empty) extends PurchaseorderheaderRepo {
   override def delete: DeleteBuilder[PurchaseorderheaderFields, PurchaseorderheaderRow] = {
-    DeleteBuilderMock(DeleteParams.empty, PurchaseorderheaderFields.structure.fields, map)
+    DeleteBuilderMock(DeleteParams.empty, PurchaseorderheaderFields.structure, map)
   }
   override def deleteById(purchaseorderid: PurchaseorderheaderId): ConnectionIO[Boolean] = {
     delay(map.remove(purchaseorderid).isDefined)
@@ -86,7 +86,7 @@ class PurchaseorderheaderRepoMock(toRow: Function1[PurchaseorderheaderRowUnsaved
     }
   }
   override def update: UpdateBuilder[PurchaseorderheaderFields, PurchaseorderheaderRow] = {
-    UpdateBuilderMock(UpdateParams.empty, PurchaseorderheaderFields.structure.fields, map)
+    UpdateBuilderMock(UpdateParams.empty, PurchaseorderheaderFields.structure, map)
   }
   override def update(row: PurchaseorderheaderRow): ConnectionIO[Boolean] = {
     delay {

--- a/typo-tester-doobie/generated-and-checked-in/adventureworks/purchasing/shipmethod/ShipmethodFields.scala
+++ b/typo-tester-doobie/generated-and-checked-in/adventureworks/purchasing/shipmethod/ShipmethodFields.scala
@@ -10,41 +10,42 @@ package shipmethod
 import adventureworks.customtypes.TypoLocalDateTime
 import adventureworks.customtypes.TypoUUID
 import adventureworks.public.Name
+import typo.dsl.Path
 import typo.dsl.SqlExpr.Field
 import typo.dsl.SqlExpr.FieldLikeNoHkt
 import typo.dsl.SqlExpr.IdField
 import typo.dsl.Structure.Relation
 
-trait ShipmethodFields[Row] {
-  val shipmethodid: IdField[ShipmethodId, Row]
-  val name: Field[Name, Row]
-  val shipbase: Field[BigDecimal, Row]
-  val shiprate: Field[BigDecimal, Row]
-  val rowguid: Field[TypoUUID, Row]
-  val modifieddate: Field[TypoLocalDateTime, Row]
+trait ShipmethodFields {
+  def shipmethodid: IdField[ShipmethodId, ShipmethodRow]
+  def name: Field[Name, ShipmethodRow]
+  def shipbase: Field[BigDecimal, ShipmethodRow]
+  def shiprate: Field[BigDecimal, ShipmethodRow]
+  def rowguid: Field[TypoUUID, ShipmethodRow]
+  def modifieddate: Field[TypoLocalDateTime, ShipmethodRow]
 }
 
 object ShipmethodFields {
-  val structure: Relation[ShipmethodFields, ShipmethodRow, ShipmethodRow] = 
-    new Impl(None, identity, (_, x) => x)
+  lazy val structure: Relation[ShipmethodFields, ShipmethodRow] =
+    new Impl(Nil)
     
-  private final class Impl[Row](val prefix: Option[String], val extract: Row => ShipmethodRow, val merge: (Row, ShipmethodRow) => Row)
-    extends Relation[ShipmethodFields, ShipmethodRow, Row] { 
+  private final class Impl(val _path: List[Path])
+    extends Relation[ShipmethodFields, ShipmethodRow] {
   
-    override val fields: ShipmethodFields[Row] = new ShipmethodFields[Row] {
-      override val shipmethodid = new IdField[ShipmethodId, Row](prefix, "shipmethodid", None, Some("int4"))(x => extract(x).shipmethodid, (row, value) => merge(row, extract(row).copy(shipmethodid = value)))
-      override val name = new Field[Name, Row](prefix, "name", None, Some("varchar"))(x => extract(x).name, (row, value) => merge(row, extract(row).copy(name = value)))
-      override val shipbase = new Field[BigDecimal, Row](prefix, "shipbase", None, Some("numeric"))(x => extract(x).shipbase, (row, value) => merge(row, extract(row).copy(shipbase = value)))
-      override val shiprate = new Field[BigDecimal, Row](prefix, "shiprate", None, Some("numeric"))(x => extract(x).shiprate, (row, value) => merge(row, extract(row).copy(shiprate = value)))
-      override val rowguid = new Field[TypoUUID, Row](prefix, "rowguid", None, Some("uuid"))(x => extract(x).rowguid, (row, value) => merge(row, extract(row).copy(rowguid = value)))
-      override val modifieddate = new Field[TypoLocalDateTime, Row](prefix, "modifieddate", Some("text"), Some("timestamp"))(x => extract(x).modifieddate, (row, value) => merge(row, extract(row).copy(modifieddate = value)))
+    override lazy val fields: ShipmethodFields = new ShipmethodFields {
+      override def shipmethodid = IdField[ShipmethodId, ShipmethodRow](_path, "shipmethodid", None, Some("int4"), x => x.shipmethodid, (row, value) => row.copy(shipmethodid = value))
+      override def name = Field[Name, ShipmethodRow](_path, "name", None, Some("varchar"), x => x.name, (row, value) => row.copy(name = value))
+      override def shipbase = Field[BigDecimal, ShipmethodRow](_path, "shipbase", None, Some("numeric"), x => x.shipbase, (row, value) => row.copy(shipbase = value))
+      override def shiprate = Field[BigDecimal, ShipmethodRow](_path, "shiprate", None, Some("numeric"), x => x.shiprate, (row, value) => row.copy(shiprate = value))
+      override def rowguid = Field[TypoUUID, ShipmethodRow](_path, "rowguid", None, Some("uuid"), x => x.rowguid, (row, value) => row.copy(rowguid = value))
+      override def modifieddate = Field[TypoLocalDateTime, ShipmethodRow](_path, "modifieddate", Some("text"), Some("timestamp"), x => x.modifieddate, (row, value) => row.copy(modifieddate = value))
     }
   
-    override val columns: List[FieldLikeNoHkt[?, Row]] =
-      List[FieldLikeNoHkt[?, Row]](fields.shipmethodid, fields.name, fields.shipbase, fields.shiprate, fields.rowguid, fields.modifieddate)
+    override lazy val columns: List[FieldLikeNoHkt[?, ShipmethodRow]] =
+      List[FieldLikeNoHkt[?, ShipmethodRow]](fields.shipmethodid, fields.name, fields.shipbase, fields.shiprate, fields.rowguid, fields.modifieddate)
   
-    override def copy[NewRow](prefix: Option[String], extract: NewRow => ShipmethodRow, merge: (NewRow, ShipmethodRow) => NewRow): Impl[NewRow] =
-      new Impl(prefix, extract, merge)
+    override def copy(path: List[Path]): Impl =
+      new Impl(path)
   }
   
 }

--- a/typo-tester-doobie/generated-and-checked-in/adventureworks/purchasing/shipmethod/ShipmethodRepoMock.scala
+++ b/typo-tester-doobie/generated-and-checked-in/adventureworks/purchasing/shipmethod/ShipmethodRepoMock.scala
@@ -24,7 +24,7 @@ import typo.dsl.UpdateParams
 class ShipmethodRepoMock(toRow: Function1[ShipmethodRowUnsaved, ShipmethodRow],
                          map: scala.collection.mutable.Map[ShipmethodId, ShipmethodRow] = scala.collection.mutable.Map.empty) extends ShipmethodRepo {
   override def delete: DeleteBuilder[ShipmethodFields, ShipmethodRow] = {
-    DeleteBuilderMock(DeleteParams.empty, ShipmethodFields.structure.fields, map)
+    DeleteBuilderMock(DeleteParams.empty, ShipmethodFields.structure, map)
   }
   override def deleteById(shipmethodid: ShipmethodId): ConnectionIO[Boolean] = {
     delay(map.remove(shipmethodid).isDefined)
@@ -86,7 +86,7 @@ class ShipmethodRepoMock(toRow: Function1[ShipmethodRowUnsaved, ShipmethodRow],
     }
   }
   override def update: UpdateBuilder[ShipmethodFields, ShipmethodRow] = {
-    UpdateBuilderMock(UpdateParams.empty, ShipmethodFields.structure.fields, map)
+    UpdateBuilderMock(UpdateParams.empty, ShipmethodFields.structure, map)
   }
   override def update(row: ShipmethodRow): ConnectionIO[Boolean] = {
     delay {

--- a/typo-tester-doobie/generated-and-checked-in/adventureworks/purchasing/vendor/VendorFields.scala
+++ b/typo-tester-doobie/generated-and-checked-in/adventureworks/purchasing/vendor/VendorFields.scala
@@ -13,46 +13,47 @@ import adventureworks.person.businessentity.BusinessentityId
 import adventureworks.public.AccountNumber
 import adventureworks.public.Flag
 import adventureworks.public.Name
+import typo.dsl.Path
 import typo.dsl.SqlExpr.Field
 import typo.dsl.SqlExpr.FieldLikeNoHkt
 import typo.dsl.SqlExpr.IdField
 import typo.dsl.SqlExpr.OptField
 import typo.dsl.Structure.Relation
 
-trait VendorFields[Row] {
-  val businessentityid: IdField[BusinessentityId, Row]
-  val accountnumber: Field[AccountNumber, Row]
-  val name: Field[Name, Row]
-  val creditrating: Field[TypoShort, Row]
-  val preferredvendorstatus: Field[Flag, Row]
-  val activeflag: Field[Flag, Row]
-  val purchasingwebserviceurl: OptField[/* max 1024 chars */ String, Row]
-  val modifieddate: Field[TypoLocalDateTime, Row]
+trait VendorFields {
+  def businessentityid: IdField[BusinessentityId, VendorRow]
+  def accountnumber: Field[AccountNumber, VendorRow]
+  def name: Field[Name, VendorRow]
+  def creditrating: Field[TypoShort, VendorRow]
+  def preferredvendorstatus: Field[Flag, VendorRow]
+  def activeflag: Field[Flag, VendorRow]
+  def purchasingwebserviceurl: OptField[/* max 1024 chars */ String, VendorRow]
+  def modifieddate: Field[TypoLocalDateTime, VendorRow]
 }
 
 object VendorFields {
-  val structure: Relation[VendorFields, VendorRow, VendorRow] = 
-    new Impl(None, identity, (_, x) => x)
+  lazy val structure: Relation[VendorFields, VendorRow] =
+    new Impl(Nil)
     
-  private final class Impl[Row](val prefix: Option[String], val extract: Row => VendorRow, val merge: (Row, VendorRow) => Row)
-    extends Relation[VendorFields, VendorRow, Row] { 
+  private final class Impl(val _path: List[Path])
+    extends Relation[VendorFields, VendorRow] {
   
-    override val fields: VendorFields[Row] = new VendorFields[Row] {
-      override val businessentityid = new IdField[BusinessentityId, Row](prefix, "businessentityid", None, Some("int4"))(x => extract(x).businessentityid, (row, value) => merge(row, extract(row).copy(businessentityid = value)))
-      override val accountnumber = new Field[AccountNumber, Row](prefix, "accountnumber", None, Some("varchar"))(x => extract(x).accountnumber, (row, value) => merge(row, extract(row).copy(accountnumber = value)))
-      override val name = new Field[Name, Row](prefix, "name", None, Some("varchar"))(x => extract(x).name, (row, value) => merge(row, extract(row).copy(name = value)))
-      override val creditrating = new Field[TypoShort, Row](prefix, "creditrating", None, Some("int2"))(x => extract(x).creditrating, (row, value) => merge(row, extract(row).copy(creditrating = value)))
-      override val preferredvendorstatus = new Field[Flag, Row](prefix, "preferredvendorstatus", None, Some("bool"))(x => extract(x).preferredvendorstatus, (row, value) => merge(row, extract(row).copy(preferredvendorstatus = value)))
-      override val activeflag = new Field[Flag, Row](prefix, "activeflag", None, Some("bool"))(x => extract(x).activeflag, (row, value) => merge(row, extract(row).copy(activeflag = value)))
-      override val purchasingwebserviceurl = new OptField[/* max 1024 chars */ String, Row](prefix, "purchasingwebserviceurl", None, None)(x => extract(x).purchasingwebserviceurl, (row, value) => merge(row, extract(row).copy(purchasingwebserviceurl = value)))
-      override val modifieddate = new Field[TypoLocalDateTime, Row](prefix, "modifieddate", Some("text"), Some("timestamp"))(x => extract(x).modifieddate, (row, value) => merge(row, extract(row).copy(modifieddate = value)))
+    override lazy val fields: VendorFields = new VendorFields {
+      override def businessentityid = IdField[BusinessentityId, VendorRow](_path, "businessentityid", None, Some("int4"), x => x.businessentityid, (row, value) => row.copy(businessentityid = value))
+      override def accountnumber = Field[AccountNumber, VendorRow](_path, "accountnumber", None, Some("varchar"), x => x.accountnumber, (row, value) => row.copy(accountnumber = value))
+      override def name = Field[Name, VendorRow](_path, "name", None, Some("varchar"), x => x.name, (row, value) => row.copy(name = value))
+      override def creditrating = Field[TypoShort, VendorRow](_path, "creditrating", None, Some("int2"), x => x.creditrating, (row, value) => row.copy(creditrating = value))
+      override def preferredvendorstatus = Field[Flag, VendorRow](_path, "preferredvendorstatus", None, Some("bool"), x => x.preferredvendorstatus, (row, value) => row.copy(preferredvendorstatus = value))
+      override def activeflag = Field[Flag, VendorRow](_path, "activeflag", None, Some("bool"), x => x.activeflag, (row, value) => row.copy(activeflag = value))
+      override def purchasingwebserviceurl = OptField[/* max 1024 chars */ String, VendorRow](_path, "purchasingwebserviceurl", None, None, x => x.purchasingwebserviceurl, (row, value) => row.copy(purchasingwebserviceurl = value))
+      override def modifieddate = Field[TypoLocalDateTime, VendorRow](_path, "modifieddate", Some("text"), Some("timestamp"), x => x.modifieddate, (row, value) => row.copy(modifieddate = value))
     }
   
-    override val columns: List[FieldLikeNoHkt[?, Row]] =
-      List[FieldLikeNoHkt[?, Row]](fields.businessentityid, fields.accountnumber, fields.name, fields.creditrating, fields.preferredvendorstatus, fields.activeflag, fields.purchasingwebserviceurl, fields.modifieddate)
+    override lazy val columns: List[FieldLikeNoHkt[?, VendorRow]] =
+      List[FieldLikeNoHkt[?, VendorRow]](fields.businessentityid, fields.accountnumber, fields.name, fields.creditrating, fields.preferredvendorstatus, fields.activeflag, fields.purchasingwebserviceurl, fields.modifieddate)
   
-    override def copy[NewRow](prefix: Option[String], extract: NewRow => VendorRow, merge: (NewRow, VendorRow) => NewRow): Impl[NewRow] =
-      new Impl(prefix, extract, merge)
+    override def copy(path: List[Path]): Impl =
+      new Impl(path)
   }
   
 }

--- a/typo-tester-doobie/generated-and-checked-in/adventureworks/purchasing/vendor/VendorRepoMock.scala
+++ b/typo-tester-doobie/generated-and-checked-in/adventureworks/purchasing/vendor/VendorRepoMock.scala
@@ -25,7 +25,7 @@ import typo.dsl.UpdateParams
 class VendorRepoMock(toRow: Function1[VendorRowUnsaved, VendorRow],
                      map: scala.collection.mutable.Map[BusinessentityId, VendorRow] = scala.collection.mutable.Map.empty) extends VendorRepo {
   override def delete: DeleteBuilder[VendorFields, VendorRow] = {
-    DeleteBuilderMock(DeleteParams.empty, VendorFields.structure.fields, map)
+    DeleteBuilderMock(DeleteParams.empty, VendorFields.structure, map)
   }
   override def deleteById(businessentityid: BusinessentityId): ConnectionIO[Boolean] = {
     delay(map.remove(businessentityid).isDefined)
@@ -87,7 +87,7 @@ class VendorRepoMock(toRow: Function1[VendorRowUnsaved, VendorRow],
     }
   }
   override def update: UpdateBuilder[VendorFields, VendorRow] = {
-    UpdateBuilderMock(UpdateParams.empty, VendorFields.structure.fields, map)
+    UpdateBuilderMock(UpdateParams.empty, VendorFields.structure, map)
   }
   override def update(row: VendorRow): ConnectionIO[Boolean] = {
     delay {

--- a/typo-tester-doobie/generated-and-checked-in/adventureworks/purchasing/vvendorwithaddresses/VvendorwithaddressesViewFields.scala
+++ b/typo-tester-doobie/generated-and-checked-in/adventureworks/purchasing/vvendorwithaddresses/VvendorwithaddressesViewFields.scala
@@ -9,47 +9,48 @@ package vvendorwithaddresses
 
 import adventureworks.person.businessentity.BusinessentityId
 import adventureworks.public.Name
+import typo.dsl.Path
 import typo.dsl.SqlExpr.Field
 import typo.dsl.SqlExpr.FieldLikeNoHkt
 import typo.dsl.SqlExpr.OptField
 import typo.dsl.Structure.Relation
 
-trait VvendorwithaddressesViewFields[Row] {
-  val businessentityid: Field[BusinessentityId, Row]
-  val name: Field[Name, Row]
-  val addresstype: Field[Name, Row]
-  val addressline1: Field[/* max 60 chars */ String, Row]
-  val addressline2: OptField[/* max 60 chars */ String, Row]
-  val city: Field[/* max 30 chars */ String, Row]
-  val stateprovincename: Field[Name, Row]
-  val postalcode: Field[/* max 15 chars */ String, Row]
-  val countryregionname: Field[Name, Row]
+trait VvendorwithaddressesViewFields {
+  def businessentityid: Field[BusinessentityId, VvendorwithaddressesViewRow]
+  def name: Field[Name, VvendorwithaddressesViewRow]
+  def addresstype: Field[Name, VvendorwithaddressesViewRow]
+  def addressline1: Field[/* max 60 chars */ String, VvendorwithaddressesViewRow]
+  def addressline2: OptField[/* max 60 chars */ String, VvendorwithaddressesViewRow]
+  def city: Field[/* max 30 chars */ String, VvendorwithaddressesViewRow]
+  def stateprovincename: Field[Name, VvendorwithaddressesViewRow]
+  def postalcode: Field[/* max 15 chars */ String, VvendorwithaddressesViewRow]
+  def countryregionname: Field[Name, VvendorwithaddressesViewRow]
 }
 
 object VvendorwithaddressesViewFields {
-  val structure: Relation[VvendorwithaddressesViewFields, VvendorwithaddressesViewRow, VvendorwithaddressesViewRow] = 
-    new Impl(None, identity, (_, x) => x)
+  lazy val structure: Relation[VvendorwithaddressesViewFields, VvendorwithaddressesViewRow] =
+    new Impl(Nil)
     
-  private final class Impl[Row](val prefix: Option[String], val extract: Row => VvendorwithaddressesViewRow, val merge: (Row, VvendorwithaddressesViewRow) => Row)
-    extends Relation[VvendorwithaddressesViewFields, VvendorwithaddressesViewRow, Row] { 
+  private final class Impl(val _path: List[Path])
+    extends Relation[VvendorwithaddressesViewFields, VvendorwithaddressesViewRow] {
   
-    override val fields: VvendorwithaddressesViewFields[Row] = new VvendorwithaddressesViewFields[Row] {
-      override val businessentityid = new Field[BusinessentityId, Row](prefix, "businessentityid", None, None)(x => extract(x).businessentityid, (row, value) => merge(row, extract(row).copy(businessentityid = value)))
-      override val name = new Field[Name, Row](prefix, "name", None, None)(x => extract(x).name, (row, value) => merge(row, extract(row).copy(name = value)))
-      override val addresstype = new Field[Name, Row](prefix, "addresstype", None, None)(x => extract(x).addresstype, (row, value) => merge(row, extract(row).copy(addresstype = value)))
-      override val addressline1 = new Field[/* max 60 chars */ String, Row](prefix, "addressline1", None, None)(x => extract(x).addressline1, (row, value) => merge(row, extract(row).copy(addressline1 = value)))
-      override val addressline2 = new OptField[/* max 60 chars */ String, Row](prefix, "addressline2", None, None)(x => extract(x).addressline2, (row, value) => merge(row, extract(row).copy(addressline2 = value)))
-      override val city = new Field[/* max 30 chars */ String, Row](prefix, "city", None, None)(x => extract(x).city, (row, value) => merge(row, extract(row).copy(city = value)))
-      override val stateprovincename = new Field[Name, Row](prefix, "stateprovincename", None, None)(x => extract(x).stateprovincename, (row, value) => merge(row, extract(row).copy(stateprovincename = value)))
-      override val postalcode = new Field[/* max 15 chars */ String, Row](prefix, "postalcode", None, None)(x => extract(x).postalcode, (row, value) => merge(row, extract(row).copy(postalcode = value)))
-      override val countryregionname = new Field[Name, Row](prefix, "countryregionname", None, None)(x => extract(x).countryregionname, (row, value) => merge(row, extract(row).copy(countryregionname = value)))
+    override lazy val fields: VvendorwithaddressesViewFields = new VvendorwithaddressesViewFields {
+      override def businessentityid = Field[BusinessentityId, VvendorwithaddressesViewRow](_path, "businessentityid", None, None, x => x.businessentityid, (row, value) => row.copy(businessentityid = value))
+      override def name = Field[Name, VvendorwithaddressesViewRow](_path, "name", None, None, x => x.name, (row, value) => row.copy(name = value))
+      override def addresstype = Field[Name, VvendorwithaddressesViewRow](_path, "addresstype", None, None, x => x.addresstype, (row, value) => row.copy(addresstype = value))
+      override def addressline1 = Field[/* max 60 chars */ String, VvendorwithaddressesViewRow](_path, "addressline1", None, None, x => x.addressline1, (row, value) => row.copy(addressline1 = value))
+      override def addressline2 = OptField[/* max 60 chars */ String, VvendorwithaddressesViewRow](_path, "addressline2", None, None, x => x.addressline2, (row, value) => row.copy(addressline2 = value))
+      override def city = Field[/* max 30 chars */ String, VvendorwithaddressesViewRow](_path, "city", None, None, x => x.city, (row, value) => row.copy(city = value))
+      override def stateprovincename = Field[Name, VvendorwithaddressesViewRow](_path, "stateprovincename", None, None, x => x.stateprovincename, (row, value) => row.copy(stateprovincename = value))
+      override def postalcode = Field[/* max 15 chars */ String, VvendorwithaddressesViewRow](_path, "postalcode", None, None, x => x.postalcode, (row, value) => row.copy(postalcode = value))
+      override def countryregionname = Field[Name, VvendorwithaddressesViewRow](_path, "countryregionname", None, None, x => x.countryregionname, (row, value) => row.copy(countryregionname = value))
     }
   
-    override val columns: List[FieldLikeNoHkt[?, Row]] =
-      List[FieldLikeNoHkt[?, Row]](fields.businessentityid, fields.name, fields.addresstype, fields.addressline1, fields.addressline2, fields.city, fields.stateprovincename, fields.postalcode, fields.countryregionname)
+    override lazy val columns: List[FieldLikeNoHkt[?, VvendorwithaddressesViewRow]] =
+      List[FieldLikeNoHkt[?, VvendorwithaddressesViewRow]](fields.businessentityid, fields.name, fields.addresstype, fields.addressline1, fields.addressline2, fields.city, fields.stateprovincename, fields.postalcode, fields.countryregionname)
   
-    override def copy[NewRow](prefix: Option[String], extract: NewRow => VvendorwithaddressesViewRow, merge: (NewRow, VvendorwithaddressesViewRow) => NewRow): Impl[NewRow] =
-      new Impl(prefix, extract, merge)
+    override def copy(path: List[Path]): Impl =
+      new Impl(path)
   }
   
 }

--- a/typo-tester-doobie/generated-and-checked-in/adventureworks/purchasing/vvendorwithcontacts/VvendorwithcontactsViewFields.scala
+++ b/typo-tester-doobie/generated-and-checked-in/adventureworks/purchasing/vvendorwithcontacts/VvendorwithcontactsViewFields.scala
@@ -11,53 +11,54 @@ import adventureworks.person.businessentity.BusinessentityId
 import adventureworks.public.Name
 import adventureworks.public.Phone
 import adventureworks.userdefined.FirstName
+import typo.dsl.Path
 import typo.dsl.SqlExpr.Field
 import typo.dsl.SqlExpr.FieldLikeNoHkt
 import typo.dsl.SqlExpr.OptField
 import typo.dsl.Structure.Relation
 
-trait VvendorwithcontactsViewFields[Row] {
-  val businessentityid: Field[BusinessentityId, Row]
-  val name: Field[Name, Row]
-  val contacttype: Field[Name, Row]
-  val title: OptField[/* max 8 chars */ String, Row]
-  val firstname: Field[/* user-picked */ FirstName, Row]
-  val middlename: OptField[Name, Row]
-  val lastname: Field[Name, Row]
-  val suffix: OptField[/* max 10 chars */ String, Row]
-  val phonenumber: OptField[Phone, Row]
-  val phonenumbertype: OptField[Name, Row]
-  val emailaddress: OptField[/* max 50 chars */ String, Row]
-  val emailpromotion: Field[Int, Row]
+trait VvendorwithcontactsViewFields {
+  def businessentityid: Field[BusinessentityId, VvendorwithcontactsViewRow]
+  def name: Field[Name, VvendorwithcontactsViewRow]
+  def contacttype: Field[Name, VvendorwithcontactsViewRow]
+  def title: OptField[/* max 8 chars */ String, VvendorwithcontactsViewRow]
+  def firstname: Field[/* user-picked */ FirstName, VvendorwithcontactsViewRow]
+  def middlename: OptField[Name, VvendorwithcontactsViewRow]
+  def lastname: Field[Name, VvendorwithcontactsViewRow]
+  def suffix: OptField[/* max 10 chars */ String, VvendorwithcontactsViewRow]
+  def phonenumber: OptField[Phone, VvendorwithcontactsViewRow]
+  def phonenumbertype: OptField[Name, VvendorwithcontactsViewRow]
+  def emailaddress: OptField[/* max 50 chars */ String, VvendorwithcontactsViewRow]
+  def emailpromotion: Field[Int, VvendorwithcontactsViewRow]
 }
 
 object VvendorwithcontactsViewFields {
-  val structure: Relation[VvendorwithcontactsViewFields, VvendorwithcontactsViewRow, VvendorwithcontactsViewRow] = 
-    new Impl(None, identity, (_, x) => x)
+  lazy val structure: Relation[VvendorwithcontactsViewFields, VvendorwithcontactsViewRow] =
+    new Impl(Nil)
     
-  private final class Impl[Row](val prefix: Option[String], val extract: Row => VvendorwithcontactsViewRow, val merge: (Row, VvendorwithcontactsViewRow) => Row)
-    extends Relation[VvendorwithcontactsViewFields, VvendorwithcontactsViewRow, Row] { 
+  private final class Impl(val _path: List[Path])
+    extends Relation[VvendorwithcontactsViewFields, VvendorwithcontactsViewRow] {
   
-    override val fields: VvendorwithcontactsViewFields[Row] = new VvendorwithcontactsViewFields[Row] {
-      override val businessentityid = new Field[BusinessentityId, Row](prefix, "businessentityid", None, None)(x => extract(x).businessentityid, (row, value) => merge(row, extract(row).copy(businessentityid = value)))
-      override val name = new Field[Name, Row](prefix, "name", None, None)(x => extract(x).name, (row, value) => merge(row, extract(row).copy(name = value)))
-      override val contacttype = new Field[Name, Row](prefix, "contacttype", None, None)(x => extract(x).contacttype, (row, value) => merge(row, extract(row).copy(contacttype = value)))
-      override val title = new OptField[/* max 8 chars */ String, Row](prefix, "title", None, None)(x => extract(x).title, (row, value) => merge(row, extract(row).copy(title = value)))
-      override val firstname = new Field[/* user-picked */ FirstName, Row](prefix, "firstname", None, None)(x => extract(x).firstname, (row, value) => merge(row, extract(row).copy(firstname = value)))
-      override val middlename = new OptField[Name, Row](prefix, "middlename", None, None)(x => extract(x).middlename, (row, value) => merge(row, extract(row).copy(middlename = value)))
-      override val lastname = new Field[Name, Row](prefix, "lastname", None, None)(x => extract(x).lastname, (row, value) => merge(row, extract(row).copy(lastname = value)))
-      override val suffix = new OptField[/* max 10 chars */ String, Row](prefix, "suffix", None, None)(x => extract(x).suffix, (row, value) => merge(row, extract(row).copy(suffix = value)))
-      override val phonenumber = new OptField[Phone, Row](prefix, "phonenumber", None, None)(x => extract(x).phonenumber, (row, value) => merge(row, extract(row).copy(phonenumber = value)))
-      override val phonenumbertype = new OptField[Name, Row](prefix, "phonenumbertype", None, None)(x => extract(x).phonenumbertype, (row, value) => merge(row, extract(row).copy(phonenumbertype = value)))
-      override val emailaddress = new OptField[/* max 50 chars */ String, Row](prefix, "emailaddress", None, None)(x => extract(x).emailaddress, (row, value) => merge(row, extract(row).copy(emailaddress = value)))
-      override val emailpromotion = new Field[Int, Row](prefix, "emailpromotion", None, None)(x => extract(x).emailpromotion, (row, value) => merge(row, extract(row).copy(emailpromotion = value)))
+    override lazy val fields: VvendorwithcontactsViewFields = new VvendorwithcontactsViewFields {
+      override def businessentityid = Field[BusinessentityId, VvendorwithcontactsViewRow](_path, "businessentityid", None, None, x => x.businessentityid, (row, value) => row.copy(businessentityid = value))
+      override def name = Field[Name, VvendorwithcontactsViewRow](_path, "name", None, None, x => x.name, (row, value) => row.copy(name = value))
+      override def contacttype = Field[Name, VvendorwithcontactsViewRow](_path, "contacttype", None, None, x => x.contacttype, (row, value) => row.copy(contacttype = value))
+      override def title = OptField[/* max 8 chars */ String, VvendorwithcontactsViewRow](_path, "title", None, None, x => x.title, (row, value) => row.copy(title = value))
+      override def firstname = Field[/* user-picked */ FirstName, VvendorwithcontactsViewRow](_path, "firstname", None, None, x => x.firstname, (row, value) => row.copy(firstname = value))
+      override def middlename = OptField[Name, VvendorwithcontactsViewRow](_path, "middlename", None, None, x => x.middlename, (row, value) => row.copy(middlename = value))
+      override def lastname = Field[Name, VvendorwithcontactsViewRow](_path, "lastname", None, None, x => x.lastname, (row, value) => row.copy(lastname = value))
+      override def suffix = OptField[/* max 10 chars */ String, VvendorwithcontactsViewRow](_path, "suffix", None, None, x => x.suffix, (row, value) => row.copy(suffix = value))
+      override def phonenumber = OptField[Phone, VvendorwithcontactsViewRow](_path, "phonenumber", None, None, x => x.phonenumber, (row, value) => row.copy(phonenumber = value))
+      override def phonenumbertype = OptField[Name, VvendorwithcontactsViewRow](_path, "phonenumbertype", None, None, x => x.phonenumbertype, (row, value) => row.copy(phonenumbertype = value))
+      override def emailaddress = OptField[/* max 50 chars */ String, VvendorwithcontactsViewRow](_path, "emailaddress", None, None, x => x.emailaddress, (row, value) => row.copy(emailaddress = value))
+      override def emailpromotion = Field[Int, VvendorwithcontactsViewRow](_path, "emailpromotion", None, None, x => x.emailpromotion, (row, value) => row.copy(emailpromotion = value))
     }
   
-    override val columns: List[FieldLikeNoHkt[?, Row]] =
-      List[FieldLikeNoHkt[?, Row]](fields.businessentityid, fields.name, fields.contacttype, fields.title, fields.firstname, fields.middlename, fields.lastname, fields.suffix, fields.phonenumber, fields.phonenumbertype, fields.emailaddress, fields.emailpromotion)
+    override lazy val columns: List[FieldLikeNoHkt[?, VvendorwithcontactsViewRow]] =
+      List[FieldLikeNoHkt[?, VvendorwithcontactsViewRow]](fields.businessentityid, fields.name, fields.contacttype, fields.title, fields.firstname, fields.middlename, fields.lastname, fields.suffix, fields.phonenumber, fields.phonenumbertype, fields.emailaddress, fields.emailpromotion)
   
-    override def copy[NewRow](prefix: Option[String], extract: NewRow => VvendorwithcontactsViewRow, merge: (NewRow, VvendorwithcontactsViewRow) => NewRow): Impl[NewRow] =
-      new Impl(prefix, extract, merge)
+    override def copy(path: List[Path]): Impl =
+      new Impl(path)
   }
   
 }

--- a/typo-tester-doobie/generated-and-checked-in/adventureworks/sa/c/CViewFields.scala
+++ b/typo-tester-doobie/generated-and-checked-in/adventureworks/sa/c/CViewFields.scala
@@ -12,43 +12,44 @@ import adventureworks.customtypes.TypoUUID
 import adventureworks.person.businessentity.BusinessentityId
 import adventureworks.sales.customer.CustomerId
 import adventureworks.sales.salesterritory.SalesterritoryId
+import typo.dsl.Path
 import typo.dsl.SqlExpr.Field
 import typo.dsl.SqlExpr.FieldLikeNoHkt
 import typo.dsl.SqlExpr.OptField
 import typo.dsl.Structure.Relation
 
-trait CViewFields[Row] {
-  val id: Field[CustomerId, Row]
-  val customerid: Field[CustomerId, Row]
-  val personid: OptField[BusinessentityId, Row]
-  val storeid: OptField[BusinessentityId, Row]
-  val territoryid: OptField[SalesterritoryId, Row]
-  val rowguid: Field[TypoUUID, Row]
-  val modifieddate: Field[TypoLocalDateTime, Row]
+trait CViewFields {
+  def id: Field[CustomerId, CViewRow]
+  def customerid: Field[CustomerId, CViewRow]
+  def personid: OptField[BusinessentityId, CViewRow]
+  def storeid: OptField[BusinessentityId, CViewRow]
+  def territoryid: OptField[SalesterritoryId, CViewRow]
+  def rowguid: Field[TypoUUID, CViewRow]
+  def modifieddate: Field[TypoLocalDateTime, CViewRow]
 }
 
 object CViewFields {
-  val structure: Relation[CViewFields, CViewRow, CViewRow] = 
-    new Impl(None, identity, (_, x) => x)
+  lazy val structure: Relation[CViewFields, CViewRow] =
+    new Impl(Nil)
     
-  private final class Impl[Row](val prefix: Option[String], val extract: Row => CViewRow, val merge: (Row, CViewRow) => Row)
-    extends Relation[CViewFields, CViewRow, Row] { 
+  private final class Impl(val _path: List[Path])
+    extends Relation[CViewFields, CViewRow] {
   
-    override val fields: CViewFields[Row] = new CViewFields[Row] {
-      override val id = new Field[CustomerId, Row](prefix, "id", None, None)(x => extract(x).id, (row, value) => merge(row, extract(row).copy(id = value)))
-      override val customerid = new Field[CustomerId, Row](prefix, "customerid", None, None)(x => extract(x).customerid, (row, value) => merge(row, extract(row).copy(customerid = value)))
-      override val personid = new OptField[BusinessentityId, Row](prefix, "personid", None, None)(x => extract(x).personid, (row, value) => merge(row, extract(row).copy(personid = value)))
-      override val storeid = new OptField[BusinessentityId, Row](prefix, "storeid", None, None)(x => extract(x).storeid, (row, value) => merge(row, extract(row).copy(storeid = value)))
-      override val territoryid = new OptField[SalesterritoryId, Row](prefix, "territoryid", None, None)(x => extract(x).territoryid, (row, value) => merge(row, extract(row).copy(territoryid = value)))
-      override val rowguid = new Field[TypoUUID, Row](prefix, "rowguid", None, None)(x => extract(x).rowguid, (row, value) => merge(row, extract(row).copy(rowguid = value)))
-      override val modifieddate = new Field[TypoLocalDateTime, Row](prefix, "modifieddate", Some("text"), None)(x => extract(x).modifieddate, (row, value) => merge(row, extract(row).copy(modifieddate = value)))
+    override lazy val fields: CViewFields = new CViewFields {
+      override def id = Field[CustomerId, CViewRow](_path, "id", None, None, x => x.id, (row, value) => row.copy(id = value))
+      override def customerid = Field[CustomerId, CViewRow](_path, "customerid", None, None, x => x.customerid, (row, value) => row.copy(customerid = value))
+      override def personid = OptField[BusinessentityId, CViewRow](_path, "personid", None, None, x => x.personid, (row, value) => row.copy(personid = value))
+      override def storeid = OptField[BusinessentityId, CViewRow](_path, "storeid", None, None, x => x.storeid, (row, value) => row.copy(storeid = value))
+      override def territoryid = OptField[SalesterritoryId, CViewRow](_path, "territoryid", None, None, x => x.territoryid, (row, value) => row.copy(territoryid = value))
+      override def rowguid = Field[TypoUUID, CViewRow](_path, "rowguid", None, None, x => x.rowguid, (row, value) => row.copy(rowguid = value))
+      override def modifieddate = Field[TypoLocalDateTime, CViewRow](_path, "modifieddate", Some("text"), None, x => x.modifieddate, (row, value) => row.copy(modifieddate = value))
     }
   
-    override val columns: List[FieldLikeNoHkt[?, Row]] =
-      List[FieldLikeNoHkt[?, Row]](fields.id, fields.customerid, fields.personid, fields.storeid, fields.territoryid, fields.rowguid, fields.modifieddate)
+    override lazy val columns: List[FieldLikeNoHkt[?, CViewRow]] =
+      List[FieldLikeNoHkt[?, CViewRow]](fields.id, fields.customerid, fields.personid, fields.storeid, fields.territoryid, fields.rowguid, fields.modifieddate)
   
-    override def copy[NewRow](prefix: Option[String], extract: NewRow => CViewRow, merge: (NewRow, CViewRow) => NewRow): Impl[NewRow] =
-      new Impl(prefix, extract, merge)
+    override def copy(path: List[Path]): Impl =
+      new Impl(path)
   }
   
 }

--- a/typo-tester-doobie/generated-and-checked-in/adventureworks/sa/cc/CcViewFields.scala
+++ b/typo-tester-doobie/generated-and-checked-in/adventureworks/sa/cc/CcViewFields.scala
@@ -10,42 +10,43 @@ package cc
 import adventureworks.customtypes.TypoLocalDateTime
 import adventureworks.customtypes.TypoShort
 import adventureworks.userdefined.CustomCreditcardId
+import typo.dsl.Path
 import typo.dsl.SqlExpr.Field
 import typo.dsl.SqlExpr.FieldLikeNoHkt
 import typo.dsl.Structure.Relation
 
-trait CcViewFields[Row] {
-  val id: Field[/* user-picked */ CustomCreditcardId, Row]
-  val creditcardid: Field[/* user-picked */ CustomCreditcardId, Row]
-  val cardtype: Field[/* max 50 chars */ String, Row]
-  val cardnumber: Field[/* max 25 chars */ String, Row]
-  val expmonth: Field[TypoShort, Row]
-  val expyear: Field[TypoShort, Row]
-  val modifieddate: Field[TypoLocalDateTime, Row]
+trait CcViewFields {
+  def id: Field[/* user-picked */ CustomCreditcardId, CcViewRow]
+  def creditcardid: Field[/* user-picked */ CustomCreditcardId, CcViewRow]
+  def cardtype: Field[/* max 50 chars */ String, CcViewRow]
+  def cardnumber: Field[/* max 25 chars */ String, CcViewRow]
+  def expmonth: Field[TypoShort, CcViewRow]
+  def expyear: Field[TypoShort, CcViewRow]
+  def modifieddate: Field[TypoLocalDateTime, CcViewRow]
 }
 
 object CcViewFields {
-  val structure: Relation[CcViewFields, CcViewRow, CcViewRow] = 
-    new Impl(None, identity, (_, x) => x)
+  lazy val structure: Relation[CcViewFields, CcViewRow] =
+    new Impl(Nil)
     
-  private final class Impl[Row](val prefix: Option[String], val extract: Row => CcViewRow, val merge: (Row, CcViewRow) => Row)
-    extends Relation[CcViewFields, CcViewRow, Row] { 
+  private final class Impl(val _path: List[Path])
+    extends Relation[CcViewFields, CcViewRow] {
   
-    override val fields: CcViewFields[Row] = new CcViewFields[Row] {
-      override val id = new Field[/* user-picked */ CustomCreditcardId, Row](prefix, "id", None, None)(x => extract(x).id, (row, value) => merge(row, extract(row).copy(id = value)))
-      override val creditcardid = new Field[/* user-picked */ CustomCreditcardId, Row](prefix, "creditcardid", None, None)(x => extract(x).creditcardid, (row, value) => merge(row, extract(row).copy(creditcardid = value)))
-      override val cardtype = new Field[/* max 50 chars */ String, Row](prefix, "cardtype", None, None)(x => extract(x).cardtype, (row, value) => merge(row, extract(row).copy(cardtype = value)))
-      override val cardnumber = new Field[/* max 25 chars */ String, Row](prefix, "cardnumber", None, None)(x => extract(x).cardnumber, (row, value) => merge(row, extract(row).copy(cardnumber = value)))
-      override val expmonth = new Field[TypoShort, Row](prefix, "expmonth", None, None)(x => extract(x).expmonth, (row, value) => merge(row, extract(row).copy(expmonth = value)))
-      override val expyear = new Field[TypoShort, Row](prefix, "expyear", None, None)(x => extract(x).expyear, (row, value) => merge(row, extract(row).copy(expyear = value)))
-      override val modifieddate = new Field[TypoLocalDateTime, Row](prefix, "modifieddate", Some("text"), None)(x => extract(x).modifieddate, (row, value) => merge(row, extract(row).copy(modifieddate = value)))
+    override lazy val fields: CcViewFields = new CcViewFields {
+      override def id = Field[/* user-picked */ CustomCreditcardId, CcViewRow](_path, "id", None, None, x => x.id, (row, value) => row.copy(id = value))
+      override def creditcardid = Field[/* user-picked */ CustomCreditcardId, CcViewRow](_path, "creditcardid", None, None, x => x.creditcardid, (row, value) => row.copy(creditcardid = value))
+      override def cardtype = Field[/* max 50 chars */ String, CcViewRow](_path, "cardtype", None, None, x => x.cardtype, (row, value) => row.copy(cardtype = value))
+      override def cardnumber = Field[/* max 25 chars */ String, CcViewRow](_path, "cardnumber", None, None, x => x.cardnumber, (row, value) => row.copy(cardnumber = value))
+      override def expmonth = Field[TypoShort, CcViewRow](_path, "expmonth", None, None, x => x.expmonth, (row, value) => row.copy(expmonth = value))
+      override def expyear = Field[TypoShort, CcViewRow](_path, "expyear", None, None, x => x.expyear, (row, value) => row.copy(expyear = value))
+      override def modifieddate = Field[TypoLocalDateTime, CcViewRow](_path, "modifieddate", Some("text"), None, x => x.modifieddate, (row, value) => row.copy(modifieddate = value))
     }
   
-    override val columns: List[FieldLikeNoHkt[?, Row]] =
-      List[FieldLikeNoHkt[?, Row]](fields.id, fields.creditcardid, fields.cardtype, fields.cardnumber, fields.expmonth, fields.expyear, fields.modifieddate)
+    override lazy val columns: List[FieldLikeNoHkt[?, CcViewRow]] =
+      List[FieldLikeNoHkt[?, CcViewRow]](fields.id, fields.creditcardid, fields.cardtype, fields.cardnumber, fields.expmonth, fields.expyear, fields.modifieddate)
   
-    override def copy[NewRow](prefix: Option[String], extract: NewRow => CcViewRow, merge: (NewRow, CcViewRow) => NewRow): Impl[NewRow] =
-      new Impl(prefix, extract, merge)
+    override def copy(path: List[Path]): Impl =
+      new Impl(path)
   }
   
 }

--- a/typo-tester-doobie/generated-and-checked-in/adventureworks/sa/cr/CrViewFields.scala
+++ b/typo-tester-doobie/generated-and-checked-in/adventureworks/sa/cr/CrViewFields.scala
@@ -10,42 +10,43 @@ package cr
 import adventureworks.customtypes.TypoLocalDateTime
 import adventureworks.sales.currency.CurrencyId
 import adventureworks.sales.currencyrate.CurrencyrateId
+import typo.dsl.Path
 import typo.dsl.SqlExpr.Field
 import typo.dsl.SqlExpr.FieldLikeNoHkt
 import typo.dsl.Structure.Relation
 
-trait CrViewFields[Row] {
-  val currencyrateid: Field[CurrencyrateId, Row]
-  val currencyratedate: Field[TypoLocalDateTime, Row]
-  val fromcurrencycode: Field[CurrencyId, Row]
-  val tocurrencycode: Field[CurrencyId, Row]
-  val averagerate: Field[BigDecimal, Row]
-  val endofdayrate: Field[BigDecimal, Row]
-  val modifieddate: Field[TypoLocalDateTime, Row]
+trait CrViewFields {
+  def currencyrateid: Field[CurrencyrateId, CrViewRow]
+  def currencyratedate: Field[TypoLocalDateTime, CrViewRow]
+  def fromcurrencycode: Field[CurrencyId, CrViewRow]
+  def tocurrencycode: Field[CurrencyId, CrViewRow]
+  def averagerate: Field[BigDecimal, CrViewRow]
+  def endofdayrate: Field[BigDecimal, CrViewRow]
+  def modifieddate: Field[TypoLocalDateTime, CrViewRow]
 }
 
 object CrViewFields {
-  val structure: Relation[CrViewFields, CrViewRow, CrViewRow] = 
-    new Impl(None, identity, (_, x) => x)
+  lazy val structure: Relation[CrViewFields, CrViewRow] =
+    new Impl(Nil)
     
-  private final class Impl[Row](val prefix: Option[String], val extract: Row => CrViewRow, val merge: (Row, CrViewRow) => Row)
-    extends Relation[CrViewFields, CrViewRow, Row] { 
+  private final class Impl(val _path: List[Path])
+    extends Relation[CrViewFields, CrViewRow] {
   
-    override val fields: CrViewFields[Row] = new CrViewFields[Row] {
-      override val currencyrateid = new Field[CurrencyrateId, Row](prefix, "currencyrateid", None, None)(x => extract(x).currencyrateid, (row, value) => merge(row, extract(row).copy(currencyrateid = value)))
-      override val currencyratedate = new Field[TypoLocalDateTime, Row](prefix, "currencyratedate", Some("text"), None)(x => extract(x).currencyratedate, (row, value) => merge(row, extract(row).copy(currencyratedate = value)))
-      override val fromcurrencycode = new Field[CurrencyId, Row](prefix, "fromcurrencycode", None, None)(x => extract(x).fromcurrencycode, (row, value) => merge(row, extract(row).copy(fromcurrencycode = value)))
-      override val tocurrencycode = new Field[CurrencyId, Row](prefix, "tocurrencycode", None, None)(x => extract(x).tocurrencycode, (row, value) => merge(row, extract(row).copy(tocurrencycode = value)))
-      override val averagerate = new Field[BigDecimal, Row](prefix, "averagerate", None, None)(x => extract(x).averagerate, (row, value) => merge(row, extract(row).copy(averagerate = value)))
-      override val endofdayrate = new Field[BigDecimal, Row](prefix, "endofdayrate", None, None)(x => extract(x).endofdayrate, (row, value) => merge(row, extract(row).copy(endofdayrate = value)))
-      override val modifieddate = new Field[TypoLocalDateTime, Row](prefix, "modifieddate", Some("text"), None)(x => extract(x).modifieddate, (row, value) => merge(row, extract(row).copy(modifieddate = value)))
+    override lazy val fields: CrViewFields = new CrViewFields {
+      override def currencyrateid = Field[CurrencyrateId, CrViewRow](_path, "currencyrateid", None, None, x => x.currencyrateid, (row, value) => row.copy(currencyrateid = value))
+      override def currencyratedate = Field[TypoLocalDateTime, CrViewRow](_path, "currencyratedate", Some("text"), None, x => x.currencyratedate, (row, value) => row.copy(currencyratedate = value))
+      override def fromcurrencycode = Field[CurrencyId, CrViewRow](_path, "fromcurrencycode", None, None, x => x.fromcurrencycode, (row, value) => row.copy(fromcurrencycode = value))
+      override def tocurrencycode = Field[CurrencyId, CrViewRow](_path, "tocurrencycode", None, None, x => x.tocurrencycode, (row, value) => row.copy(tocurrencycode = value))
+      override def averagerate = Field[BigDecimal, CrViewRow](_path, "averagerate", None, None, x => x.averagerate, (row, value) => row.copy(averagerate = value))
+      override def endofdayrate = Field[BigDecimal, CrViewRow](_path, "endofdayrate", None, None, x => x.endofdayrate, (row, value) => row.copy(endofdayrate = value))
+      override def modifieddate = Field[TypoLocalDateTime, CrViewRow](_path, "modifieddate", Some("text"), None, x => x.modifieddate, (row, value) => row.copy(modifieddate = value))
     }
   
-    override val columns: List[FieldLikeNoHkt[?, Row]] =
-      List[FieldLikeNoHkt[?, Row]](fields.currencyrateid, fields.currencyratedate, fields.fromcurrencycode, fields.tocurrencycode, fields.averagerate, fields.endofdayrate, fields.modifieddate)
+    override lazy val columns: List[FieldLikeNoHkt[?, CrViewRow]] =
+      List[FieldLikeNoHkt[?, CrViewRow]](fields.currencyrateid, fields.currencyratedate, fields.fromcurrencycode, fields.tocurrencycode, fields.averagerate, fields.endofdayrate, fields.modifieddate)
   
-    override def copy[NewRow](prefix: Option[String], extract: NewRow => CrViewRow, merge: (NewRow, CrViewRow) => NewRow): Impl[NewRow] =
-      new Impl(prefix, extract, merge)
+    override def copy(path: List[Path]): Impl =
+      new Impl(path)
   }
   
 }

--- a/typo-tester-doobie/generated-and-checked-in/adventureworks/sa/crc/CrcViewFields.scala
+++ b/typo-tester-doobie/generated-and-checked-in/adventureworks/sa/crc/CrcViewFields.scala
@@ -10,34 +10,35 @@ package crc
 import adventureworks.customtypes.TypoLocalDateTime
 import adventureworks.person.countryregion.CountryregionId
 import adventureworks.sales.currency.CurrencyId
+import typo.dsl.Path
 import typo.dsl.SqlExpr.Field
 import typo.dsl.SqlExpr.FieldLikeNoHkt
 import typo.dsl.Structure.Relation
 
-trait CrcViewFields[Row] {
-  val countryregioncode: Field[CountryregionId, Row]
-  val currencycode: Field[CurrencyId, Row]
-  val modifieddate: Field[TypoLocalDateTime, Row]
+trait CrcViewFields {
+  def countryregioncode: Field[CountryregionId, CrcViewRow]
+  def currencycode: Field[CurrencyId, CrcViewRow]
+  def modifieddate: Field[TypoLocalDateTime, CrcViewRow]
 }
 
 object CrcViewFields {
-  val structure: Relation[CrcViewFields, CrcViewRow, CrcViewRow] = 
-    new Impl(None, identity, (_, x) => x)
+  lazy val structure: Relation[CrcViewFields, CrcViewRow] =
+    new Impl(Nil)
     
-  private final class Impl[Row](val prefix: Option[String], val extract: Row => CrcViewRow, val merge: (Row, CrcViewRow) => Row)
-    extends Relation[CrcViewFields, CrcViewRow, Row] { 
+  private final class Impl(val _path: List[Path])
+    extends Relation[CrcViewFields, CrcViewRow] {
   
-    override val fields: CrcViewFields[Row] = new CrcViewFields[Row] {
-      override val countryregioncode = new Field[CountryregionId, Row](prefix, "countryregioncode", None, None)(x => extract(x).countryregioncode, (row, value) => merge(row, extract(row).copy(countryregioncode = value)))
-      override val currencycode = new Field[CurrencyId, Row](prefix, "currencycode", None, None)(x => extract(x).currencycode, (row, value) => merge(row, extract(row).copy(currencycode = value)))
-      override val modifieddate = new Field[TypoLocalDateTime, Row](prefix, "modifieddate", Some("text"), None)(x => extract(x).modifieddate, (row, value) => merge(row, extract(row).copy(modifieddate = value)))
+    override lazy val fields: CrcViewFields = new CrcViewFields {
+      override def countryregioncode = Field[CountryregionId, CrcViewRow](_path, "countryregioncode", None, None, x => x.countryregioncode, (row, value) => row.copy(countryregioncode = value))
+      override def currencycode = Field[CurrencyId, CrcViewRow](_path, "currencycode", None, None, x => x.currencycode, (row, value) => row.copy(currencycode = value))
+      override def modifieddate = Field[TypoLocalDateTime, CrcViewRow](_path, "modifieddate", Some("text"), None, x => x.modifieddate, (row, value) => row.copy(modifieddate = value))
     }
   
-    override val columns: List[FieldLikeNoHkt[?, Row]] =
-      List[FieldLikeNoHkt[?, Row]](fields.countryregioncode, fields.currencycode, fields.modifieddate)
+    override lazy val columns: List[FieldLikeNoHkt[?, CrcViewRow]] =
+      List[FieldLikeNoHkt[?, CrcViewRow]](fields.countryregioncode, fields.currencycode, fields.modifieddate)
   
-    override def copy[NewRow](prefix: Option[String], extract: NewRow => CrcViewRow, merge: (NewRow, CrcViewRow) => NewRow): Impl[NewRow] =
-      new Impl(prefix, extract, merge)
+    override def copy(path: List[Path]): Impl =
+      new Impl(path)
   }
   
 }

--- a/typo-tester-doobie/generated-and-checked-in/adventureworks/sa/cu/CuViewFields.scala
+++ b/typo-tester-doobie/generated-and-checked-in/adventureworks/sa/cu/CuViewFields.scala
@@ -10,36 +10,37 @@ package cu
 import adventureworks.customtypes.TypoLocalDateTime
 import adventureworks.public.Name
 import adventureworks.sales.currency.CurrencyId
+import typo.dsl.Path
 import typo.dsl.SqlExpr.Field
 import typo.dsl.SqlExpr.FieldLikeNoHkt
 import typo.dsl.Structure.Relation
 
-trait CuViewFields[Row] {
-  val id: Field[CurrencyId, Row]
-  val currencycode: Field[CurrencyId, Row]
-  val name: Field[Name, Row]
-  val modifieddate: Field[TypoLocalDateTime, Row]
+trait CuViewFields {
+  def id: Field[CurrencyId, CuViewRow]
+  def currencycode: Field[CurrencyId, CuViewRow]
+  def name: Field[Name, CuViewRow]
+  def modifieddate: Field[TypoLocalDateTime, CuViewRow]
 }
 
 object CuViewFields {
-  val structure: Relation[CuViewFields, CuViewRow, CuViewRow] = 
-    new Impl(None, identity, (_, x) => x)
+  lazy val structure: Relation[CuViewFields, CuViewRow] =
+    new Impl(Nil)
     
-  private final class Impl[Row](val prefix: Option[String], val extract: Row => CuViewRow, val merge: (Row, CuViewRow) => Row)
-    extends Relation[CuViewFields, CuViewRow, Row] { 
+  private final class Impl(val _path: List[Path])
+    extends Relation[CuViewFields, CuViewRow] {
   
-    override val fields: CuViewFields[Row] = new CuViewFields[Row] {
-      override val id = new Field[CurrencyId, Row](prefix, "id", None, None)(x => extract(x).id, (row, value) => merge(row, extract(row).copy(id = value)))
-      override val currencycode = new Field[CurrencyId, Row](prefix, "currencycode", None, None)(x => extract(x).currencycode, (row, value) => merge(row, extract(row).copy(currencycode = value)))
-      override val name = new Field[Name, Row](prefix, "name", None, None)(x => extract(x).name, (row, value) => merge(row, extract(row).copy(name = value)))
-      override val modifieddate = new Field[TypoLocalDateTime, Row](prefix, "modifieddate", Some("text"), None)(x => extract(x).modifieddate, (row, value) => merge(row, extract(row).copy(modifieddate = value)))
+    override lazy val fields: CuViewFields = new CuViewFields {
+      override def id = Field[CurrencyId, CuViewRow](_path, "id", None, None, x => x.id, (row, value) => row.copy(id = value))
+      override def currencycode = Field[CurrencyId, CuViewRow](_path, "currencycode", None, None, x => x.currencycode, (row, value) => row.copy(currencycode = value))
+      override def name = Field[Name, CuViewRow](_path, "name", None, None, x => x.name, (row, value) => row.copy(name = value))
+      override def modifieddate = Field[TypoLocalDateTime, CuViewRow](_path, "modifieddate", Some("text"), None, x => x.modifieddate, (row, value) => row.copy(modifieddate = value))
     }
   
-    override val columns: List[FieldLikeNoHkt[?, Row]] =
-      List[FieldLikeNoHkt[?, Row]](fields.id, fields.currencycode, fields.name, fields.modifieddate)
+    override lazy val columns: List[FieldLikeNoHkt[?, CuViewRow]] =
+      List[FieldLikeNoHkt[?, CuViewRow]](fields.id, fields.currencycode, fields.name, fields.modifieddate)
   
-    override def copy[NewRow](prefix: Option[String], extract: NewRow => CuViewRow, merge: (NewRow, CuViewRow) => NewRow): Impl[NewRow] =
-      new Impl(prefix, extract, merge)
+    override def copy(path: List[Path]): Impl =
+      new Impl(path)
   }
   
 }

--- a/typo-tester-doobie/generated-and-checked-in/adventureworks/sa/pcc/PccViewFields.scala
+++ b/typo-tester-doobie/generated-and-checked-in/adventureworks/sa/pcc/PccViewFields.scala
@@ -10,36 +10,37 @@ package pcc
 import adventureworks.customtypes.TypoLocalDateTime
 import adventureworks.person.businessentity.BusinessentityId
 import adventureworks.userdefined.CustomCreditcardId
+import typo.dsl.Path
 import typo.dsl.SqlExpr.Field
 import typo.dsl.SqlExpr.FieldLikeNoHkt
 import typo.dsl.Structure.Relation
 
-trait PccViewFields[Row] {
-  val id: Field[BusinessentityId, Row]
-  val businessentityid: Field[BusinessentityId, Row]
-  val creditcardid: Field[/* user-picked */ CustomCreditcardId, Row]
-  val modifieddate: Field[TypoLocalDateTime, Row]
+trait PccViewFields {
+  def id: Field[BusinessentityId, PccViewRow]
+  def businessentityid: Field[BusinessentityId, PccViewRow]
+  def creditcardid: Field[/* user-picked */ CustomCreditcardId, PccViewRow]
+  def modifieddate: Field[TypoLocalDateTime, PccViewRow]
 }
 
 object PccViewFields {
-  val structure: Relation[PccViewFields, PccViewRow, PccViewRow] = 
-    new Impl(None, identity, (_, x) => x)
+  lazy val structure: Relation[PccViewFields, PccViewRow] =
+    new Impl(Nil)
     
-  private final class Impl[Row](val prefix: Option[String], val extract: Row => PccViewRow, val merge: (Row, PccViewRow) => Row)
-    extends Relation[PccViewFields, PccViewRow, Row] { 
+  private final class Impl(val _path: List[Path])
+    extends Relation[PccViewFields, PccViewRow] {
   
-    override val fields: PccViewFields[Row] = new PccViewFields[Row] {
-      override val id = new Field[BusinessentityId, Row](prefix, "id", None, None)(x => extract(x).id, (row, value) => merge(row, extract(row).copy(id = value)))
-      override val businessentityid = new Field[BusinessentityId, Row](prefix, "businessentityid", None, None)(x => extract(x).businessentityid, (row, value) => merge(row, extract(row).copy(businessentityid = value)))
-      override val creditcardid = new Field[/* user-picked */ CustomCreditcardId, Row](prefix, "creditcardid", None, None)(x => extract(x).creditcardid, (row, value) => merge(row, extract(row).copy(creditcardid = value)))
-      override val modifieddate = new Field[TypoLocalDateTime, Row](prefix, "modifieddate", Some("text"), None)(x => extract(x).modifieddate, (row, value) => merge(row, extract(row).copy(modifieddate = value)))
+    override lazy val fields: PccViewFields = new PccViewFields {
+      override def id = Field[BusinessentityId, PccViewRow](_path, "id", None, None, x => x.id, (row, value) => row.copy(id = value))
+      override def businessentityid = Field[BusinessentityId, PccViewRow](_path, "businessentityid", None, None, x => x.businessentityid, (row, value) => row.copy(businessentityid = value))
+      override def creditcardid = Field[/* user-picked */ CustomCreditcardId, PccViewRow](_path, "creditcardid", None, None, x => x.creditcardid, (row, value) => row.copy(creditcardid = value))
+      override def modifieddate = Field[TypoLocalDateTime, PccViewRow](_path, "modifieddate", Some("text"), None, x => x.modifieddate, (row, value) => row.copy(modifieddate = value))
     }
   
-    override val columns: List[FieldLikeNoHkt[?, Row]] =
-      List[FieldLikeNoHkt[?, Row]](fields.id, fields.businessentityid, fields.creditcardid, fields.modifieddate)
+    override lazy val columns: List[FieldLikeNoHkt[?, PccViewRow]] =
+      List[FieldLikeNoHkt[?, PccViewRow]](fields.id, fields.businessentityid, fields.creditcardid, fields.modifieddate)
   
-    override def copy[NewRow](prefix: Option[String], extract: NewRow => PccViewRow, merge: (NewRow, PccViewRow) => NewRow): Impl[NewRow] =
-      new Impl(prefix, extract, merge)
+    override def copy(path: List[Path]): Impl =
+      new Impl(path)
   }
   
 }

--- a/typo-tester-doobie/generated-and-checked-in/adventureworks/sa/s/SViewFields.scala
+++ b/typo-tester-doobie/generated-and-checked-in/adventureworks/sa/s/SViewFields.scala
@@ -12,43 +12,44 @@ import adventureworks.customtypes.TypoUUID
 import adventureworks.customtypes.TypoXml
 import adventureworks.person.businessentity.BusinessentityId
 import adventureworks.public.Name
+import typo.dsl.Path
 import typo.dsl.SqlExpr.Field
 import typo.dsl.SqlExpr.FieldLikeNoHkt
 import typo.dsl.SqlExpr.OptField
 import typo.dsl.Structure.Relation
 
-trait SViewFields[Row] {
-  val id: Field[BusinessentityId, Row]
-  val businessentityid: Field[BusinessentityId, Row]
-  val name: Field[Name, Row]
-  val salespersonid: OptField[BusinessentityId, Row]
-  val demographics: OptField[TypoXml, Row]
-  val rowguid: Field[TypoUUID, Row]
-  val modifieddate: Field[TypoLocalDateTime, Row]
+trait SViewFields {
+  def id: Field[BusinessentityId, SViewRow]
+  def businessentityid: Field[BusinessentityId, SViewRow]
+  def name: Field[Name, SViewRow]
+  def salespersonid: OptField[BusinessentityId, SViewRow]
+  def demographics: OptField[TypoXml, SViewRow]
+  def rowguid: Field[TypoUUID, SViewRow]
+  def modifieddate: Field[TypoLocalDateTime, SViewRow]
 }
 
 object SViewFields {
-  val structure: Relation[SViewFields, SViewRow, SViewRow] = 
-    new Impl(None, identity, (_, x) => x)
+  lazy val structure: Relation[SViewFields, SViewRow] =
+    new Impl(Nil)
     
-  private final class Impl[Row](val prefix: Option[String], val extract: Row => SViewRow, val merge: (Row, SViewRow) => Row)
-    extends Relation[SViewFields, SViewRow, Row] { 
+  private final class Impl(val _path: List[Path])
+    extends Relation[SViewFields, SViewRow] {
   
-    override val fields: SViewFields[Row] = new SViewFields[Row] {
-      override val id = new Field[BusinessentityId, Row](prefix, "id", None, None)(x => extract(x).id, (row, value) => merge(row, extract(row).copy(id = value)))
-      override val businessentityid = new Field[BusinessentityId, Row](prefix, "businessentityid", None, None)(x => extract(x).businessentityid, (row, value) => merge(row, extract(row).copy(businessentityid = value)))
-      override val name = new Field[Name, Row](prefix, "name", None, None)(x => extract(x).name, (row, value) => merge(row, extract(row).copy(name = value)))
-      override val salespersonid = new OptField[BusinessentityId, Row](prefix, "salespersonid", None, None)(x => extract(x).salespersonid, (row, value) => merge(row, extract(row).copy(salespersonid = value)))
-      override val demographics = new OptField[TypoXml, Row](prefix, "demographics", None, None)(x => extract(x).demographics, (row, value) => merge(row, extract(row).copy(demographics = value)))
-      override val rowguid = new Field[TypoUUID, Row](prefix, "rowguid", None, None)(x => extract(x).rowguid, (row, value) => merge(row, extract(row).copy(rowguid = value)))
-      override val modifieddate = new Field[TypoLocalDateTime, Row](prefix, "modifieddate", Some("text"), None)(x => extract(x).modifieddate, (row, value) => merge(row, extract(row).copy(modifieddate = value)))
+    override lazy val fields: SViewFields = new SViewFields {
+      override def id = Field[BusinessentityId, SViewRow](_path, "id", None, None, x => x.id, (row, value) => row.copy(id = value))
+      override def businessentityid = Field[BusinessentityId, SViewRow](_path, "businessentityid", None, None, x => x.businessentityid, (row, value) => row.copy(businessentityid = value))
+      override def name = Field[Name, SViewRow](_path, "name", None, None, x => x.name, (row, value) => row.copy(name = value))
+      override def salespersonid = OptField[BusinessentityId, SViewRow](_path, "salespersonid", None, None, x => x.salespersonid, (row, value) => row.copy(salespersonid = value))
+      override def demographics = OptField[TypoXml, SViewRow](_path, "demographics", None, None, x => x.demographics, (row, value) => row.copy(demographics = value))
+      override def rowguid = Field[TypoUUID, SViewRow](_path, "rowguid", None, None, x => x.rowguid, (row, value) => row.copy(rowguid = value))
+      override def modifieddate = Field[TypoLocalDateTime, SViewRow](_path, "modifieddate", Some("text"), None, x => x.modifieddate, (row, value) => row.copy(modifieddate = value))
     }
   
-    override val columns: List[FieldLikeNoHkt[?, Row]] =
-      List[FieldLikeNoHkt[?, Row]](fields.id, fields.businessentityid, fields.name, fields.salespersonid, fields.demographics, fields.rowguid, fields.modifieddate)
+    override lazy val columns: List[FieldLikeNoHkt[?, SViewRow]] =
+      List[FieldLikeNoHkt[?, SViewRow]](fields.id, fields.businessentityid, fields.name, fields.salespersonid, fields.demographics, fields.rowguid, fields.modifieddate)
   
-    override def copy[NewRow](prefix: Option[String], extract: NewRow => SViewRow, merge: (NewRow, SViewRow) => NewRow): Impl[NewRow] =
-      new Impl(prefix, extract, merge)
+    override def copy(path: List[Path]): Impl =
+      new Impl(path)
   }
   
 }

--- a/typo-tester-doobie/generated-and-checked-in/adventureworks/sa/sci/SciViewFields.scala
+++ b/typo-tester-doobie/generated-and-checked-in/adventureworks/sa/sci/SciViewFields.scala
@@ -10,42 +10,43 @@ package sci
 import adventureworks.customtypes.TypoLocalDateTime
 import adventureworks.production.product.ProductId
 import adventureworks.sales.shoppingcartitem.ShoppingcartitemId
+import typo.dsl.Path
 import typo.dsl.SqlExpr.Field
 import typo.dsl.SqlExpr.FieldLikeNoHkt
 import typo.dsl.Structure.Relation
 
-trait SciViewFields[Row] {
-  val id: Field[ShoppingcartitemId, Row]
-  val shoppingcartitemid: Field[ShoppingcartitemId, Row]
-  val shoppingcartid: Field[/* max 50 chars */ String, Row]
-  val quantity: Field[Int, Row]
-  val productid: Field[ProductId, Row]
-  val datecreated: Field[TypoLocalDateTime, Row]
-  val modifieddate: Field[TypoLocalDateTime, Row]
+trait SciViewFields {
+  def id: Field[ShoppingcartitemId, SciViewRow]
+  def shoppingcartitemid: Field[ShoppingcartitemId, SciViewRow]
+  def shoppingcartid: Field[/* max 50 chars */ String, SciViewRow]
+  def quantity: Field[Int, SciViewRow]
+  def productid: Field[ProductId, SciViewRow]
+  def datecreated: Field[TypoLocalDateTime, SciViewRow]
+  def modifieddate: Field[TypoLocalDateTime, SciViewRow]
 }
 
 object SciViewFields {
-  val structure: Relation[SciViewFields, SciViewRow, SciViewRow] = 
-    new Impl(None, identity, (_, x) => x)
+  lazy val structure: Relation[SciViewFields, SciViewRow] =
+    new Impl(Nil)
     
-  private final class Impl[Row](val prefix: Option[String], val extract: Row => SciViewRow, val merge: (Row, SciViewRow) => Row)
-    extends Relation[SciViewFields, SciViewRow, Row] { 
+  private final class Impl(val _path: List[Path])
+    extends Relation[SciViewFields, SciViewRow] {
   
-    override val fields: SciViewFields[Row] = new SciViewFields[Row] {
-      override val id = new Field[ShoppingcartitemId, Row](prefix, "id", None, None)(x => extract(x).id, (row, value) => merge(row, extract(row).copy(id = value)))
-      override val shoppingcartitemid = new Field[ShoppingcartitemId, Row](prefix, "shoppingcartitemid", None, None)(x => extract(x).shoppingcartitemid, (row, value) => merge(row, extract(row).copy(shoppingcartitemid = value)))
-      override val shoppingcartid = new Field[/* max 50 chars */ String, Row](prefix, "shoppingcartid", None, None)(x => extract(x).shoppingcartid, (row, value) => merge(row, extract(row).copy(shoppingcartid = value)))
-      override val quantity = new Field[Int, Row](prefix, "quantity", None, None)(x => extract(x).quantity, (row, value) => merge(row, extract(row).copy(quantity = value)))
-      override val productid = new Field[ProductId, Row](prefix, "productid", None, None)(x => extract(x).productid, (row, value) => merge(row, extract(row).copy(productid = value)))
-      override val datecreated = new Field[TypoLocalDateTime, Row](prefix, "datecreated", Some("text"), None)(x => extract(x).datecreated, (row, value) => merge(row, extract(row).copy(datecreated = value)))
-      override val modifieddate = new Field[TypoLocalDateTime, Row](prefix, "modifieddate", Some("text"), None)(x => extract(x).modifieddate, (row, value) => merge(row, extract(row).copy(modifieddate = value)))
+    override lazy val fields: SciViewFields = new SciViewFields {
+      override def id = Field[ShoppingcartitemId, SciViewRow](_path, "id", None, None, x => x.id, (row, value) => row.copy(id = value))
+      override def shoppingcartitemid = Field[ShoppingcartitemId, SciViewRow](_path, "shoppingcartitemid", None, None, x => x.shoppingcartitemid, (row, value) => row.copy(shoppingcartitemid = value))
+      override def shoppingcartid = Field[/* max 50 chars */ String, SciViewRow](_path, "shoppingcartid", None, None, x => x.shoppingcartid, (row, value) => row.copy(shoppingcartid = value))
+      override def quantity = Field[Int, SciViewRow](_path, "quantity", None, None, x => x.quantity, (row, value) => row.copy(quantity = value))
+      override def productid = Field[ProductId, SciViewRow](_path, "productid", None, None, x => x.productid, (row, value) => row.copy(productid = value))
+      override def datecreated = Field[TypoLocalDateTime, SciViewRow](_path, "datecreated", Some("text"), None, x => x.datecreated, (row, value) => row.copy(datecreated = value))
+      override def modifieddate = Field[TypoLocalDateTime, SciViewRow](_path, "modifieddate", Some("text"), None, x => x.modifieddate, (row, value) => row.copy(modifieddate = value))
     }
   
-    override val columns: List[FieldLikeNoHkt[?, Row]] =
-      List[FieldLikeNoHkt[?, Row]](fields.id, fields.shoppingcartitemid, fields.shoppingcartid, fields.quantity, fields.productid, fields.datecreated, fields.modifieddate)
+    override lazy val columns: List[FieldLikeNoHkt[?, SciViewRow]] =
+      List[FieldLikeNoHkt[?, SciViewRow]](fields.id, fields.shoppingcartitemid, fields.shoppingcartid, fields.quantity, fields.productid, fields.datecreated, fields.modifieddate)
   
-    override def copy[NewRow](prefix: Option[String], extract: NewRow => SciViewRow, merge: (NewRow, SciViewRow) => NewRow): Impl[NewRow] =
-      new Impl(prefix, extract, merge)
+    override def copy(path: List[Path]): Impl =
+      new Impl(path)
   }
   
 }

--- a/typo-tester-doobie/generated-and-checked-in/adventureworks/sa/so/SoViewFields.scala
+++ b/typo-tester-doobie/generated-and-checked-in/adventureworks/sa/so/SoViewFields.scala
@@ -10,53 +10,54 @@ package so
 import adventureworks.customtypes.TypoLocalDateTime
 import adventureworks.customtypes.TypoUUID
 import adventureworks.sales.specialoffer.SpecialofferId
+import typo.dsl.Path
 import typo.dsl.SqlExpr.Field
 import typo.dsl.SqlExpr.FieldLikeNoHkt
 import typo.dsl.SqlExpr.OptField
 import typo.dsl.Structure.Relation
 
-trait SoViewFields[Row] {
-  val id: Field[SpecialofferId, Row]
-  val specialofferid: Field[SpecialofferId, Row]
-  val description: Field[/* max 255 chars */ String, Row]
-  val discountpct: Field[BigDecimal, Row]
-  val `type`: Field[/* max 50 chars */ String, Row]
-  val category: Field[/* max 50 chars */ String, Row]
-  val startdate: Field[TypoLocalDateTime, Row]
-  val enddate: Field[TypoLocalDateTime, Row]
-  val minqty: Field[Int, Row]
-  val maxqty: OptField[Int, Row]
-  val rowguid: Field[TypoUUID, Row]
-  val modifieddate: Field[TypoLocalDateTime, Row]
+trait SoViewFields {
+  def id: Field[SpecialofferId, SoViewRow]
+  def specialofferid: Field[SpecialofferId, SoViewRow]
+  def description: Field[/* max 255 chars */ String, SoViewRow]
+  def discountpct: Field[BigDecimal, SoViewRow]
+  def `type`: Field[/* max 50 chars */ String, SoViewRow]
+  def category: Field[/* max 50 chars */ String, SoViewRow]
+  def startdate: Field[TypoLocalDateTime, SoViewRow]
+  def enddate: Field[TypoLocalDateTime, SoViewRow]
+  def minqty: Field[Int, SoViewRow]
+  def maxqty: OptField[Int, SoViewRow]
+  def rowguid: Field[TypoUUID, SoViewRow]
+  def modifieddate: Field[TypoLocalDateTime, SoViewRow]
 }
 
 object SoViewFields {
-  val structure: Relation[SoViewFields, SoViewRow, SoViewRow] = 
-    new Impl(None, identity, (_, x) => x)
+  lazy val structure: Relation[SoViewFields, SoViewRow] =
+    new Impl(Nil)
     
-  private final class Impl[Row](val prefix: Option[String], val extract: Row => SoViewRow, val merge: (Row, SoViewRow) => Row)
-    extends Relation[SoViewFields, SoViewRow, Row] { 
+  private final class Impl(val _path: List[Path])
+    extends Relation[SoViewFields, SoViewRow] {
   
-    override val fields: SoViewFields[Row] = new SoViewFields[Row] {
-      override val id = new Field[SpecialofferId, Row](prefix, "id", None, None)(x => extract(x).id, (row, value) => merge(row, extract(row).copy(id = value)))
-      override val specialofferid = new Field[SpecialofferId, Row](prefix, "specialofferid", None, None)(x => extract(x).specialofferid, (row, value) => merge(row, extract(row).copy(specialofferid = value)))
-      override val description = new Field[/* max 255 chars */ String, Row](prefix, "description", None, None)(x => extract(x).description, (row, value) => merge(row, extract(row).copy(description = value)))
-      override val discountpct = new Field[BigDecimal, Row](prefix, "discountpct", None, None)(x => extract(x).discountpct, (row, value) => merge(row, extract(row).copy(discountpct = value)))
-      override val `type` = new Field[/* max 50 chars */ String, Row](prefix, "type", None, None)(x => extract(x).`type`, (row, value) => merge(row, extract(row).copy(`type` = value)))
-      override val category = new Field[/* max 50 chars */ String, Row](prefix, "category", None, None)(x => extract(x).category, (row, value) => merge(row, extract(row).copy(category = value)))
-      override val startdate = new Field[TypoLocalDateTime, Row](prefix, "startdate", Some("text"), None)(x => extract(x).startdate, (row, value) => merge(row, extract(row).copy(startdate = value)))
-      override val enddate = new Field[TypoLocalDateTime, Row](prefix, "enddate", Some("text"), None)(x => extract(x).enddate, (row, value) => merge(row, extract(row).copy(enddate = value)))
-      override val minqty = new Field[Int, Row](prefix, "minqty", None, None)(x => extract(x).minqty, (row, value) => merge(row, extract(row).copy(minqty = value)))
-      override val maxqty = new OptField[Int, Row](prefix, "maxqty", None, None)(x => extract(x).maxqty, (row, value) => merge(row, extract(row).copy(maxqty = value)))
-      override val rowguid = new Field[TypoUUID, Row](prefix, "rowguid", None, None)(x => extract(x).rowguid, (row, value) => merge(row, extract(row).copy(rowguid = value)))
-      override val modifieddate = new Field[TypoLocalDateTime, Row](prefix, "modifieddate", Some("text"), None)(x => extract(x).modifieddate, (row, value) => merge(row, extract(row).copy(modifieddate = value)))
+    override lazy val fields: SoViewFields = new SoViewFields {
+      override def id = Field[SpecialofferId, SoViewRow](_path, "id", None, None, x => x.id, (row, value) => row.copy(id = value))
+      override def specialofferid = Field[SpecialofferId, SoViewRow](_path, "specialofferid", None, None, x => x.specialofferid, (row, value) => row.copy(specialofferid = value))
+      override def description = Field[/* max 255 chars */ String, SoViewRow](_path, "description", None, None, x => x.description, (row, value) => row.copy(description = value))
+      override def discountpct = Field[BigDecimal, SoViewRow](_path, "discountpct", None, None, x => x.discountpct, (row, value) => row.copy(discountpct = value))
+      override def `type` = Field[/* max 50 chars */ String, SoViewRow](_path, "type", None, None, x => x.`type`, (row, value) => row.copy(`type` = value))
+      override def category = Field[/* max 50 chars */ String, SoViewRow](_path, "category", None, None, x => x.category, (row, value) => row.copy(category = value))
+      override def startdate = Field[TypoLocalDateTime, SoViewRow](_path, "startdate", Some("text"), None, x => x.startdate, (row, value) => row.copy(startdate = value))
+      override def enddate = Field[TypoLocalDateTime, SoViewRow](_path, "enddate", Some("text"), None, x => x.enddate, (row, value) => row.copy(enddate = value))
+      override def minqty = Field[Int, SoViewRow](_path, "minqty", None, None, x => x.minqty, (row, value) => row.copy(minqty = value))
+      override def maxqty = OptField[Int, SoViewRow](_path, "maxqty", None, None, x => x.maxqty, (row, value) => row.copy(maxqty = value))
+      override def rowguid = Field[TypoUUID, SoViewRow](_path, "rowguid", None, None, x => x.rowguid, (row, value) => row.copy(rowguid = value))
+      override def modifieddate = Field[TypoLocalDateTime, SoViewRow](_path, "modifieddate", Some("text"), None, x => x.modifieddate, (row, value) => row.copy(modifieddate = value))
     }
   
-    override val columns: List[FieldLikeNoHkt[?, Row]] =
-      List[FieldLikeNoHkt[?, Row]](fields.id, fields.specialofferid, fields.description, fields.discountpct, fields.`type`, fields.category, fields.startdate, fields.enddate, fields.minqty, fields.maxqty, fields.rowguid, fields.modifieddate)
+    override lazy val columns: List[FieldLikeNoHkt[?, SoViewRow]] =
+      List[FieldLikeNoHkt[?, SoViewRow]](fields.id, fields.specialofferid, fields.description, fields.discountpct, fields.`type`, fields.category, fields.startdate, fields.enddate, fields.minqty, fields.maxqty, fields.rowguid, fields.modifieddate)
   
-    override def copy[NewRow](prefix: Option[String], extract: NewRow => SoViewRow, merge: (NewRow, SoViewRow) => NewRow): Impl[NewRow] =
-      new Impl(prefix, extract, merge)
+    override def copy(path: List[Path]): Impl =
+      new Impl(path)
   }
   
 }

--- a/typo-tester-doobie/generated-and-checked-in/adventureworks/sa/sod/SodViewFields.scala
+++ b/typo-tester-doobie/generated-and-checked-in/adventureworks/sa/sod/SodViewFields.scala
@@ -13,51 +13,52 @@ import adventureworks.customtypes.TypoUUID
 import adventureworks.production.product.ProductId
 import adventureworks.sales.salesorderheader.SalesorderheaderId
 import adventureworks.sales.specialoffer.SpecialofferId
+import typo.dsl.Path
 import typo.dsl.SqlExpr.Field
 import typo.dsl.SqlExpr.FieldLikeNoHkt
 import typo.dsl.SqlExpr.OptField
 import typo.dsl.Structure.Relation
 
-trait SodViewFields[Row] {
-  val id: Field[Int, Row]
-  val salesorderid: Field[SalesorderheaderId, Row]
-  val salesorderdetailid: Field[Int, Row]
-  val carriertrackingnumber: OptField[/* max 25 chars */ String, Row]
-  val orderqty: Field[TypoShort, Row]
-  val productid: Field[ProductId, Row]
-  val specialofferid: Field[SpecialofferId, Row]
-  val unitprice: Field[BigDecimal, Row]
-  val unitpricediscount: Field[BigDecimal, Row]
-  val rowguid: Field[TypoUUID, Row]
-  val modifieddate: Field[TypoLocalDateTime, Row]
+trait SodViewFields {
+  def id: Field[Int, SodViewRow]
+  def salesorderid: Field[SalesorderheaderId, SodViewRow]
+  def salesorderdetailid: Field[Int, SodViewRow]
+  def carriertrackingnumber: OptField[/* max 25 chars */ String, SodViewRow]
+  def orderqty: Field[TypoShort, SodViewRow]
+  def productid: Field[ProductId, SodViewRow]
+  def specialofferid: Field[SpecialofferId, SodViewRow]
+  def unitprice: Field[BigDecimal, SodViewRow]
+  def unitpricediscount: Field[BigDecimal, SodViewRow]
+  def rowguid: Field[TypoUUID, SodViewRow]
+  def modifieddate: Field[TypoLocalDateTime, SodViewRow]
 }
 
 object SodViewFields {
-  val structure: Relation[SodViewFields, SodViewRow, SodViewRow] = 
-    new Impl(None, identity, (_, x) => x)
+  lazy val structure: Relation[SodViewFields, SodViewRow] =
+    new Impl(Nil)
     
-  private final class Impl[Row](val prefix: Option[String], val extract: Row => SodViewRow, val merge: (Row, SodViewRow) => Row)
-    extends Relation[SodViewFields, SodViewRow, Row] { 
+  private final class Impl(val _path: List[Path])
+    extends Relation[SodViewFields, SodViewRow] {
   
-    override val fields: SodViewFields[Row] = new SodViewFields[Row] {
-      override val id = new Field[Int, Row](prefix, "id", None, None)(x => extract(x).id, (row, value) => merge(row, extract(row).copy(id = value)))
-      override val salesorderid = new Field[SalesorderheaderId, Row](prefix, "salesorderid", None, None)(x => extract(x).salesorderid, (row, value) => merge(row, extract(row).copy(salesorderid = value)))
-      override val salesorderdetailid = new Field[Int, Row](prefix, "salesorderdetailid", None, None)(x => extract(x).salesorderdetailid, (row, value) => merge(row, extract(row).copy(salesorderdetailid = value)))
-      override val carriertrackingnumber = new OptField[/* max 25 chars */ String, Row](prefix, "carriertrackingnumber", None, None)(x => extract(x).carriertrackingnumber, (row, value) => merge(row, extract(row).copy(carriertrackingnumber = value)))
-      override val orderqty = new Field[TypoShort, Row](prefix, "orderqty", None, None)(x => extract(x).orderqty, (row, value) => merge(row, extract(row).copy(orderqty = value)))
-      override val productid = new Field[ProductId, Row](prefix, "productid", None, None)(x => extract(x).productid, (row, value) => merge(row, extract(row).copy(productid = value)))
-      override val specialofferid = new Field[SpecialofferId, Row](prefix, "specialofferid", None, None)(x => extract(x).specialofferid, (row, value) => merge(row, extract(row).copy(specialofferid = value)))
-      override val unitprice = new Field[BigDecimal, Row](prefix, "unitprice", None, None)(x => extract(x).unitprice, (row, value) => merge(row, extract(row).copy(unitprice = value)))
-      override val unitpricediscount = new Field[BigDecimal, Row](prefix, "unitpricediscount", None, None)(x => extract(x).unitpricediscount, (row, value) => merge(row, extract(row).copy(unitpricediscount = value)))
-      override val rowguid = new Field[TypoUUID, Row](prefix, "rowguid", None, None)(x => extract(x).rowguid, (row, value) => merge(row, extract(row).copy(rowguid = value)))
-      override val modifieddate = new Field[TypoLocalDateTime, Row](prefix, "modifieddate", Some("text"), None)(x => extract(x).modifieddate, (row, value) => merge(row, extract(row).copy(modifieddate = value)))
+    override lazy val fields: SodViewFields = new SodViewFields {
+      override def id = Field[Int, SodViewRow](_path, "id", None, None, x => x.id, (row, value) => row.copy(id = value))
+      override def salesorderid = Field[SalesorderheaderId, SodViewRow](_path, "salesorderid", None, None, x => x.salesorderid, (row, value) => row.copy(salesorderid = value))
+      override def salesorderdetailid = Field[Int, SodViewRow](_path, "salesorderdetailid", None, None, x => x.salesorderdetailid, (row, value) => row.copy(salesorderdetailid = value))
+      override def carriertrackingnumber = OptField[/* max 25 chars */ String, SodViewRow](_path, "carriertrackingnumber", None, None, x => x.carriertrackingnumber, (row, value) => row.copy(carriertrackingnumber = value))
+      override def orderqty = Field[TypoShort, SodViewRow](_path, "orderqty", None, None, x => x.orderqty, (row, value) => row.copy(orderqty = value))
+      override def productid = Field[ProductId, SodViewRow](_path, "productid", None, None, x => x.productid, (row, value) => row.copy(productid = value))
+      override def specialofferid = Field[SpecialofferId, SodViewRow](_path, "specialofferid", None, None, x => x.specialofferid, (row, value) => row.copy(specialofferid = value))
+      override def unitprice = Field[BigDecimal, SodViewRow](_path, "unitprice", None, None, x => x.unitprice, (row, value) => row.copy(unitprice = value))
+      override def unitpricediscount = Field[BigDecimal, SodViewRow](_path, "unitpricediscount", None, None, x => x.unitpricediscount, (row, value) => row.copy(unitpricediscount = value))
+      override def rowguid = Field[TypoUUID, SodViewRow](_path, "rowguid", None, None, x => x.rowguid, (row, value) => row.copy(rowguid = value))
+      override def modifieddate = Field[TypoLocalDateTime, SodViewRow](_path, "modifieddate", Some("text"), None, x => x.modifieddate, (row, value) => row.copy(modifieddate = value))
     }
   
-    override val columns: List[FieldLikeNoHkt[?, Row]] =
-      List[FieldLikeNoHkt[?, Row]](fields.id, fields.salesorderid, fields.salesorderdetailid, fields.carriertrackingnumber, fields.orderqty, fields.productid, fields.specialofferid, fields.unitprice, fields.unitpricediscount, fields.rowguid, fields.modifieddate)
+    override lazy val columns: List[FieldLikeNoHkt[?, SodViewRow]] =
+      List[FieldLikeNoHkt[?, SodViewRow]](fields.id, fields.salesorderid, fields.salesorderdetailid, fields.carriertrackingnumber, fields.orderqty, fields.productid, fields.specialofferid, fields.unitprice, fields.unitpricediscount, fields.rowguid, fields.modifieddate)
   
-    override def copy[NewRow](prefix: Option[String], extract: NewRow => SodViewRow, merge: (NewRow, SodViewRow) => NewRow): Impl[NewRow] =
-      new Impl(prefix, extract, merge)
+    override def copy(path: List[Path]): Impl =
+      new Impl(path)
   }
   
 }

--- a/typo-tester-doobie/generated-and-checked-in/adventureworks/sa/soh/SohViewFields.scala
+++ b/typo-tester-doobie/generated-and-checked-in/adventureworks/sa/soh/SohViewFields.scala
@@ -21,81 +21,82 @@ import adventureworks.sales.customer.CustomerId
 import adventureworks.sales.salesorderheader.SalesorderheaderId
 import adventureworks.sales.salesterritory.SalesterritoryId
 import adventureworks.userdefined.CustomCreditcardId
+import typo.dsl.Path
 import typo.dsl.SqlExpr.Field
 import typo.dsl.SqlExpr.FieldLikeNoHkt
 import typo.dsl.SqlExpr.OptField
 import typo.dsl.Structure.Relation
 
-trait SohViewFields[Row] {
-  val id: Field[SalesorderheaderId, Row]
-  val salesorderid: Field[SalesorderheaderId, Row]
-  val revisionnumber: Field[TypoShort, Row]
-  val orderdate: Field[TypoLocalDateTime, Row]
-  val duedate: Field[TypoLocalDateTime, Row]
-  val shipdate: OptField[TypoLocalDateTime, Row]
-  val status: Field[TypoShort, Row]
-  val onlineorderflag: Field[Flag, Row]
-  val purchaseordernumber: OptField[OrderNumber, Row]
-  val accountnumber: OptField[AccountNumber, Row]
-  val customerid: Field[CustomerId, Row]
-  val salespersonid: OptField[BusinessentityId, Row]
-  val territoryid: OptField[SalesterritoryId, Row]
-  val billtoaddressid: Field[AddressId, Row]
-  val shiptoaddressid: Field[AddressId, Row]
-  val shipmethodid: Field[ShipmethodId, Row]
-  val creditcardid: OptField[/* user-picked */ CustomCreditcardId, Row]
-  val creditcardapprovalcode: OptField[/* max 15 chars */ String, Row]
-  val currencyrateid: OptField[CurrencyrateId, Row]
-  val subtotal: Field[BigDecimal, Row]
-  val taxamt: Field[BigDecimal, Row]
-  val freight: Field[BigDecimal, Row]
-  val totaldue: OptField[BigDecimal, Row]
-  val comment: OptField[/* max 128 chars */ String, Row]
-  val rowguid: Field[TypoUUID, Row]
-  val modifieddate: Field[TypoLocalDateTime, Row]
+trait SohViewFields {
+  def id: Field[SalesorderheaderId, SohViewRow]
+  def salesorderid: Field[SalesorderheaderId, SohViewRow]
+  def revisionnumber: Field[TypoShort, SohViewRow]
+  def orderdate: Field[TypoLocalDateTime, SohViewRow]
+  def duedate: Field[TypoLocalDateTime, SohViewRow]
+  def shipdate: OptField[TypoLocalDateTime, SohViewRow]
+  def status: Field[TypoShort, SohViewRow]
+  def onlineorderflag: Field[Flag, SohViewRow]
+  def purchaseordernumber: OptField[OrderNumber, SohViewRow]
+  def accountnumber: OptField[AccountNumber, SohViewRow]
+  def customerid: Field[CustomerId, SohViewRow]
+  def salespersonid: OptField[BusinessentityId, SohViewRow]
+  def territoryid: OptField[SalesterritoryId, SohViewRow]
+  def billtoaddressid: Field[AddressId, SohViewRow]
+  def shiptoaddressid: Field[AddressId, SohViewRow]
+  def shipmethodid: Field[ShipmethodId, SohViewRow]
+  def creditcardid: OptField[/* user-picked */ CustomCreditcardId, SohViewRow]
+  def creditcardapprovalcode: OptField[/* max 15 chars */ String, SohViewRow]
+  def currencyrateid: OptField[CurrencyrateId, SohViewRow]
+  def subtotal: Field[BigDecimal, SohViewRow]
+  def taxamt: Field[BigDecimal, SohViewRow]
+  def freight: Field[BigDecimal, SohViewRow]
+  def totaldue: OptField[BigDecimal, SohViewRow]
+  def comment: OptField[/* max 128 chars */ String, SohViewRow]
+  def rowguid: Field[TypoUUID, SohViewRow]
+  def modifieddate: Field[TypoLocalDateTime, SohViewRow]
 }
 
 object SohViewFields {
-  val structure: Relation[SohViewFields, SohViewRow, SohViewRow] = 
-    new Impl(None, identity, (_, x) => x)
+  lazy val structure: Relation[SohViewFields, SohViewRow] =
+    new Impl(Nil)
     
-  private final class Impl[Row](val prefix: Option[String], val extract: Row => SohViewRow, val merge: (Row, SohViewRow) => Row)
-    extends Relation[SohViewFields, SohViewRow, Row] { 
+  private final class Impl(val _path: List[Path])
+    extends Relation[SohViewFields, SohViewRow] {
   
-    override val fields: SohViewFields[Row] = new SohViewFields[Row] {
-      override val id = new Field[SalesorderheaderId, Row](prefix, "id", None, None)(x => extract(x).id, (row, value) => merge(row, extract(row).copy(id = value)))
-      override val salesorderid = new Field[SalesorderheaderId, Row](prefix, "salesorderid", None, None)(x => extract(x).salesorderid, (row, value) => merge(row, extract(row).copy(salesorderid = value)))
-      override val revisionnumber = new Field[TypoShort, Row](prefix, "revisionnumber", None, None)(x => extract(x).revisionnumber, (row, value) => merge(row, extract(row).copy(revisionnumber = value)))
-      override val orderdate = new Field[TypoLocalDateTime, Row](prefix, "orderdate", Some("text"), None)(x => extract(x).orderdate, (row, value) => merge(row, extract(row).copy(orderdate = value)))
-      override val duedate = new Field[TypoLocalDateTime, Row](prefix, "duedate", Some("text"), None)(x => extract(x).duedate, (row, value) => merge(row, extract(row).copy(duedate = value)))
-      override val shipdate = new OptField[TypoLocalDateTime, Row](prefix, "shipdate", Some("text"), None)(x => extract(x).shipdate, (row, value) => merge(row, extract(row).copy(shipdate = value)))
-      override val status = new Field[TypoShort, Row](prefix, "status", None, None)(x => extract(x).status, (row, value) => merge(row, extract(row).copy(status = value)))
-      override val onlineorderflag = new Field[Flag, Row](prefix, "onlineorderflag", None, None)(x => extract(x).onlineorderflag, (row, value) => merge(row, extract(row).copy(onlineorderflag = value)))
-      override val purchaseordernumber = new OptField[OrderNumber, Row](prefix, "purchaseordernumber", None, None)(x => extract(x).purchaseordernumber, (row, value) => merge(row, extract(row).copy(purchaseordernumber = value)))
-      override val accountnumber = new OptField[AccountNumber, Row](prefix, "accountnumber", None, None)(x => extract(x).accountnumber, (row, value) => merge(row, extract(row).copy(accountnumber = value)))
-      override val customerid = new Field[CustomerId, Row](prefix, "customerid", None, None)(x => extract(x).customerid, (row, value) => merge(row, extract(row).copy(customerid = value)))
-      override val salespersonid = new OptField[BusinessentityId, Row](prefix, "salespersonid", None, None)(x => extract(x).salespersonid, (row, value) => merge(row, extract(row).copy(salespersonid = value)))
-      override val territoryid = new OptField[SalesterritoryId, Row](prefix, "territoryid", None, None)(x => extract(x).territoryid, (row, value) => merge(row, extract(row).copy(territoryid = value)))
-      override val billtoaddressid = new Field[AddressId, Row](prefix, "billtoaddressid", None, None)(x => extract(x).billtoaddressid, (row, value) => merge(row, extract(row).copy(billtoaddressid = value)))
-      override val shiptoaddressid = new Field[AddressId, Row](prefix, "shiptoaddressid", None, None)(x => extract(x).shiptoaddressid, (row, value) => merge(row, extract(row).copy(shiptoaddressid = value)))
-      override val shipmethodid = new Field[ShipmethodId, Row](prefix, "shipmethodid", None, None)(x => extract(x).shipmethodid, (row, value) => merge(row, extract(row).copy(shipmethodid = value)))
-      override val creditcardid = new OptField[/* user-picked */ CustomCreditcardId, Row](prefix, "creditcardid", None, None)(x => extract(x).creditcardid, (row, value) => merge(row, extract(row).copy(creditcardid = value)))
-      override val creditcardapprovalcode = new OptField[/* max 15 chars */ String, Row](prefix, "creditcardapprovalcode", None, None)(x => extract(x).creditcardapprovalcode, (row, value) => merge(row, extract(row).copy(creditcardapprovalcode = value)))
-      override val currencyrateid = new OptField[CurrencyrateId, Row](prefix, "currencyrateid", None, None)(x => extract(x).currencyrateid, (row, value) => merge(row, extract(row).copy(currencyrateid = value)))
-      override val subtotal = new Field[BigDecimal, Row](prefix, "subtotal", None, None)(x => extract(x).subtotal, (row, value) => merge(row, extract(row).copy(subtotal = value)))
-      override val taxamt = new Field[BigDecimal, Row](prefix, "taxamt", None, None)(x => extract(x).taxamt, (row, value) => merge(row, extract(row).copy(taxamt = value)))
-      override val freight = new Field[BigDecimal, Row](prefix, "freight", None, None)(x => extract(x).freight, (row, value) => merge(row, extract(row).copy(freight = value)))
-      override val totaldue = new OptField[BigDecimal, Row](prefix, "totaldue", None, None)(x => extract(x).totaldue, (row, value) => merge(row, extract(row).copy(totaldue = value)))
-      override val comment = new OptField[/* max 128 chars */ String, Row](prefix, "comment", None, None)(x => extract(x).comment, (row, value) => merge(row, extract(row).copy(comment = value)))
-      override val rowguid = new Field[TypoUUID, Row](prefix, "rowguid", None, None)(x => extract(x).rowguid, (row, value) => merge(row, extract(row).copy(rowguid = value)))
-      override val modifieddate = new Field[TypoLocalDateTime, Row](prefix, "modifieddate", Some("text"), None)(x => extract(x).modifieddate, (row, value) => merge(row, extract(row).copy(modifieddate = value)))
+    override lazy val fields: SohViewFields = new SohViewFields {
+      override def id = Field[SalesorderheaderId, SohViewRow](_path, "id", None, None, x => x.id, (row, value) => row.copy(id = value))
+      override def salesorderid = Field[SalesorderheaderId, SohViewRow](_path, "salesorderid", None, None, x => x.salesorderid, (row, value) => row.copy(salesorderid = value))
+      override def revisionnumber = Field[TypoShort, SohViewRow](_path, "revisionnumber", None, None, x => x.revisionnumber, (row, value) => row.copy(revisionnumber = value))
+      override def orderdate = Field[TypoLocalDateTime, SohViewRow](_path, "orderdate", Some("text"), None, x => x.orderdate, (row, value) => row.copy(orderdate = value))
+      override def duedate = Field[TypoLocalDateTime, SohViewRow](_path, "duedate", Some("text"), None, x => x.duedate, (row, value) => row.copy(duedate = value))
+      override def shipdate = OptField[TypoLocalDateTime, SohViewRow](_path, "shipdate", Some("text"), None, x => x.shipdate, (row, value) => row.copy(shipdate = value))
+      override def status = Field[TypoShort, SohViewRow](_path, "status", None, None, x => x.status, (row, value) => row.copy(status = value))
+      override def onlineorderflag = Field[Flag, SohViewRow](_path, "onlineorderflag", None, None, x => x.onlineorderflag, (row, value) => row.copy(onlineorderflag = value))
+      override def purchaseordernumber = OptField[OrderNumber, SohViewRow](_path, "purchaseordernumber", None, None, x => x.purchaseordernumber, (row, value) => row.copy(purchaseordernumber = value))
+      override def accountnumber = OptField[AccountNumber, SohViewRow](_path, "accountnumber", None, None, x => x.accountnumber, (row, value) => row.copy(accountnumber = value))
+      override def customerid = Field[CustomerId, SohViewRow](_path, "customerid", None, None, x => x.customerid, (row, value) => row.copy(customerid = value))
+      override def salespersonid = OptField[BusinessentityId, SohViewRow](_path, "salespersonid", None, None, x => x.salespersonid, (row, value) => row.copy(salespersonid = value))
+      override def territoryid = OptField[SalesterritoryId, SohViewRow](_path, "territoryid", None, None, x => x.territoryid, (row, value) => row.copy(territoryid = value))
+      override def billtoaddressid = Field[AddressId, SohViewRow](_path, "billtoaddressid", None, None, x => x.billtoaddressid, (row, value) => row.copy(billtoaddressid = value))
+      override def shiptoaddressid = Field[AddressId, SohViewRow](_path, "shiptoaddressid", None, None, x => x.shiptoaddressid, (row, value) => row.copy(shiptoaddressid = value))
+      override def shipmethodid = Field[ShipmethodId, SohViewRow](_path, "shipmethodid", None, None, x => x.shipmethodid, (row, value) => row.copy(shipmethodid = value))
+      override def creditcardid = OptField[/* user-picked */ CustomCreditcardId, SohViewRow](_path, "creditcardid", None, None, x => x.creditcardid, (row, value) => row.copy(creditcardid = value))
+      override def creditcardapprovalcode = OptField[/* max 15 chars */ String, SohViewRow](_path, "creditcardapprovalcode", None, None, x => x.creditcardapprovalcode, (row, value) => row.copy(creditcardapprovalcode = value))
+      override def currencyrateid = OptField[CurrencyrateId, SohViewRow](_path, "currencyrateid", None, None, x => x.currencyrateid, (row, value) => row.copy(currencyrateid = value))
+      override def subtotal = Field[BigDecimal, SohViewRow](_path, "subtotal", None, None, x => x.subtotal, (row, value) => row.copy(subtotal = value))
+      override def taxamt = Field[BigDecimal, SohViewRow](_path, "taxamt", None, None, x => x.taxamt, (row, value) => row.copy(taxamt = value))
+      override def freight = Field[BigDecimal, SohViewRow](_path, "freight", None, None, x => x.freight, (row, value) => row.copy(freight = value))
+      override def totaldue = OptField[BigDecimal, SohViewRow](_path, "totaldue", None, None, x => x.totaldue, (row, value) => row.copy(totaldue = value))
+      override def comment = OptField[/* max 128 chars */ String, SohViewRow](_path, "comment", None, None, x => x.comment, (row, value) => row.copy(comment = value))
+      override def rowguid = Field[TypoUUID, SohViewRow](_path, "rowguid", None, None, x => x.rowguid, (row, value) => row.copy(rowguid = value))
+      override def modifieddate = Field[TypoLocalDateTime, SohViewRow](_path, "modifieddate", Some("text"), None, x => x.modifieddate, (row, value) => row.copy(modifieddate = value))
     }
   
-    override val columns: List[FieldLikeNoHkt[?, Row]] =
-      List[FieldLikeNoHkt[?, Row]](fields.id, fields.salesorderid, fields.revisionnumber, fields.orderdate, fields.duedate, fields.shipdate, fields.status, fields.onlineorderflag, fields.purchaseordernumber, fields.accountnumber, fields.customerid, fields.salespersonid, fields.territoryid, fields.billtoaddressid, fields.shiptoaddressid, fields.shipmethodid, fields.creditcardid, fields.creditcardapprovalcode, fields.currencyrateid, fields.subtotal, fields.taxamt, fields.freight, fields.totaldue, fields.comment, fields.rowguid, fields.modifieddate)
+    override lazy val columns: List[FieldLikeNoHkt[?, SohViewRow]] =
+      List[FieldLikeNoHkt[?, SohViewRow]](fields.id, fields.salesorderid, fields.revisionnumber, fields.orderdate, fields.duedate, fields.shipdate, fields.status, fields.onlineorderflag, fields.purchaseordernumber, fields.accountnumber, fields.customerid, fields.salespersonid, fields.territoryid, fields.billtoaddressid, fields.shiptoaddressid, fields.shipmethodid, fields.creditcardid, fields.creditcardapprovalcode, fields.currencyrateid, fields.subtotal, fields.taxamt, fields.freight, fields.totaldue, fields.comment, fields.rowguid, fields.modifieddate)
   
-    override def copy[NewRow](prefix: Option[String], extract: NewRow => SohViewRow, merge: (NewRow, SohViewRow) => NewRow): Impl[NewRow] =
-      new Impl(prefix, extract, merge)
+    override def copy(path: List[Path]): Impl =
+      new Impl(path)
   }
   
 }

--- a/typo-tester-doobie/generated-and-checked-in/adventureworks/sa/sohsr/SohsrViewFields.scala
+++ b/typo-tester-doobie/generated-and-checked-in/adventureworks/sa/sohsr/SohsrViewFields.scala
@@ -10,34 +10,35 @@ package sohsr
 import adventureworks.customtypes.TypoLocalDateTime
 import adventureworks.sales.salesorderheader.SalesorderheaderId
 import adventureworks.sales.salesreason.SalesreasonId
+import typo.dsl.Path
 import typo.dsl.SqlExpr.Field
 import typo.dsl.SqlExpr.FieldLikeNoHkt
 import typo.dsl.Structure.Relation
 
-trait SohsrViewFields[Row] {
-  val salesorderid: Field[SalesorderheaderId, Row]
-  val salesreasonid: Field[SalesreasonId, Row]
-  val modifieddate: Field[TypoLocalDateTime, Row]
+trait SohsrViewFields {
+  def salesorderid: Field[SalesorderheaderId, SohsrViewRow]
+  def salesreasonid: Field[SalesreasonId, SohsrViewRow]
+  def modifieddate: Field[TypoLocalDateTime, SohsrViewRow]
 }
 
 object SohsrViewFields {
-  val structure: Relation[SohsrViewFields, SohsrViewRow, SohsrViewRow] = 
-    new Impl(None, identity, (_, x) => x)
+  lazy val structure: Relation[SohsrViewFields, SohsrViewRow] =
+    new Impl(Nil)
     
-  private final class Impl[Row](val prefix: Option[String], val extract: Row => SohsrViewRow, val merge: (Row, SohsrViewRow) => Row)
-    extends Relation[SohsrViewFields, SohsrViewRow, Row] { 
+  private final class Impl(val _path: List[Path])
+    extends Relation[SohsrViewFields, SohsrViewRow] {
   
-    override val fields: SohsrViewFields[Row] = new SohsrViewFields[Row] {
-      override val salesorderid = new Field[SalesorderheaderId, Row](prefix, "salesorderid", None, None)(x => extract(x).salesorderid, (row, value) => merge(row, extract(row).copy(salesorderid = value)))
-      override val salesreasonid = new Field[SalesreasonId, Row](prefix, "salesreasonid", None, None)(x => extract(x).salesreasonid, (row, value) => merge(row, extract(row).copy(salesreasonid = value)))
-      override val modifieddate = new Field[TypoLocalDateTime, Row](prefix, "modifieddate", Some("text"), None)(x => extract(x).modifieddate, (row, value) => merge(row, extract(row).copy(modifieddate = value)))
+    override lazy val fields: SohsrViewFields = new SohsrViewFields {
+      override def salesorderid = Field[SalesorderheaderId, SohsrViewRow](_path, "salesorderid", None, None, x => x.salesorderid, (row, value) => row.copy(salesorderid = value))
+      override def salesreasonid = Field[SalesreasonId, SohsrViewRow](_path, "salesreasonid", None, None, x => x.salesreasonid, (row, value) => row.copy(salesreasonid = value))
+      override def modifieddate = Field[TypoLocalDateTime, SohsrViewRow](_path, "modifieddate", Some("text"), None, x => x.modifieddate, (row, value) => row.copy(modifieddate = value))
     }
   
-    override val columns: List[FieldLikeNoHkt[?, Row]] =
-      List[FieldLikeNoHkt[?, Row]](fields.salesorderid, fields.salesreasonid, fields.modifieddate)
+    override lazy val columns: List[FieldLikeNoHkt[?, SohsrViewRow]] =
+      List[FieldLikeNoHkt[?, SohsrViewRow]](fields.salesorderid, fields.salesreasonid, fields.modifieddate)
   
-    override def copy[NewRow](prefix: Option[String], extract: NewRow => SohsrViewRow, merge: (NewRow, SohsrViewRow) => NewRow): Impl[NewRow] =
-      new Impl(prefix, extract, merge)
+    override def copy(path: List[Path]): Impl =
+      new Impl(path)
   }
   
 }

--- a/typo-tester-doobie/generated-and-checked-in/adventureworks/sa/sop/SopViewFields.scala
+++ b/typo-tester-doobie/generated-and-checked-in/adventureworks/sa/sop/SopViewFields.scala
@@ -11,38 +11,39 @@ import adventureworks.customtypes.TypoLocalDateTime
 import adventureworks.customtypes.TypoUUID
 import adventureworks.production.product.ProductId
 import adventureworks.sales.specialoffer.SpecialofferId
+import typo.dsl.Path
 import typo.dsl.SqlExpr.Field
 import typo.dsl.SqlExpr.FieldLikeNoHkt
 import typo.dsl.Structure.Relation
 
-trait SopViewFields[Row] {
-  val id: Field[SpecialofferId, Row]
-  val specialofferid: Field[SpecialofferId, Row]
-  val productid: Field[ProductId, Row]
-  val rowguid: Field[TypoUUID, Row]
-  val modifieddate: Field[TypoLocalDateTime, Row]
+trait SopViewFields {
+  def id: Field[SpecialofferId, SopViewRow]
+  def specialofferid: Field[SpecialofferId, SopViewRow]
+  def productid: Field[ProductId, SopViewRow]
+  def rowguid: Field[TypoUUID, SopViewRow]
+  def modifieddate: Field[TypoLocalDateTime, SopViewRow]
 }
 
 object SopViewFields {
-  val structure: Relation[SopViewFields, SopViewRow, SopViewRow] = 
-    new Impl(None, identity, (_, x) => x)
+  lazy val structure: Relation[SopViewFields, SopViewRow] =
+    new Impl(Nil)
     
-  private final class Impl[Row](val prefix: Option[String], val extract: Row => SopViewRow, val merge: (Row, SopViewRow) => Row)
-    extends Relation[SopViewFields, SopViewRow, Row] { 
+  private final class Impl(val _path: List[Path])
+    extends Relation[SopViewFields, SopViewRow] {
   
-    override val fields: SopViewFields[Row] = new SopViewFields[Row] {
-      override val id = new Field[SpecialofferId, Row](prefix, "id", None, None)(x => extract(x).id, (row, value) => merge(row, extract(row).copy(id = value)))
-      override val specialofferid = new Field[SpecialofferId, Row](prefix, "specialofferid", None, None)(x => extract(x).specialofferid, (row, value) => merge(row, extract(row).copy(specialofferid = value)))
-      override val productid = new Field[ProductId, Row](prefix, "productid", None, None)(x => extract(x).productid, (row, value) => merge(row, extract(row).copy(productid = value)))
-      override val rowguid = new Field[TypoUUID, Row](prefix, "rowguid", None, None)(x => extract(x).rowguid, (row, value) => merge(row, extract(row).copy(rowguid = value)))
-      override val modifieddate = new Field[TypoLocalDateTime, Row](prefix, "modifieddate", Some("text"), None)(x => extract(x).modifieddate, (row, value) => merge(row, extract(row).copy(modifieddate = value)))
+    override lazy val fields: SopViewFields = new SopViewFields {
+      override def id = Field[SpecialofferId, SopViewRow](_path, "id", None, None, x => x.id, (row, value) => row.copy(id = value))
+      override def specialofferid = Field[SpecialofferId, SopViewRow](_path, "specialofferid", None, None, x => x.specialofferid, (row, value) => row.copy(specialofferid = value))
+      override def productid = Field[ProductId, SopViewRow](_path, "productid", None, None, x => x.productid, (row, value) => row.copy(productid = value))
+      override def rowguid = Field[TypoUUID, SopViewRow](_path, "rowguid", None, None, x => x.rowguid, (row, value) => row.copy(rowguid = value))
+      override def modifieddate = Field[TypoLocalDateTime, SopViewRow](_path, "modifieddate", Some("text"), None, x => x.modifieddate, (row, value) => row.copy(modifieddate = value))
     }
   
-    override val columns: List[FieldLikeNoHkt[?, Row]] =
-      List[FieldLikeNoHkt[?, Row]](fields.id, fields.specialofferid, fields.productid, fields.rowguid, fields.modifieddate)
+    override lazy val columns: List[FieldLikeNoHkt[?, SopViewRow]] =
+      List[FieldLikeNoHkt[?, SopViewRow]](fields.id, fields.specialofferid, fields.productid, fields.rowguid, fields.modifieddate)
   
-    override def copy[NewRow](prefix: Option[String], extract: NewRow => SopViewRow, merge: (NewRow, SopViewRow) => NewRow): Impl[NewRow] =
-      new Impl(prefix, extract, merge)
+    override def copy(path: List[Path]): Impl =
+      new Impl(path)
   }
   
 }

--- a/typo-tester-doobie/generated-and-checked-in/adventureworks/sa/sp/SpViewFields.scala
+++ b/typo-tester-doobie/generated-and-checked-in/adventureworks/sa/sp/SpViewFields.scala
@@ -11,49 +11,50 @@ import adventureworks.customtypes.TypoLocalDateTime
 import adventureworks.customtypes.TypoUUID
 import adventureworks.person.businessentity.BusinessentityId
 import adventureworks.sales.salesterritory.SalesterritoryId
+import typo.dsl.Path
 import typo.dsl.SqlExpr.Field
 import typo.dsl.SqlExpr.FieldLikeNoHkt
 import typo.dsl.SqlExpr.OptField
 import typo.dsl.Structure.Relation
 
-trait SpViewFields[Row] {
-  val id: Field[BusinessentityId, Row]
-  val businessentityid: Field[BusinessentityId, Row]
-  val territoryid: OptField[SalesterritoryId, Row]
-  val salesquota: OptField[BigDecimal, Row]
-  val bonus: Field[BigDecimal, Row]
-  val commissionpct: Field[BigDecimal, Row]
-  val salesytd: Field[BigDecimal, Row]
-  val saleslastyear: Field[BigDecimal, Row]
-  val rowguid: Field[TypoUUID, Row]
-  val modifieddate: Field[TypoLocalDateTime, Row]
+trait SpViewFields {
+  def id: Field[BusinessentityId, SpViewRow]
+  def businessentityid: Field[BusinessentityId, SpViewRow]
+  def territoryid: OptField[SalesterritoryId, SpViewRow]
+  def salesquota: OptField[BigDecimal, SpViewRow]
+  def bonus: Field[BigDecimal, SpViewRow]
+  def commissionpct: Field[BigDecimal, SpViewRow]
+  def salesytd: Field[BigDecimal, SpViewRow]
+  def saleslastyear: Field[BigDecimal, SpViewRow]
+  def rowguid: Field[TypoUUID, SpViewRow]
+  def modifieddate: Field[TypoLocalDateTime, SpViewRow]
 }
 
 object SpViewFields {
-  val structure: Relation[SpViewFields, SpViewRow, SpViewRow] = 
-    new Impl(None, identity, (_, x) => x)
+  lazy val structure: Relation[SpViewFields, SpViewRow] =
+    new Impl(Nil)
     
-  private final class Impl[Row](val prefix: Option[String], val extract: Row => SpViewRow, val merge: (Row, SpViewRow) => Row)
-    extends Relation[SpViewFields, SpViewRow, Row] { 
+  private final class Impl(val _path: List[Path])
+    extends Relation[SpViewFields, SpViewRow] {
   
-    override val fields: SpViewFields[Row] = new SpViewFields[Row] {
-      override val id = new Field[BusinessentityId, Row](prefix, "id", None, None)(x => extract(x).id, (row, value) => merge(row, extract(row).copy(id = value)))
-      override val businessentityid = new Field[BusinessentityId, Row](prefix, "businessentityid", None, None)(x => extract(x).businessentityid, (row, value) => merge(row, extract(row).copy(businessentityid = value)))
-      override val territoryid = new OptField[SalesterritoryId, Row](prefix, "territoryid", None, None)(x => extract(x).territoryid, (row, value) => merge(row, extract(row).copy(territoryid = value)))
-      override val salesquota = new OptField[BigDecimal, Row](prefix, "salesquota", None, None)(x => extract(x).salesquota, (row, value) => merge(row, extract(row).copy(salesquota = value)))
-      override val bonus = new Field[BigDecimal, Row](prefix, "bonus", None, None)(x => extract(x).bonus, (row, value) => merge(row, extract(row).copy(bonus = value)))
-      override val commissionpct = new Field[BigDecimal, Row](prefix, "commissionpct", None, None)(x => extract(x).commissionpct, (row, value) => merge(row, extract(row).copy(commissionpct = value)))
-      override val salesytd = new Field[BigDecimal, Row](prefix, "salesytd", None, None)(x => extract(x).salesytd, (row, value) => merge(row, extract(row).copy(salesytd = value)))
-      override val saleslastyear = new Field[BigDecimal, Row](prefix, "saleslastyear", None, None)(x => extract(x).saleslastyear, (row, value) => merge(row, extract(row).copy(saleslastyear = value)))
-      override val rowguid = new Field[TypoUUID, Row](prefix, "rowguid", None, None)(x => extract(x).rowguid, (row, value) => merge(row, extract(row).copy(rowguid = value)))
-      override val modifieddate = new Field[TypoLocalDateTime, Row](prefix, "modifieddate", Some("text"), None)(x => extract(x).modifieddate, (row, value) => merge(row, extract(row).copy(modifieddate = value)))
+    override lazy val fields: SpViewFields = new SpViewFields {
+      override def id = Field[BusinessentityId, SpViewRow](_path, "id", None, None, x => x.id, (row, value) => row.copy(id = value))
+      override def businessentityid = Field[BusinessentityId, SpViewRow](_path, "businessentityid", None, None, x => x.businessentityid, (row, value) => row.copy(businessentityid = value))
+      override def territoryid = OptField[SalesterritoryId, SpViewRow](_path, "territoryid", None, None, x => x.territoryid, (row, value) => row.copy(territoryid = value))
+      override def salesquota = OptField[BigDecimal, SpViewRow](_path, "salesquota", None, None, x => x.salesquota, (row, value) => row.copy(salesquota = value))
+      override def bonus = Field[BigDecimal, SpViewRow](_path, "bonus", None, None, x => x.bonus, (row, value) => row.copy(bonus = value))
+      override def commissionpct = Field[BigDecimal, SpViewRow](_path, "commissionpct", None, None, x => x.commissionpct, (row, value) => row.copy(commissionpct = value))
+      override def salesytd = Field[BigDecimal, SpViewRow](_path, "salesytd", None, None, x => x.salesytd, (row, value) => row.copy(salesytd = value))
+      override def saleslastyear = Field[BigDecimal, SpViewRow](_path, "saleslastyear", None, None, x => x.saleslastyear, (row, value) => row.copy(saleslastyear = value))
+      override def rowguid = Field[TypoUUID, SpViewRow](_path, "rowguid", None, None, x => x.rowguid, (row, value) => row.copy(rowguid = value))
+      override def modifieddate = Field[TypoLocalDateTime, SpViewRow](_path, "modifieddate", Some("text"), None, x => x.modifieddate, (row, value) => row.copy(modifieddate = value))
     }
   
-    override val columns: List[FieldLikeNoHkt[?, Row]] =
-      List[FieldLikeNoHkt[?, Row]](fields.id, fields.businessentityid, fields.territoryid, fields.salesquota, fields.bonus, fields.commissionpct, fields.salesytd, fields.saleslastyear, fields.rowguid, fields.modifieddate)
+    override lazy val columns: List[FieldLikeNoHkt[?, SpViewRow]] =
+      List[FieldLikeNoHkt[?, SpViewRow]](fields.id, fields.businessentityid, fields.territoryid, fields.salesquota, fields.bonus, fields.commissionpct, fields.salesytd, fields.saleslastyear, fields.rowguid, fields.modifieddate)
   
-    override def copy[NewRow](prefix: Option[String], extract: NewRow => SpViewRow, merge: (NewRow, SpViewRow) => NewRow): Impl[NewRow] =
-      new Impl(prefix, extract, merge)
+    override def copy(path: List[Path]): Impl =
+      new Impl(path)
   }
   
 }

--- a/typo-tester-doobie/generated-and-checked-in/adventureworks/sa/spqh/SpqhViewFields.scala
+++ b/typo-tester-doobie/generated-and-checked-in/adventureworks/sa/spqh/SpqhViewFields.scala
@@ -10,40 +10,41 @@ package spqh
 import adventureworks.customtypes.TypoLocalDateTime
 import adventureworks.customtypes.TypoUUID
 import adventureworks.person.businessentity.BusinessentityId
+import typo.dsl.Path
 import typo.dsl.SqlExpr.Field
 import typo.dsl.SqlExpr.FieldLikeNoHkt
 import typo.dsl.Structure.Relation
 
-trait SpqhViewFields[Row] {
-  val id: Field[BusinessentityId, Row]
-  val businessentityid: Field[BusinessentityId, Row]
-  val quotadate: Field[TypoLocalDateTime, Row]
-  val salesquota: Field[BigDecimal, Row]
-  val rowguid: Field[TypoUUID, Row]
-  val modifieddate: Field[TypoLocalDateTime, Row]
+trait SpqhViewFields {
+  def id: Field[BusinessentityId, SpqhViewRow]
+  def businessentityid: Field[BusinessentityId, SpqhViewRow]
+  def quotadate: Field[TypoLocalDateTime, SpqhViewRow]
+  def salesquota: Field[BigDecimal, SpqhViewRow]
+  def rowguid: Field[TypoUUID, SpqhViewRow]
+  def modifieddate: Field[TypoLocalDateTime, SpqhViewRow]
 }
 
 object SpqhViewFields {
-  val structure: Relation[SpqhViewFields, SpqhViewRow, SpqhViewRow] = 
-    new Impl(None, identity, (_, x) => x)
+  lazy val structure: Relation[SpqhViewFields, SpqhViewRow] =
+    new Impl(Nil)
     
-  private final class Impl[Row](val prefix: Option[String], val extract: Row => SpqhViewRow, val merge: (Row, SpqhViewRow) => Row)
-    extends Relation[SpqhViewFields, SpqhViewRow, Row] { 
+  private final class Impl(val _path: List[Path])
+    extends Relation[SpqhViewFields, SpqhViewRow] {
   
-    override val fields: SpqhViewFields[Row] = new SpqhViewFields[Row] {
-      override val id = new Field[BusinessentityId, Row](prefix, "id", None, None)(x => extract(x).id, (row, value) => merge(row, extract(row).copy(id = value)))
-      override val businessentityid = new Field[BusinessentityId, Row](prefix, "businessentityid", None, None)(x => extract(x).businessentityid, (row, value) => merge(row, extract(row).copy(businessentityid = value)))
-      override val quotadate = new Field[TypoLocalDateTime, Row](prefix, "quotadate", Some("text"), None)(x => extract(x).quotadate, (row, value) => merge(row, extract(row).copy(quotadate = value)))
-      override val salesquota = new Field[BigDecimal, Row](prefix, "salesquota", None, None)(x => extract(x).salesquota, (row, value) => merge(row, extract(row).copy(salesquota = value)))
-      override val rowguid = new Field[TypoUUID, Row](prefix, "rowguid", None, None)(x => extract(x).rowguid, (row, value) => merge(row, extract(row).copy(rowguid = value)))
-      override val modifieddate = new Field[TypoLocalDateTime, Row](prefix, "modifieddate", Some("text"), None)(x => extract(x).modifieddate, (row, value) => merge(row, extract(row).copy(modifieddate = value)))
+    override lazy val fields: SpqhViewFields = new SpqhViewFields {
+      override def id = Field[BusinessentityId, SpqhViewRow](_path, "id", None, None, x => x.id, (row, value) => row.copy(id = value))
+      override def businessentityid = Field[BusinessentityId, SpqhViewRow](_path, "businessentityid", None, None, x => x.businessentityid, (row, value) => row.copy(businessentityid = value))
+      override def quotadate = Field[TypoLocalDateTime, SpqhViewRow](_path, "quotadate", Some("text"), None, x => x.quotadate, (row, value) => row.copy(quotadate = value))
+      override def salesquota = Field[BigDecimal, SpqhViewRow](_path, "salesquota", None, None, x => x.salesquota, (row, value) => row.copy(salesquota = value))
+      override def rowguid = Field[TypoUUID, SpqhViewRow](_path, "rowguid", None, None, x => x.rowguid, (row, value) => row.copy(rowguid = value))
+      override def modifieddate = Field[TypoLocalDateTime, SpqhViewRow](_path, "modifieddate", Some("text"), None, x => x.modifieddate, (row, value) => row.copy(modifieddate = value))
     }
   
-    override val columns: List[FieldLikeNoHkt[?, Row]] =
-      List[FieldLikeNoHkt[?, Row]](fields.id, fields.businessentityid, fields.quotadate, fields.salesquota, fields.rowguid, fields.modifieddate)
+    override lazy val columns: List[FieldLikeNoHkt[?, SpqhViewRow]] =
+      List[FieldLikeNoHkt[?, SpqhViewRow]](fields.id, fields.businessentityid, fields.quotadate, fields.salesquota, fields.rowguid, fields.modifieddate)
   
-    override def copy[NewRow](prefix: Option[String], extract: NewRow => SpqhViewRow, merge: (NewRow, SpqhViewRow) => NewRow): Impl[NewRow] =
-      new Impl(prefix, extract, merge)
+    override def copy(path: List[Path]): Impl =
+      new Impl(path)
   }
   
 }

--- a/typo-tester-doobie/generated-and-checked-in/adventureworks/sa/sr/SrViewFields.scala
+++ b/typo-tester-doobie/generated-and-checked-in/adventureworks/sa/sr/SrViewFields.scala
@@ -10,38 +10,39 @@ package sr
 import adventureworks.customtypes.TypoLocalDateTime
 import adventureworks.public.Name
 import adventureworks.sales.salesreason.SalesreasonId
+import typo.dsl.Path
 import typo.dsl.SqlExpr.Field
 import typo.dsl.SqlExpr.FieldLikeNoHkt
 import typo.dsl.Structure.Relation
 
-trait SrViewFields[Row] {
-  val id: Field[SalesreasonId, Row]
-  val salesreasonid: Field[SalesreasonId, Row]
-  val name: Field[Name, Row]
-  val reasontype: Field[Name, Row]
-  val modifieddate: Field[TypoLocalDateTime, Row]
+trait SrViewFields {
+  def id: Field[SalesreasonId, SrViewRow]
+  def salesreasonid: Field[SalesreasonId, SrViewRow]
+  def name: Field[Name, SrViewRow]
+  def reasontype: Field[Name, SrViewRow]
+  def modifieddate: Field[TypoLocalDateTime, SrViewRow]
 }
 
 object SrViewFields {
-  val structure: Relation[SrViewFields, SrViewRow, SrViewRow] = 
-    new Impl(None, identity, (_, x) => x)
+  lazy val structure: Relation[SrViewFields, SrViewRow] =
+    new Impl(Nil)
     
-  private final class Impl[Row](val prefix: Option[String], val extract: Row => SrViewRow, val merge: (Row, SrViewRow) => Row)
-    extends Relation[SrViewFields, SrViewRow, Row] { 
+  private final class Impl(val _path: List[Path])
+    extends Relation[SrViewFields, SrViewRow] {
   
-    override val fields: SrViewFields[Row] = new SrViewFields[Row] {
-      override val id = new Field[SalesreasonId, Row](prefix, "id", None, None)(x => extract(x).id, (row, value) => merge(row, extract(row).copy(id = value)))
-      override val salesreasonid = new Field[SalesreasonId, Row](prefix, "salesreasonid", None, None)(x => extract(x).salesreasonid, (row, value) => merge(row, extract(row).copy(salesreasonid = value)))
-      override val name = new Field[Name, Row](prefix, "name", None, None)(x => extract(x).name, (row, value) => merge(row, extract(row).copy(name = value)))
-      override val reasontype = new Field[Name, Row](prefix, "reasontype", None, None)(x => extract(x).reasontype, (row, value) => merge(row, extract(row).copy(reasontype = value)))
-      override val modifieddate = new Field[TypoLocalDateTime, Row](prefix, "modifieddate", Some("text"), None)(x => extract(x).modifieddate, (row, value) => merge(row, extract(row).copy(modifieddate = value)))
+    override lazy val fields: SrViewFields = new SrViewFields {
+      override def id = Field[SalesreasonId, SrViewRow](_path, "id", None, None, x => x.id, (row, value) => row.copy(id = value))
+      override def salesreasonid = Field[SalesreasonId, SrViewRow](_path, "salesreasonid", None, None, x => x.salesreasonid, (row, value) => row.copy(salesreasonid = value))
+      override def name = Field[Name, SrViewRow](_path, "name", None, None, x => x.name, (row, value) => row.copy(name = value))
+      override def reasontype = Field[Name, SrViewRow](_path, "reasontype", None, None, x => x.reasontype, (row, value) => row.copy(reasontype = value))
+      override def modifieddate = Field[TypoLocalDateTime, SrViewRow](_path, "modifieddate", Some("text"), None, x => x.modifieddate, (row, value) => row.copy(modifieddate = value))
     }
   
-    override val columns: List[FieldLikeNoHkt[?, Row]] =
-      List[FieldLikeNoHkt[?, Row]](fields.id, fields.salesreasonid, fields.name, fields.reasontype, fields.modifieddate)
+    override lazy val columns: List[FieldLikeNoHkt[?, SrViewRow]] =
+      List[FieldLikeNoHkt[?, SrViewRow]](fields.id, fields.salesreasonid, fields.name, fields.reasontype, fields.modifieddate)
   
-    override def copy[NewRow](prefix: Option[String], extract: NewRow => SrViewRow, merge: (NewRow, SrViewRow) => NewRow): Impl[NewRow] =
-      new Impl(prefix, extract, merge)
+    override def copy(path: List[Path]): Impl =
+      new Impl(path)
   }
   
 }

--- a/typo-tester-doobie/generated-and-checked-in/adventureworks/sa/st/StViewFields.scala
+++ b/typo-tester-doobie/generated-and-checked-in/adventureworks/sa/st/StViewFields.scala
@@ -12,50 +12,51 @@ import adventureworks.customtypes.TypoUUID
 import adventureworks.person.countryregion.CountryregionId
 import adventureworks.public.Name
 import adventureworks.sales.salesterritory.SalesterritoryId
+import typo.dsl.Path
 import typo.dsl.SqlExpr.Field
 import typo.dsl.SqlExpr.FieldLikeNoHkt
 import typo.dsl.Structure.Relation
 
-trait StViewFields[Row] {
-  val id: Field[SalesterritoryId, Row]
-  val territoryid: Field[SalesterritoryId, Row]
-  val name: Field[Name, Row]
-  val countryregioncode: Field[CountryregionId, Row]
-  val group: Field[/* max 50 chars */ String, Row]
-  val salesytd: Field[BigDecimal, Row]
-  val saleslastyear: Field[BigDecimal, Row]
-  val costytd: Field[BigDecimal, Row]
-  val costlastyear: Field[BigDecimal, Row]
-  val rowguid: Field[TypoUUID, Row]
-  val modifieddate: Field[TypoLocalDateTime, Row]
+trait StViewFields {
+  def id: Field[SalesterritoryId, StViewRow]
+  def territoryid: Field[SalesterritoryId, StViewRow]
+  def name: Field[Name, StViewRow]
+  def countryregioncode: Field[CountryregionId, StViewRow]
+  def group: Field[/* max 50 chars */ String, StViewRow]
+  def salesytd: Field[BigDecimal, StViewRow]
+  def saleslastyear: Field[BigDecimal, StViewRow]
+  def costytd: Field[BigDecimal, StViewRow]
+  def costlastyear: Field[BigDecimal, StViewRow]
+  def rowguid: Field[TypoUUID, StViewRow]
+  def modifieddate: Field[TypoLocalDateTime, StViewRow]
 }
 
 object StViewFields {
-  val structure: Relation[StViewFields, StViewRow, StViewRow] = 
-    new Impl(None, identity, (_, x) => x)
+  lazy val structure: Relation[StViewFields, StViewRow] =
+    new Impl(Nil)
     
-  private final class Impl[Row](val prefix: Option[String], val extract: Row => StViewRow, val merge: (Row, StViewRow) => Row)
-    extends Relation[StViewFields, StViewRow, Row] { 
+  private final class Impl(val _path: List[Path])
+    extends Relation[StViewFields, StViewRow] {
   
-    override val fields: StViewFields[Row] = new StViewFields[Row] {
-      override val id = new Field[SalesterritoryId, Row](prefix, "id", None, None)(x => extract(x).id, (row, value) => merge(row, extract(row).copy(id = value)))
-      override val territoryid = new Field[SalesterritoryId, Row](prefix, "territoryid", None, None)(x => extract(x).territoryid, (row, value) => merge(row, extract(row).copy(territoryid = value)))
-      override val name = new Field[Name, Row](prefix, "name", None, None)(x => extract(x).name, (row, value) => merge(row, extract(row).copy(name = value)))
-      override val countryregioncode = new Field[CountryregionId, Row](prefix, "countryregioncode", None, None)(x => extract(x).countryregioncode, (row, value) => merge(row, extract(row).copy(countryregioncode = value)))
-      override val group = new Field[/* max 50 chars */ String, Row](prefix, "group", None, None)(x => extract(x).group, (row, value) => merge(row, extract(row).copy(group = value)))
-      override val salesytd = new Field[BigDecimal, Row](prefix, "salesytd", None, None)(x => extract(x).salesytd, (row, value) => merge(row, extract(row).copy(salesytd = value)))
-      override val saleslastyear = new Field[BigDecimal, Row](prefix, "saleslastyear", None, None)(x => extract(x).saleslastyear, (row, value) => merge(row, extract(row).copy(saleslastyear = value)))
-      override val costytd = new Field[BigDecimal, Row](prefix, "costytd", None, None)(x => extract(x).costytd, (row, value) => merge(row, extract(row).copy(costytd = value)))
-      override val costlastyear = new Field[BigDecimal, Row](prefix, "costlastyear", None, None)(x => extract(x).costlastyear, (row, value) => merge(row, extract(row).copy(costlastyear = value)))
-      override val rowguid = new Field[TypoUUID, Row](prefix, "rowguid", None, None)(x => extract(x).rowguid, (row, value) => merge(row, extract(row).copy(rowguid = value)))
-      override val modifieddate = new Field[TypoLocalDateTime, Row](prefix, "modifieddate", Some("text"), None)(x => extract(x).modifieddate, (row, value) => merge(row, extract(row).copy(modifieddate = value)))
+    override lazy val fields: StViewFields = new StViewFields {
+      override def id = Field[SalesterritoryId, StViewRow](_path, "id", None, None, x => x.id, (row, value) => row.copy(id = value))
+      override def territoryid = Field[SalesterritoryId, StViewRow](_path, "territoryid", None, None, x => x.territoryid, (row, value) => row.copy(territoryid = value))
+      override def name = Field[Name, StViewRow](_path, "name", None, None, x => x.name, (row, value) => row.copy(name = value))
+      override def countryregioncode = Field[CountryregionId, StViewRow](_path, "countryregioncode", None, None, x => x.countryregioncode, (row, value) => row.copy(countryregioncode = value))
+      override def group = Field[/* max 50 chars */ String, StViewRow](_path, "group", None, None, x => x.group, (row, value) => row.copy(group = value))
+      override def salesytd = Field[BigDecimal, StViewRow](_path, "salesytd", None, None, x => x.salesytd, (row, value) => row.copy(salesytd = value))
+      override def saleslastyear = Field[BigDecimal, StViewRow](_path, "saleslastyear", None, None, x => x.saleslastyear, (row, value) => row.copy(saleslastyear = value))
+      override def costytd = Field[BigDecimal, StViewRow](_path, "costytd", None, None, x => x.costytd, (row, value) => row.copy(costytd = value))
+      override def costlastyear = Field[BigDecimal, StViewRow](_path, "costlastyear", None, None, x => x.costlastyear, (row, value) => row.copy(costlastyear = value))
+      override def rowguid = Field[TypoUUID, StViewRow](_path, "rowguid", None, None, x => x.rowguid, (row, value) => row.copy(rowguid = value))
+      override def modifieddate = Field[TypoLocalDateTime, StViewRow](_path, "modifieddate", Some("text"), None, x => x.modifieddate, (row, value) => row.copy(modifieddate = value))
     }
   
-    override val columns: List[FieldLikeNoHkt[?, Row]] =
-      List[FieldLikeNoHkt[?, Row]](fields.id, fields.territoryid, fields.name, fields.countryregioncode, fields.group, fields.salesytd, fields.saleslastyear, fields.costytd, fields.costlastyear, fields.rowguid, fields.modifieddate)
+    override lazy val columns: List[FieldLikeNoHkt[?, StViewRow]] =
+      List[FieldLikeNoHkt[?, StViewRow]](fields.id, fields.territoryid, fields.name, fields.countryregioncode, fields.group, fields.salesytd, fields.saleslastyear, fields.costytd, fields.costlastyear, fields.rowguid, fields.modifieddate)
   
-    override def copy[NewRow](prefix: Option[String], extract: NewRow => StViewRow, merge: (NewRow, StViewRow) => NewRow): Impl[NewRow] =
-      new Impl(prefix, extract, merge)
+    override def copy(path: List[Path]): Impl =
+      new Impl(path)
   }
   
 }

--- a/typo-tester-doobie/generated-and-checked-in/adventureworks/sa/sth/SthViewFields.scala
+++ b/typo-tester-doobie/generated-and-checked-in/adventureworks/sa/sth/SthViewFields.scala
@@ -11,43 +11,44 @@ import adventureworks.customtypes.TypoLocalDateTime
 import adventureworks.customtypes.TypoUUID
 import adventureworks.person.businessentity.BusinessentityId
 import adventureworks.sales.salesterritory.SalesterritoryId
+import typo.dsl.Path
 import typo.dsl.SqlExpr.Field
 import typo.dsl.SqlExpr.FieldLikeNoHkt
 import typo.dsl.SqlExpr.OptField
 import typo.dsl.Structure.Relation
 
-trait SthViewFields[Row] {
-  val id: Field[SalesterritoryId, Row]
-  val businessentityid: Field[BusinessentityId, Row]
-  val territoryid: Field[SalesterritoryId, Row]
-  val startdate: Field[TypoLocalDateTime, Row]
-  val enddate: OptField[TypoLocalDateTime, Row]
-  val rowguid: Field[TypoUUID, Row]
-  val modifieddate: Field[TypoLocalDateTime, Row]
+trait SthViewFields {
+  def id: Field[SalesterritoryId, SthViewRow]
+  def businessentityid: Field[BusinessentityId, SthViewRow]
+  def territoryid: Field[SalesterritoryId, SthViewRow]
+  def startdate: Field[TypoLocalDateTime, SthViewRow]
+  def enddate: OptField[TypoLocalDateTime, SthViewRow]
+  def rowguid: Field[TypoUUID, SthViewRow]
+  def modifieddate: Field[TypoLocalDateTime, SthViewRow]
 }
 
 object SthViewFields {
-  val structure: Relation[SthViewFields, SthViewRow, SthViewRow] = 
-    new Impl(None, identity, (_, x) => x)
+  lazy val structure: Relation[SthViewFields, SthViewRow] =
+    new Impl(Nil)
     
-  private final class Impl[Row](val prefix: Option[String], val extract: Row => SthViewRow, val merge: (Row, SthViewRow) => Row)
-    extends Relation[SthViewFields, SthViewRow, Row] { 
+  private final class Impl(val _path: List[Path])
+    extends Relation[SthViewFields, SthViewRow] {
   
-    override val fields: SthViewFields[Row] = new SthViewFields[Row] {
-      override val id = new Field[SalesterritoryId, Row](prefix, "id", None, None)(x => extract(x).id, (row, value) => merge(row, extract(row).copy(id = value)))
-      override val businessentityid = new Field[BusinessentityId, Row](prefix, "businessentityid", None, None)(x => extract(x).businessentityid, (row, value) => merge(row, extract(row).copy(businessentityid = value)))
-      override val territoryid = new Field[SalesterritoryId, Row](prefix, "territoryid", None, None)(x => extract(x).territoryid, (row, value) => merge(row, extract(row).copy(territoryid = value)))
-      override val startdate = new Field[TypoLocalDateTime, Row](prefix, "startdate", Some("text"), None)(x => extract(x).startdate, (row, value) => merge(row, extract(row).copy(startdate = value)))
-      override val enddate = new OptField[TypoLocalDateTime, Row](prefix, "enddate", Some("text"), None)(x => extract(x).enddate, (row, value) => merge(row, extract(row).copy(enddate = value)))
-      override val rowguid = new Field[TypoUUID, Row](prefix, "rowguid", None, None)(x => extract(x).rowguid, (row, value) => merge(row, extract(row).copy(rowguid = value)))
-      override val modifieddate = new Field[TypoLocalDateTime, Row](prefix, "modifieddate", Some("text"), None)(x => extract(x).modifieddate, (row, value) => merge(row, extract(row).copy(modifieddate = value)))
+    override lazy val fields: SthViewFields = new SthViewFields {
+      override def id = Field[SalesterritoryId, SthViewRow](_path, "id", None, None, x => x.id, (row, value) => row.copy(id = value))
+      override def businessentityid = Field[BusinessentityId, SthViewRow](_path, "businessentityid", None, None, x => x.businessentityid, (row, value) => row.copy(businessentityid = value))
+      override def territoryid = Field[SalesterritoryId, SthViewRow](_path, "territoryid", None, None, x => x.territoryid, (row, value) => row.copy(territoryid = value))
+      override def startdate = Field[TypoLocalDateTime, SthViewRow](_path, "startdate", Some("text"), None, x => x.startdate, (row, value) => row.copy(startdate = value))
+      override def enddate = OptField[TypoLocalDateTime, SthViewRow](_path, "enddate", Some("text"), None, x => x.enddate, (row, value) => row.copy(enddate = value))
+      override def rowguid = Field[TypoUUID, SthViewRow](_path, "rowguid", None, None, x => x.rowguid, (row, value) => row.copy(rowguid = value))
+      override def modifieddate = Field[TypoLocalDateTime, SthViewRow](_path, "modifieddate", Some("text"), None, x => x.modifieddate, (row, value) => row.copy(modifieddate = value))
     }
   
-    override val columns: List[FieldLikeNoHkt[?, Row]] =
-      List[FieldLikeNoHkt[?, Row]](fields.id, fields.businessentityid, fields.territoryid, fields.startdate, fields.enddate, fields.rowguid, fields.modifieddate)
+    override lazy val columns: List[FieldLikeNoHkt[?, SthViewRow]] =
+      List[FieldLikeNoHkt[?, SthViewRow]](fields.id, fields.businessentityid, fields.territoryid, fields.startdate, fields.enddate, fields.rowguid, fields.modifieddate)
   
-    override def copy[NewRow](prefix: Option[String], extract: NewRow => SthViewRow, merge: (NewRow, SthViewRow) => NewRow): Impl[NewRow] =
-      new Impl(prefix, extract, merge)
+    override def copy(path: List[Path]): Impl =
+      new Impl(path)
   }
   
 }

--- a/typo-tester-doobie/generated-and-checked-in/adventureworks/sa/tr/TrViewFields.scala
+++ b/typo-tester-doobie/generated-and-checked-in/adventureworks/sa/tr/TrViewFields.scala
@@ -13,44 +13,45 @@ import adventureworks.customtypes.TypoUUID
 import adventureworks.person.stateprovince.StateprovinceId
 import adventureworks.public.Name
 import adventureworks.sales.salestaxrate.SalestaxrateId
+import typo.dsl.Path
 import typo.dsl.SqlExpr.Field
 import typo.dsl.SqlExpr.FieldLikeNoHkt
 import typo.dsl.Structure.Relation
 
-trait TrViewFields[Row] {
-  val id: Field[SalestaxrateId, Row]
-  val salestaxrateid: Field[SalestaxrateId, Row]
-  val stateprovinceid: Field[StateprovinceId, Row]
-  val taxtype: Field[TypoShort, Row]
-  val taxrate: Field[BigDecimal, Row]
-  val name: Field[Name, Row]
-  val rowguid: Field[TypoUUID, Row]
-  val modifieddate: Field[TypoLocalDateTime, Row]
+trait TrViewFields {
+  def id: Field[SalestaxrateId, TrViewRow]
+  def salestaxrateid: Field[SalestaxrateId, TrViewRow]
+  def stateprovinceid: Field[StateprovinceId, TrViewRow]
+  def taxtype: Field[TypoShort, TrViewRow]
+  def taxrate: Field[BigDecimal, TrViewRow]
+  def name: Field[Name, TrViewRow]
+  def rowguid: Field[TypoUUID, TrViewRow]
+  def modifieddate: Field[TypoLocalDateTime, TrViewRow]
 }
 
 object TrViewFields {
-  val structure: Relation[TrViewFields, TrViewRow, TrViewRow] = 
-    new Impl(None, identity, (_, x) => x)
+  lazy val structure: Relation[TrViewFields, TrViewRow] =
+    new Impl(Nil)
     
-  private final class Impl[Row](val prefix: Option[String], val extract: Row => TrViewRow, val merge: (Row, TrViewRow) => Row)
-    extends Relation[TrViewFields, TrViewRow, Row] { 
+  private final class Impl(val _path: List[Path])
+    extends Relation[TrViewFields, TrViewRow] {
   
-    override val fields: TrViewFields[Row] = new TrViewFields[Row] {
-      override val id = new Field[SalestaxrateId, Row](prefix, "id", None, None)(x => extract(x).id, (row, value) => merge(row, extract(row).copy(id = value)))
-      override val salestaxrateid = new Field[SalestaxrateId, Row](prefix, "salestaxrateid", None, None)(x => extract(x).salestaxrateid, (row, value) => merge(row, extract(row).copy(salestaxrateid = value)))
-      override val stateprovinceid = new Field[StateprovinceId, Row](prefix, "stateprovinceid", None, None)(x => extract(x).stateprovinceid, (row, value) => merge(row, extract(row).copy(stateprovinceid = value)))
-      override val taxtype = new Field[TypoShort, Row](prefix, "taxtype", None, None)(x => extract(x).taxtype, (row, value) => merge(row, extract(row).copy(taxtype = value)))
-      override val taxrate = new Field[BigDecimal, Row](prefix, "taxrate", None, None)(x => extract(x).taxrate, (row, value) => merge(row, extract(row).copy(taxrate = value)))
-      override val name = new Field[Name, Row](prefix, "name", None, None)(x => extract(x).name, (row, value) => merge(row, extract(row).copy(name = value)))
-      override val rowguid = new Field[TypoUUID, Row](prefix, "rowguid", None, None)(x => extract(x).rowguid, (row, value) => merge(row, extract(row).copy(rowguid = value)))
-      override val modifieddate = new Field[TypoLocalDateTime, Row](prefix, "modifieddate", Some("text"), None)(x => extract(x).modifieddate, (row, value) => merge(row, extract(row).copy(modifieddate = value)))
+    override lazy val fields: TrViewFields = new TrViewFields {
+      override def id = Field[SalestaxrateId, TrViewRow](_path, "id", None, None, x => x.id, (row, value) => row.copy(id = value))
+      override def salestaxrateid = Field[SalestaxrateId, TrViewRow](_path, "salestaxrateid", None, None, x => x.salestaxrateid, (row, value) => row.copy(salestaxrateid = value))
+      override def stateprovinceid = Field[StateprovinceId, TrViewRow](_path, "stateprovinceid", None, None, x => x.stateprovinceid, (row, value) => row.copy(stateprovinceid = value))
+      override def taxtype = Field[TypoShort, TrViewRow](_path, "taxtype", None, None, x => x.taxtype, (row, value) => row.copy(taxtype = value))
+      override def taxrate = Field[BigDecimal, TrViewRow](_path, "taxrate", None, None, x => x.taxrate, (row, value) => row.copy(taxrate = value))
+      override def name = Field[Name, TrViewRow](_path, "name", None, None, x => x.name, (row, value) => row.copy(name = value))
+      override def rowguid = Field[TypoUUID, TrViewRow](_path, "rowguid", None, None, x => x.rowguid, (row, value) => row.copy(rowguid = value))
+      override def modifieddate = Field[TypoLocalDateTime, TrViewRow](_path, "modifieddate", Some("text"), None, x => x.modifieddate, (row, value) => row.copy(modifieddate = value))
     }
   
-    override val columns: List[FieldLikeNoHkt[?, Row]] =
-      List[FieldLikeNoHkt[?, Row]](fields.id, fields.salestaxrateid, fields.stateprovinceid, fields.taxtype, fields.taxrate, fields.name, fields.rowguid, fields.modifieddate)
+    override lazy val columns: List[FieldLikeNoHkt[?, TrViewRow]] =
+      List[FieldLikeNoHkt[?, TrViewRow]](fields.id, fields.salestaxrateid, fields.stateprovinceid, fields.taxtype, fields.taxrate, fields.name, fields.rowguid, fields.modifieddate)
   
-    override def copy[NewRow](prefix: Option[String], extract: NewRow => TrViewRow, merge: (NewRow, TrViewRow) => NewRow): Impl[NewRow] =
-      new Impl(prefix, extract, merge)
+    override def copy(path: List[Path]): Impl =
+      new Impl(path)
   }
   
 }

--- a/typo-tester-doobie/generated-and-checked-in/adventureworks/sales/countryregioncurrency/CountryregioncurrencyFields.scala
+++ b/typo-tester-doobie/generated-and-checked-in/adventureworks/sales/countryregioncurrency/CountryregioncurrencyFields.scala
@@ -10,35 +10,36 @@ package countryregioncurrency
 import adventureworks.customtypes.TypoLocalDateTime
 import adventureworks.person.countryregion.CountryregionId
 import adventureworks.sales.currency.CurrencyId
+import typo.dsl.Path
 import typo.dsl.SqlExpr.Field
 import typo.dsl.SqlExpr.FieldLikeNoHkt
 import typo.dsl.SqlExpr.IdField
 import typo.dsl.Structure.Relation
 
-trait CountryregioncurrencyFields[Row] {
-  val countryregioncode: IdField[CountryregionId, Row]
-  val currencycode: IdField[CurrencyId, Row]
-  val modifieddate: Field[TypoLocalDateTime, Row]
+trait CountryregioncurrencyFields {
+  def countryregioncode: IdField[CountryregionId, CountryregioncurrencyRow]
+  def currencycode: IdField[CurrencyId, CountryregioncurrencyRow]
+  def modifieddate: Field[TypoLocalDateTime, CountryregioncurrencyRow]
 }
 
 object CountryregioncurrencyFields {
-  val structure: Relation[CountryregioncurrencyFields, CountryregioncurrencyRow, CountryregioncurrencyRow] = 
-    new Impl(None, identity, (_, x) => x)
+  lazy val structure: Relation[CountryregioncurrencyFields, CountryregioncurrencyRow] =
+    new Impl(Nil)
     
-  private final class Impl[Row](val prefix: Option[String], val extract: Row => CountryregioncurrencyRow, val merge: (Row, CountryregioncurrencyRow) => Row)
-    extends Relation[CountryregioncurrencyFields, CountryregioncurrencyRow, Row] { 
+  private final class Impl(val _path: List[Path])
+    extends Relation[CountryregioncurrencyFields, CountryregioncurrencyRow] {
   
-    override val fields: CountryregioncurrencyFields[Row] = new CountryregioncurrencyFields[Row] {
-      override val countryregioncode = new IdField[CountryregionId, Row](prefix, "countryregioncode", None, None)(x => extract(x).countryregioncode, (row, value) => merge(row, extract(row).copy(countryregioncode = value)))
-      override val currencycode = new IdField[CurrencyId, Row](prefix, "currencycode", None, Some("bpchar"))(x => extract(x).currencycode, (row, value) => merge(row, extract(row).copy(currencycode = value)))
-      override val modifieddate = new Field[TypoLocalDateTime, Row](prefix, "modifieddate", Some("text"), Some("timestamp"))(x => extract(x).modifieddate, (row, value) => merge(row, extract(row).copy(modifieddate = value)))
+    override lazy val fields: CountryregioncurrencyFields = new CountryregioncurrencyFields {
+      override def countryregioncode = IdField[CountryregionId, CountryregioncurrencyRow](_path, "countryregioncode", None, None, x => x.countryregioncode, (row, value) => row.copy(countryregioncode = value))
+      override def currencycode = IdField[CurrencyId, CountryregioncurrencyRow](_path, "currencycode", None, Some("bpchar"), x => x.currencycode, (row, value) => row.copy(currencycode = value))
+      override def modifieddate = Field[TypoLocalDateTime, CountryregioncurrencyRow](_path, "modifieddate", Some("text"), Some("timestamp"), x => x.modifieddate, (row, value) => row.copy(modifieddate = value))
     }
   
-    override val columns: List[FieldLikeNoHkt[?, Row]] =
-      List[FieldLikeNoHkt[?, Row]](fields.countryregioncode, fields.currencycode, fields.modifieddate)
+    override lazy val columns: List[FieldLikeNoHkt[?, CountryregioncurrencyRow]] =
+      List[FieldLikeNoHkt[?, CountryregioncurrencyRow]](fields.countryregioncode, fields.currencycode, fields.modifieddate)
   
-    override def copy[NewRow](prefix: Option[String], extract: NewRow => CountryregioncurrencyRow, merge: (NewRow, CountryregioncurrencyRow) => NewRow): Impl[NewRow] =
-      new Impl(prefix, extract, merge)
+    override def copy(path: List[Path]): Impl =
+      new Impl(path)
   }
   
 }

--- a/typo-tester-doobie/generated-and-checked-in/adventureworks/sales/countryregioncurrency/CountryregioncurrencyRepoMock.scala
+++ b/typo-tester-doobie/generated-and-checked-in/adventureworks/sales/countryregioncurrency/CountryregioncurrencyRepoMock.scala
@@ -24,7 +24,7 @@ import typo.dsl.UpdateParams
 class CountryregioncurrencyRepoMock(toRow: Function1[CountryregioncurrencyRowUnsaved, CountryregioncurrencyRow],
                                     map: scala.collection.mutable.Map[CountryregioncurrencyId, CountryregioncurrencyRow] = scala.collection.mutable.Map.empty) extends CountryregioncurrencyRepo {
   override def delete: DeleteBuilder[CountryregioncurrencyFields, CountryregioncurrencyRow] = {
-    DeleteBuilderMock(DeleteParams.empty, CountryregioncurrencyFields.structure.fields, map)
+    DeleteBuilderMock(DeleteParams.empty, CountryregioncurrencyFields.structure, map)
   }
   override def deleteById(compositeId: CountryregioncurrencyId): ConnectionIO[Boolean] = {
     delay(map.remove(compositeId).isDefined)
@@ -86,7 +86,7 @@ class CountryregioncurrencyRepoMock(toRow: Function1[CountryregioncurrencyRowUns
     }
   }
   override def update: UpdateBuilder[CountryregioncurrencyFields, CountryregioncurrencyRow] = {
-    UpdateBuilderMock(UpdateParams.empty, CountryregioncurrencyFields.structure.fields, map)
+    UpdateBuilderMock(UpdateParams.empty, CountryregioncurrencyFields.structure, map)
   }
   override def update(row: CountryregioncurrencyRow): ConnectionIO[Boolean] = {
     delay {

--- a/typo-tester-doobie/generated-and-checked-in/adventureworks/sales/creditcard/CreditcardFields.scala
+++ b/typo-tester-doobie/generated-and-checked-in/adventureworks/sales/creditcard/CreditcardFields.scala
@@ -10,41 +10,42 @@ package creditcard
 import adventureworks.customtypes.TypoLocalDateTime
 import adventureworks.customtypes.TypoShort
 import adventureworks.userdefined.CustomCreditcardId
+import typo.dsl.Path
 import typo.dsl.SqlExpr.Field
 import typo.dsl.SqlExpr.FieldLikeNoHkt
 import typo.dsl.SqlExpr.IdField
 import typo.dsl.Structure.Relation
 
-trait CreditcardFields[Row] {
-  val creditcardid: IdField[/* user-picked */ CustomCreditcardId, Row]
-  val cardtype: Field[/* max 50 chars */ String, Row]
-  val cardnumber: Field[/* max 25 chars */ String, Row]
-  val expmonth: Field[TypoShort, Row]
-  val expyear: Field[TypoShort, Row]
-  val modifieddate: Field[TypoLocalDateTime, Row]
+trait CreditcardFields {
+  def creditcardid: IdField[/* user-picked */ CustomCreditcardId, CreditcardRow]
+  def cardtype: Field[/* max 50 chars */ String, CreditcardRow]
+  def cardnumber: Field[/* max 25 chars */ String, CreditcardRow]
+  def expmonth: Field[TypoShort, CreditcardRow]
+  def expyear: Field[TypoShort, CreditcardRow]
+  def modifieddate: Field[TypoLocalDateTime, CreditcardRow]
 }
 
 object CreditcardFields {
-  val structure: Relation[CreditcardFields, CreditcardRow, CreditcardRow] = 
-    new Impl(None, identity, (_, x) => x)
+  lazy val structure: Relation[CreditcardFields, CreditcardRow] =
+    new Impl(Nil)
     
-  private final class Impl[Row](val prefix: Option[String], val extract: Row => CreditcardRow, val merge: (Row, CreditcardRow) => Row)
-    extends Relation[CreditcardFields, CreditcardRow, Row] { 
+  private final class Impl(val _path: List[Path])
+    extends Relation[CreditcardFields, CreditcardRow] {
   
-    override val fields: CreditcardFields[Row] = new CreditcardFields[Row] {
-      override val creditcardid = new IdField[/* user-picked */ CustomCreditcardId, Row](prefix, "creditcardid", None, Some("int4"))(x => extract(x).creditcardid, (row, value) => merge(row, extract(row).copy(creditcardid = value)))
-      override val cardtype = new Field[/* max 50 chars */ String, Row](prefix, "cardtype", None, None)(x => extract(x).cardtype, (row, value) => merge(row, extract(row).copy(cardtype = value)))
-      override val cardnumber = new Field[/* max 25 chars */ String, Row](prefix, "cardnumber", None, None)(x => extract(x).cardnumber, (row, value) => merge(row, extract(row).copy(cardnumber = value)))
-      override val expmonth = new Field[TypoShort, Row](prefix, "expmonth", None, Some("int2"))(x => extract(x).expmonth, (row, value) => merge(row, extract(row).copy(expmonth = value)))
-      override val expyear = new Field[TypoShort, Row](prefix, "expyear", None, Some("int2"))(x => extract(x).expyear, (row, value) => merge(row, extract(row).copy(expyear = value)))
-      override val modifieddate = new Field[TypoLocalDateTime, Row](prefix, "modifieddate", Some("text"), Some("timestamp"))(x => extract(x).modifieddate, (row, value) => merge(row, extract(row).copy(modifieddate = value)))
+    override lazy val fields: CreditcardFields = new CreditcardFields {
+      override def creditcardid = IdField[/* user-picked */ CustomCreditcardId, CreditcardRow](_path, "creditcardid", None, Some("int4"), x => x.creditcardid, (row, value) => row.copy(creditcardid = value))
+      override def cardtype = Field[/* max 50 chars */ String, CreditcardRow](_path, "cardtype", None, None, x => x.cardtype, (row, value) => row.copy(cardtype = value))
+      override def cardnumber = Field[/* max 25 chars */ String, CreditcardRow](_path, "cardnumber", None, None, x => x.cardnumber, (row, value) => row.copy(cardnumber = value))
+      override def expmonth = Field[TypoShort, CreditcardRow](_path, "expmonth", None, Some("int2"), x => x.expmonth, (row, value) => row.copy(expmonth = value))
+      override def expyear = Field[TypoShort, CreditcardRow](_path, "expyear", None, Some("int2"), x => x.expyear, (row, value) => row.copy(expyear = value))
+      override def modifieddate = Field[TypoLocalDateTime, CreditcardRow](_path, "modifieddate", Some("text"), Some("timestamp"), x => x.modifieddate, (row, value) => row.copy(modifieddate = value))
     }
   
-    override val columns: List[FieldLikeNoHkt[?, Row]] =
-      List[FieldLikeNoHkt[?, Row]](fields.creditcardid, fields.cardtype, fields.cardnumber, fields.expmonth, fields.expyear, fields.modifieddate)
+    override lazy val columns: List[FieldLikeNoHkt[?, CreditcardRow]] =
+      List[FieldLikeNoHkt[?, CreditcardRow]](fields.creditcardid, fields.cardtype, fields.cardnumber, fields.expmonth, fields.expyear, fields.modifieddate)
   
-    override def copy[NewRow](prefix: Option[String], extract: NewRow => CreditcardRow, merge: (NewRow, CreditcardRow) => NewRow): Impl[NewRow] =
-      new Impl(prefix, extract, merge)
+    override def copy(path: List[Path]): Impl =
+      new Impl(path)
   }
   
 }

--- a/typo-tester-doobie/generated-and-checked-in/adventureworks/sales/creditcard/CreditcardRepoMock.scala
+++ b/typo-tester-doobie/generated-and-checked-in/adventureworks/sales/creditcard/CreditcardRepoMock.scala
@@ -26,7 +26,7 @@ import typo.dsl.UpdateParams
 class CreditcardRepoMock(toRow: Function1[CreditcardRowUnsaved, CreditcardRow],
                          map: scala.collection.mutable.Map[/* user-picked */ CustomCreditcardId, CreditcardRow] = scala.collection.mutable.Map.empty) extends CreditcardRepo {
   override def delete: DeleteBuilder[CreditcardFields, CreditcardRow] = {
-    DeleteBuilderMock(DeleteParams.empty, CreditcardFields.structure.fields, map)
+    DeleteBuilderMock(DeleteParams.empty, CreditcardFields.structure, map)
   }
   override def deleteById(creditcardid: /* user-picked */ CustomCreditcardId): ConnectionIO[Boolean] = {
     delay(map.remove(creditcardid).isDefined)
@@ -88,7 +88,7 @@ class CreditcardRepoMock(toRow: Function1[CreditcardRowUnsaved, CreditcardRow],
     }
   }
   override def update: UpdateBuilder[CreditcardFields, CreditcardRow] = {
-    UpdateBuilderMock(UpdateParams.empty, CreditcardFields.structure.fields, map)
+    UpdateBuilderMock(UpdateParams.empty, CreditcardFields.structure, map)
   }
   override def update(row: CreditcardRow): ConnectionIO[Boolean] = {
     delay {

--- a/typo-tester-doobie/generated-and-checked-in/adventureworks/sales/currency/CurrencyFields.scala
+++ b/typo-tester-doobie/generated-and-checked-in/adventureworks/sales/currency/CurrencyFields.scala
@@ -9,35 +9,36 @@ package currency
 
 import adventureworks.customtypes.TypoLocalDateTime
 import adventureworks.public.Name
+import typo.dsl.Path
 import typo.dsl.SqlExpr.Field
 import typo.dsl.SqlExpr.FieldLikeNoHkt
 import typo.dsl.SqlExpr.IdField
 import typo.dsl.Structure.Relation
 
-trait CurrencyFields[Row] {
-  val currencycode: IdField[CurrencyId, Row]
-  val name: Field[Name, Row]
-  val modifieddate: Field[TypoLocalDateTime, Row]
+trait CurrencyFields {
+  def currencycode: IdField[CurrencyId, CurrencyRow]
+  def name: Field[Name, CurrencyRow]
+  def modifieddate: Field[TypoLocalDateTime, CurrencyRow]
 }
 
 object CurrencyFields {
-  val structure: Relation[CurrencyFields, CurrencyRow, CurrencyRow] = 
-    new Impl(None, identity, (_, x) => x)
+  lazy val structure: Relation[CurrencyFields, CurrencyRow] =
+    new Impl(Nil)
     
-  private final class Impl[Row](val prefix: Option[String], val extract: Row => CurrencyRow, val merge: (Row, CurrencyRow) => Row)
-    extends Relation[CurrencyFields, CurrencyRow, Row] { 
+  private final class Impl(val _path: List[Path])
+    extends Relation[CurrencyFields, CurrencyRow] {
   
-    override val fields: CurrencyFields[Row] = new CurrencyFields[Row] {
-      override val currencycode = new IdField[CurrencyId, Row](prefix, "currencycode", None, Some("bpchar"))(x => extract(x).currencycode, (row, value) => merge(row, extract(row).copy(currencycode = value)))
-      override val name = new Field[Name, Row](prefix, "name", None, Some("varchar"))(x => extract(x).name, (row, value) => merge(row, extract(row).copy(name = value)))
-      override val modifieddate = new Field[TypoLocalDateTime, Row](prefix, "modifieddate", Some("text"), Some("timestamp"))(x => extract(x).modifieddate, (row, value) => merge(row, extract(row).copy(modifieddate = value)))
+    override lazy val fields: CurrencyFields = new CurrencyFields {
+      override def currencycode = IdField[CurrencyId, CurrencyRow](_path, "currencycode", None, Some("bpchar"), x => x.currencycode, (row, value) => row.copy(currencycode = value))
+      override def name = Field[Name, CurrencyRow](_path, "name", None, Some("varchar"), x => x.name, (row, value) => row.copy(name = value))
+      override def modifieddate = Field[TypoLocalDateTime, CurrencyRow](_path, "modifieddate", Some("text"), Some("timestamp"), x => x.modifieddate, (row, value) => row.copy(modifieddate = value))
     }
   
-    override val columns: List[FieldLikeNoHkt[?, Row]] =
-      List[FieldLikeNoHkt[?, Row]](fields.currencycode, fields.name, fields.modifieddate)
+    override lazy val columns: List[FieldLikeNoHkt[?, CurrencyRow]] =
+      List[FieldLikeNoHkt[?, CurrencyRow]](fields.currencycode, fields.name, fields.modifieddate)
   
-    override def copy[NewRow](prefix: Option[String], extract: NewRow => CurrencyRow, merge: (NewRow, CurrencyRow) => NewRow): Impl[NewRow] =
-      new Impl(prefix, extract, merge)
+    override def copy(path: List[Path]): Impl =
+      new Impl(path)
   }
   
 }

--- a/typo-tester-doobie/generated-and-checked-in/adventureworks/sales/currency/CurrencyRepoMock.scala
+++ b/typo-tester-doobie/generated-and-checked-in/adventureworks/sales/currency/CurrencyRepoMock.scala
@@ -24,7 +24,7 @@ import typo.dsl.UpdateParams
 class CurrencyRepoMock(toRow: Function1[CurrencyRowUnsaved, CurrencyRow],
                        map: scala.collection.mutable.Map[CurrencyId, CurrencyRow] = scala.collection.mutable.Map.empty) extends CurrencyRepo {
   override def delete: DeleteBuilder[CurrencyFields, CurrencyRow] = {
-    DeleteBuilderMock(DeleteParams.empty, CurrencyFields.structure.fields, map)
+    DeleteBuilderMock(DeleteParams.empty, CurrencyFields.structure, map)
   }
   override def deleteById(currencycode: CurrencyId): ConnectionIO[Boolean] = {
     delay(map.remove(currencycode).isDefined)
@@ -86,7 +86,7 @@ class CurrencyRepoMock(toRow: Function1[CurrencyRowUnsaved, CurrencyRow],
     }
   }
   override def update: UpdateBuilder[CurrencyFields, CurrencyRow] = {
-    UpdateBuilderMock(UpdateParams.empty, CurrencyFields.structure.fields, map)
+    UpdateBuilderMock(UpdateParams.empty, CurrencyFields.structure, map)
   }
   override def update(row: CurrencyRow): ConnectionIO[Boolean] = {
     delay {

--- a/typo-tester-doobie/generated-and-checked-in/adventureworks/sales/currencyrate/CurrencyrateFields.scala
+++ b/typo-tester-doobie/generated-and-checked-in/adventureworks/sales/currencyrate/CurrencyrateFields.scala
@@ -9,43 +9,44 @@ package currencyrate
 
 import adventureworks.customtypes.TypoLocalDateTime
 import adventureworks.sales.currency.CurrencyId
+import typo.dsl.Path
 import typo.dsl.SqlExpr.Field
 import typo.dsl.SqlExpr.FieldLikeNoHkt
 import typo.dsl.SqlExpr.IdField
 import typo.dsl.Structure.Relation
 
-trait CurrencyrateFields[Row] {
-  val currencyrateid: IdField[CurrencyrateId, Row]
-  val currencyratedate: Field[TypoLocalDateTime, Row]
-  val fromcurrencycode: Field[CurrencyId, Row]
-  val tocurrencycode: Field[CurrencyId, Row]
-  val averagerate: Field[BigDecimal, Row]
-  val endofdayrate: Field[BigDecimal, Row]
-  val modifieddate: Field[TypoLocalDateTime, Row]
+trait CurrencyrateFields {
+  def currencyrateid: IdField[CurrencyrateId, CurrencyrateRow]
+  def currencyratedate: Field[TypoLocalDateTime, CurrencyrateRow]
+  def fromcurrencycode: Field[CurrencyId, CurrencyrateRow]
+  def tocurrencycode: Field[CurrencyId, CurrencyrateRow]
+  def averagerate: Field[BigDecimal, CurrencyrateRow]
+  def endofdayrate: Field[BigDecimal, CurrencyrateRow]
+  def modifieddate: Field[TypoLocalDateTime, CurrencyrateRow]
 }
 
 object CurrencyrateFields {
-  val structure: Relation[CurrencyrateFields, CurrencyrateRow, CurrencyrateRow] = 
-    new Impl(None, identity, (_, x) => x)
+  lazy val structure: Relation[CurrencyrateFields, CurrencyrateRow] =
+    new Impl(Nil)
     
-  private final class Impl[Row](val prefix: Option[String], val extract: Row => CurrencyrateRow, val merge: (Row, CurrencyrateRow) => Row)
-    extends Relation[CurrencyrateFields, CurrencyrateRow, Row] { 
+  private final class Impl(val _path: List[Path])
+    extends Relation[CurrencyrateFields, CurrencyrateRow] {
   
-    override val fields: CurrencyrateFields[Row] = new CurrencyrateFields[Row] {
-      override val currencyrateid = new IdField[CurrencyrateId, Row](prefix, "currencyrateid", None, Some("int4"))(x => extract(x).currencyrateid, (row, value) => merge(row, extract(row).copy(currencyrateid = value)))
-      override val currencyratedate = new Field[TypoLocalDateTime, Row](prefix, "currencyratedate", Some("text"), Some("timestamp"))(x => extract(x).currencyratedate, (row, value) => merge(row, extract(row).copy(currencyratedate = value)))
-      override val fromcurrencycode = new Field[CurrencyId, Row](prefix, "fromcurrencycode", None, Some("bpchar"))(x => extract(x).fromcurrencycode, (row, value) => merge(row, extract(row).copy(fromcurrencycode = value)))
-      override val tocurrencycode = new Field[CurrencyId, Row](prefix, "tocurrencycode", None, Some("bpchar"))(x => extract(x).tocurrencycode, (row, value) => merge(row, extract(row).copy(tocurrencycode = value)))
-      override val averagerate = new Field[BigDecimal, Row](prefix, "averagerate", None, Some("numeric"))(x => extract(x).averagerate, (row, value) => merge(row, extract(row).copy(averagerate = value)))
-      override val endofdayrate = new Field[BigDecimal, Row](prefix, "endofdayrate", None, Some("numeric"))(x => extract(x).endofdayrate, (row, value) => merge(row, extract(row).copy(endofdayrate = value)))
-      override val modifieddate = new Field[TypoLocalDateTime, Row](prefix, "modifieddate", Some("text"), Some("timestamp"))(x => extract(x).modifieddate, (row, value) => merge(row, extract(row).copy(modifieddate = value)))
+    override lazy val fields: CurrencyrateFields = new CurrencyrateFields {
+      override def currencyrateid = IdField[CurrencyrateId, CurrencyrateRow](_path, "currencyrateid", None, Some("int4"), x => x.currencyrateid, (row, value) => row.copy(currencyrateid = value))
+      override def currencyratedate = Field[TypoLocalDateTime, CurrencyrateRow](_path, "currencyratedate", Some("text"), Some("timestamp"), x => x.currencyratedate, (row, value) => row.copy(currencyratedate = value))
+      override def fromcurrencycode = Field[CurrencyId, CurrencyrateRow](_path, "fromcurrencycode", None, Some("bpchar"), x => x.fromcurrencycode, (row, value) => row.copy(fromcurrencycode = value))
+      override def tocurrencycode = Field[CurrencyId, CurrencyrateRow](_path, "tocurrencycode", None, Some("bpchar"), x => x.tocurrencycode, (row, value) => row.copy(tocurrencycode = value))
+      override def averagerate = Field[BigDecimal, CurrencyrateRow](_path, "averagerate", None, Some("numeric"), x => x.averagerate, (row, value) => row.copy(averagerate = value))
+      override def endofdayrate = Field[BigDecimal, CurrencyrateRow](_path, "endofdayrate", None, Some("numeric"), x => x.endofdayrate, (row, value) => row.copy(endofdayrate = value))
+      override def modifieddate = Field[TypoLocalDateTime, CurrencyrateRow](_path, "modifieddate", Some("text"), Some("timestamp"), x => x.modifieddate, (row, value) => row.copy(modifieddate = value))
     }
   
-    override val columns: List[FieldLikeNoHkt[?, Row]] =
-      List[FieldLikeNoHkt[?, Row]](fields.currencyrateid, fields.currencyratedate, fields.fromcurrencycode, fields.tocurrencycode, fields.averagerate, fields.endofdayrate, fields.modifieddate)
+    override lazy val columns: List[FieldLikeNoHkt[?, CurrencyrateRow]] =
+      List[FieldLikeNoHkt[?, CurrencyrateRow]](fields.currencyrateid, fields.currencyratedate, fields.fromcurrencycode, fields.tocurrencycode, fields.averagerate, fields.endofdayrate, fields.modifieddate)
   
-    override def copy[NewRow](prefix: Option[String], extract: NewRow => CurrencyrateRow, merge: (NewRow, CurrencyrateRow) => NewRow): Impl[NewRow] =
-      new Impl(prefix, extract, merge)
+    override def copy(path: List[Path]): Impl =
+      new Impl(path)
   }
   
 }

--- a/typo-tester-doobie/generated-and-checked-in/adventureworks/sales/currencyrate/CurrencyrateRepoMock.scala
+++ b/typo-tester-doobie/generated-and-checked-in/adventureworks/sales/currencyrate/CurrencyrateRepoMock.scala
@@ -24,7 +24,7 @@ import typo.dsl.UpdateParams
 class CurrencyrateRepoMock(toRow: Function1[CurrencyrateRowUnsaved, CurrencyrateRow],
                            map: scala.collection.mutable.Map[CurrencyrateId, CurrencyrateRow] = scala.collection.mutable.Map.empty) extends CurrencyrateRepo {
   override def delete: DeleteBuilder[CurrencyrateFields, CurrencyrateRow] = {
-    DeleteBuilderMock(DeleteParams.empty, CurrencyrateFields.structure.fields, map)
+    DeleteBuilderMock(DeleteParams.empty, CurrencyrateFields.structure, map)
   }
   override def deleteById(currencyrateid: CurrencyrateId): ConnectionIO[Boolean] = {
     delay(map.remove(currencyrateid).isDefined)
@@ -86,7 +86,7 @@ class CurrencyrateRepoMock(toRow: Function1[CurrencyrateRowUnsaved, Currencyrate
     }
   }
   override def update: UpdateBuilder[CurrencyrateFields, CurrencyrateRow] = {
-    UpdateBuilderMock(UpdateParams.empty, CurrencyrateFields.structure.fields, map)
+    UpdateBuilderMock(UpdateParams.empty, CurrencyrateFields.structure, map)
   }
   override def update(row: CurrencyrateRow): ConnectionIO[Boolean] = {
     delay {

--- a/typo-tester-doobie/generated-and-checked-in/adventureworks/sales/customer/CustomerFields.scala
+++ b/typo-tester-doobie/generated-and-checked-in/adventureworks/sales/customer/CustomerFields.scala
@@ -11,42 +11,43 @@ import adventureworks.customtypes.TypoLocalDateTime
 import adventureworks.customtypes.TypoUUID
 import adventureworks.person.businessentity.BusinessentityId
 import adventureworks.sales.salesterritory.SalesterritoryId
+import typo.dsl.Path
 import typo.dsl.SqlExpr.Field
 import typo.dsl.SqlExpr.FieldLikeNoHkt
 import typo.dsl.SqlExpr.IdField
 import typo.dsl.SqlExpr.OptField
 import typo.dsl.Structure.Relation
 
-trait CustomerFields[Row] {
-  val customerid: IdField[CustomerId, Row]
-  val personid: OptField[BusinessentityId, Row]
-  val storeid: OptField[BusinessentityId, Row]
-  val territoryid: OptField[SalesterritoryId, Row]
-  val rowguid: Field[TypoUUID, Row]
-  val modifieddate: Field[TypoLocalDateTime, Row]
+trait CustomerFields {
+  def customerid: IdField[CustomerId, CustomerRow]
+  def personid: OptField[BusinessentityId, CustomerRow]
+  def storeid: OptField[BusinessentityId, CustomerRow]
+  def territoryid: OptField[SalesterritoryId, CustomerRow]
+  def rowguid: Field[TypoUUID, CustomerRow]
+  def modifieddate: Field[TypoLocalDateTime, CustomerRow]
 }
 
 object CustomerFields {
-  val structure: Relation[CustomerFields, CustomerRow, CustomerRow] = 
-    new Impl(None, identity, (_, x) => x)
+  lazy val structure: Relation[CustomerFields, CustomerRow] =
+    new Impl(Nil)
     
-  private final class Impl[Row](val prefix: Option[String], val extract: Row => CustomerRow, val merge: (Row, CustomerRow) => Row)
-    extends Relation[CustomerFields, CustomerRow, Row] { 
+  private final class Impl(val _path: List[Path])
+    extends Relation[CustomerFields, CustomerRow] {
   
-    override val fields: CustomerFields[Row] = new CustomerFields[Row] {
-      override val customerid = new IdField[CustomerId, Row](prefix, "customerid", None, Some("int4"))(x => extract(x).customerid, (row, value) => merge(row, extract(row).copy(customerid = value)))
-      override val personid = new OptField[BusinessentityId, Row](prefix, "personid", None, Some("int4"))(x => extract(x).personid, (row, value) => merge(row, extract(row).copy(personid = value)))
-      override val storeid = new OptField[BusinessentityId, Row](prefix, "storeid", None, Some("int4"))(x => extract(x).storeid, (row, value) => merge(row, extract(row).copy(storeid = value)))
-      override val territoryid = new OptField[SalesterritoryId, Row](prefix, "territoryid", None, Some("int4"))(x => extract(x).territoryid, (row, value) => merge(row, extract(row).copy(territoryid = value)))
-      override val rowguid = new Field[TypoUUID, Row](prefix, "rowguid", None, Some("uuid"))(x => extract(x).rowguid, (row, value) => merge(row, extract(row).copy(rowguid = value)))
-      override val modifieddate = new Field[TypoLocalDateTime, Row](prefix, "modifieddate", Some("text"), Some("timestamp"))(x => extract(x).modifieddate, (row, value) => merge(row, extract(row).copy(modifieddate = value)))
+    override lazy val fields: CustomerFields = new CustomerFields {
+      override def customerid = IdField[CustomerId, CustomerRow](_path, "customerid", None, Some("int4"), x => x.customerid, (row, value) => row.copy(customerid = value))
+      override def personid = OptField[BusinessentityId, CustomerRow](_path, "personid", None, Some("int4"), x => x.personid, (row, value) => row.copy(personid = value))
+      override def storeid = OptField[BusinessentityId, CustomerRow](_path, "storeid", None, Some("int4"), x => x.storeid, (row, value) => row.copy(storeid = value))
+      override def territoryid = OptField[SalesterritoryId, CustomerRow](_path, "territoryid", None, Some("int4"), x => x.territoryid, (row, value) => row.copy(territoryid = value))
+      override def rowguid = Field[TypoUUID, CustomerRow](_path, "rowguid", None, Some("uuid"), x => x.rowguid, (row, value) => row.copy(rowguid = value))
+      override def modifieddate = Field[TypoLocalDateTime, CustomerRow](_path, "modifieddate", Some("text"), Some("timestamp"), x => x.modifieddate, (row, value) => row.copy(modifieddate = value))
     }
   
-    override val columns: List[FieldLikeNoHkt[?, Row]] =
-      List[FieldLikeNoHkt[?, Row]](fields.customerid, fields.personid, fields.storeid, fields.territoryid, fields.rowguid, fields.modifieddate)
+    override lazy val columns: List[FieldLikeNoHkt[?, CustomerRow]] =
+      List[FieldLikeNoHkt[?, CustomerRow]](fields.customerid, fields.personid, fields.storeid, fields.territoryid, fields.rowguid, fields.modifieddate)
   
-    override def copy[NewRow](prefix: Option[String], extract: NewRow => CustomerRow, merge: (NewRow, CustomerRow) => NewRow): Impl[NewRow] =
-      new Impl(prefix, extract, merge)
+    override def copy(path: List[Path]): Impl =
+      new Impl(path)
   }
   
 }

--- a/typo-tester-doobie/generated-and-checked-in/adventureworks/sales/customer/CustomerRepoMock.scala
+++ b/typo-tester-doobie/generated-and-checked-in/adventureworks/sales/customer/CustomerRepoMock.scala
@@ -24,7 +24,7 @@ import typo.dsl.UpdateParams
 class CustomerRepoMock(toRow: Function1[CustomerRowUnsaved, CustomerRow],
                        map: scala.collection.mutable.Map[CustomerId, CustomerRow] = scala.collection.mutable.Map.empty) extends CustomerRepo {
   override def delete: DeleteBuilder[CustomerFields, CustomerRow] = {
-    DeleteBuilderMock(DeleteParams.empty, CustomerFields.structure.fields, map)
+    DeleteBuilderMock(DeleteParams.empty, CustomerFields.structure, map)
   }
   override def deleteById(customerid: CustomerId): ConnectionIO[Boolean] = {
     delay(map.remove(customerid).isDefined)
@@ -86,7 +86,7 @@ class CustomerRepoMock(toRow: Function1[CustomerRowUnsaved, CustomerRow],
     }
   }
   override def update: UpdateBuilder[CustomerFields, CustomerRow] = {
-    UpdateBuilderMock(UpdateParams.empty, CustomerFields.structure.fields, map)
+    UpdateBuilderMock(UpdateParams.empty, CustomerFields.structure, map)
   }
   override def update(row: CustomerRow): ConnectionIO[Boolean] = {
     delay {

--- a/typo-tester-doobie/generated-and-checked-in/adventureworks/sales/personcreditcard/PersoncreditcardFields.scala
+++ b/typo-tester-doobie/generated-and-checked-in/adventureworks/sales/personcreditcard/PersoncreditcardFields.scala
@@ -10,35 +10,36 @@ package personcreditcard
 import adventureworks.customtypes.TypoLocalDateTime
 import adventureworks.person.businessentity.BusinessentityId
 import adventureworks.userdefined.CustomCreditcardId
+import typo.dsl.Path
 import typo.dsl.SqlExpr.Field
 import typo.dsl.SqlExpr.FieldLikeNoHkt
 import typo.dsl.SqlExpr.IdField
 import typo.dsl.Structure.Relation
 
-trait PersoncreditcardFields[Row] {
-  val businessentityid: IdField[BusinessentityId, Row]
-  val creditcardid: IdField[/* user-picked */ CustomCreditcardId, Row]
-  val modifieddate: Field[TypoLocalDateTime, Row]
+trait PersoncreditcardFields {
+  def businessentityid: IdField[BusinessentityId, PersoncreditcardRow]
+  def creditcardid: IdField[/* user-picked */ CustomCreditcardId, PersoncreditcardRow]
+  def modifieddate: Field[TypoLocalDateTime, PersoncreditcardRow]
 }
 
 object PersoncreditcardFields {
-  val structure: Relation[PersoncreditcardFields, PersoncreditcardRow, PersoncreditcardRow] = 
-    new Impl(None, identity, (_, x) => x)
+  lazy val structure: Relation[PersoncreditcardFields, PersoncreditcardRow] =
+    new Impl(Nil)
     
-  private final class Impl[Row](val prefix: Option[String], val extract: Row => PersoncreditcardRow, val merge: (Row, PersoncreditcardRow) => Row)
-    extends Relation[PersoncreditcardFields, PersoncreditcardRow, Row] { 
+  private final class Impl(val _path: List[Path])
+    extends Relation[PersoncreditcardFields, PersoncreditcardRow] {
   
-    override val fields: PersoncreditcardFields[Row] = new PersoncreditcardFields[Row] {
-      override val businessentityid = new IdField[BusinessentityId, Row](prefix, "businessentityid", None, Some("int4"))(x => extract(x).businessentityid, (row, value) => merge(row, extract(row).copy(businessentityid = value)))
-      override val creditcardid = new IdField[/* user-picked */ CustomCreditcardId, Row](prefix, "creditcardid", None, Some("int4"))(x => extract(x).creditcardid, (row, value) => merge(row, extract(row).copy(creditcardid = value)))
-      override val modifieddate = new Field[TypoLocalDateTime, Row](prefix, "modifieddate", Some("text"), Some("timestamp"))(x => extract(x).modifieddate, (row, value) => merge(row, extract(row).copy(modifieddate = value)))
+    override lazy val fields: PersoncreditcardFields = new PersoncreditcardFields {
+      override def businessentityid = IdField[BusinessentityId, PersoncreditcardRow](_path, "businessentityid", None, Some("int4"), x => x.businessentityid, (row, value) => row.copy(businessentityid = value))
+      override def creditcardid = IdField[/* user-picked */ CustomCreditcardId, PersoncreditcardRow](_path, "creditcardid", None, Some("int4"), x => x.creditcardid, (row, value) => row.copy(creditcardid = value))
+      override def modifieddate = Field[TypoLocalDateTime, PersoncreditcardRow](_path, "modifieddate", Some("text"), Some("timestamp"), x => x.modifieddate, (row, value) => row.copy(modifieddate = value))
     }
   
-    override val columns: List[FieldLikeNoHkt[?, Row]] =
-      List[FieldLikeNoHkt[?, Row]](fields.businessentityid, fields.creditcardid, fields.modifieddate)
+    override lazy val columns: List[FieldLikeNoHkt[?, PersoncreditcardRow]] =
+      List[FieldLikeNoHkt[?, PersoncreditcardRow]](fields.businessentityid, fields.creditcardid, fields.modifieddate)
   
-    override def copy[NewRow](prefix: Option[String], extract: NewRow => PersoncreditcardRow, merge: (NewRow, PersoncreditcardRow) => NewRow): Impl[NewRow] =
-      new Impl(prefix, extract, merge)
+    override def copy(path: List[Path]): Impl =
+      new Impl(path)
   }
   
 }

--- a/typo-tester-doobie/generated-and-checked-in/adventureworks/sales/personcreditcard/PersoncreditcardRepoMock.scala
+++ b/typo-tester-doobie/generated-and-checked-in/adventureworks/sales/personcreditcard/PersoncreditcardRepoMock.scala
@@ -26,7 +26,7 @@ import typo.dsl.UpdateParams
 class PersoncreditcardRepoMock(toRow: Function1[PersoncreditcardRowUnsaved, PersoncreditcardRow],
                                map: scala.collection.mutable.Map[PersoncreditcardId, PersoncreditcardRow] = scala.collection.mutable.Map.empty) extends PersoncreditcardRepo {
   override def delete: DeleteBuilder[PersoncreditcardFields, PersoncreditcardRow] = {
-    DeleteBuilderMock(DeleteParams.empty, PersoncreditcardFields.structure.fields, map)
+    DeleteBuilderMock(DeleteParams.empty, PersoncreditcardFields.structure, map)
   }
   override def deleteById(compositeId: PersoncreditcardId): ConnectionIO[Boolean] = {
     delay(map.remove(compositeId).isDefined)
@@ -88,7 +88,7 @@ class PersoncreditcardRepoMock(toRow: Function1[PersoncreditcardRowUnsaved, Pers
     }
   }
   override def update: UpdateBuilder[PersoncreditcardFields, PersoncreditcardRow] = {
-    UpdateBuilderMock(UpdateParams.empty, PersoncreditcardFields.structure.fields, map)
+    UpdateBuilderMock(UpdateParams.empty, PersoncreditcardFields.structure, map)
   }
   override def update(row: PersoncreditcardRow): ConnectionIO[Boolean] = {
     delay {

--- a/typo-tester-doobie/generated-and-checked-in/adventureworks/sales/salesorderdetail/SalesorderdetailFields.scala
+++ b/typo-tester-doobie/generated-and-checked-in/adventureworks/sales/salesorderdetail/SalesorderdetailFields.scala
@@ -13,50 +13,51 @@ import adventureworks.customtypes.TypoUUID
 import adventureworks.production.product.ProductId
 import adventureworks.sales.salesorderheader.SalesorderheaderId
 import adventureworks.sales.specialoffer.SpecialofferId
+import typo.dsl.Path
 import typo.dsl.SqlExpr.Field
 import typo.dsl.SqlExpr.FieldLikeNoHkt
 import typo.dsl.SqlExpr.IdField
 import typo.dsl.SqlExpr.OptField
 import typo.dsl.Structure.Relation
 
-trait SalesorderdetailFields[Row] {
-  val salesorderid: IdField[SalesorderheaderId, Row]
-  val salesorderdetailid: IdField[Int, Row]
-  val carriertrackingnumber: OptField[/* max 25 chars */ String, Row]
-  val orderqty: Field[TypoShort, Row]
-  val productid: Field[ProductId, Row]
-  val specialofferid: Field[SpecialofferId, Row]
-  val unitprice: Field[BigDecimal, Row]
-  val unitpricediscount: Field[BigDecimal, Row]
-  val rowguid: Field[TypoUUID, Row]
-  val modifieddate: Field[TypoLocalDateTime, Row]
+trait SalesorderdetailFields {
+  def salesorderid: IdField[SalesorderheaderId, SalesorderdetailRow]
+  def salesorderdetailid: IdField[Int, SalesorderdetailRow]
+  def carriertrackingnumber: OptField[/* max 25 chars */ String, SalesorderdetailRow]
+  def orderqty: Field[TypoShort, SalesorderdetailRow]
+  def productid: Field[ProductId, SalesorderdetailRow]
+  def specialofferid: Field[SpecialofferId, SalesorderdetailRow]
+  def unitprice: Field[BigDecimal, SalesorderdetailRow]
+  def unitpricediscount: Field[BigDecimal, SalesorderdetailRow]
+  def rowguid: Field[TypoUUID, SalesorderdetailRow]
+  def modifieddate: Field[TypoLocalDateTime, SalesorderdetailRow]
 }
 
 object SalesorderdetailFields {
-  val structure: Relation[SalesorderdetailFields, SalesorderdetailRow, SalesorderdetailRow] = 
-    new Impl(None, identity, (_, x) => x)
+  lazy val structure: Relation[SalesorderdetailFields, SalesorderdetailRow] =
+    new Impl(Nil)
     
-  private final class Impl[Row](val prefix: Option[String], val extract: Row => SalesorderdetailRow, val merge: (Row, SalesorderdetailRow) => Row)
-    extends Relation[SalesorderdetailFields, SalesorderdetailRow, Row] { 
+  private final class Impl(val _path: List[Path])
+    extends Relation[SalesorderdetailFields, SalesorderdetailRow] {
   
-    override val fields: SalesorderdetailFields[Row] = new SalesorderdetailFields[Row] {
-      override val salesorderid = new IdField[SalesorderheaderId, Row](prefix, "salesorderid", None, Some("int4"))(x => extract(x).salesorderid, (row, value) => merge(row, extract(row).copy(salesorderid = value)))
-      override val salesorderdetailid = new IdField[Int, Row](prefix, "salesorderdetailid", None, Some("int4"))(x => extract(x).salesorderdetailid, (row, value) => merge(row, extract(row).copy(salesorderdetailid = value)))
-      override val carriertrackingnumber = new OptField[/* max 25 chars */ String, Row](prefix, "carriertrackingnumber", None, None)(x => extract(x).carriertrackingnumber, (row, value) => merge(row, extract(row).copy(carriertrackingnumber = value)))
-      override val orderqty = new Field[TypoShort, Row](prefix, "orderqty", None, Some("int2"))(x => extract(x).orderqty, (row, value) => merge(row, extract(row).copy(orderqty = value)))
-      override val productid = new Field[ProductId, Row](prefix, "productid", None, Some("int4"))(x => extract(x).productid, (row, value) => merge(row, extract(row).copy(productid = value)))
-      override val specialofferid = new Field[SpecialofferId, Row](prefix, "specialofferid", None, Some("int4"))(x => extract(x).specialofferid, (row, value) => merge(row, extract(row).copy(specialofferid = value)))
-      override val unitprice = new Field[BigDecimal, Row](prefix, "unitprice", None, Some("numeric"))(x => extract(x).unitprice, (row, value) => merge(row, extract(row).copy(unitprice = value)))
-      override val unitpricediscount = new Field[BigDecimal, Row](prefix, "unitpricediscount", None, Some("numeric"))(x => extract(x).unitpricediscount, (row, value) => merge(row, extract(row).copy(unitpricediscount = value)))
-      override val rowguid = new Field[TypoUUID, Row](prefix, "rowguid", None, Some("uuid"))(x => extract(x).rowguid, (row, value) => merge(row, extract(row).copy(rowguid = value)))
-      override val modifieddate = new Field[TypoLocalDateTime, Row](prefix, "modifieddate", Some("text"), Some("timestamp"))(x => extract(x).modifieddate, (row, value) => merge(row, extract(row).copy(modifieddate = value)))
+    override lazy val fields: SalesorderdetailFields = new SalesorderdetailFields {
+      override def salesorderid = IdField[SalesorderheaderId, SalesorderdetailRow](_path, "salesorderid", None, Some("int4"), x => x.salesorderid, (row, value) => row.copy(salesorderid = value))
+      override def salesorderdetailid = IdField[Int, SalesorderdetailRow](_path, "salesorderdetailid", None, Some("int4"), x => x.salesorderdetailid, (row, value) => row.copy(salesorderdetailid = value))
+      override def carriertrackingnumber = OptField[/* max 25 chars */ String, SalesorderdetailRow](_path, "carriertrackingnumber", None, None, x => x.carriertrackingnumber, (row, value) => row.copy(carriertrackingnumber = value))
+      override def orderqty = Field[TypoShort, SalesorderdetailRow](_path, "orderqty", None, Some("int2"), x => x.orderqty, (row, value) => row.copy(orderqty = value))
+      override def productid = Field[ProductId, SalesorderdetailRow](_path, "productid", None, Some("int4"), x => x.productid, (row, value) => row.copy(productid = value))
+      override def specialofferid = Field[SpecialofferId, SalesorderdetailRow](_path, "specialofferid", None, Some("int4"), x => x.specialofferid, (row, value) => row.copy(specialofferid = value))
+      override def unitprice = Field[BigDecimal, SalesorderdetailRow](_path, "unitprice", None, Some("numeric"), x => x.unitprice, (row, value) => row.copy(unitprice = value))
+      override def unitpricediscount = Field[BigDecimal, SalesorderdetailRow](_path, "unitpricediscount", None, Some("numeric"), x => x.unitpricediscount, (row, value) => row.copy(unitpricediscount = value))
+      override def rowguid = Field[TypoUUID, SalesorderdetailRow](_path, "rowguid", None, Some("uuid"), x => x.rowguid, (row, value) => row.copy(rowguid = value))
+      override def modifieddate = Field[TypoLocalDateTime, SalesorderdetailRow](_path, "modifieddate", Some("text"), Some("timestamp"), x => x.modifieddate, (row, value) => row.copy(modifieddate = value))
     }
   
-    override val columns: List[FieldLikeNoHkt[?, Row]] =
-      List[FieldLikeNoHkt[?, Row]](fields.salesorderid, fields.salesorderdetailid, fields.carriertrackingnumber, fields.orderqty, fields.productid, fields.specialofferid, fields.unitprice, fields.unitpricediscount, fields.rowguid, fields.modifieddate)
+    override lazy val columns: List[FieldLikeNoHkt[?, SalesorderdetailRow]] =
+      List[FieldLikeNoHkt[?, SalesorderdetailRow]](fields.salesorderid, fields.salesorderdetailid, fields.carriertrackingnumber, fields.orderqty, fields.productid, fields.specialofferid, fields.unitprice, fields.unitpricediscount, fields.rowguid, fields.modifieddate)
   
-    override def copy[NewRow](prefix: Option[String], extract: NewRow => SalesorderdetailRow, merge: (NewRow, SalesorderdetailRow) => NewRow): Impl[NewRow] =
-      new Impl(prefix, extract, merge)
+    override def copy(path: List[Path]): Impl =
+      new Impl(path)
   }
   
 }

--- a/typo-tester-doobie/generated-and-checked-in/adventureworks/sales/salesorderdetail/SalesorderdetailRepoMock.scala
+++ b/typo-tester-doobie/generated-and-checked-in/adventureworks/sales/salesorderdetail/SalesorderdetailRepoMock.scala
@@ -24,7 +24,7 @@ import typo.dsl.UpdateParams
 class SalesorderdetailRepoMock(toRow: Function1[SalesorderdetailRowUnsaved, SalesorderdetailRow],
                                map: scala.collection.mutable.Map[SalesorderdetailId, SalesorderdetailRow] = scala.collection.mutable.Map.empty) extends SalesorderdetailRepo {
   override def delete: DeleteBuilder[SalesorderdetailFields, SalesorderdetailRow] = {
-    DeleteBuilderMock(DeleteParams.empty, SalesorderdetailFields.structure.fields, map)
+    DeleteBuilderMock(DeleteParams.empty, SalesorderdetailFields.structure, map)
   }
   override def deleteById(compositeId: SalesorderdetailId): ConnectionIO[Boolean] = {
     delay(map.remove(compositeId).isDefined)
@@ -86,7 +86,7 @@ class SalesorderdetailRepoMock(toRow: Function1[SalesorderdetailRowUnsaved, Sale
     }
   }
   override def update: UpdateBuilder[SalesorderdetailFields, SalesorderdetailRow] = {
-    UpdateBuilderMock(UpdateParams.empty, SalesorderdetailFields.structure.fields, map)
+    UpdateBuilderMock(UpdateParams.empty, SalesorderdetailFields.structure, map)
   }
   override def update(row: SalesorderdetailRow): ConnectionIO[Boolean] = {
     delay {

--- a/typo-tester-doobie/generated-and-checked-in/adventureworks/sales/salesorderheader/SalesorderheaderFields.scala
+++ b/typo-tester-doobie/generated-and-checked-in/adventureworks/sales/salesorderheader/SalesorderheaderFields.scala
@@ -20,80 +20,81 @@ import adventureworks.sales.currencyrate.CurrencyrateId
 import adventureworks.sales.customer.CustomerId
 import adventureworks.sales.salesterritory.SalesterritoryId
 import adventureworks.userdefined.CustomCreditcardId
+import typo.dsl.Path
 import typo.dsl.SqlExpr.Field
 import typo.dsl.SqlExpr.FieldLikeNoHkt
 import typo.dsl.SqlExpr.IdField
 import typo.dsl.SqlExpr.OptField
 import typo.dsl.Structure.Relation
 
-trait SalesorderheaderFields[Row] {
-  val salesorderid: IdField[SalesorderheaderId, Row]
-  val revisionnumber: Field[TypoShort, Row]
-  val orderdate: Field[TypoLocalDateTime, Row]
-  val duedate: Field[TypoLocalDateTime, Row]
-  val shipdate: OptField[TypoLocalDateTime, Row]
-  val status: Field[TypoShort, Row]
-  val onlineorderflag: Field[Flag, Row]
-  val purchaseordernumber: OptField[OrderNumber, Row]
-  val accountnumber: OptField[AccountNumber, Row]
-  val customerid: Field[CustomerId, Row]
-  val salespersonid: OptField[BusinessentityId, Row]
-  val territoryid: OptField[SalesterritoryId, Row]
-  val billtoaddressid: Field[AddressId, Row]
-  val shiptoaddressid: Field[AddressId, Row]
-  val shipmethodid: Field[ShipmethodId, Row]
-  val creditcardid: OptField[/* user-picked */ CustomCreditcardId, Row]
-  val creditcardapprovalcode: OptField[/* max 15 chars */ String, Row]
-  val currencyrateid: OptField[CurrencyrateId, Row]
-  val subtotal: Field[BigDecimal, Row]
-  val taxamt: Field[BigDecimal, Row]
-  val freight: Field[BigDecimal, Row]
-  val totaldue: OptField[BigDecimal, Row]
-  val comment: OptField[/* max 128 chars */ String, Row]
-  val rowguid: Field[TypoUUID, Row]
-  val modifieddate: Field[TypoLocalDateTime, Row]
+trait SalesorderheaderFields {
+  def salesorderid: IdField[SalesorderheaderId, SalesorderheaderRow]
+  def revisionnumber: Field[TypoShort, SalesorderheaderRow]
+  def orderdate: Field[TypoLocalDateTime, SalesorderheaderRow]
+  def duedate: Field[TypoLocalDateTime, SalesorderheaderRow]
+  def shipdate: OptField[TypoLocalDateTime, SalesorderheaderRow]
+  def status: Field[TypoShort, SalesorderheaderRow]
+  def onlineorderflag: Field[Flag, SalesorderheaderRow]
+  def purchaseordernumber: OptField[OrderNumber, SalesorderheaderRow]
+  def accountnumber: OptField[AccountNumber, SalesorderheaderRow]
+  def customerid: Field[CustomerId, SalesorderheaderRow]
+  def salespersonid: OptField[BusinessentityId, SalesorderheaderRow]
+  def territoryid: OptField[SalesterritoryId, SalesorderheaderRow]
+  def billtoaddressid: Field[AddressId, SalesorderheaderRow]
+  def shiptoaddressid: Field[AddressId, SalesorderheaderRow]
+  def shipmethodid: Field[ShipmethodId, SalesorderheaderRow]
+  def creditcardid: OptField[/* user-picked */ CustomCreditcardId, SalesorderheaderRow]
+  def creditcardapprovalcode: OptField[/* max 15 chars */ String, SalesorderheaderRow]
+  def currencyrateid: OptField[CurrencyrateId, SalesorderheaderRow]
+  def subtotal: Field[BigDecimal, SalesorderheaderRow]
+  def taxamt: Field[BigDecimal, SalesorderheaderRow]
+  def freight: Field[BigDecimal, SalesorderheaderRow]
+  def totaldue: OptField[BigDecimal, SalesorderheaderRow]
+  def comment: OptField[/* max 128 chars */ String, SalesorderheaderRow]
+  def rowguid: Field[TypoUUID, SalesorderheaderRow]
+  def modifieddate: Field[TypoLocalDateTime, SalesorderheaderRow]
 }
 
 object SalesorderheaderFields {
-  val structure: Relation[SalesorderheaderFields, SalesorderheaderRow, SalesorderheaderRow] = 
-    new Impl(None, identity, (_, x) => x)
+  lazy val structure: Relation[SalesorderheaderFields, SalesorderheaderRow] =
+    new Impl(Nil)
     
-  private final class Impl[Row](val prefix: Option[String], val extract: Row => SalesorderheaderRow, val merge: (Row, SalesorderheaderRow) => Row)
-    extends Relation[SalesorderheaderFields, SalesorderheaderRow, Row] { 
+  private final class Impl(val _path: List[Path])
+    extends Relation[SalesorderheaderFields, SalesorderheaderRow] {
   
-    override val fields: SalesorderheaderFields[Row] = new SalesorderheaderFields[Row] {
-      override val salesorderid = new IdField[SalesorderheaderId, Row](prefix, "salesorderid", None, Some("int4"))(x => extract(x).salesorderid, (row, value) => merge(row, extract(row).copy(salesorderid = value)))
-      override val revisionnumber = new Field[TypoShort, Row](prefix, "revisionnumber", None, Some("int2"))(x => extract(x).revisionnumber, (row, value) => merge(row, extract(row).copy(revisionnumber = value)))
-      override val orderdate = new Field[TypoLocalDateTime, Row](prefix, "orderdate", Some("text"), Some("timestamp"))(x => extract(x).orderdate, (row, value) => merge(row, extract(row).copy(orderdate = value)))
-      override val duedate = new Field[TypoLocalDateTime, Row](prefix, "duedate", Some("text"), Some("timestamp"))(x => extract(x).duedate, (row, value) => merge(row, extract(row).copy(duedate = value)))
-      override val shipdate = new OptField[TypoLocalDateTime, Row](prefix, "shipdate", Some("text"), Some("timestamp"))(x => extract(x).shipdate, (row, value) => merge(row, extract(row).copy(shipdate = value)))
-      override val status = new Field[TypoShort, Row](prefix, "status", None, Some("int2"))(x => extract(x).status, (row, value) => merge(row, extract(row).copy(status = value)))
-      override val onlineorderflag = new Field[Flag, Row](prefix, "onlineorderflag", None, Some("bool"))(x => extract(x).onlineorderflag, (row, value) => merge(row, extract(row).copy(onlineorderflag = value)))
-      override val purchaseordernumber = new OptField[OrderNumber, Row](prefix, "purchaseordernumber", None, Some("varchar"))(x => extract(x).purchaseordernumber, (row, value) => merge(row, extract(row).copy(purchaseordernumber = value)))
-      override val accountnumber = new OptField[AccountNumber, Row](prefix, "accountnumber", None, Some("varchar"))(x => extract(x).accountnumber, (row, value) => merge(row, extract(row).copy(accountnumber = value)))
-      override val customerid = new Field[CustomerId, Row](prefix, "customerid", None, Some("int4"))(x => extract(x).customerid, (row, value) => merge(row, extract(row).copy(customerid = value)))
-      override val salespersonid = new OptField[BusinessentityId, Row](prefix, "salespersonid", None, Some("int4"))(x => extract(x).salespersonid, (row, value) => merge(row, extract(row).copy(salespersonid = value)))
-      override val territoryid = new OptField[SalesterritoryId, Row](prefix, "territoryid", None, Some("int4"))(x => extract(x).territoryid, (row, value) => merge(row, extract(row).copy(territoryid = value)))
-      override val billtoaddressid = new Field[AddressId, Row](prefix, "billtoaddressid", None, Some("int4"))(x => extract(x).billtoaddressid, (row, value) => merge(row, extract(row).copy(billtoaddressid = value)))
-      override val shiptoaddressid = new Field[AddressId, Row](prefix, "shiptoaddressid", None, Some("int4"))(x => extract(x).shiptoaddressid, (row, value) => merge(row, extract(row).copy(shiptoaddressid = value)))
-      override val shipmethodid = new Field[ShipmethodId, Row](prefix, "shipmethodid", None, Some("int4"))(x => extract(x).shipmethodid, (row, value) => merge(row, extract(row).copy(shipmethodid = value)))
-      override val creditcardid = new OptField[/* user-picked */ CustomCreditcardId, Row](prefix, "creditcardid", None, Some("int4"))(x => extract(x).creditcardid, (row, value) => merge(row, extract(row).copy(creditcardid = value)))
-      override val creditcardapprovalcode = new OptField[/* max 15 chars */ String, Row](prefix, "creditcardapprovalcode", None, None)(x => extract(x).creditcardapprovalcode, (row, value) => merge(row, extract(row).copy(creditcardapprovalcode = value)))
-      override val currencyrateid = new OptField[CurrencyrateId, Row](prefix, "currencyrateid", None, Some("int4"))(x => extract(x).currencyrateid, (row, value) => merge(row, extract(row).copy(currencyrateid = value)))
-      override val subtotal = new Field[BigDecimal, Row](prefix, "subtotal", None, Some("numeric"))(x => extract(x).subtotal, (row, value) => merge(row, extract(row).copy(subtotal = value)))
-      override val taxamt = new Field[BigDecimal, Row](prefix, "taxamt", None, Some("numeric"))(x => extract(x).taxamt, (row, value) => merge(row, extract(row).copy(taxamt = value)))
-      override val freight = new Field[BigDecimal, Row](prefix, "freight", None, Some("numeric"))(x => extract(x).freight, (row, value) => merge(row, extract(row).copy(freight = value)))
-      override val totaldue = new OptField[BigDecimal, Row](prefix, "totaldue", None, Some("numeric"))(x => extract(x).totaldue, (row, value) => merge(row, extract(row).copy(totaldue = value)))
-      override val comment = new OptField[/* max 128 chars */ String, Row](prefix, "comment", None, None)(x => extract(x).comment, (row, value) => merge(row, extract(row).copy(comment = value)))
-      override val rowguid = new Field[TypoUUID, Row](prefix, "rowguid", None, Some("uuid"))(x => extract(x).rowguid, (row, value) => merge(row, extract(row).copy(rowguid = value)))
-      override val modifieddate = new Field[TypoLocalDateTime, Row](prefix, "modifieddate", Some("text"), Some("timestamp"))(x => extract(x).modifieddate, (row, value) => merge(row, extract(row).copy(modifieddate = value)))
+    override lazy val fields: SalesorderheaderFields = new SalesorderheaderFields {
+      override def salesorderid = IdField[SalesorderheaderId, SalesorderheaderRow](_path, "salesorderid", None, Some("int4"), x => x.salesorderid, (row, value) => row.copy(salesorderid = value))
+      override def revisionnumber = Field[TypoShort, SalesorderheaderRow](_path, "revisionnumber", None, Some("int2"), x => x.revisionnumber, (row, value) => row.copy(revisionnumber = value))
+      override def orderdate = Field[TypoLocalDateTime, SalesorderheaderRow](_path, "orderdate", Some("text"), Some("timestamp"), x => x.orderdate, (row, value) => row.copy(orderdate = value))
+      override def duedate = Field[TypoLocalDateTime, SalesorderheaderRow](_path, "duedate", Some("text"), Some("timestamp"), x => x.duedate, (row, value) => row.copy(duedate = value))
+      override def shipdate = OptField[TypoLocalDateTime, SalesorderheaderRow](_path, "shipdate", Some("text"), Some("timestamp"), x => x.shipdate, (row, value) => row.copy(shipdate = value))
+      override def status = Field[TypoShort, SalesorderheaderRow](_path, "status", None, Some("int2"), x => x.status, (row, value) => row.copy(status = value))
+      override def onlineorderflag = Field[Flag, SalesorderheaderRow](_path, "onlineorderflag", None, Some("bool"), x => x.onlineorderflag, (row, value) => row.copy(onlineorderflag = value))
+      override def purchaseordernumber = OptField[OrderNumber, SalesorderheaderRow](_path, "purchaseordernumber", None, Some("varchar"), x => x.purchaseordernumber, (row, value) => row.copy(purchaseordernumber = value))
+      override def accountnumber = OptField[AccountNumber, SalesorderheaderRow](_path, "accountnumber", None, Some("varchar"), x => x.accountnumber, (row, value) => row.copy(accountnumber = value))
+      override def customerid = Field[CustomerId, SalesorderheaderRow](_path, "customerid", None, Some("int4"), x => x.customerid, (row, value) => row.copy(customerid = value))
+      override def salespersonid = OptField[BusinessentityId, SalesorderheaderRow](_path, "salespersonid", None, Some("int4"), x => x.salespersonid, (row, value) => row.copy(salespersonid = value))
+      override def territoryid = OptField[SalesterritoryId, SalesorderheaderRow](_path, "territoryid", None, Some("int4"), x => x.territoryid, (row, value) => row.copy(territoryid = value))
+      override def billtoaddressid = Field[AddressId, SalesorderheaderRow](_path, "billtoaddressid", None, Some("int4"), x => x.billtoaddressid, (row, value) => row.copy(billtoaddressid = value))
+      override def shiptoaddressid = Field[AddressId, SalesorderheaderRow](_path, "shiptoaddressid", None, Some("int4"), x => x.shiptoaddressid, (row, value) => row.copy(shiptoaddressid = value))
+      override def shipmethodid = Field[ShipmethodId, SalesorderheaderRow](_path, "shipmethodid", None, Some("int4"), x => x.shipmethodid, (row, value) => row.copy(shipmethodid = value))
+      override def creditcardid = OptField[/* user-picked */ CustomCreditcardId, SalesorderheaderRow](_path, "creditcardid", None, Some("int4"), x => x.creditcardid, (row, value) => row.copy(creditcardid = value))
+      override def creditcardapprovalcode = OptField[/* max 15 chars */ String, SalesorderheaderRow](_path, "creditcardapprovalcode", None, None, x => x.creditcardapprovalcode, (row, value) => row.copy(creditcardapprovalcode = value))
+      override def currencyrateid = OptField[CurrencyrateId, SalesorderheaderRow](_path, "currencyrateid", None, Some("int4"), x => x.currencyrateid, (row, value) => row.copy(currencyrateid = value))
+      override def subtotal = Field[BigDecimal, SalesorderheaderRow](_path, "subtotal", None, Some("numeric"), x => x.subtotal, (row, value) => row.copy(subtotal = value))
+      override def taxamt = Field[BigDecimal, SalesorderheaderRow](_path, "taxamt", None, Some("numeric"), x => x.taxamt, (row, value) => row.copy(taxamt = value))
+      override def freight = Field[BigDecimal, SalesorderheaderRow](_path, "freight", None, Some("numeric"), x => x.freight, (row, value) => row.copy(freight = value))
+      override def totaldue = OptField[BigDecimal, SalesorderheaderRow](_path, "totaldue", None, Some("numeric"), x => x.totaldue, (row, value) => row.copy(totaldue = value))
+      override def comment = OptField[/* max 128 chars */ String, SalesorderheaderRow](_path, "comment", None, None, x => x.comment, (row, value) => row.copy(comment = value))
+      override def rowguid = Field[TypoUUID, SalesorderheaderRow](_path, "rowguid", None, Some("uuid"), x => x.rowguid, (row, value) => row.copy(rowguid = value))
+      override def modifieddate = Field[TypoLocalDateTime, SalesorderheaderRow](_path, "modifieddate", Some("text"), Some("timestamp"), x => x.modifieddate, (row, value) => row.copy(modifieddate = value))
     }
   
-    override val columns: List[FieldLikeNoHkt[?, Row]] =
-      List[FieldLikeNoHkt[?, Row]](fields.salesorderid, fields.revisionnumber, fields.orderdate, fields.duedate, fields.shipdate, fields.status, fields.onlineorderflag, fields.purchaseordernumber, fields.accountnumber, fields.customerid, fields.salespersonid, fields.territoryid, fields.billtoaddressid, fields.shiptoaddressid, fields.shipmethodid, fields.creditcardid, fields.creditcardapprovalcode, fields.currencyrateid, fields.subtotal, fields.taxamt, fields.freight, fields.totaldue, fields.comment, fields.rowguid, fields.modifieddate)
+    override lazy val columns: List[FieldLikeNoHkt[?, SalesorderheaderRow]] =
+      List[FieldLikeNoHkt[?, SalesorderheaderRow]](fields.salesorderid, fields.revisionnumber, fields.orderdate, fields.duedate, fields.shipdate, fields.status, fields.onlineorderflag, fields.purchaseordernumber, fields.accountnumber, fields.customerid, fields.salespersonid, fields.territoryid, fields.billtoaddressid, fields.shiptoaddressid, fields.shipmethodid, fields.creditcardid, fields.creditcardapprovalcode, fields.currencyrateid, fields.subtotal, fields.taxamt, fields.freight, fields.totaldue, fields.comment, fields.rowguid, fields.modifieddate)
   
-    override def copy[NewRow](prefix: Option[String], extract: NewRow => SalesorderheaderRow, merge: (NewRow, SalesorderheaderRow) => NewRow): Impl[NewRow] =
-      new Impl(prefix, extract, merge)
+    override def copy(path: List[Path]): Impl =
+      new Impl(path)
   }
   
 }

--- a/typo-tester-doobie/generated-and-checked-in/adventureworks/sales/salesorderheader/SalesorderheaderRepoMock.scala
+++ b/typo-tester-doobie/generated-and-checked-in/adventureworks/sales/salesorderheader/SalesorderheaderRepoMock.scala
@@ -24,7 +24,7 @@ import typo.dsl.UpdateParams
 class SalesorderheaderRepoMock(toRow: Function1[SalesorderheaderRowUnsaved, SalesorderheaderRow],
                                map: scala.collection.mutable.Map[SalesorderheaderId, SalesorderheaderRow] = scala.collection.mutable.Map.empty) extends SalesorderheaderRepo {
   override def delete: DeleteBuilder[SalesorderheaderFields, SalesorderheaderRow] = {
-    DeleteBuilderMock(DeleteParams.empty, SalesorderheaderFields.structure.fields, map)
+    DeleteBuilderMock(DeleteParams.empty, SalesorderheaderFields.structure, map)
   }
   override def deleteById(salesorderid: SalesorderheaderId): ConnectionIO[Boolean] = {
     delay(map.remove(salesorderid).isDefined)
@@ -86,7 +86,7 @@ class SalesorderheaderRepoMock(toRow: Function1[SalesorderheaderRowUnsaved, Sale
     }
   }
   override def update: UpdateBuilder[SalesorderheaderFields, SalesorderheaderRow] = {
-    UpdateBuilderMock(UpdateParams.empty, SalesorderheaderFields.structure.fields, map)
+    UpdateBuilderMock(UpdateParams.empty, SalesorderheaderFields.structure, map)
   }
   override def update(row: SalesorderheaderRow): ConnectionIO[Boolean] = {
     delay {

--- a/typo-tester-doobie/generated-and-checked-in/adventureworks/sales/salesorderheadersalesreason/SalesorderheadersalesreasonFields.scala
+++ b/typo-tester-doobie/generated-and-checked-in/adventureworks/sales/salesorderheadersalesreason/SalesorderheadersalesreasonFields.scala
@@ -10,35 +10,36 @@ package salesorderheadersalesreason
 import adventureworks.customtypes.TypoLocalDateTime
 import adventureworks.sales.salesorderheader.SalesorderheaderId
 import adventureworks.sales.salesreason.SalesreasonId
+import typo.dsl.Path
 import typo.dsl.SqlExpr.Field
 import typo.dsl.SqlExpr.FieldLikeNoHkt
 import typo.dsl.SqlExpr.IdField
 import typo.dsl.Structure.Relation
 
-trait SalesorderheadersalesreasonFields[Row] {
-  val salesorderid: IdField[SalesorderheaderId, Row]
-  val salesreasonid: IdField[SalesreasonId, Row]
-  val modifieddate: Field[TypoLocalDateTime, Row]
+trait SalesorderheadersalesreasonFields {
+  def salesorderid: IdField[SalesorderheaderId, SalesorderheadersalesreasonRow]
+  def salesreasonid: IdField[SalesreasonId, SalesorderheadersalesreasonRow]
+  def modifieddate: Field[TypoLocalDateTime, SalesorderheadersalesreasonRow]
 }
 
 object SalesorderheadersalesreasonFields {
-  val structure: Relation[SalesorderheadersalesreasonFields, SalesorderheadersalesreasonRow, SalesorderheadersalesreasonRow] = 
-    new Impl(None, identity, (_, x) => x)
+  lazy val structure: Relation[SalesorderheadersalesreasonFields, SalesorderheadersalesreasonRow] =
+    new Impl(Nil)
     
-  private final class Impl[Row](val prefix: Option[String], val extract: Row => SalesorderheadersalesreasonRow, val merge: (Row, SalesorderheadersalesreasonRow) => Row)
-    extends Relation[SalesorderheadersalesreasonFields, SalesorderheadersalesreasonRow, Row] { 
+  private final class Impl(val _path: List[Path])
+    extends Relation[SalesorderheadersalesreasonFields, SalesorderheadersalesreasonRow] {
   
-    override val fields: SalesorderheadersalesreasonFields[Row] = new SalesorderheadersalesreasonFields[Row] {
-      override val salesorderid = new IdField[SalesorderheaderId, Row](prefix, "salesorderid", None, Some("int4"))(x => extract(x).salesorderid, (row, value) => merge(row, extract(row).copy(salesorderid = value)))
-      override val salesreasonid = new IdField[SalesreasonId, Row](prefix, "salesreasonid", None, Some("int4"))(x => extract(x).salesreasonid, (row, value) => merge(row, extract(row).copy(salesreasonid = value)))
-      override val modifieddate = new Field[TypoLocalDateTime, Row](prefix, "modifieddate", Some("text"), Some("timestamp"))(x => extract(x).modifieddate, (row, value) => merge(row, extract(row).copy(modifieddate = value)))
+    override lazy val fields: SalesorderheadersalesreasonFields = new SalesorderheadersalesreasonFields {
+      override def salesorderid = IdField[SalesorderheaderId, SalesorderheadersalesreasonRow](_path, "salesorderid", None, Some("int4"), x => x.salesorderid, (row, value) => row.copy(salesorderid = value))
+      override def salesreasonid = IdField[SalesreasonId, SalesorderheadersalesreasonRow](_path, "salesreasonid", None, Some("int4"), x => x.salesreasonid, (row, value) => row.copy(salesreasonid = value))
+      override def modifieddate = Field[TypoLocalDateTime, SalesorderheadersalesreasonRow](_path, "modifieddate", Some("text"), Some("timestamp"), x => x.modifieddate, (row, value) => row.copy(modifieddate = value))
     }
   
-    override val columns: List[FieldLikeNoHkt[?, Row]] =
-      List[FieldLikeNoHkt[?, Row]](fields.salesorderid, fields.salesreasonid, fields.modifieddate)
+    override lazy val columns: List[FieldLikeNoHkt[?, SalesorderheadersalesreasonRow]] =
+      List[FieldLikeNoHkt[?, SalesorderheadersalesreasonRow]](fields.salesorderid, fields.salesreasonid, fields.modifieddate)
   
-    override def copy[NewRow](prefix: Option[String], extract: NewRow => SalesorderheadersalesreasonRow, merge: (NewRow, SalesorderheadersalesreasonRow) => NewRow): Impl[NewRow] =
-      new Impl(prefix, extract, merge)
+    override def copy(path: List[Path]): Impl =
+      new Impl(path)
   }
   
 }

--- a/typo-tester-doobie/generated-and-checked-in/adventureworks/sales/salesorderheadersalesreason/SalesorderheadersalesreasonRepoMock.scala
+++ b/typo-tester-doobie/generated-and-checked-in/adventureworks/sales/salesorderheadersalesreason/SalesorderheadersalesreasonRepoMock.scala
@@ -24,7 +24,7 @@ import typo.dsl.UpdateParams
 class SalesorderheadersalesreasonRepoMock(toRow: Function1[SalesorderheadersalesreasonRowUnsaved, SalesorderheadersalesreasonRow],
                                           map: scala.collection.mutable.Map[SalesorderheadersalesreasonId, SalesorderheadersalesreasonRow] = scala.collection.mutable.Map.empty) extends SalesorderheadersalesreasonRepo {
   override def delete: DeleteBuilder[SalesorderheadersalesreasonFields, SalesorderheadersalesreasonRow] = {
-    DeleteBuilderMock(DeleteParams.empty, SalesorderheadersalesreasonFields.structure.fields, map)
+    DeleteBuilderMock(DeleteParams.empty, SalesorderheadersalesreasonFields.structure, map)
   }
   override def deleteById(compositeId: SalesorderheadersalesreasonId): ConnectionIO[Boolean] = {
     delay(map.remove(compositeId).isDefined)
@@ -86,7 +86,7 @@ class SalesorderheadersalesreasonRepoMock(toRow: Function1[Salesorderheadersales
     }
   }
   override def update: UpdateBuilder[SalesorderheadersalesreasonFields, SalesorderheadersalesreasonRow] = {
-    UpdateBuilderMock(UpdateParams.empty, SalesorderheadersalesreasonFields.structure.fields, map)
+    UpdateBuilderMock(UpdateParams.empty, SalesorderheadersalesreasonFields.structure, map)
   }
   override def update(row: SalesorderheadersalesreasonRow): ConnectionIO[Boolean] = {
     delay {

--- a/typo-tester-doobie/generated-and-checked-in/adventureworks/sales/salesperson/SalespersonFields.scala
+++ b/typo-tester-doobie/generated-and-checked-in/adventureworks/sales/salesperson/SalespersonFields.scala
@@ -11,48 +11,49 @@ import adventureworks.customtypes.TypoLocalDateTime
 import adventureworks.customtypes.TypoUUID
 import adventureworks.person.businessentity.BusinessentityId
 import adventureworks.sales.salesterritory.SalesterritoryId
+import typo.dsl.Path
 import typo.dsl.SqlExpr.Field
 import typo.dsl.SqlExpr.FieldLikeNoHkt
 import typo.dsl.SqlExpr.IdField
 import typo.dsl.SqlExpr.OptField
 import typo.dsl.Structure.Relation
 
-trait SalespersonFields[Row] {
-  val businessentityid: IdField[BusinessentityId, Row]
-  val territoryid: OptField[SalesterritoryId, Row]
-  val salesquota: OptField[BigDecimal, Row]
-  val bonus: Field[BigDecimal, Row]
-  val commissionpct: Field[BigDecimal, Row]
-  val salesytd: Field[BigDecimal, Row]
-  val saleslastyear: Field[BigDecimal, Row]
-  val rowguid: Field[TypoUUID, Row]
-  val modifieddate: Field[TypoLocalDateTime, Row]
+trait SalespersonFields {
+  def businessentityid: IdField[BusinessentityId, SalespersonRow]
+  def territoryid: OptField[SalesterritoryId, SalespersonRow]
+  def salesquota: OptField[BigDecimal, SalespersonRow]
+  def bonus: Field[BigDecimal, SalespersonRow]
+  def commissionpct: Field[BigDecimal, SalespersonRow]
+  def salesytd: Field[BigDecimal, SalespersonRow]
+  def saleslastyear: Field[BigDecimal, SalespersonRow]
+  def rowguid: Field[TypoUUID, SalespersonRow]
+  def modifieddate: Field[TypoLocalDateTime, SalespersonRow]
 }
 
 object SalespersonFields {
-  val structure: Relation[SalespersonFields, SalespersonRow, SalespersonRow] = 
-    new Impl(None, identity, (_, x) => x)
+  lazy val structure: Relation[SalespersonFields, SalespersonRow] =
+    new Impl(Nil)
     
-  private final class Impl[Row](val prefix: Option[String], val extract: Row => SalespersonRow, val merge: (Row, SalespersonRow) => Row)
-    extends Relation[SalespersonFields, SalespersonRow, Row] { 
+  private final class Impl(val _path: List[Path])
+    extends Relation[SalespersonFields, SalespersonRow] {
   
-    override val fields: SalespersonFields[Row] = new SalespersonFields[Row] {
-      override val businessentityid = new IdField[BusinessentityId, Row](prefix, "businessentityid", None, Some("int4"))(x => extract(x).businessentityid, (row, value) => merge(row, extract(row).copy(businessentityid = value)))
-      override val territoryid = new OptField[SalesterritoryId, Row](prefix, "territoryid", None, Some("int4"))(x => extract(x).territoryid, (row, value) => merge(row, extract(row).copy(territoryid = value)))
-      override val salesquota = new OptField[BigDecimal, Row](prefix, "salesquota", None, Some("numeric"))(x => extract(x).salesquota, (row, value) => merge(row, extract(row).copy(salesquota = value)))
-      override val bonus = new Field[BigDecimal, Row](prefix, "bonus", None, Some("numeric"))(x => extract(x).bonus, (row, value) => merge(row, extract(row).copy(bonus = value)))
-      override val commissionpct = new Field[BigDecimal, Row](prefix, "commissionpct", None, Some("numeric"))(x => extract(x).commissionpct, (row, value) => merge(row, extract(row).copy(commissionpct = value)))
-      override val salesytd = new Field[BigDecimal, Row](prefix, "salesytd", None, Some("numeric"))(x => extract(x).salesytd, (row, value) => merge(row, extract(row).copy(salesytd = value)))
-      override val saleslastyear = new Field[BigDecimal, Row](prefix, "saleslastyear", None, Some("numeric"))(x => extract(x).saleslastyear, (row, value) => merge(row, extract(row).copy(saleslastyear = value)))
-      override val rowguid = new Field[TypoUUID, Row](prefix, "rowguid", None, Some("uuid"))(x => extract(x).rowguid, (row, value) => merge(row, extract(row).copy(rowguid = value)))
-      override val modifieddate = new Field[TypoLocalDateTime, Row](prefix, "modifieddate", Some("text"), Some("timestamp"))(x => extract(x).modifieddate, (row, value) => merge(row, extract(row).copy(modifieddate = value)))
+    override lazy val fields: SalespersonFields = new SalespersonFields {
+      override def businessentityid = IdField[BusinessentityId, SalespersonRow](_path, "businessentityid", None, Some("int4"), x => x.businessentityid, (row, value) => row.copy(businessentityid = value))
+      override def territoryid = OptField[SalesterritoryId, SalespersonRow](_path, "territoryid", None, Some("int4"), x => x.territoryid, (row, value) => row.copy(territoryid = value))
+      override def salesquota = OptField[BigDecimal, SalespersonRow](_path, "salesquota", None, Some("numeric"), x => x.salesquota, (row, value) => row.copy(salesquota = value))
+      override def bonus = Field[BigDecimal, SalespersonRow](_path, "bonus", None, Some("numeric"), x => x.bonus, (row, value) => row.copy(bonus = value))
+      override def commissionpct = Field[BigDecimal, SalespersonRow](_path, "commissionpct", None, Some("numeric"), x => x.commissionpct, (row, value) => row.copy(commissionpct = value))
+      override def salesytd = Field[BigDecimal, SalespersonRow](_path, "salesytd", None, Some("numeric"), x => x.salesytd, (row, value) => row.copy(salesytd = value))
+      override def saleslastyear = Field[BigDecimal, SalespersonRow](_path, "saleslastyear", None, Some("numeric"), x => x.saleslastyear, (row, value) => row.copy(saleslastyear = value))
+      override def rowguid = Field[TypoUUID, SalespersonRow](_path, "rowguid", None, Some("uuid"), x => x.rowguid, (row, value) => row.copy(rowguid = value))
+      override def modifieddate = Field[TypoLocalDateTime, SalespersonRow](_path, "modifieddate", Some("text"), Some("timestamp"), x => x.modifieddate, (row, value) => row.copy(modifieddate = value))
     }
   
-    override val columns: List[FieldLikeNoHkt[?, Row]] =
-      List[FieldLikeNoHkt[?, Row]](fields.businessentityid, fields.territoryid, fields.salesquota, fields.bonus, fields.commissionpct, fields.salesytd, fields.saleslastyear, fields.rowguid, fields.modifieddate)
+    override lazy val columns: List[FieldLikeNoHkt[?, SalespersonRow]] =
+      List[FieldLikeNoHkt[?, SalespersonRow]](fields.businessentityid, fields.territoryid, fields.salesquota, fields.bonus, fields.commissionpct, fields.salesytd, fields.saleslastyear, fields.rowguid, fields.modifieddate)
   
-    override def copy[NewRow](prefix: Option[String], extract: NewRow => SalespersonRow, merge: (NewRow, SalespersonRow) => NewRow): Impl[NewRow] =
-      new Impl(prefix, extract, merge)
+    override def copy(path: List[Path]): Impl =
+      new Impl(path)
   }
   
 }

--- a/typo-tester-doobie/generated-and-checked-in/adventureworks/sales/salesperson/SalespersonRepoMock.scala
+++ b/typo-tester-doobie/generated-and-checked-in/adventureworks/sales/salesperson/SalespersonRepoMock.scala
@@ -25,7 +25,7 @@ import typo.dsl.UpdateParams
 class SalespersonRepoMock(toRow: Function1[SalespersonRowUnsaved, SalespersonRow],
                           map: scala.collection.mutable.Map[BusinessentityId, SalespersonRow] = scala.collection.mutable.Map.empty) extends SalespersonRepo {
   override def delete: DeleteBuilder[SalespersonFields, SalespersonRow] = {
-    DeleteBuilderMock(DeleteParams.empty, SalespersonFields.structure.fields, map)
+    DeleteBuilderMock(DeleteParams.empty, SalespersonFields.structure, map)
   }
   override def deleteById(businessentityid: BusinessentityId): ConnectionIO[Boolean] = {
     delay(map.remove(businessentityid).isDefined)
@@ -87,7 +87,7 @@ class SalespersonRepoMock(toRow: Function1[SalespersonRowUnsaved, SalespersonRow
     }
   }
   override def update: UpdateBuilder[SalespersonFields, SalespersonRow] = {
-    UpdateBuilderMock(UpdateParams.empty, SalespersonFields.structure.fields, map)
+    UpdateBuilderMock(UpdateParams.empty, SalespersonFields.structure, map)
   }
   override def update(row: SalespersonRow): ConnectionIO[Boolean] = {
     delay {

--- a/typo-tester-doobie/generated-and-checked-in/adventureworks/sales/salespersonquotahistory/SalespersonquotahistoryFields.scala
+++ b/typo-tester-doobie/generated-and-checked-in/adventureworks/sales/salespersonquotahistory/SalespersonquotahistoryFields.scala
@@ -10,39 +10,40 @@ package salespersonquotahistory
 import adventureworks.customtypes.TypoLocalDateTime
 import adventureworks.customtypes.TypoUUID
 import adventureworks.person.businessentity.BusinessentityId
+import typo.dsl.Path
 import typo.dsl.SqlExpr.Field
 import typo.dsl.SqlExpr.FieldLikeNoHkt
 import typo.dsl.SqlExpr.IdField
 import typo.dsl.Structure.Relation
 
-trait SalespersonquotahistoryFields[Row] {
-  val businessentityid: IdField[BusinessentityId, Row]
-  val quotadate: IdField[TypoLocalDateTime, Row]
-  val salesquota: Field[BigDecimal, Row]
-  val rowguid: Field[TypoUUID, Row]
-  val modifieddate: Field[TypoLocalDateTime, Row]
+trait SalespersonquotahistoryFields {
+  def businessentityid: IdField[BusinessentityId, SalespersonquotahistoryRow]
+  def quotadate: IdField[TypoLocalDateTime, SalespersonquotahistoryRow]
+  def salesquota: Field[BigDecimal, SalespersonquotahistoryRow]
+  def rowguid: Field[TypoUUID, SalespersonquotahistoryRow]
+  def modifieddate: Field[TypoLocalDateTime, SalespersonquotahistoryRow]
 }
 
 object SalespersonquotahistoryFields {
-  val structure: Relation[SalespersonquotahistoryFields, SalespersonquotahistoryRow, SalespersonquotahistoryRow] = 
-    new Impl(None, identity, (_, x) => x)
+  lazy val structure: Relation[SalespersonquotahistoryFields, SalespersonquotahistoryRow] =
+    new Impl(Nil)
     
-  private final class Impl[Row](val prefix: Option[String], val extract: Row => SalespersonquotahistoryRow, val merge: (Row, SalespersonquotahistoryRow) => Row)
-    extends Relation[SalespersonquotahistoryFields, SalespersonquotahistoryRow, Row] { 
+  private final class Impl(val _path: List[Path])
+    extends Relation[SalespersonquotahistoryFields, SalespersonquotahistoryRow] {
   
-    override val fields: SalespersonquotahistoryFields[Row] = new SalespersonquotahistoryFields[Row] {
-      override val businessentityid = new IdField[BusinessentityId, Row](prefix, "businessentityid", None, Some("int4"))(x => extract(x).businessentityid, (row, value) => merge(row, extract(row).copy(businessentityid = value)))
-      override val quotadate = new IdField[TypoLocalDateTime, Row](prefix, "quotadate", Some("text"), Some("timestamp"))(x => extract(x).quotadate, (row, value) => merge(row, extract(row).copy(quotadate = value)))
-      override val salesquota = new Field[BigDecimal, Row](prefix, "salesquota", None, Some("numeric"))(x => extract(x).salesquota, (row, value) => merge(row, extract(row).copy(salesquota = value)))
-      override val rowguid = new Field[TypoUUID, Row](prefix, "rowguid", None, Some("uuid"))(x => extract(x).rowguid, (row, value) => merge(row, extract(row).copy(rowguid = value)))
-      override val modifieddate = new Field[TypoLocalDateTime, Row](prefix, "modifieddate", Some("text"), Some("timestamp"))(x => extract(x).modifieddate, (row, value) => merge(row, extract(row).copy(modifieddate = value)))
+    override lazy val fields: SalespersonquotahistoryFields = new SalespersonquotahistoryFields {
+      override def businessentityid = IdField[BusinessentityId, SalespersonquotahistoryRow](_path, "businessentityid", None, Some("int4"), x => x.businessentityid, (row, value) => row.copy(businessentityid = value))
+      override def quotadate = IdField[TypoLocalDateTime, SalespersonquotahistoryRow](_path, "quotadate", Some("text"), Some("timestamp"), x => x.quotadate, (row, value) => row.copy(quotadate = value))
+      override def salesquota = Field[BigDecimal, SalespersonquotahistoryRow](_path, "salesquota", None, Some("numeric"), x => x.salesquota, (row, value) => row.copy(salesquota = value))
+      override def rowguid = Field[TypoUUID, SalespersonquotahistoryRow](_path, "rowguid", None, Some("uuid"), x => x.rowguid, (row, value) => row.copy(rowguid = value))
+      override def modifieddate = Field[TypoLocalDateTime, SalespersonquotahistoryRow](_path, "modifieddate", Some("text"), Some("timestamp"), x => x.modifieddate, (row, value) => row.copy(modifieddate = value))
     }
   
-    override val columns: List[FieldLikeNoHkt[?, Row]] =
-      List[FieldLikeNoHkt[?, Row]](fields.businessentityid, fields.quotadate, fields.salesquota, fields.rowguid, fields.modifieddate)
+    override lazy val columns: List[FieldLikeNoHkt[?, SalespersonquotahistoryRow]] =
+      List[FieldLikeNoHkt[?, SalespersonquotahistoryRow]](fields.businessentityid, fields.quotadate, fields.salesquota, fields.rowguid, fields.modifieddate)
   
-    override def copy[NewRow](prefix: Option[String], extract: NewRow => SalespersonquotahistoryRow, merge: (NewRow, SalespersonquotahistoryRow) => NewRow): Impl[NewRow] =
-      new Impl(prefix, extract, merge)
+    override def copy(path: List[Path]): Impl =
+      new Impl(path)
   }
   
 }

--- a/typo-tester-doobie/generated-and-checked-in/adventureworks/sales/salespersonquotahistory/SalespersonquotahistoryRepoMock.scala
+++ b/typo-tester-doobie/generated-and-checked-in/adventureworks/sales/salespersonquotahistory/SalespersonquotahistoryRepoMock.scala
@@ -24,7 +24,7 @@ import typo.dsl.UpdateParams
 class SalespersonquotahistoryRepoMock(toRow: Function1[SalespersonquotahistoryRowUnsaved, SalespersonquotahistoryRow],
                                       map: scala.collection.mutable.Map[SalespersonquotahistoryId, SalespersonquotahistoryRow] = scala.collection.mutable.Map.empty) extends SalespersonquotahistoryRepo {
   override def delete: DeleteBuilder[SalespersonquotahistoryFields, SalespersonquotahistoryRow] = {
-    DeleteBuilderMock(DeleteParams.empty, SalespersonquotahistoryFields.structure.fields, map)
+    DeleteBuilderMock(DeleteParams.empty, SalespersonquotahistoryFields.structure, map)
   }
   override def deleteById(compositeId: SalespersonquotahistoryId): ConnectionIO[Boolean] = {
     delay(map.remove(compositeId).isDefined)
@@ -86,7 +86,7 @@ class SalespersonquotahistoryRepoMock(toRow: Function1[SalespersonquotahistoryRo
     }
   }
   override def update: UpdateBuilder[SalespersonquotahistoryFields, SalespersonquotahistoryRow] = {
-    UpdateBuilderMock(UpdateParams.empty, SalespersonquotahistoryFields.structure.fields, map)
+    UpdateBuilderMock(UpdateParams.empty, SalespersonquotahistoryFields.structure, map)
   }
   override def update(row: SalespersonquotahistoryRow): ConnectionIO[Boolean] = {
     delay {

--- a/typo-tester-doobie/generated-and-checked-in/adventureworks/sales/salesreason/SalesreasonFields.scala
+++ b/typo-tester-doobie/generated-and-checked-in/adventureworks/sales/salesreason/SalesreasonFields.scala
@@ -9,37 +9,38 @@ package salesreason
 
 import adventureworks.customtypes.TypoLocalDateTime
 import adventureworks.public.Name
+import typo.dsl.Path
 import typo.dsl.SqlExpr.Field
 import typo.dsl.SqlExpr.FieldLikeNoHkt
 import typo.dsl.SqlExpr.IdField
 import typo.dsl.Structure.Relation
 
-trait SalesreasonFields[Row] {
-  val salesreasonid: IdField[SalesreasonId, Row]
-  val name: Field[Name, Row]
-  val reasontype: Field[Name, Row]
-  val modifieddate: Field[TypoLocalDateTime, Row]
+trait SalesreasonFields {
+  def salesreasonid: IdField[SalesreasonId, SalesreasonRow]
+  def name: Field[Name, SalesreasonRow]
+  def reasontype: Field[Name, SalesreasonRow]
+  def modifieddate: Field[TypoLocalDateTime, SalesreasonRow]
 }
 
 object SalesreasonFields {
-  val structure: Relation[SalesreasonFields, SalesreasonRow, SalesreasonRow] = 
-    new Impl(None, identity, (_, x) => x)
+  lazy val structure: Relation[SalesreasonFields, SalesreasonRow] =
+    new Impl(Nil)
     
-  private final class Impl[Row](val prefix: Option[String], val extract: Row => SalesreasonRow, val merge: (Row, SalesreasonRow) => Row)
-    extends Relation[SalesreasonFields, SalesreasonRow, Row] { 
+  private final class Impl(val _path: List[Path])
+    extends Relation[SalesreasonFields, SalesreasonRow] {
   
-    override val fields: SalesreasonFields[Row] = new SalesreasonFields[Row] {
-      override val salesreasonid = new IdField[SalesreasonId, Row](prefix, "salesreasonid", None, Some("int4"))(x => extract(x).salesreasonid, (row, value) => merge(row, extract(row).copy(salesreasonid = value)))
-      override val name = new Field[Name, Row](prefix, "name", None, Some("varchar"))(x => extract(x).name, (row, value) => merge(row, extract(row).copy(name = value)))
-      override val reasontype = new Field[Name, Row](prefix, "reasontype", None, Some("varchar"))(x => extract(x).reasontype, (row, value) => merge(row, extract(row).copy(reasontype = value)))
-      override val modifieddate = new Field[TypoLocalDateTime, Row](prefix, "modifieddate", Some("text"), Some("timestamp"))(x => extract(x).modifieddate, (row, value) => merge(row, extract(row).copy(modifieddate = value)))
+    override lazy val fields: SalesreasonFields = new SalesreasonFields {
+      override def salesreasonid = IdField[SalesreasonId, SalesreasonRow](_path, "salesreasonid", None, Some("int4"), x => x.salesreasonid, (row, value) => row.copy(salesreasonid = value))
+      override def name = Field[Name, SalesreasonRow](_path, "name", None, Some("varchar"), x => x.name, (row, value) => row.copy(name = value))
+      override def reasontype = Field[Name, SalesreasonRow](_path, "reasontype", None, Some("varchar"), x => x.reasontype, (row, value) => row.copy(reasontype = value))
+      override def modifieddate = Field[TypoLocalDateTime, SalesreasonRow](_path, "modifieddate", Some("text"), Some("timestamp"), x => x.modifieddate, (row, value) => row.copy(modifieddate = value))
     }
   
-    override val columns: List[FieldLikeNoHkt[?, Row]] =
-      List[FieldLikeNoHkt[?, Row]](fields.salesreasonid, fields.name, fields.reasontype, fields.modifieddate)
+    override lazy val columns: List[FieldLikeNoHkt[?, SalesreasonRow]] =
+      List[FieldLikeNoHkt[?, SalesreasonRow]](fields.salesreasonid, fields.name, fields.reasontype, fields.modifieddate)
   
-    override def copy[NewRow](prefix: Option[String], extract: NewRow => SalesreasonRow, merge: (NewRow, SalesreasonRow) => NewRow): Impl[NewRow] =
-      new Impl(prefix, extract, merge)
+    override def copy(path: List[Path]): Impl =
+      new Impl(path)
   }
   
 }

--- a/typo-tester-doobie/generated-and-checked-in/adventureworks/sales/salesreason/SalesreasonRepoMock.scala
+++ b/typo-tester-doobie/generated-and-checked-in/adventureworks/sales/salesreason/SalesreasonRepoMock.scala
@@ -24,7 +24,7 @@ import typo.dsl.UpdateParams
 class SalesreasonRepoMock(toRow: Function1[SalesreasonRowUnsaved, SalesreasonRow],
                           map: scala.collection.mutable.Map[SalesreasonId, SalesreasonRow] = scala.collection.mutable.Map.empty) extends SalesreasonRepo {
   override def delete: DeleteBuilder[SalesreasonFields, SalesreasonRow] = {
-    DeleteBuilderMock(DeleteParams.empty, SalesreasonFields.structure.fields, map)
+    DeleteBuilderMock(DeleteParams.empty, SalesreasonFields.structure, map)
   }
   override def deleteById(salesreasonid: SalesreasonId): ConnectionIO[Boolean] = {
     delay(map.remove(salesreasonid).isDefined)
@@ -86,7 +86,7 @@ class SalesreasonRepoMock(toRow: Function1[SalesreasonRowUnsaved, SalesreasonRow
     }
   }
   override def update: UpdateBuilder[SalesreasonFields, SalesreasonRow] = {
-    UpdateBuilderMock(UpdateParams.empty, SalesreasonFields.structure.fields, map)
+    UpdateBuilderMock(UpdateParams.empty, SalesreasonFields.structure, map)
   }
   override def update(row: SalesreasonRow): ConnectionIO[Boolean] = {
     delay {

--- a/typo-tester-doobie/generated-and-checked-in/adventureworks/sales/salestaxrate/SalestaxrateFields.scala
+++ b/typo-tester-doobie/generated-and-checked-in/adventureworks/sales/salestaxrate/SalestaxrateFields.scala
@@ -12,43 +12,44 @@ import adventureworks.customtypes.TypoShort
 import adventureworks.customtypes.TypoUUID
 import adventureworks.person.stateprovince.StateprovinceId
 import adventureworks.public.Name
+import typo.dsl.Path
 import typo.dsl.SqlExpr.Field
 import typo.dsl.SqlExpr.FieldLikeNoHkt
 import typo.dsl.SqlExpr.IdField
 import typo.dsl.Structure.Relation
 
-trait SalestaxrateFields[Row] {
-  val salestaxrateid: IdField[SalestaxrateId, Row]
-  val stateprovinceid: Field[StateprovinceId, Row]
-  val taxtype: Field[TypoShort, Row]
-  val taxrate: Field[BigDecimal, Row]
-  val name: Field[Name, Row]
-  val rowguid: Field[TypoUUID, Row]
-  val modifieddate: Field[TypoLocalDateTime, Row]
+trait SalestaxrateFields {
+  def salestaxrateid: IdField[SalestaxrateId, SalestaxrateRow]
+  def stateprovinceid: Field[StateprovinceId, SalestaxrateRow]
+  def taxtype: Field[TypoShort, SalestaxrateRow]
+  def taxrate: Field[BigDecimal, SalestaxrateRow]
+  def name: Field[Name, SalestaxrateRow]
+  def rowguid: Field[TypoUUID, SalestaxrateRow]
+  def modifieddate: Field[TypoLocalDateTime, SalestaxrateRow]
 }
 
 object SalestaxrateFields {
-  val structure: Relation[SalestaxrateFields, SalestaxrateRow, SalestaxrateRow] = 
-    new Impl(None, identity, (_, x) => x)
+  lazy val structure: Relation[SalestaxrateFields, SalestaxrateRow] =
+    new Impl(Nil)
     
-  private final class Impl[Row](val prefix: Option[String], val extract: Row => SalestaxrateRow, val merge: (Row, SalestaxrateRow) => Row)
-    extends Relation[SalestaxrateFields, SalestaxrateRow, Row] { 
+  private final class Impl(val _path: List[Path])
+    extends Relation[SalestaxrateFields, SalestaxrateRow] {
   
-    override val fields: SalestaxrateFields[Row] = new SalestaxrateFields[Row] {
-      override val salestaxrateid = new IdField[SalestaxrateId, Row](prefix, "salestaxrateid", None, Some("int4"))(x => extract(x).salestaxrateid, (row, value) => merge(row, extract(row).copy(salestaxrateid = value)))
-      override val stateprovinceid = new Field[StateprovinceId, Row](prefix, "stateprovinceid", None, Some("int4"))(x => extract(x).stateprovinceid, (row, value) => merge(row, extract(row).copy(stateprovinceid = value)))
-      override val taxtype = new Field[TypoShort, Row](prefix, "taxtype", None, Some("int2"))(x => extract(x).taxtype, (row, value) => merge(row, extract(row).copy(taxtype = value)))
-      override val taxrate = new Field[BigDecimal, Row](prefix, "taxrate", None, Some("numeric"))(x => extract(x).taxrate, (row, value) => merge(row, extract(row).copy(taxrate = value)))
-      override val name = new Field[Name, Row](prefix, "name", None, Some("varchar"))(x => extract(x).name, (row, value) => merge(row, extract(row).copy(name = value)))
-      override val rowguid = new Field[TypoUUID, Row](prefix, "rowguid", None, Some("uuid"))(x => extract(x).rowguid, (row, value) => merge(row, extract(row).copy(rowguid = value)))
-      override val modifieddate = new Field[TypoLocalDateTime, Row](prefix, "modifieddate", Some("text"), Some("timestamp"))(x => extract(x).modifieddate, (row, value) => merge(row, extract(row).copy(modifieddate = value)))
+    override lazy val fields: SalestaxrateFields = new SalestaxrateFields {
+      override def salestaxrateid = IdField[SalestaxrateId, SalestaxrateRow](_path, "salestaxrateid", None, Some("int4"), x => x.salestaxrateid, (row, value) => row.copy(salestaxrateid = value))
+      override def stateprovinceid = Field[StateprovinceId, SalestaxrateRow](_path, "stateprovinceid", None, Some("int4"), x => x.stateprovinceid, (row, value) => row.copy(stateprovinceid = value))
+      override def taxtype = Field[TypoShort, SalestaxrateRow](_path, "taxtype", None, Some("int2"), x => x.taxtype, (row, value) => row.copy(taxtype = value))
+      override def taxrate = Field[BigDecimal, SalestaxrateRow](_path, "taxrate", None, Some("numeric"), x => x.taxrate, (row, value) => row.copy(taxrate = value))
+      override def name = Field[Name, SalestaxrateRow](_path, "name", None, Some("varchar"), x => x.name, (row, value) => row.copy(name = value))
+      override def rowguid = Field[TypoUUID, SalestaxrateRow](_path, "rowguid", None, Some("uuid"), x => x.rowguid, (row, value) => row.copy(rowguid = value))
+      override def modifieddate = Field[TypoLocalDateTime, SalestaxrateRow](_path, "modifieddate", Some("text"), Some("timestamp"), x => x.modifieddate, (row, value) => row.copy(modifieddate = value))
     }
   
-    override val columns: List[FieldLikeNoHkt[?, Row]] =
-      List[FieldLikeNoHkt[?, Row]](fields.salestaxrateid, fields.stateprovinceid, fields.taxtype, fields.taxrate, fields.name, fields.rowguid, fields.modifieddate)
+    override lazy val columns: List[FieldLikeNoHkt[?, SalestaxrateRow]] =
+      List[FieldLikeNoHkt[?, SalestaxrateRow]](fields.salestaxrateid, fields.stateprovinceid, fields.taxtype, fields.taxrate, fields.name, fields.rowguid, fields.modifieddate)
   
-    override def copy[NewRow](prefix: Option[String], extract: NewRow => SalestaxrateRow, merge: (NewRow, SalestaxrateRow) => NewRow): Impl[NewRow] =
-      new Impl(prefix, extract, merge)
+    override def copy(path: List[Path]): Impl =
+      new Impl(path)
   }
   
 }

--- a/typo-tester-doobie/generated-and-checked-in/adventureworks/sales/salestaxrate/SalestaxrateRepoMock.scala
+++ b/typo-tester-doobie/generated-and-checked-in/adventureworks/sales/salestaxrate/SalestaxrateRepoMock.scala
@@ -24,7 +24,7 @@ import typo.dsl.UpdateParams
 class SalestaxrateRepoMock(toRow: Function1[SalestaxrateRowUnsaved, SalestaxrateRow],
                            map: scala.collection.mutable.Map[SalestaxrateId, SalestaxrateRow] = scala.collection.mutable.Map.empty) extends SalestaxrateRepo {
   override def delete: DeleteBuilder[SalestaxrateFields, SalestaxrateRow] = {
-    DeleteBuilderMock(DeleteParams.empty, SalestaxrateFields.structure.fields, map)
+    DeleteBuilderMock(DeleteParams.empty, SalestaxrateFields.structure, map)
   }
   override def deleteById(salestaxrateid: SalestaxrateId): ConnectionIO[Boolean] = {
     delay(map.remove(salestaxrateid).isDefined)
@@ -86,7 +86,7 @@ class SalestaxrateRepoMock(toRow: Function1[SalestaxrateRowUnsaved, Salestaxrate
     }
   }
   override def update: UpdateBuilder[SalestaxrateFields, SalestaxrateRow] = {
-    UpdateBuilderMock(UpdateParams.empty, SalestaxrateFields.structure.fields, map)
+    UpdateBuilderMock(UpdateParams.empty, SalestaxrateFields.structure, map)
   }
   override def update(row: SalestaxrateRow): ConnectionIO[Boolean] = {
     delay {

--- a/typo-tester-doobie/generated-and-checked-in/adventureworks/sales/salesterritory/SalesterritoryFields.scala
+++ b/typo-tester-doobie/generated-and-checked-in/adventureworks/sales/salesterritory/SalesterritoryFields.scala
@@ -11,49 +11,50 @@ import adventureworks.customtypes.TypoLocalDateTime
 import adventureworks.customtypes.TypoUUID
 import adventureworks.person.countryregion.CountryregionId
 import adventureworks.public.Name
+import typo.dsl.Path
 import typo.dsl.SqlExpr.Field
 import typo.dsl.SqlExpr.FieldLikeNoHkt
 import typo.dsl.SqlExpr.IdField
 import typo.dsl.Structure.Relation
 
-trait SalesterritoryFields[Row] {
-  val territoryid: IdField[SalesterritoryId, Row]
-  val name: Field[Name, Row]
-  val countryregioncode: Field[CountryregionId, Row]
-  val group: Field[/* max 50 chars */ String, Row]
-  val salesytd: Field[BigDecimal, Row]
-  val saleslastyear: Field[BigDecimal, Row]
-  val costytd: Field[BigDecimal, Row]
-  val costlastyear: Field[BigDecimal, Row]
-  val rowguid: Field[TypoUUID, Row]
-  val modifieddate: Field[TypoLocalDateTime, Row]
+trait SalesterritoryFields {
+  def territoryid: IdField[SalesterritoryId, SalesterritoryRow]
+  def name: Field[Name, SalesterritoryRow]
+  def countryregioncode: Field[CountryregionId, SalesterritoryRow]
+  def group: Field[/* max 50 chars */ String, SalesterritoryRow]
+  def salesytd: Field[BigDecimal, SalesterritoryRow]
+  def saleslastyear: Field[BigDecimal, SalesterritoryRow]
+  def costytd: Field[BigDecimal, SalesterritoryRow]
+  def costlastyear: Field[BigDecimal, SalesterritoryRow]
+  def rowguid: Field[TypoUUID, SalesterritoryRow]
+  def modifieddate: Field[TypoLocalDateTime, SalesterritoryRow]
 }
 
 object SalesterritoryFields {
-  val structure: Relation[SalesterritoryFields, SalesterritoryRow, SalesterritoryRow] = 
-    new Impl(None, identity, (_, x) => x)
+  lazy val structure: Relation[SalesterritoryFields, SalesterritoryRow] =
+    new Impl(Nil)
     
-  private final class Impl[Row](val prefix: Option[String], val extract: Row => SalesterritoryRow, val merge: (Row, SalesterritoryRow) => Row)
-    extends Relation[SalesterritoryFields, SalesterritoryRow, Row] { 
+  private final class Impl(val _path: List[Path])
+    extends Relation[SalesterritoryFields, SalesterritoryRow] {
   
-    override val fields: SalesterritoryFields[Row] = new SalesterritoryFields[Row] {
-      override val territoryid = new IdField[SalesterritoryId, Row](prefix, "territoryid", None, Some("int4"))(x => extract(x).territoryid, (row, value) => merge(row, extract(row).copy(territoryid = value)))
-      override val name = new Field[Name, Row](prefix, "name", None, Some("varchar"))(x => extract(x).name, (row, value) => merge(row, extract(row).copy(name = value)))
-      override val countryregioncode = new Field[CountryregionId, Row](prefix, "countryregioncode", None, None)(x => extract(x).countryregioncode, (row, value) => merge(row, extract(row).copy(countryregioncode = value)))
-      override val group = new Field[/* max 50 chars */ String, Row](prefix, "group", None, None)(x => extract(x).group, (row, value) => merge(row, extract(row).copy(group = value)))
-      override val salesytd = new Field[BigDecimal, Row](prefix, "salesytd", None, Some("numeric"))(x => extract(x).salesytd, (row, value) => merge(row, extract(row).copy(salesytd = value)))
-      override val saleslastyear = new Field[BigDecimal, Row](prefix, "saleslastyear", None, Some("numeric"))(x => extract(x).saleslastyear, (row, value) => merge(row, extract(row).copy(saleslastyear = value)))
-      override val costytd = new Field[BigDecimal, Row](prefix, "costytd", None, Some("numeric"))(x => extract(x).costytd, (row, value) => merge(row, extract(row).copy(costytd = value)))
-      override val costlastyear = new Field[BigDecimal, Row](prefix, "costlastyear", None, Some("numeric"))(x => extract(x).costlastyear, (row, value) => merge(row, extract(row).copy(costlastyear = value)))
-      override val rowguid = new Field[TypoUUID, Row](prefix, "rowguid", None, Some("uuid"))(x => extract(x).rowguid, (row, value) => merge(row, extract(row).copy(rowguid = value)))
-      override val modifieddate = new Field[TypoLocalDateTime, Row](prefix, "modifieddate", Some("text"), Some("timestamp"))(x => extract(x).modifieddate, (row, value) => merge(row, extract(row).copy(modifieddate = value)))
+    override lazy val fields: SalesterritoryFields = new SalesterritoryFields {
+      override def territoryid = IdField[SalesterritoryId, SalesterritoryRow](_path, "territoryid", None, Some("int4"), x => x.territoryid, (row, value) => row.copy(territoryid = value))
+      override def name = Field[Name, SalesterritoryRow](_path, "name", None, Some("varchar"), x => x.name, (row, value) => row.copy(name = value))
+      override def countryregioncode = Field[CountryregionId, SalesterritoryRow](_path, "countryregioncode", None, None, x => x.countryregioncode, (row, value) => row.copy(countryregioncode = value))
+      override def group = Field[/* max 50 chars */ String, SalesterritoryRow](_path, "group", None, None, x => x.group, (row, value) => row.copy(group = value))
+      override def salesytd = Field[BigDecimal, SalesterritoryRow](_path, "salesytd", None, Some("numeric"), x => x.salesytd, (row, value) => row.copy(salesytd = value))
+      override def saleslastyear = Field[BigDecimal, SalesterritoryRow](_path, "saleslastyear", None, Some("numeric"), x => x.saleslastyear, (row, value) => row.copy(saleslastyear = value))
+      override def costytd = Field[BigDecimal, SalesterritoryRow](_path, "costytd", None, Some("numeric"), x => x.costytd, (row, value) => row.copy(costytd = value))
+      override def costlastyear = Field[BigDecimal, SalesterritoryRow](_path, "costlastyear", None, Some("numeric"), x => x.costlastyear, (row, value) => row.copy(costlastyear = value))
+      override def rowguid = Field[TypoUUID, SalesterritoryRow](_path, "rowguid", None, Some("uuid"), x => x.rowguid, (row, value) => row.copy(rowguid = value))
+      override def modifieddate = Field[TypoLocalDateTime, SalesterritoryRow](_path, "modifieddate", Some("text"), Some("timestamp"), x => x.modifieddate, (row, value) => row.copy(modifieddate = value))
     }
   
-    override val columns: List[FieldLikeNoHkt[?, Row]] =
-      List[FieldLikeNoHkt[?, Row]](fields.territoryid, fields.name, fields.countryregioncode, fields.group, fields.salesytd, fields.saleslastyear, fields.costytd, fields.costlastyear, fields.rowguid, fields.modifieddate)
+    override lazy val columns: List[FieldLikeNoHkt[?, SalesterritoryRow]] =
+      List[FieldLikeNoHkt[?, SalesterritoryRow]](fields.territoryid, fields.name, fields.countryregioncode, fields.group, fields.salesytd, fields.saleslastyear, fields.costytd, fields.costlastyear, fields.rowguid, fields.modifieddate)
   
-    override def copy[NewRow](prefix: Option[String], extract: NewRow => SalesterritoryRow, merge: (NewRow, SalesterritoryRow) => NewRow): Impl[NewRow] =
-      new Impl(prefix, extract, merge)
+    override def copy(path: List[Path]): Impl =
+      new Impl(path)
   }
   
 }

--- a/typo-tester-doobie/generated-and-checked-in/adventureworks/sales/salesterritory/SalesterritoryRepoMock.scala
+++ b/typo-tester-doobie/generated-and-checked-in/adventureworks/sales/salesterritory/SalesterritoryRepoMock.scala
@@ -24,7 +24,7 @@ import typo.dsl.UpdateParams
 class SalesterritoryRepoMock(toRow: Function1[SalesterritoryRowUnsaved, SalesterritoryRow],
                              map: scala.collection.mutable.Map[SalesterritoryId, SalesterritoryRow] = scala.collection.mutable.Map.empty) extends SalesterritoryRepo {
   override def delete: DeleteBuilder[SalesterritoryFields, SalesterritoryRow] = {
-    DeleteBuilderMock(DeleteParams.empty, SalesterritoryFields.structure.fields, map)
+    DeleteBuilderMock(DeleteParams.empty, SalesterritoryFields.structure, map)
   }
   override def deleteById(territoryid: SalesterritoryId): ConnectionIO[Boolean] = {
     delay(map.remove(territoryid).isDefined)
@@ -86,7 +86,7 @@ class SalesterritoryRepoMock(toRow: Function1[SalesterritoryRowUnsaved, Salester
     }
   }
   override def update: UpdateBuilder[SalesterritoryFields, SalesterritoryRow] = {
-    UpdateBuilderMock(UpdateParams.empty, SalesterritoryFields.structure.fields, map)
+    UpdateBuilderMock(UpdateParams.empty, SalesterritoryFields.structure, map)
   }
   override def update(row: SalesterritoryRow): ConnectionIO[Boolean] = {
     delay {

--- a/typo-tester-doobie/generated-and-checked-in/adventureworks/sales/salesterritoryhistory/SalesterritoryhistoryFields.scala
+++ b/typo-tester-doobie/generated-and-checked-in/adventureworks/sales/salesterritoryhistory/SalesterritoryhistoryFields.scala
@@ -11,42 +11,43 @@ import adventureworks.customtypes.TypoLocalDateTime
 import adventureworks.customtypes.TypoUUID
 import adventureworks.person.businessentity.BusinessentityId
 import adventureworks.sales.salesterritory.SalesterritoryId
+import typo.dsl.Path
 import typo.dsl.SqlExpr.Field
 import typo.dsl.SqlExpr.FieldLikeNoHkt
 import typo.dsl.SqlExpr.IdField
 import typo.dsl.SqlExpr.OptField
 import typo.dsl.Structure.Relation
 
-trait SalesterritoryhistoryFields[Row] {
-  val businessentityid: IdField[BusinessentityId, Row]
-  val territoryid: IdField[SalesterritoryId, Row]
-  val startdate: IdField[TypoLocalDateTime, Row]
-  val enddate: OptField[TypoLocalDateTime, Row]
-  val rowguid: Field[TypoUUID, Row]
-  val modifieddate: Field[TypoLocalDateTime, Row]
+trait SalesterritoryhistoryFields {
+  def businessentityid: IdField[BusinessentityId, SalesterritoryhistoryRow]
+  def territoryid: IdField[SalesterritoryId, SalesterritoryhistoryRow]
+  def startdate: IdField[TypoLocalDateTime, SalesterritoryhistoryRow]
+  def enddate: OptField[TypoLocalDateTime, SalesterritoryhistoryRow]
+  def rowguid: Field[TypoUUID, SalesterritoryhistoryRow]
+  def modifieddate: Field[TypoLocalDateTime, SalesterritoryhistoryRow]
 }
 
 object SalesterritoryhistoryFields {
-  val structure: Relation[SalesterritoryhistoryFields, SalesterritoryhistoryRow, SalesterritoryhistoryRow] = 
-    new Impl(None, identity, (_, x) => x)
+  lazy val structure: Relation[SalesterritoryhistoryFields, SalesterritoryhistoryRow] =
+    new Impl(Nil)
     
-  private final class Impl[Row](val prefix: Option[String], val extract: Row => SalesterritoryhistoryRow, val merge: (Row, SalesterritoryhistoryRow) => Row)
-    extends Relation[SalesterritoryhistoryFields, SalesterritoryhistoryRow, Row] { 
+  private final class Impl(val _path: List[Path])
+    extends Relation[SalesterritoryhistoryFields, SalesterritoryhistoryRow] {
   
-    override val fields: SalesterritoryhistoryFields[Row] = new SalesterritoryhistoryFields[Row] {
-      override val businessentityid = new IdField[BusinessentityId, Row](prefix, "businessentityid", None, Some("int4"))(x => extract(x).businessentityid, (row, value) => merge(row, extract(row).copy(businessentityid = value)))
-      override val territoryid = new IdField[SalesterritoryId, Row](prefix, "territoryid", None, Some("int4"))(x => extract(x).territoryid, (row, value) => merge(row, extract(row).copy(territoryid = value)))
-      override val startdate = new IdField[TypoLocalDateTime, Row](prefix, "startdate", Some("text"), Some("timestamp"))(x => extract(x).startdate, (row, value) => merge(row, extract(row).copy(startdate = value)))
-      override val enddate = new OptField[TypoLocalDateTime, Row](prefix, "enddate", Some("text"), Some("timestamp"))(x => extract(x).enddate, (row, value) => merge(row, extract(row).copy(enddate = value)))
-      override val rowguid = new Field[TypoUUID, Row](prefix, "rowguid", None, Some("uuid"))(x => extract(x).rowguid, (row, value) => merge(row, extract(row).copy(rowguid = value)))
-      override val modifieddate = new Field[TypoLocalDateTime, Row](prefix, "modifieddate", Some("text"), Some("timestamp"))(x => extract(x).modifieddate, (row, value) => merge(row, extract(row).copy(modifieddate = value)))
+    override lazy val fields: SalesterritoryhistoryFields = new SalesterritoryhistoryFields {
+      override def businessentityid = IdField[BusinessentityId, SalesterritoryhistoryRow](_path, "businessentityid", None, Some("int4"), x => x.businessentityid, (row, value) => row.copy(businessentityid = value))
+      override def territoryid = IdField[SalesterritoryId, SalesterritoryhistoryRow](_path, "territoryid", None, Some("int4"), x => x.territoryid, (row, value) => row.copy(territoryid = value))
+      override def startdate = IdField[TypoLocalDateTime, SalesterritoryhistoryRow](_path, "startdate", Some("text"), Some("timestamp"), x => x.startdate, (row, value) => row.copy(startdate = value))
+      override def enddate = OptField[TypoLocalDateTime, SalesterritoryhistoryRow](_path, "enddate", Some("text"), Some("timestamp"), x => x.enddate, (row, value) => row.copy(enddate = value))
+      override def rowguid = Field[TypoUUID, SalesterritoryhistoryRow](_path, "rowguid", None, Some("uuid"), x => x.rowguid, (row, value) => row.copy(rowguid = value))
+      override def modifieddate = Field[TypoLocalDateTime, SalesterritoryhistoryRow](_path, "modifieddate", Some("text"), Some("timestamp"), x => x.modifieddate, (row, value) => row.copy(modifieddate = value))
     }
   
-    override val columns: List[FieldLikeNoHkt[?, Row]] =
-      List[FieldLikeNoHkt[?, Row]](fields.businessentityid, fields.territoryid, fields.startdate, fields.enddate, fields.rowguid, fields.modifieddate)
+    override lazy val columns: List[FieldLikeNoHkt[?, SalesterritoryhistoryRow]] =
+      List[FieldLikeNoHkt[?, SalesterritoryhistoryRow]](fields.businessentityid, fields.territoryid, fields.startdate, fields.enddate, fields.rowguid, fields.modifieddate)
   
-    override def copy[NewRow](prefix: Option[String], extract: NewRow => SalesterritoryhistoryRow, merge: (NewRow, SalesterritoryhistoryRow) => NewRow): Impl[NewRow] =
-      new Impl(prefix, extract, merge)
+    override def copy(path: List[Path]): Impl =
+      new Impl(path)
   }
   
 }

--- a/typo-tester-doobie/generated-and-checked-in/adventureworks/sales/salesterritoryhistory/SalesterritoryhistoryRepoMock.scala
+++ b/typo-tester-doobie/generated-and-checked-in/adventureworks/sales/salesterritoryhistory/SalesterritoryhistoryRepoMock.scala
@@ -24,7 +24,7 @@ import typo.dsl.UpdateParams
 class SalesterritoryhistoryRepoMock(toRow: Function1[SalesterritoryhistoryRowUnsaved, SalesterritoryhistoryRow],
                                     map: scala.collection.mutable.Map[SalesterritoryhistoryId, SalesterritoryhistoryRow] = scala.collection.mutable.Map.empty) extends SalesterritoryhistoryRepo {
   override def delete: DeleteBuilder[SalesterritoryhistoryFields, SalesterritoryhistoryRow] = {
-    DeleteBuilderMock(DeleteParams.empty, SalesterritoryhistoryFields.structure.fields, map)
+    DeleteBuilderMock(DeleteParams.empty, SalesterritoryhistoryFields.structure, map)
   }
   override def deleteById(compositeId: SalesterritoryhistoryId): ConnectionIO[Boolean] = {
     delay(map.remove(compositeId).isDefined)
@@ -86,7 +86,7 @@ class SalesterritoryhistoryRepoMock(toRow: Function1[SalesterritoryhistoryRowUns
     }
   }
   override def update: UpdateBuilder[SalesterritoryhistoryFields, SalesterritoryhistoryRow] = {
-    UpdateBuilderMock(UpdateParams.empty, SalesterritoryhistoryFields.structure.fields, map)
+    UpdateBuilderMock(UpdateParams.empty, SalesterritoryhistoryFields.structure, map)
   }
   override def update(row: SalesterritoryhistoryRow): ConnectionIO[Boolean] = {
     delay {

--- a/typo-tester-doobie/generated-and-checked-in/adventureworks/sales/shoppingcartitem/ShoppingcartitemFields.scala
+++ b/typo-tester-doobie/generated-and-checked-in/adventureworks/sales/shoppingcartitem/ShoppingcartitemFields.scala
@@ -9,41 +9,42 @@ package shoppingcartitem
 
 import adventureworks.customtypes.TypoLocalDateTime
 import adventureworks.production.product.ProductId
+import typo.dsl.Path
 import typo.dsl.SqlExpr.Field
 import typo.dsl.SqlExpr.FieldLikeNoHkt
 import typo.dsl.SqlExpr.IdField
 import typo.dsl.Structure.Relation
 
-trait ShoppingcartitemFields[Row] {
-  val shoppingcartitemid: IdField[ShoppingcartitemId, Row]
-  val shoppingcartid: Field[/* max 50 chars */ String, Row]
-  val quantity: Field[Int, Row]
-  val productid: Field[ProductId, Row]
-  val datecreated: Field[TypoLocalDateTime, Row]
-  val modifieddate: Field[TypoLocalDateTime, Row]
+trait ShoppingcartitemFields {
+  def shoppingcartitemid: IdField[ShoppingcartitemId, ShoppingcartitemRow]
+  def shoppingcartid: Field[/* max 50 chars */ String, ShoppingcartitemRow]
+  def quantity: Field[Int, ShoppingcartitemRow]
+  def productid: Field[ProductId, ShoppingcartitemRow]
+  def datecreated: Field[TypoLocalDateTime, ShoppingcartitemRow]
+  def modifieddate: Field[TypoLocalDateTime, ShoppingcartitemRow]
 }
 
 object ShoppingcartitemFields {
-  val structure: Relation[ShoppingcartitemFields, ShoppingcartitemRow, ShoppingcartitemRow] = 
-    new Impl(None, identity, (_, x) => x)
+  lazy val structure: Relation[ShoppingcartitemFields, ShoppingcartitemRow] =
+    new Impl(Nil)
     
-  private final class Impl[Row](val prefix: Option[String], val extract: Row => ShoppingcartitemRow, val merge: (Row, ShoppingcartitemRow) => Row)
-    extends Relation[ShoppingcartitemFields, ShoppingcartitemRow, Row] { 
+  private final class Impl(val _path: List[Path])
+    extends Relation[ShoppingcartitemFields, ShoppingcartitemRow] {
   
-    override val fields: ShoppingcartitemFields[Row] = new ShoppingcartitemFields[Row] {
-      override val shoppingcartitemid = new IdField[ShoppingcartitemId, Row](prefix, "shoppingcartitemid", None, Some("int4"))(x => extract(x).shoppingcartitemid, (row, value) => merge(row, extract(row).copy(shoppingcartitemid = value)))
-      override val shoppingcartid = new Field[/* max 50 chars */ String, Row](prefix, "shoppingcartid", None, None)(x => extract(x).shoppingcartid, (row, value) => merge(row, extract(row).copy(shoppingcartid = value)))
-      override val quantity = new Field[Int, Row](prefix, "quantity", None, Some("int4"))(x => extract(x).quantity, (row, value) => merge(row, extract(row).copy(quantity = value)))
-      override val productid = new Field[ProductId, Row](prefix, "productid", None, Some("int4"))(x => extract(x).productid, (row, value) => merge(row, extract(row).copy(productid = value)))
-      override val datecreated = new Field[TypoLocalDateTime, Row](prefix, "datecreated", Some("text"), Some("timestamp"))(x => extract(x).datecreated, (row, value) => merge(row, extract(row).copy(datecreated = value)))
-      override val modifieddate = new Field[TypoLocalDateTime, Row](prefix, "modifieddate", Some("text"), Some("timestamp"))(x => extract(x).modifieddate, (row, value) => merge(row, extract(row).copy(modifieddate = value)))
+    override lazy val fields: ShoppingcartitemFields = new ShoppingcartitemFields {
+      override def shoppingcartitemid = IdField[ShoppingcartitemId, ShoppingcartitemRow](_path, "shoppingcartitemid", None, Some("int4"), x => x.shoppingcartitemid, (row, value) => row.copy(shoppingcartitemid = value))
+      override def shoppingcartid = Field[/* max 50 chars */ String, ShoppingcartitemRow](_path, "shoppingcartid", None, None, x => x.shoppingcartid, (row, value) => row.copy(shoppingcartid = value))
+      override def quantity = Field[Int, ShoppingcartitemRow](_path, "quantity", None, Some("int4"), x => x.quantity, (row, value) => row.copy(quantity = value))
+      override def productid = Field[ProductId, ShoppingcartitemRow](_path, "productid", None, Some("int4"), x => x.productid, (row, value) => row.copy(productid = value))
+      override def datecreated = Field[TypoLocalDateTime, ShoppingcartitemRow](_path, "datecreated", Some("text"), Some("timestamp"), x => x.datecreated, (row, value) => row.copy(datecreated = value))
+      override def modifieddate = Field[TypoLocalDateTime, ShoppingcartitemRow](_path, "modifieddate", Some("text"), Some("timestamp"), x => x.modifieddate, (row, value) => row.copy(modifieddate = value))
     }
   
-    override val columns: List[FieldLikeNoHkt[?, Row]] =
-      List[FieldLikeNoHkt[?, Row]](fields.shoppingcartitemid, fields.shoppingcartid, fields.quantity, fields.productid, fields.datecreated, fields.modifieddate)
+    override lazy val columns: List[FieldLikeNoHkt[?, ShoppingcartitemRow]] =
+      List[FieldLikeNoHkt[?, ShoppingcartitemRow]](fields.shoppingcartitemid, fields.shoppingcartid, fields.quantity, fields.productid, fields.datecreated, fields.modifieddate)
   
-    override def copy[NewRow](prefix: Option[String], extract: NewRow => ShoppingcartitemRow, merge: (NewRow, ShoppingcartitemRow) => NewRow): Impl[NewRow] =
-      new Impl(prefix, extract, merge)
+    override def copy(path: List[Path]): Impl =
+      new Impl(path)
   }
   
 }

--- a/typo-tester-doobie/generated-and-checked-in/adventureworks/sales/shoppingcartitem/ShoppingcartitemRepoMock.scala
+++ b/typo-tester-doobie/generated-and-checked-in/adventureworks/sales/shoppingcartitem/ShoppingcartitemRepoMock.scala
@@ -24,7 +24,7 @@ import typo.dsl.UpdateParams
 class ShoppingcartitemRepoMock(toRow: Function1[ShoppingcartitemRowUnsaved, ShoppingcartitemRow],
                                map: scala.collection.mutable.Map[ShoppingcartitemId, ShoppingcartitemRow] = scala.collection.mutable.Map.empty) extends ShoppingcartitemRepo {
   override def delete: DeleteBuilder[ShoppingcartitemFields, ShoppingcartitemRow] = {
-    DeleteBuilderMock(DeleteParams.empty, ShoppingcartitemFields.structure.fields, map)
+    DeleteBuilderMock(DeleteParams.empty, ShoppingcartitemFields.structure, map)
   }
   override def deleteById(shoppingcartitemid: ShoppingcartitemId): ConnectionIO[Boolean] = {
     delay(map.remove(shoppingcartitemid).isDefined)
@@ -86,7 +86,7 @@ class ShoppingcartitemRepoMock(toRow: Function1[ShoppingcartitemRowUnsaved, Shop
     }
   }
   override def update: UpdateBuilder[ShoppingcartitemFields, ShoppingcartitemRow] = {
-    UpdateBuilderMock(UpdateParams.empty, ShoppingcartitemFields.structure.fields, map)
+    UpdateBuilderMock(UpdateParams.empty, ShoppingcartitemFields.structure, map)
   }
   override def update(row: ShoppingcartitemRow): ConnectionIO[Boolean] = {
     delay {

--- a/typo-tester-doobie/generated-and-checked-in/adventureworks/sales/specialoffer/SpecialofferFields.scala
+++ b/typo-tester-doobie/generated-and-checked-in/adventureworks/sales/specialoffer/SpecialofferFields.scala
@@ -9,52 +9,53 @@ package specialoffer
 
 import adventureworks.customtypes.TypoLocalDateTime
 import adventureworks.customtypes.TypoUUID
+import typo.dsl.Path
 import typo.dsl.SqlExpr.Field
 import typo.dsl.SqlExpr.FieldLikeNoHkt
 import typo.dsl.SqlExpr.IdField
 import typo.dsl.SqlExpr.OptField
 import typo.dsl.Structure.Relation
 
-trait SpecialofferFields[Row] {
-  val specialofferid: IdField[SpecialofferId, Row]
-  val description: Field[/* max 255 chars */ String, Row]
-  val discountpct: Field[BigDecimal, Row]
-  val `type`: Field[/* max 50 chars */ String, Row]
-  val category: Field[/* max 50 chars */ String, Row]
-  val startdate: Field[TypoLocalDateTime, Row]
-  val enddate: Field[TypoLocalDateTime, Row]
-  val minqty: Field[Int, Row]
-  val maxqty: OptField[Int, Row]
-  val rowguid: Field[TypoUUID, Row]
-  val modifieddate: Field[TypoLocalDateTime, Row]
+trait SpecialofferFields {
+  def specialofferid: IdField[SpecialofferId, SpecialofferRow]
+  def description: Field[/* max 255 chars */ String, SpecialofferRow]
+  def discountpct: Field[BigDecimal, SpecialofferRow]
+  def `type`: Field[/* max 50 chars */ String, SpecialofferRow]
+  def category: Field[/* max 50 chars */ String, SpecialofferRow]
+  def startdate: Field[TypoLocalDateTime, SpecialofferRow]
+  def enddate: Field[TypoLocalDateTime, SpecialofferRow]
+  def minqty: Field[Int, SpecialofferRow]
+  def maxqty: OptField[Int, SpecialofferRow]
+  def rowguid: Field[TypoUUID, SpecialofferRow]
+  def modifieddate: Field[TypoLocalDateTime, SpecialofferRow]
 }
 
 object SpecialofferFields {
-  val structure: Relation[SpecialofferFields, SpecialofferRow, SpecialofferRow] = 
-    new Impl(None, identity, (_, x) => x)
+  lazy val structure: Relation[SpecialofferFields, SpecialofferRow] =
+    new Impl(Nil)
     
-  private final class Impl[Row](val prefix: Option[String], val extract: Row => SpecialofferRow, val merge: (Row, SpecialofferRow) => Row)
-    extends Relation[SpecialofferFields, SpecialofferRow, Row] { 
+  private final class Impl(val _path: List[Path])
+    extends Relation[SpecialofferFields, SpecialofferRow] {
   
-    override val fields: SpecialofferFields[Row] = new SpecialofferFields[Row] {
-      override val specialofferid = new IdField[SpecialofferId, Row](prefix, "specialofferid", None, Some("int4"))(x => extract(x).specialofferid, (row, value) => merge(row, extract(row).copy(specialofferid = value)))
-      override val description = new Field[/* max 255 chars */ String, Row](prefix, "description", None, None)(x => extract(x).description, (row, value) => merge(row, extract(row).copy(description = value)))
-      override val discountpct = new Field[BigDecimal, Row](prefix, "discountpct", None, Some("numeric"))(x => extract(x).discountpct, (row, value) => merge(row, extract(row).copy(discountpct = value)))
-      override val `type` = new Field[/* max 50 chars */ String, Row](prefix, "type", None, None)(x => extract(x).`type`, (row, value) => merge(row, extract(row).copy(`type` = value)))
-      override val category = new Field[/* max 50 chars */ String, Row](prefix, "category", None, None)(x => extract(x).category, (row, value) => merge(row, extract(row).copy(category = value)))
-      override val startdate = new Field[TypoLocalDateTime, Row](prefix, "startdate", Some("text"), Some("timestamp"))(x => extract(x).startdate, (row, value) => merge(row, extract(row).copy(startdate = value)))
-      override val enddate = new Field[TypoLocalDateTime, Row](prefix, "enddate", Some("text"), Some("timestamp"))(x => extract(x).enddate, (row, value) => merge(row, extract(row).copy(enddate = value)))
-      override val minqty = new Field[Int, Row](prefix, "minqty", None, Some("int4"))(x => extract(x).minqty, (row, value) => merge(row, extract(row).copy(minqty = value)))
-      override val maxqty = new OptField[Int, Row](prefix, "maxqty", None, Some("int4"))(x => extract(x).maxqty, (row, value) => merge(row, extract(row).copy(maxqty = value)))
-      override val rowguid = new Field[TypoUUID, Row](prefix, "rowguid", None, Some("uuid"))(x => extract(x).rowguid, (row, value) => merge(row, extract(row).copy(rowguid = value)))
-      override val modifieddate = new Field[TypoLocalDateTime, Row](prefix, "modifieddate", Some("text"), Some("timestamp"))(x => extract(x).modifieddate, (row, value) => merge(row, extract(row).copy(modifieddate = value)))
+    override lazy val fields: SpecialofferFields = new SpecialofferFields {
+      override def specialofferid = IdField[SpecialofferId, SpecialofferRow](_path, "specialofferid", None, Some("int4"), x => x.specialofferid, (row, value) => row.copy(specialofferid = value))
+      override def description = Field[/* max 255 chars */ String, SpecialofferRow](_path, "description", None, None, x => x.description, (row, value) => row.copy(description = value))
+      override def discountpct = Field[BigDecimal, SpecialofferRow](_path, "discountpct", None, Some("numeric"), x => x.discountpct, (row, value) => row.copy(discountpct = value))
+      override def `type` = Field[/* max 50 chars */ String, SpecialofferRow](_path, "type", None, None, x => x.`type`, (row, value) => row.copy(`type` = value))
+      override def category = Field[/* max 50 chars */ String, SpecialofferRow](_path, "category", None, None, x => x.category, (row, value) => row.copy(category = value))
+      override def startdate = Field[TypoLocalDateTime, SpecialofferRow](_path, "startdate", Some("text"), Some("timestamp"), x => x.startdate, (row, value) => row.copy(startdate = value))
+      override def enddate = Field[TypoLocalDateTime, SpecialofferRow](_path, "enddate", Some("text"), Some("timestamp"), x => x.enddate, (row, value) => row.copy(enddate = value))
+      override def minqty = Field[Int, SpecialofferRow](_path, "minqty", None, Some("int4"), x => x.minqty, (row, value) => row.copy(minqty = value))
+      override def maxqty = OptField[Int, SpecialofferRow](_path, "maxqty", None, Some("int4"), x => x.maxqty, (row, value) => row.copy(maxqty = value))
+      override def rowguid = Field[TypoUUID, SpecialofferRow](_path, "rowguid", None, Some("uuid"), x => x.rowguid, (row, value) => row.copy(rowguid = value))
+      override def modifieddate = Field[TypoLocalDateTime, SpecialofferRow](_path, "modifieddate", Some("text"), Some("timestamp"), x => x.modifieddate, (row, value) => row.copy(modifieddate = value))
     }
   
-    override val columns: List[FieldLikeNoHkt[?, Row]] =
-      List[FieldLikeNoHkt[?, Row]](fields.specialofferid, fields.description, fields.discountpct, fields.`type`, fields.category, fields.startdate, fields.enddate, fields.minqty, fields.maxqty, fields.rowguid, fields.modifieddate)
+    override lazy val columns: List[FieldLikeNoHkt[?, SpecialofferRow]] =
+      List[FieldLikeNoHkt[?, SpecialofferRow]](fields.specialofferid, fields.description, fields.discountpct, fields.`type`, fields.category, fields.startdate, fields.enddate, fields.minqty, fields.maxqty, fields.rowguid, fields.modifieddate)
   
-    override def copy[NewRow](prefix: Option[String], extract: NewRow => SpecialofferRow, merge: (NewRow, SpecialofferRow) => NewRow): Impl[NewRow] =
-      new Impl(prefix, extract, merge)
+    override def copy(path: List[Path]): Impl =
+      new Impl(path)
   }
   
 }

--- a/typo-tester-doobie/generated-and-checked-in/adventureworks/sales/specialoffer/SpecialofferRepoMock.scala
+++ b/typo-tester-doobie/generated-and-checked-in/adventureworks/sales/specialoffer/SpecialofferRepoMock.scala
@@ -24,7 +24,7 @@ import typo.dsl.UpdateParams
 class SpecialofferRepoMock(toRow: Function1[SpecialofferRowUnsaved, SpecialofferRow],
                            map: scala.collection.mutable.Map[SpecialofferId, SpecialofferRow] = scala.collection.mutable.Map.empty) extends SpecialofferRepo {
   override def delete: DeleteBuilder[SpecialofferFields, SpecialofferRow] = {
-    DeleteBuilderMock(DeleteParams.empty, SpecialofferFields.structure.fields, map)
+    DeleteBuilderMock(DeleteParams.empty, SpecialofferFields.structure, map)
   }
   override def deleteById(specialofferid: SpecialofferId): ConnectionIO[Boolean] = {
     delay(map.remove(specialofferid).isDefined)
@@ -86,7 +86,7 @@ class SpecialofferRepoMock(toRow: Function1[SpecialofferRowUnsaved, Specialoffer
     }
   }
   override def update: UpdateBuilder[SpecialofferFields, SpecialofferRow] = {
-    UpdateBuilderMock(UpdateParams.empty, SpecialofferFields.structure.fields, map)
+    UpdateBuilderMock(UpdateParams.empty, SpecialofferFields.structure, map)
   }
   override def update(row: SpecialofferRow): ConnectionIO[Boolean] = {
     delay {

--- a/typo-tester-doobie/generated-and-checked-in/adventureworks/sales/specialofferproduct/SpecialofferproductFields.scala
+++ b/typo-tester-doobie/generated-and-checked-in/adventureworks/sales/specialofferproduct/SpecialofferproductFields.scala
@@ -11,37 +11,38 @@ import adventureworks.customtypes.TypoLocalDateTime
 import adventureworks.customtypes.TypoUUID
 import adventureworks.production.product.ProductId
 import adventureworks.sales.specialoffer.SpecialofferId
+import typo.dsl.Path
 import typo.dsl.SqlExpr.Field
 import typo.dsl.SqlExpr.FieldLikeNoHkt
 import typo.dsl.SqlExpr.IdField
 import typo.dsl.Structure.Relation
 
-trait SpecialofferproductFields[Row] {
-  val specialofferid: IdField[SpecialofferId, Row]
-  val productid: IdField[ProductId, Row]
-  val rowguid: Field[TypoUUID, Row]
-  val modifieddate: Field[TypoLocalDateTime, Row]
+trait SpecialofferproductFields {
+  def specialofferid: IdField[SpecialofferId, SpecialofferproductRow]
+  def productid: IdField[ProductId, SpecialofferproductRow]
+  def rowguid: Field[TypoUUID, SpecialofferproductRow]
+  def modifieddate: Field[TypoLocalDateTime, SpecialofferproductRow]
 }
 
 object SpecialofferproductFields {
-  val structure: Relation[SpecialofferproductFields, SpecialofferproductRow, SpecialofferproductRow] = 
-    new Impl(None, identity, (_, x) => x)
+  lazy val structure: Relation[SpecialofferproductFields, SpecialofferproductRow] =
+    new Impl(Nil)
     
-  private final class Impl[Row](val prefix: Option[String], val extract: Row => SpecialofferproductRow, val merge: (Row, SpecialofferproductRow) => Row)
-    extends Relation[SpecialofferproductFields, SpecialofferproductRow, Row] { 
+  private final class Impl(val _path: List[Path])
+    extends Relation[SpecialofferproductFields, SpecialofferproductRow] {
   
-    override val fields: SpecialofferproductFields[Row] = new SpecialofferproductFields[Row] {
-      override val specialofferid = new IdField[SpecialofferId, Row](prefix, "specialofferid", None, Some("int4"))(x => extract(x).specialofferid, (row, value) => merge(row, extract(row).copy(specialofferid = value)))
-      override val productid = new IdField[ProductId, Row](prefix, "productid", None, Some("int4"))(x => extract(x).productid, (row, value) => merge(row, extract(row).copy(productid = value)))
-      override val rowguid = new Field[TypoUUID, Row](prefix, "rowguid", None, Some("uuid"))(x => extract(x).rowguid, (row, value) => merge(row, extract(row).copy(rowguid = value)))
-      override val modifieddate = new Field[TypoLocalDateTime, Row](prefix, "modifieddate", Some("text"), Some("timestamp"))(x => extract(x).modifieddate, (row, value) => merge(row, extract(row).copy(modifieddate = value)))
+    override lazy val fields: SpecialofferproductFields = new SpecialofferproductFields {
+      override def specialofferid = IdField[SpecialofferId, SpecialofferproductRow](_path, "specialofferid", None, Some("int4"), x => x.specialofferid, (row, value) => row.copy(specialofferid = value))
+      override def productid = IdField[ProductId, SpecialofferproductRow](_path, "productid", None, Some("int4"), x => x.productid, (row, value) => row.copy(productid = value))
+      override def rowguid = Field[TypoUUID, SpecialofferproductRow](_path, "rowguid", None, Some("uuid"), x => x.rowguid, (row, value) => row.copy(rowguid = value))
+      override def modifieddate = Field[TypoLocalDateTime, SpecialofferproductRow](_path, "modifieddate", Some("text"), Some("timestamp"), x => x.modifieddate, (row, value) => row.copy(modifieddate = value))
     }
   
-    override val columns: List[FieldLikeNoHkt[?, Row]] =
-      List[FieldLikeNoHkt[?, Row]](fields.specialofferid, fields.productid, fields.rowguid, fields.modifieddate)
+    override lazy val columns: List[FieldLikeNoHkt[?, SpecialofferproductRow]] =
+      List[FieldLikeNoHkt[?, SpecialofferproductRow]](fields.specialofferid, fields.productid, fields.rowguid, fields.modifieddate)
   
-    override def copy[NewRow](prefix: Option[String], extract: NewRow => SpecialofferproductRow, merge: (NewRow, SpecialofferproductRow) => NewRow): Impl[NewRow] =
-      new Impl(prefix, extract, merge)
+    override def copy(path: List[Path]): Impl =
+      new Impl(path)
   }
   
 }

--- a/typo-tester-doobie/generated-and-checked-in/adventureworks/sales/specialofferproduct/SpecialofferproductRepoMock.scala
+++ b/typo-tester-doobie/generated-and-checked-in/adventureworks/sales/specialofferproduct/SpecialofferproductRepoMock.scala
@@ -24,7 +24,7 @@ import typo.dsl.UpdateParams
 class SpecialofferproductRepoMock(toRow: Function1[SpecialofferproductRowUnsaved, SpecialofferproductRow],
                                   map: scala.collection.mutable.Map[SpecialofferproductId, SpecialofferproductRow] = scala.collection.mutable.Map.empty) extends SpecialofferproductRepo {
   override def delete: DeleteBuilder[SpecialofferproductFields, SpecialofferproductRow] = {
-    DeleteBuilderMock(DeleteParams.empty, SpecialofferproductFields.structure.fields, map)
+    DeleteBuilderMock(DeleteParams.empty, SpecialofferproductFields.structure, map)
   }
   override def deleteById(compositeId: SpecialofferproductId): ConnectionIO[Boolean] = {
     delay(map.remove(compositeId).isDefined)
@@ -86,7 +86,7 @@ class SpecialofferproductRepoMock(toRow: Function1[SpecialofferproductRowUnsaved
     }
   }
   override def update: UpdateBuilder[SpecialofferproductFields, SpecialofferproductRow] = {
-    UpdateBuilderMock(UpdateParams.empty, SpecialofferproductFields.structure.fields, map)
+    UpdateBuilderMock(UpdateParams.empty, SpecialofferproductFields.structure, map)
   }
   override def update(row: SpecialofferproductRow): ConnectionIO[Boolean] = {
     delay {

--- a/typo-tester-doobie/generated-and-checked-in/adventureworks/sales/store/StoreRepoMock.scala
+++ b/typo-tester-doobie/generated-and-checked-in/adventureworks/sales/store/StoreRepoMock.scala
@@ -25,7 +25,7 @@ import typo.dsl.UpdateParams
 class StoreRepoMock(toRow: Function1[StoreRowUnsaved, StoreRow],
                     map: scala.collection.mutable.Map[BusinessentityId, StoreRow] = scala.collection.mutable.Map.empty) extends StoreRepo {
   override def delete: DeleteBuilder[StoreFields, StoreRow] = {
-    DeleteBuilderMock(DeleteParams.empty, StoreFields.structure.fields, map)
+    DeleteBuilderMock(DeleteParams.empty, StoreFields.structure, map)
   }
   override def deleteById(businessentityid: BusinessentityId): ConnectionIO[Boolean] = {
     delay(map.remove(businessentityid).isDefined)
@@ -87,7 +87,7 @@ class StoreRepoMock(toRow: Function1[StoreRowUnsaved, StoreRow],
     }
   }
   override def update: UpdateBuilder[StoreFields, StoreRow] = {
-    UpdateBuilderMock(UpdateParams.empty, StoreFields.structure.fields, map)
+    UpdateBuilderMock(UpdateParams.empty, StoreFields.structure, map)
   }
   override def update(row: StoreRow): ConnectionIO[Boolean] = {
     delay {

--- a/typo-tester-doobie/generated-and-checked-in/adventureworks/sales/vindividualcustomer/VindividualcustomerViewFields.scala
+++ b/typo-tester-doobie/generated-and-checked-in/adventureworks/sales/vindividualcustomer/VindividualcustomerViewFields.scala
@@ -12,65 +12,66 @@ import adventureworks.person.businessentity.BusinessentityId
 import adventureworks.public.Name
 import adventureworks.public.Phone
 import adventureworks.userdefined.FirstName
+import typo.dsl.Path
 import typo.dsl.SqlExpr.Field
 import typo.dsl.SqlExpr.FieldLikeNoHkt
 import typo.dsl.SqlExpr.OptField
 import typo.dsl.Structure.Relation
 
-trait VindividualcustomerViewFields[Row] {
-  val businessentityid: Field[BusinessentityId, Row]
-  val title: OptField[/* max 8 chars */ String, Row]
-  val firstname: Field[/* user-picked */ FirstName, Row]
-  val middlename: OptField[Name, Row]
-  val lastname: Field[Name, Row]
-  val suffix: OptField[/* max 10 chars */ String, Row]
-  val phonenumber: OptField[Phone, Row]
-  val phonenumbertype: OptField[Name, Row]
-  val emailaddress: OptField[/* max 50 chars */ String, Row]
-  val emailpromotion: Field[Int, Row]
-  val addresstype: Field[Name, Row]
-  val addressline1: Field[/* max 60 chars */ String, Row]
-  val addressline2: OptField[/* max 60 chars */ String, Row]
-  val city: Field[/* max 30 chars */ String, Row]
-  val stateprovincename: Field[Name, Row]
-  val postalcode: Field[/* max 15 chars */ String, Row]
-  val countryregionname: Field[Name, Row]
-  val demographics: OptField[TypoXml, Row]
+trait VindividualcustomerViewFields {
+  def businessentityid: Field[BusinessentityId, VindividualcustomerViewRow]
+  def title: OptField[/* max 8 chars */ String, VindividualcustomerViewRow]
+  def firstname: Field[/* user-picked */ FirstName, VindividualcustomerViewRow]
+  def middlename: OptField[Name, VindividualcustomerViewRow]
+  def lastname: Field[Name, VindividualcustomerViewRow]
+  def suffix: OptField[/* max 10 chars */ String, VindividualcustomerViewRow]
+  def phonenumber: OptField[Phone, VindividualcustomerViewRow]
+  def phonenumbertype: OptField[Name, VindividualcustomerViewRow]
+  def emailaddress: OptField[/* max 50 chars */ String, VindividualcustomerViewRow]
+  def emailpromotion: Field[Int, VindividualcustomerViewRow]
+  def addresstype: Field[Name, VindividualcustomerViewRow]
+  def addressline1: Field[/* max 60 chars */ String, VindividualcustomerViewRow]
+  def addressline2: OptField[/* max 60 chars */ String, VindividualcustomerViewRow]
+  def city: Field[/* max 30 chars */ String, VindividualcustomerViewRow]
+  def stateprovincename: Field[Name, VindividualcustomerViewRow]
+  def postalcode: Field[/* max 15 chars */ String, VindividualcustomerViewRow]
+  def countryregionname: Field[Name, VindividualcustomerViewRow]
+  def demographics: OptField[TypoXml, VindividualcustomerViewRow]
 }
 
 object VindividualcustomerViewFields {
-  val structure: Relation[VindividualcustomerViewFields, VindividualcustomerViewRow, VindividualcustomerViewRow] = 
-    new Impl(None, identity, (_, x) => x)
+  lazy val structure: Relation[VindividualcustomerViewFields, VindividualcustomerViewRow] =
+    new Impl(Nil)
     
-  private final class Impl[Row](val prefix: Option[String], val extract: Row => VindividualcustomerViewRow, val merge: (Row, VindividualcustomerViewRow) => Row)
-    extends Relation[VindividualcustomerViewFields, VindividualcustomerViewRow, Row] { 
+  private final class Impl(val _path: List[Path])
+    extends Relation[VindividualcustomerViewFields, VindividualcustomerViewRow] {
   
-    override val fields: VindividualcustomerViewFields[Row] = new VindividualcustomerViewFields[Row] {
-      override val businessentityid = new Field[BusinessentityId, Row](prefix, "businessentityid", None, None)(x => extract(x).businessentityid, (row, value) => merge(row, extract(row).copy(businessentityid = value)))
-      override val title = new OptField[/* max 8 chars */ String, Row](prefix, "title", None, None)(x => extract(x).title, (row, value) => merge(row, extract(row).copy(title = value)))
-      override val firstname = new Field[/* user-picked */ FirstName, Row](prefix, "firstname", None, None)(x => extract(x).firstname, (row, value) => merge(row, extract(row).copy(firstname = value)))
-      override val middlename = new OptField[Name, Row](prefix, "middlename", None, None)(x => extract(x).middlename, (row, value) => merge(row, extract(row).copy(middlename = value)))
-      override val lastname = new Field[Name, Row](prefix, "lastname", None, None)(x => extract(x).lastname, (row, value) => merge(row, extract(row).copy(lastname = value)))
-      override val suffix = new OptField[/* max 10 chars */ String, Row](prefix, "suffix", None, None)(x => extract(x).suffix, (row, value) => merge(row, extract(row).copy(suffix = value)))
-      override val phonenumber = new OptField[Phone, Row](prefix, "phonenumber", None, None)(x => extract(x).phonenumber, (row, value) => merge(row, extract(row).copy(phonenumber = value)))
-      override val phonenumbertype = new OptField[Name, Row](prefix, "phonenumbertype", None, None)(x => extract(x).phonenumbertype, (row, value) => merge(row, extract(row).copy(phonenumbertype = value)))
-      override val emailaddress = new OptField[/* max 50 chars */ String, Row](prefix, "emailaddress", None, None)(x => extract(x).emailaddress, (row, value) => merge(row, extract(row).copy(emailaddress = value)))
-      override val emailpromotion = new Field[Int, Row](prefix, "emailpromotion", None, None)(x => extract(x).emailpromotion, (row, value) => merge(row, extract(row).copy(emailpromotion = value)))
-      override val addresstype = new Field[Name, Row](prefix, "addresstype", None, None)(x => extract(x).addresstype, (row, value) => merge(row, extract(row).copy(addresstype = value)))
-      override val addressline1 = new Field[/* max 60 chars */ String, Row](prefix, "addressline1", None, None)(x => extract(x).addressline1, (row, value) => merge(row, extract(row).copy(addressline1 = value)))
-      override val addressline2 = new OptField[/* max 60 chars */ String, Row](prefix, "addressline2", None, None)(x => extract(x).addressline2, (row, value) => merge(row, extract(row).copy(addressline2 = value)))
-      override val city = new Field[/* max 30 chars */ String, Row](prefix, "city", None, None)(x => extract(x).city, (row, value) => merge(row, extract(row).copy(city = value)))
-      override val stateprovincename = new Field[Name, Row](prefix, "stateprovincename", None, None)(x => extract(x).stateprovincename, (row, value) => merge(row, extract(row).copy(stateprovincename = value)))
-      override val postalcode = new Field[/* max 15 chars */ String, Row](prefix, "postalcode", None, None)(x => extract(x).postalcode, (row, value) => merge(row, extract(row).copy(postalcode = value)))
-      override val countryregionname = new Field[Name, Row](prefix, "countryregionname", None, None)(x => extract(x).countryregionname, (row, value) => merge(row, extract(row).copy(countryregionname = value)))
-      override val demographics = new OptField[TypoXml, Row](prefix, "demographics", None, None)(x => extract(x).demographics, (row, value) => merge(row, extract(row).copy(demographics = value)))
+    override lazy val fields: VindividualcustomerViewFields = new VindividualcustomerViewFields {
+      override def businessentityid = Field[BusinessentityId, VindividualcustomerViewRow](_path, "businessentityid", None, None, x => x.businessentityid, (row, value) => row.copy(businessentityid = value))
+      override def title = OptField[/* max 8 chars */ String, VindividualcustomerViewRow](_path, "title", None, None, x => x.title, (row, value) => row.copy(title = value))
+      override def firstname = Field[/* user-picked */ FirstName, VindividualcustomerViewRow](_path, "firstname", None, None, x => x.firstname, (row, value) => row.copy(firstname = value))
+      override def middlename = OptField[Name, VindividualcustomerViewRow](_path, "middlename", None, None, x => x.middlename, (row, value) => row.copy(middlename = value))
+      override def lastname = Field[Name, VindividualcustomerViewRow](_path, "lastname", None, None, x => x.lastname, (row, value) => row.copy(lastname = value))
+      override def suffix = OptField[/* max 10 chars */ String, VindividualcustomerViewRow](_path, "suffix", None, None, x => x.suffix, (row, value) => row.copy(suffix = value))
+      override def phonenumber = OptField[Phone, VindividualcustomerViewRow](_path, "phonenumber", None, None, x => x.phonenumber, (row, value) => row.copy(phonenumber = value))
+      override def phonenumbertype = OptField[Name, VindividualcustomerViewRow](_path, "phonenumbertype", None, None, x => x.phonenumbertype, (row, value) => row.copy(phonenumbertype = value))
+      override def emailaddress = OptField[/* max 50 chars */ String, VindividualcustomerViewRow](_path, "emailaddress", None, None, x => x.emailaddress, (row, value) => row.copy(emailaddress = value))
+      override def emailpromotion = Field[Int, VindividualcustomerViewRow](_path, "emailpromotion", None, None, x => x.emailpromotion, (row, value) => row.copy(emailpromotion = value))
+      override def addresstype = Field[Name, VindividualcustomerViewRow](_path, "addresstype", None, None, x => x.addresstype, (row, value) => row.copy(addresstype = value))
+      override def addressline1 = Field[/* max 60 chars */ String, VindividualcustomerViewRow](_path, "addressline1", None, None, x => x.addressline1, (row, value) => row.copy(addressline1 = value))
+      override def addressline2 = OptField[/* max 60 chars */ String, VindividualcustomerViewRow](_path, "addressline2", None, None, x => x.addressline2, (row, value) => row.copy(addressline2 = value))
+      override def city = Field[/* max 30 chars */ String, VindividualcustomerViewRow](_path, "city", None, None, x => x.city, (row, value) => row.copy(city = value))
+      override def stateprovincename = Field[Name, VindividualcustomerViewRow](_path, "stateprovincename", None, None, x => x.stateprovincename, (row, value) => row.copy(stateprovincename = value))
+      override def postalcode = Field[/* max 15 chars */ String, VindividualcustomerViewRow](_path, "postalcode", None, None, x => x.postalcode, (row, value) => row.copy(postalcode = value))
+      override def countryregionname = Field[Name, VindividualcustomerViewRow](_path, "countryregionname", None, None, x => x.countryregionname, (row, value) => row.copy(countryregionname = value))
+      override def demographics = OptField[TypoXml, VindividualcustomerViewRow](_path, "demographics", None, None, x => x.demographics, (row, value) => row.copy(demographics = value))
     }
   
-    override val columns: List[FieldLikeNoHkt[?, Row]] =
-      List[FieldLikeNoHkt[?, Row]](fields.businessentityid, fields.title, fields.firstname, fields.middlename, fields.lastname, fields.suffix, fields.phonenumber, fields.phonenumbertype, fields.emailaddress, fields.emailpromotion, fields.addresstype, fields.addressline1, fields.addressline2, fields.city, fields.stateprovincename, fields.postalcode, fields.countryregionname, fields.demographics)
+    override lazy val columns: List[FieldLikeNoHkt[?, VindividualcustomerViewRow]] =
+      List[FieldLikeNoHkt[?, VindividualcustomerViewRow]](fields.businessentityid, fields.title, fields.firstname, fields.middlename, fields.lastname, fields.suffix, fields.phonenumber, fields.phonenumbertype, fields.emailaddress, fields.emailpromotion, fields.addresstype, fields.addressline1, fields.addressline2, fields.city, fields.stateprovincename, fields.postalcode, fields.countryregionname, fields.demographics)
   
-    override def copy[NewRow](prefix: Option[String], extract: NewRow => VindividualcustomerViewRow, merge: (NewRow, VindividualcustomerViewRow) => NewRow): Impl[NewRow] =
-      new Impl(prefix, extract, merge)
+    override def copy(path: List[Path]): Impl =
+      new Impl(path)
   }
   
 }

--- a/typo-tester-doobie/generated-and-checked-in/adventureworks/sales/vpersondemographics/VpersondemographicsViewFields.scala
+++ b/typo-tester-doobie/generated-and-checked-in/adventureworks/sales/vpersondemographics/VpersondemographicsViewFields.scala
@@ -10,55 +10,56 @@ package vpersondemographics
 import adventureworks.customtypes.TypoLocalDate
 import adventureworks.customtypes.TypoMoney
 import adventureworks.person.businessentity.BusinessentityId
+import typo.dsl.Path
 import typo.dsl.SqlExpr.Field
 import typo.dsl.SqlExpr.FieldLikeNoHkt
 import typo.dsl.SqlExpr.OptField
 import typo.dsl.Structure.Relation
 
-trait VpersondemographicsViewFields[Row] {
-  val businessentityid: Field[BusinessentityId, Row]
-  val totalpurchaseytd: OptField[TypoMoney, Row]
-  val datefirstpurchase: OptField[TypoLocalDate, Row]
-  val birthdate: OptField[TypoLocalDate, Row]
-  val maritalstatus: OptField[/* max 1 chars */ String, Row]
-  val yearlyincome: OptField[/* max 30 chars */ String, Row]
-  val gender: OptField[/* max 1 chars */ String, Row]
-  val totalchildren: OptField[Int, Row]
-  val numberchildrenathome: OptField[Int, Row]
-  val education: OptField[/* max 30 chars */ String, Row]
-  val occupation: OptField[/* max 30 chars */ String, Row]
-  val homeownerflag: OptField[Boolean, Row]
-  val numbercarsowned: OptField[Int, Row]
+trait VpersondemographicsViewFields {
+  def businessentityid: Field[BusinessentityId, VpersondemographicsViewRow]
+  def totalpurchaseytd: OptField[TypoMoney, VpersondemographicsViewRow]
+  def datefirstpurchase: OptField[TypoLocalDate, VpersondemographicsViewRow]
+  def birthdate: OptField[TypoLocalDate, VpersondemographicsViewRow]
+  def maritalstatus: OptField[/* max 1 chars */ String, VpersondemographicsViewRow]
+  def yearlyincome: OptField[/* max 30 chars */ String, VpersondemographicsViewRow]
+  def gender: OptField[/* max 1 chars */ String, VpersondemographicsViewRow]
+  def totalchildren: OptField[Int, VpersondemographicsViewRow]
+  def numberchildrenathome: OptField[Int, VpersondemographicsViewRow]
+  def education: OptField[/* max 30 chars */ String, VpersondemographicsViewRow]
+  def occupation: OptField[/* max 30 chars */ String, VpersondemographicsViewRow]
+  def homeownerflag: OptField[Boolean, VpersondemographicsViewRow]
+  def numbercarsowned: OptField[Int, VpersondemographicsViewRow]
 }
 
 object VpersondemographicsViewFields {
-  val structure: Relation[VpersondemographicsViewFields, VpersondemographicsViewRow, VpersondemographicsViewRow] = 
-    new Impl(None, identity, (_, x) => x)
+  lazy val structure: Relation[VpersondemographicsViewFields, VpersondemographicsViewRow] =
+    new Impl(Nil)
     
-  private final class Impl[Row](val prefix: Option[String], val extract: Row => VpersondemographicsViewRow, val merge: (Row, VpersondemographicsViewRow) => Row)
-    extends Relation[VpersondemographicsViewFields, VpersondemographicsViewRow, Row] { 
+  private final class Impl(val _path: List[Path])
+    extends Relation[VpersondemographicsViewFields, VpersondemographicsViewRow] {
   
-    override val fields: VpersondemographicsViewFields[Row] = new VpersondemographicsViewFields[Row] {
-      override val businessentityid = new Field[BusinessentityId, Row](prefix, "businessentityid", None, None)(x => extract(x).businessentityid, (row, value) => merge(row, extract(row).copy(businessentityid = value)))
-      override val totalpurchaseytd = new OptField[TypoMoney, Row](prefix, "totalpurchaseytd", Some("numeric"), None)(x => extract(x).totalpurchaseytd, (row, value) => merge(row, extract(row).copy(totalpurchaseytd = value)))
-      override val datefirstpurchase = new OptField[TypoLocalDate, Row](prefix, "datefirstpurchase", Some("text"), None)(x => extract(x).datefirstpurchase, (row, value) => merge(row, extract(row).copy(datefirstpurchase = value)))
-      override val birthdate = new OptField[TypoLocalDate, Row](prefix, "birthdate", Some("text"), None)(x => extract(x).birthdate, (row, value) => merge(row, extract(row).copy(birthdate = value)))
-      override val maritalstatus = new OptField[/* max 1 chars */ String, Row](prefix, "maritalstatus", None, None)(x => extract(x).maritalstatus, (row, value) => merge(row, extract(row).copy(maritalstatus = value)))
-      override val yearlyincome = new OptField[/* max 30 chars */ String, Row](prefix, "yearlyincome", None, None)(x => extract(x).yearlyincome, (row, value) => merge(row, extract(row).copy(yearlyincome = value)))
-      override val gender = new OptField[/* max 1 chars */ String, Row](prefix, "gender", None, None)(x => extract(x).gender, (row, value) => merge(row, extract(row).copy(gender = value)))
-      override val totalchildren = new OptField[Int, Row](prefix, "totalchildren", None, None)(x => extract(x).totalchildren, (row, value) => merge(row, extract(row).copy(totalchildren = value)))
-      override val numberchildrenathome = new OptField[Int, Row](prefix, "numberchildrenathome", None, None)(x => extract(x).numberchildrenathome, (row, value) => merge(row, extract(row).copy(numberchildrenathome = value)))
-      override val education = new OptField[/* max 30 chars */ String, Row](prefix, "education", None, None)(x => extract(x).education, (row, value) => merge(row, extract(row).copy(education = value)))
-      override val occupation = new OptField[/* max 30 chars */ String, Row](prefix, "occupation", None, None)(x => extract(x).occupation, (row, value) => merge(row, extract(row).copy(occupation = value)))
-      override val homeownerflag = new OptField[Boolean, Row](prefix, "homeownerflag", None, None)(x => extract(x).homeownerflag, (row, value) => merge(row, extract(row).copy(homeownerflag = value)))
-      override val numbercarsowned = new OptField[Int, Row](prefix, "numbercarsowned", None, None)(x => extract(x).numbercarsowned, (row, value) => merge(row, extract(row).copy(numbercarsowned = value)))
+    override lazy val fields: VpersondemographicsViewFields = new VpersondemographicsViewFields {
+      override def businessentityid = Field[BusinessentityId, VpersondemographicsViewRow](_path, "businessentityid", None, None, x => x.businessentityid, (row, value) => row.copy(businessentityid = value))
+      override def totalpurchaseytd = OptField[TypoMoney, VpersondemographicsViewRow](_path, "totalpurchaseytd", Some("numeric"), None, x => x.totalpurchaseytd, (row, value) => row.copy(totalpurchaseytd = value))
+      override def datefirstpurchase = OptField[TypoLocalDate, VpersondemographicsViewRow](_path, "datefirstpurchase", Some("text"), None, x => x.datefirstpurchase, (row, value) => row.copy(datefirstpurchase = value))
+      override def birthdate = OptField[TypoLocalDate, VpersondemographicsViewRow](_path, "birthdate", Some("text"), None, x => x.birthdate, (row, value) => row.copy(birthdate = value))
+      override def maritalstatus = OptField[/* max 1 chars */ String, VpersondemographicsViewRow](_path, "maritalstatus", None, None, x => x.maritalstatus, (row, value) => row.copy(maritalstatus = value))
+      override def yearlyincome = OptField[/* max 30 chars */ String, VpersondemographicsViewRow](_path, "yearlyincome", None, None, x => x.yearlyincome, (row, value) => row.copy(yearlyincome = value))
+      override def gender = OptField[/* max 1 chars */ String, VpersondemographicsViewRow](_path, "gender", None, None, x => x.gender, (row, value) => row.copy(gender = value))
+      override def totalchildren = OptField[Int, VpersondemographicsViewRow](_path, "totalchildren", None, None, x => x.totalchildren, (row, value) => row.copy(totalchildren = value))
+      override def numberchildrenathome = OptField[Int, VpersondemographicsViewRow](_path, "numberchildrenathome", None, None, x => x.numberchildrenathome, (row, value) => row.copy(numberchildrenathome = value))
+      override def education = OptField[/* max 30 chars */ String, VpersondemographicsViewRow](_path, "education", None, None, x => x.education, (row, value) => row.copy(education = value))
+      override def occupation = OptField[/* max 30 chars */ String, VpersondemographicsViewRow](_path, "occupation", None, None, x => x.occupation, (row, value) => row.copy(occupation = value))
+      override def homeownerflag = OptField[Boolean, VpersondemographicsViewRow](_path, "homeownerflag", None, None, x => x.homeownerflag, (row, value) => row.copy(homeownerflag = value))
+      override def numbercarsowned = OptField[Int, VpersondemographicsViewRow](_path, "numbercarsowned", None, None, x => x.numbercarsowned, (row, value) => row.copy(numbercarsowned = value))
     }
   
-    override val columns: List[FieldLikeNoHkt[?, Row]] =
-      List[FieldLikeNoHkt[?, Row]](fields.businessentityid, fields.totalpurchaseytd, fields.datefirstpurchase, fields.birthdate, fields.maritalstatus, fields.yearlyincome, fields.gender, fields.totalchildren, fields.numberchildrenathome, fields.education, fields.occupation, fields.homeownerflag, fields.numbercarsowned)
+    override lazy val columns: List[FieldLikeNoHkt[?, VpersondemographicsViewRow]] =
+      List[FieldLikeNoHkt[?, VpersondemographicsViewRow]](fields.businessentityid, fields.totalpurchaseytd, fields.datefirstpurchase, fields.birthdate, fields.maritalstatus, fields.yearlyincome, fields.gender, fields.totalchildren, fields.numberchildrenathome, fields.education, fields.occupation, fields.homeownerflag, fields.numbercarsowned)
   
-    override def copy[NewRow](prefix: Option[String], extract: NewRow => VpersondemographicsViewRow, merge: (NewRow, VpersondemographicsViewRow) => NewRow): Impl[NewRow] =
-      new Impl(prefix, extract, merge)
+    override def copy(path: List[Path]): Impl =
+      new Impl(path)
   }
   
 }

--- a/typo-tester-doobie/generated-and-checked-in/adventureworks/sales/vsalesperson/VsalespersonViewFields.scala
+++ b/typo-tester-doobie/generated-and-checked-in/adventureworks/sales/vsalesperson/VsalespersonViewFields.scala
@@ -11,73 +11,74 @@ import adventureworks.person.businessentity.BusinessentityId
 import adventureworks.public.Name
 import adventureworks.public.Phone
 import adventureworks.userdefined.FirstName
+import typo.dsl.Path
 import typo.dsl.SqlExpr.Field
 import typo.dsl.SqlExpr.FieldLikeNoHkt
 import typo.dsl.SqlExpr.OptField
 import typo.dsl.Structure.Relation
 
-trait VsalespersonViewFields[Row] {
-  val businessentityid: Field[BusinessentityId, Row]
-  val title: OptField[/* max 8 chars */ String, Row]
-  val firstname: Field[/* user-picked */ FirstName, Row]
-  val middlename: OptField[Name, Row]
-  val lastname: Field[Name, Row]
-  val suffix: OptField[/* max 10 chars */ String, Row]
-  val jobtitle: Field[/* max 50 chars */ String, Row]
-  val phonenumber: OptField[Phone, Row]
-  val phonenumbertype: OptField[Name, Row]
-  val emailaddress: OptField[/* max 50 chars */ String, Row]
-  val emailpromotion: Field[Int, Row]
-  val addressline1: Field[/* max 60 chars */ String, Row]
-  val addressline2: OptField[/* max 60 chars */ String, Row]
-  val city: Field[/* max 30 chars */ String, Row]
-  val stateprovincename: Field[Name, Row]
-  val postalcode: Field[/* max 15 chars */ String, Row]
-  val countryregionname: Field[Name, Row]
-  val territoryname: OptField[Name, Row]
-  val territorygroup: OptField[/* max 50 chars */ String, Row]
-  val salesquota: OptField[BigDecimal, Row]
-  val salesytd: Field[BigDecimal, Row]
-  val saleslastyear: Field[BigDecimal, Row]
+trait VsalespersonViewFields {
+  def businessentityid: Field[BusinessentityId, VsalespersonViewRow]
+  def title: OptField[/* max 8 chars */ String, VsalespersonViewRow]
+  def firstname: Field[/* user-picked */ FirstName, VsalespersonViewRow]
+  def middlename: OptField[Name, VsalespersonViewRow]
+  def lastname: Field[Name, VsalespersonViewRow]
+  def suffix: OptField[/* max 10 chars */ String, VsalespersonViewRow]
+  def jobtitle: Field[/* max 50 chars */ String, VsalespersonViewRow]
+  def phonenumber: OptField[Phone, VsalespersonViewRow]
+  def phonenumbertype: OptField[Name, VsalespersonViewRow]
+  def emailaddress: OptField[/* max 50 chars */ String, VsalespersonViewRow]
+  def emailpromotion: Field[Int, VsalespersonViewRow]
+  def addressline1: Field[/* max 60 chars */ String, VsalespersonViewRow]
+  def addressline2: OptField[/* max 60 chars */ String, VsalespersonViewRow]
+  def city: Field[/* max 30 chars */ String, VsalespersonViewRow]
+  def stateprovincename: Field[Name, VsalespersonViewRow]
+  def postalcode: Field[/* max 15 chars */ String, VsalespersonViewRow]
+  def countryregionname: Field[Name, VsalespersonViewRow]
+  def territoryname: OptField[Name, VsalespersonViewRow]
+  def territorygroup: OptField[/* max 50 chars */ String, VsalespersonViewRow]
+  def salesquota: OptField[BigDecimal, VsalespersonViewRow]
+  def salesytd: Field[BigDecimal, VsalespersonViewRow]
+  def saleslastyear: Field[BigDecimal, VsalespersonViewRow]
 }
 
 object VsalespersonViewFields {
-  val structure: Relation[VsalespersonViewFields, VsalespersonViewRow, VsalespersonViewRow] = 
-    new Impl(None, identity, (_, x) => x)
+  lazy val structure: Relation[VsalespersonViewFields, VsalespersonViewRow] =
+    new Impl(Nil)
     
-  private final class Impl[Row](val prefix: Option[String], val extract: Row => VsalespersonViewRow, val merge: (Row, VsalespersonViewRow) => Row)
-    extends Relation[VsalespersonViewFields, VsalespersonViewRow, Row] { 
+  private final class Impl(val _path: List[Path])
+    extends Relation[VsalespersonViewFields, VsalespersonViewRow] {
   
-    override val fields: VsalespersonViewFields[Row] = new VsalespersonViewFields[Row] {
-      override val businessentityid = new Field[BusinessentityId, Row](prefix, "businessentityid", None, None)(x => extract(x).businessentityid, (row, value) => merge(row, extract(row).copy(businessentityid = value)))
-      override val title = new OptField[/* max 8 chars */ String, Row](prefix, "title", None, None)(x => extract(x).title, (row, value) => merge(row, extract(row).copy(title = value)))
-      override val firstname = new Field[/* user-picked */ FirstName, Row](prefix, "firstname", None, None)(x => extract(x).firstname, (row, value) => merge(row, extract(row).copy(firstname = value)))
-      override val middlename = new OptField[Name, Row](prefix, "middlename", None, None)(x => extract(x).middlename, (row, value) => merge(row, extract(row).copy(middlename = value)))
-      override val lastname = new Field[Name, Row](prefix, "lastname", None, None)(x => extract(x).lastname, (row, value) => merge(row, extract(row).copy(lastname = value)))
-      override val suffix = new OptField[/* max 10 chars */ String, Row](prefix, "suffix", None, None)(x => extract(x).suffix, (row, value) => merge(row, extract(row).copy(suffix = value)))
-      override val jobtitle = new Field[/* max 50 chars */ String, Row](prefix, "jobtitle", None, None)(x => extract(x).jobtitle, (row, value) => merge(row, extract(row).copy(jobtitle = value)))
-      override val phonenumber = new OptField[Phone, Row](prefix, "phonenumber", None, None)(x => extract(x).phonenumber, (row, value) => merge(row, extract(row).copy(phonenumber = value)))
-      override val phonenumbertype = new OptField[Name, Row](prefix, "phonenumbertype", None, None)(x => extract(x).phonenumbertype, (row, value) => merge(row, extract(row).copy(phonenumbertype = value)))
-      override val emailaddress = new OptField[/* max 50 chars */ String, Row](prefix, "emailaddress", None, None)(x => extract(x).emailaddress, (row, value) => merge(row, extract(row).copy(emailaddress = value)))
-      override val emailpromotion = new Field[Int, Row](prefix, "emailpromotion", None, None)(x => extract(x).emailpromotion, (row, value) => merge(row, extract(row).copy(emailpromotion = value)))
-      override val addressline1 = new Field[/* max 60 chars */ String, Row](prefix, "addressline1", None, None)(x => extract(x).addressline1, (row, value) => merge(row, extract(row).copy(addressline1 = value)))
-      override val addressline2 = new OptField[/* max 60 chars */ String, Row](prefix, "addressline2", None, None)(x => extract(x).addressline2, (row, value) => merge(row, extract(row).copy(addressline2 = value)))
-      override val city = new Field[/* max 30 chars */ String, Row](prefix, "city", None, None)(x => extract(x).city, (row, value) => merge(row, extract(row).copy(city = value)))
-      override val stateprovincename = new Field[Name, Row](prefix, "stateprovincename", None, None)(x => extract(x).stateprovincename, (row, value) => merge(row, extract(row).copy(stateprovincename = value)))
-      override val postalcode = new Field[/* max 15 chars */ String, Row](prefix, "postalcode", None, None)(x => extract(x).postalcode, (row, value) => merge(row, extract(row).copy(postalcode = value)))
-      override val countryregionname = new Field[Name, Row](prefix, "countryregionname", None, None)(x => extract(x).countryregionname, (row, value) => merge(row, extract(row).copy(countryregionname = value)))
-      override val territoryname = new OptField[Name, Row](prefix, "territoryname", None, None)(x => extract(x).territoryname, (row, value) => merge(row, extract(row).copy(territoryname = value)))
-      override val territorygroup = new OptField[/* max 50 chars */ String, Row](prefix, "territorygroup", None, None)(x => extract(x).territorygroup, (row, value) => merge(row, extract(row).copy(territorygroup = value)))
-      override val salesquota = new OptField[BigDecimal, Row](prefix, "salesquota", None, None)(x => extract(x).salesquota, (row, value) => merge(row, extract(row).copy(salesquota = value)))
-      override val salesytd = new Field[BigDecimal, Row](prefix, "salesytd", None, None)(x => extract(x).salesytd, (row, value) => merge(row, extract(row).copy(salesytd = value)))
-      override val saleslastyear = new Field[BigDecimal, Row](prefix, "saleslastyear", None, None)(x => extract(x).saleslastyear, (row, value) => merge(row, extract(row).copy(saleslastyear = value)))
+    override lazy val fields: VsalespersonViewFields = new VsalespersonViewFields {
+      override def businessentityid = Field[BusinessentityId, VsalespersonViewRow](_path, "businessentityid", None, None, x => x.businessentityid, (row, value) => row.copy(businessentityid = value))
+      override def title = OptField[/* max 8 chars */ String, VsalespersonViewRow](_path, "title", None, None, x => x.title, (row, value) => row.copy(title = value))
+      override def firstname = Field[/* user-picked */ FirstName, VsalespersonViewRow](_path, "firstname", None, None, x => x.firstname, (row, value) => row.copy(firstname = value))
+      override def middlename = OptField[Name, VsalespersonViewRow](_path, "middlename", None, None, x => x.middlename, (row, value) => row.copy(middlename = value))
+      override def lastname = Field[Name, VsalespersonViewRow](_path, "lastname", None, None, x => x.lastname, (row, value) => row.copy(lastname = value))
+      override def suffix = OptField[/* max 10 chars */ String, VsalespersonViewRow](_path, "suffix", None, None, x => x.suffix, (row, value) => row.copy(suffix = value))
+      override def jobtitle = Field[/* max 50 chars */ String, VsalespersonViewRow](_path, "jobtitle", None, None, x => x.jobtitle, (row, value) => row.copy(jobtitle = value))
+      override def phonenumber = OptField[Phone, VsalespersonViewRow](_path, "phonenumber", None, None, x => x.phonenumber, (row, value) => row.copy(phonenumber = value))
+      override def phonenumbertype = OptField[Name, VsalespersonViewRow](_path, "phonenumbertype", None, None, x => x.phonenumbertype, (row, value) => row.copy(phonenumbertype = value))
+      override def emailaddress = OptField[/* max 50 chars */ String, VsalespersonViewRow](_path, "emailaddress", None, None, x => x.emailaddress, (row, value) => row.copy(emailaddress = value))
+      override def emailpromotion = Field[Int, VsalespersonViewRow](_path, "emailpromotion", None, None, x => x.emailpromotion, (row, value) => row.copy(emailpromotion = value))
+      override def addressline1 = Field[/* max 60 chars */ String, VsalespersonViewRow](_path, "addressline1", None, None, x => x.addressline1, (row, value) => row.copy(addressline1 = value))
+      override def addressline2 = OptField[/* max 60 chars */ String, VsalespersonViewRow](_path, "addressline2", None, None, x => x.addressline2, (row, value) => row.copy(addressline2 = value))
+      override def city = Field[/* max 30 chars */ String, VsalespersonViewRow](_path, "city", None, None, x => x.city, (row, value) => row.copy(city = value))
+      override def stateprovincename = Field[Name, VsalespersonViewRow](_path, "stateprovincename", None, None, x => x.stateprovincename, (row, value) => row.copy(stateprovincename = value))
+      override def postalcode = Field[/* max 15 chars */ String, VsalespersonViewRow](_path, "postalcode", None, None, x => x.postalcode, (row, value) => row.copy(postalcode = value))
+      override def countryregionname = Field[Name, VsalespersonViewRow](_path, "countryregionname", None, None, x => x.countryregionname, (row, value) => row.copy(countryregionname = value))
+      override def territoryname = OptField[Name, VsalespersonViewRow](_path, "territoryname", None, None, x => x.territoryname, (row, value) => row.copy(territoryname = value))
+      override def territorygroup = OptField[/* max 50 chars */ String, VsalespersonViewRow](_path, "territorygroup", None, None, x => x.territorygroup, (row, value) => row.copy(territorygroup = value))
+      override def salesquota = OptField[BigDecimal, VsalespersonViewRow](_path, "salesquota", None, None, x => x.salesquota, (row, value) => row.copy(salesquota = value))
+      override def salesytd = Field[BigDecimal, VsalespersonViewRow](_path, "salesytd", None, None, x => x.salesytd, (row, value) => row.copy(salesytd = value))
+      override def saleslastyear = Field[BigDecimal, VsalespersonViewRow](_path, "saleslastyear", None, None, x => x.saleslastyear, (row, value) => row.copy(saleslastyear = value))
     }
   
-    override val columns: List[FieldLikeNoHkt[?, Row]] =
-      List[FieldLikeNoHkt[?, Row]](fields.businessentityid, fields.title, fields.firstname, fields.middlename, fields.lastname, fields.suffix, fields.jobtitle, fields.phonenumber, fields.phonenumbertype, fields.emailaddress, fields.emailpromotion, fields.addressline1, fields.addressline2, fields.city, fields.stateprovincename, fields.postalcode, fields.countryregionname, fields.territoryname, fields.territorygroup, fields.salesquota, fields.salesytd, fields.saleslastyear)
+    override lazy val columns: List[FieldLikeNoHkt[?, VsalespersonViewRow]] =
+      List[FieldLikeNoHkt[?, VsalespersonViewRow]](fields.businessentityid, fields.title, fields.firstname, fields.middlename, fields.lastname, fields.suffix, fields.jobtitle, fields.phonenumber, fields.phonenumbertype, fields.emailaddress, fields.emailpromotion, fields.addressline1, fields.addressline2, fields.city, fields.stateprovincename, fields.postalcode, fields.countryregionname, fields.territoryname, fields.territorygroup, fields.salesquota, fields.salesytd, fields.saleslastyear)
   
-    override def copy[NewRow](prefix: Option[String], extract: NewRow => VsalespersonViewRow, merge: (NewRow, VsalespersonViewRow) => NewRow): Impl[NewRow] =
-      new Impl(prefix, extract, merge)
+    override def copy(path: List[Path]): Impl =
+      new Impl(path)
   }
   
 }

--- a/typo-tester-doobie/generated-and-checked-in/adventureworks/sales/vsalespersonsalesbyfiscalyears/VsalespersonsalesbyfiscalyearsViewFields.scala
+++ b/typo-tester-doobie/generated-and-checked-in/adventureworks/sales/vsalespersonsalesbyfiscalyears/VsalespersonsalesbyfiscalyearsViewFields.scala
@@ -7,42 +7,43 @@ package adventureworks
 package sales
 package vsalespersonsalesbyfiscalyears
 
+import typo.dsl.Path
 import typo.dsl.SqlExpr.FieldLikeNoHkt
 import typo.dsl.SqlExpr.OptField
 import typo.dsl.Structure.Relation
 
-trait VsalespersonsalesbyfiscalyearsViewFields[Row] {
-  val SalesPersonID: OptField[Int, Row]
-  val FullName: OptField[String, Row]
-  val JobTitle: OptField[String, Row]
-  val SalesTerritory: OptField[String, Row]
-  val `2012`: OptField[BigDecimal, Row]
-  val `2013`: OptField[BigDecimal, Row]
-  val `2014`: OptField[BigDecimal, Row]
+trait VsalespersonsalesbyfiscalyearsViewFields {
+  def SalesPersonID: OptField[Int, VsalespersonsalesbyfiscalyearsViewRow]
+  def FullName: OptField[String, VsalespersonsalesbyfiscalyearsViewRow]
+  def JobTitle: OptField[String, VsalespersonsalesbyfiscalyearsViewRow]
+  def SalesTerritory: OptField[String, VsalespersonsalesbyfiscalyearsViewRow]
+  def `2012`: OptField[BigDecimal, VsalespersonsalesbyfiscalyearsViewRow]
+  def `2013`: OptField[BigDecimal, VsalespersonsalesbyfiscalyearsViewRow]
+  def `2014`: OptField[BigDecimal, VsalespersonsalesbyfiscalyearsViewRow]
 }
 
 object VsalespersonsalesbyfiscalyearsViewFields {
-  val structure: Relation[VsalespersonsalesbyfiscalyearsViewFields, VsalespersonsalesbyfiscalyearsViewRow, VsalespersonsalesbyfiscalyearsViewRow] = 
-    new Impl(None, identity, (_, x) => x)
+  lazy val structure: Relation[VsalespersonsalesbyfiscalyearsViewFields, VsalespersonsalesbyfiscalyearsViewRow] =
+    new Impl(Nil)
     
-  private final class Impl[Row](val prefix: Option[String], val extract: Row => VsalespersonsalesbyfiscalyearsViewRow, val merge: (Row, VsalespersonsalesbyfiscalyearsViewRow) => Row)
-    extends Relation[VsalespersonsalesbyfiscalyearsViewFields, VsalespersonsalesbyfiscalyearsViewRow, Row] { 
+  private final class Impl(val _path: List[Path])
+    extends Relation[VsalespersonsalesbyfiscalyearsViewFields, VsalespersonsalesbyfiscalyearsViewRow] {
   
-    override val fields: VsalespersonsalesbyfiscalyearsViewFields[Row] = new VsalespersonsalesbyfiscalyearsViewFields[Row] {
-      override val SalesPersonID = new OptField[Int, Row](prefix, "SalesPersonID", None, None)(x => extract(x).SalesPersonID, (row, value) => merge(row, extract(row).copy(SalesPersonID = value)))
-      override val FullName = new OptField[String, Row](prefix, "FullName", None, None)(x => extract(x).FullName, (row, value) => merge(row, extract(row).copy(FullName = value)))
-      override val JobTitle = new OptField[String, Row](prefix, "JobTitle", None, None)(x => extract(x).JobTitle, (row, value) => merge(row, extract(row).copy(JobTitle = value)))
-      override val SalesTerritory = new OptField[String, Row](prefix, "SalesTerritory", None, None)(x => extract(x).SalesTerritory, (row, value) => merge(row, extract(row).copy(SalesTerritory = value)))
-      override val `2012` = new OptField[BigDecimal, Row](prefix, "2012", None, None)(x => extract(x).`2012`, (row, value) => merge(row, extract(row).copy(`2012` = value)))
-      override val `2013` = new OptField[BigDecimal, Row](prefix, "2013", None, None)(x => extract(x).`2013`, (row, value) => merge(row, extract(row).copy(`2013` = value)))
-      override val `2014` = new OptField[BigDecimal, Row](prefix, "2014", None, None)(x => extract(x).`2014`, (row, value) => merge(row, extract(row).copy(`2014` = value)))
+    override lazy val fields: VsalespersonsalesbyfiscalyearsViewFields = new VsalespersonsalesbyfiscalyearsViewFields {
+      override def SalesPersonID = OptField[Int, VsalespersonsalesbyfiscalyearsViewRow](_path, "SalesPersonID", None, None, x => x.SalesPersonID, (row, value) => row.copy(SalesPersonID = value))
+      override def FullName = OptField[String, VsalespersonsalesbyfiscalyearsViewRow](_path, "FullName", None, None, x => x.FullName, (row, value) => row.copy(FullName = value))
+      override def JobTitle = OptField[String, VsalespersonsalesbyfiscalyearsViewRow](_path, "JobTitle", None, None, x => x.JobTitle, (row, value) => row.copy(JobTitle = value))
+      override def SalesTerritory = OptField[String, VsalespersonsalesbyfiscalyearsViewRow](_path, "SalesTerritory", None, None, x => x.SalesTerritory, (row, value) => row.copy(SalesTerritory = value))
+      override def `2012` = OptField[BigDecimal, VsalespersonsalesbyfiscalyearsViewRow](_path, "2012", None, None, x => x.`2012`, (row, value) => row.copy(`2012` = value))
+      override def `2013` = OptField[BigDecimal, VsalespersonsalesbyfiscalyearsViewRow](_path, "2013", None, None, x => x.`2013`, (row, value) => row.copy(`2013` = value))
+      override def `2014` = OptField[BigDecimal, VsalespersonsalesbyfiscalyearsViewRow](_path, "2014", None, None, x => x.`2014`, (row, value) => row.copy(`2014` = value))
     }
   
-    override val columns: List[FieldLikeNoHkt[?, Row]] =
-      List[FieldLikeNoHkt[?, Row]](fields.SalesPersonID, fields.FullName, fields.JobTitle, fields.SalesTerritory, fields.`2012`, fields.`2013`, fields.`2014`)
+    override lazy val columns: List[FieldLikeNoHkt[?, VsalespersonsalesbyfiscalyearsViewRow]] =
+      List[FieldLikeNoHkt[?, VsalespersonsalesbyfiscalyearsViewRow]](fields.SalesPersonID, fields.FullName, fields.JobTitle, fields.SalesTerritory, fields.`2012`, fields.`2013`, fields.`2014`)
   
-    override def copy[NewRow](prefix: Option[String], extract: NewRow => VsalespersonsalesbyfiscalyearsViewRow, merge: (NewRow, VsalespersonsalesbyfiscalyearsViewRow) => NewRow): Impl[NewRow] =
-      new Impl(prefix, extract, merge)
+    override def copy(path: List[Path]): Impl =
+      new Impl(path)
   }
   
 }

--- a/typo-tester-doobie/generated-and-checked-in/adventureworks/sales/vsalespersonsalesbyfiscalyearsdata/VsalespersonsalesbyfiscalyearsdataViewFields.scala
+++ b/typo-tester-doobie/generated-and-checked-in/adventureworks/sales/vsalespersonsalesbyfiscalyearsdata/VsalespersonsalesbyfiscalyearsdataViewFields.scala
@@ -9,41 +9,42 @@ package vsalespersonsalesbyfiscalyearsdata
 
 import adventureworks.person.businessentity.BusinessentityId
 import adventureworks.public.Name
+import typo.dsl.Path
 import typo.dsl.SqlExpr.Field
 import typo.dsl.SqlExpr.FieldLikeNoHkt
 import typo.dsl.SqlExpr.OptField
 import typo.dsl.Structure.Relation
 
-trait VsalespersonsalesbyfiscalyearsdataViewFields[Row] {
-  val salespersonid: OptField[BusinessentityId, Row]
-  val fullname: OptField[String, Row]
-  val jobtitle: Field[/* max 50 chars */ String, Row]
-  val salesterritory: Field[Name, Row]
-  val salestotal: OptField[BigDecimal, Row]
-  val fiscalyear: OptField[BigDecimal, Row]
+trait VsalespersonsalesbyfiscalyearsdataViewFields {
+  def salespersonid: OptField[BusinessentityId, VsalespersonsalesbyfiscalyearsdataViewRow]
+  def fullname: OptField[String, VsalespersonsalesbyfiscalyearsdataViewRow]
+  def jobtitle: Field[/* max 50 chars */ String, VsalespersonsalesbyfiscalyearsdataViewRow]
+  def salesterritory: Field[Name, VsalespersonsalesbyfiscalyearsdataViewRow]
+  def salestotal: OptField[BigDecimal, VsalespersonsalesbyfiscalyearsdataViewRow]
+  def fiscalyear: OptField[BigDecimal, VsalespersonsalesbyfiscalyearsdataViewRow]
 }
 
 object VsalespersonsalesbyfiscalyearsdataViewFields {
-  val structure: Relation[VsalespersonsalesbyfiscalyearsdataViewFields, VsalespersonsalesbyfiscalyearsdataViewRow, VsalespersonsalesbyfiscalyearsdataViewRow] = 
-    new Impl(None, identity, (_, x) => x)
+  lazy val structure: Relation[VsalespersonsalesbyfiscalyearsdataViewFields, VsalespersonsalesbyfiscalyearsdataViewRow] =
+    new Impl(Nil)
     
-  private final class Impl[Row](val prefix: Option[String], val extract: Row => VsalespersonsalesbyfiscalyearsdataViewRow, val merge: (Row, VsalespersonsalesbyfiscalyearsdataViewRow) => Row)
-    extends Relation[VsalespersonsalesbyfiscalyearsdataViewFields, VsalespersonsalesbyfiscalyearsdataViewRow, Row] { 
+  private final class Impl(val _path: List[Path])
+    extends Relation[VsalespersonsalesbyfiscalyearsdataViewFields, VsalespersonsalesbyfiscalyearsdataViewRow] {
   
-    override val fields: VsalespersonsalesbyfiscalyearsdataViewFields[Row] = new VsalespersonsalesbyfiscalyearsdataViewFields[Row] {
-      override val salespersonid = new OptField[BusinessentityId, Row](prefix, "salespersonid", None, None)(x => extract(x).salespersonid, (row, value) => merge(row, extract(row).copy(salespersonid = value)))
-      override val fullname = new OptField[String, Row](prefix, "fullname", None, None)(x => extract(x).fullname, (row, value) => merge(row, extract(row).copy(fullname = value)))
-      override val jobtitle = new Field[/* max 50 chars */ String, Row](prefix, "jobtitle", None, None)(x => extract(x).jobtitle, (row, value) => merge(row, extract(row).copy(jobtitle = value)))
-      override val salesterritory = new Field[Name, Row](prefix, "salesterritory", None, None)(x => extract(x).salesterritory, (row, value) => merge(row, extract(row).copy(salesterritory = value)))
-      override val salestotal = new OptField[BigDecimal, Row](prefix, "salestotal", None, None)(x => extract(x).salestotal, (row, value) => merge(row, extract(row).copy(salestotal = value)))
-      override val fiscalyear = new OptField[BigDecimal, Row](prefix, "fiscalyear", None, None)(x => extract(x).fiscalyear, (row, value) => merge(row, extract(row).copy(fiscalyear = value)))
+    override lazy val fields: VsalespersonsalesbyfiscalyearsdataViewFields = new VsalespersonsalesbyfiscalyearsdataViewFields {
+      override def salespersonid = OptField[BusinessentityId, VsalespersonsalesbyfiscalyearsdataViewRow](_path, "salespersonid", None, None, x => x.salespersonid, (row, value) => row.copy(salespersonid = value))
+      override def fullname = OptField[String, VsalespersonsalesbyfiscalyearsdataViewRow](_path, "fullname", None, None, x => x.fullname, (row, value) => row.copy(fullname = value))
+      override def jobtitle = Field[/* max 50 chars */ String, VsalespersonsalesbyfiscalyearsdataViewRow](_path, "jobtitle", None, None, x => x.jobtitle, (row, value) => row.copy(jobtitle = value))
+      override def salesterritory = Field[Name, VsalespersonsalesbyfiscalyearsdataViewRow](_path, "salesterritory", None, None, x => x.salesterritory, (row, value) => row.copy(salesterritory = value))
+      override def salestotal = OptField[BigDecimal, VsalespersonsalesbyfiscalyearsdataViewRow](_path, "salestotal", None, None, x => x.salestotal, (row, value) => row.copy(salestotal = value))
+      override def fiscalyear = OptField[BigDecimal, VsalespersonsalesbyfiscalyearsdataViewRow](_path, "fiscalyear", None, None, x => x.fiscalyear, (row, value) => row.copy(fiscalyear = value))
     }
   
-    override val columns: List[FieldLikeNoHkt[?, Row]] =
-      List[FieldLikeNoHkt[?, Row]](fields.salespersonid, fields.fullname, fields.jobtitle, fields.salesterritory, fields.salestotal, fields.fiscalyear)
+    override lazy val columns: List[FieldLikeNoHkt[?, VsalespersonsalesbyfiscalyearsdataViewRow]] =
+      List[FieldLikeNoHkt[?, VsalespersonsalesbyfiscalyearsdataViewRow]](fields.salespersonid, fields.fullname, fields.jobtitle, fields.salesterritory, fields.salestotal, fields.fiscalyear)
   
-    override def copy[NewRow](prefix: Option[String], extract: NewRow => VsalespersonsalesbyfiscalyearsdataViewRow, merge: (NewRow, VsalespersonsalesbyfiscalyearsdataViewRow) => NewRow): Impl[NewRow] =
-      new Impl(prefix, extract, merge)
+    override def copy(path: List[Path]): Impl =
+      new Impl(path)
   }
   
 }

--- a/typo-tester-doobie/generated-and-checked-in/adventureworks/sales/vstorewithaddresses/VstorewithaddressesViewFields.scala
+++ b/typo-tester-doobie/generated-and-checked-in/adventureworks/sales/vstorewithaddresses/VstorewithaddressesViewFields.scala
@@ -9,47 +9,48 @@ package vstorewithaddresses
 
 import adventureworks.person.businessentity.BusinessentityId
 import adventureworks.public.Name
+import typo.dsl.Path
 import typo.dsl.SqlExpr.Field
 import typo.dsl.SqlExpr.FieldLikeNoHkt
 import typo.dsl.SqlExpr.OptField
 import typo.dsl.Structure.Relation
 
-trait VstorewithaddressesViewFields[Row] {
-  val businessentityid: Field[BusinessentityId, Row]
-  val name: Field[Name, Row]
-  val addresstype: Field[Name, Row]
-  val addressline1: Field[/* max 60 chars */ String, Row]
-  val addressline2: OptField[/* max 60 chars */ String, Row]
-  val city: Field[/* max 30 chars */ String, Row]
-  val stateprovincename: Field[Name, Row]
-  val postalcode: Field[/* max 15 chars */ String, Row]
-  val countryregionname: Field[Name, Row]
+trait VstorewithaddressesViewFields {
+  def businessentityid: Field[BusinessentityId, VstorewithaddressesViewRow]
+  def name: Field[Name, VstorewithaddressesViewRow]
+  def addresstype: Field[Name, VstorewithaddressesViewRow]
+  def addressline1: Field[/* max 60 chars */ String, VstorewithaddressesViewRow]
+  def addressline2: OptField[/* max 60 chars */ String, VstorewithaddressesViewRow]
+  def city: Field[/* max 30 chars */ String, VstorewithaddressesViewRow]
+  def stateprovincename: Field[Name, VstorewithaddressesViewRow]
+  def postalcode: Field[/* max 15 chars */ String, VstorewithaddressesViewRow]
+  def countryregionname: Field[Name, VstorewithaddressesViewRow]
 }
 
 object VstorewithaddressesViewFields {
-  val structure: Relation[VstorewithaddressesViewFields, VstorewithaddressesViewRow, VstorewithaddressesViewRow] = 
-    new Impl(None, identity, (_, x) => x)
+  lazy val structure: Relation[VstorewithaddressesViewFields, VstorewithaddressesViewRow] =
+    new Impl(Nil)
     
-  private final class Impl[Row](val prefix: Option[String], val extract: Row => VstorewithaddressesViewRow, val merge: (Row, VstorewithaddressesViewRow) => Row)
-    extends Relation[VstorewithaddressesViewFields, VstorewithaddressesViewRow, Row] { 
+  private final class Impl(val _path: List[Path])
+    extends Relation[VstorewithaddressesViewFields, VstorewithaddressesViewRow] {
   
-    override val fields: VstorewithaddressesViewFields[Row] = new VstorewithaddressesViewFields[Row] {
-      override val businessentityid = new Field[BusinessentityId, Row](prefix, "businessentityid", None, None)(x => extract(x).businessentityid, (row, value) => merge(row, extract(row).copy(businessentityid = value)))
-      override val name = new Field[Name, Row](prefix, "name", None, None)(x => extract(x).name, (row, value) => merge(row, extract(row).copy(name = value)))
-      override val addresstype = new Field[Name, Row](prefix, "addresstype", None, None)(x => extract(x).addresstype, (row, value) => merge(row, extract(row).copy(addresstype = value)))
-      override val addressline1 = new Field[/* max 60 chars */ String, Row](prefix, "addressline1", None, None)(x => extract(x).addressline1, (row, value) => merge(row, extract(row).copy(addressline1 = value)))
-      override val addressline2 = new OptField[/* max 60 chars */ String, Row](prefix, "addressline2", None, None)(x => extract(x).addressline2, (row, value) => merge(row, extract(row).copy(addressline2 = value)))
-      override val city = new Field[/* max 30 chars */ String, Row](prefix, "city", None, None)(x => extract(x).city, (row, value) => merge(row, extract(row).copy(city = value)))
-      override val stateprovincename = new Field[Name, Row](prefix, "stateprovincename", None, None)(x => extract(x).stateprovincename, (row, value) => merge(row, extract(row).copy(stateprovincename = value)))
-      override val postalcode = new Field[/* max 15 chars */ String, Row](prefix, "postalcode", None, None)(x => extract(x).postalcode, (row, value) => merge(row, extract(row).copy(postalcode = value)))
-      override val countryregionname = new Field[Name, Row](prefix, "countryregionname", None, None)(x => extract(x).countryregionname, (row, value) => merge(row, extract(row).copy(countryregionname = value)))
+    override lazy val fields: VstorewithaddressesViewFields = new VstorewithaddressesViewFields {
+      override def businessentityid = Field[BusinessentityId, VstorewithaddressesViewRow](_path, "businessentityid", None, None, x => x.businessentityid, (row, value) => row.copy(businessentityid = value))
+      override def name = Field[Name, VstorewithaddressesViewRow](_path, "name", None, None, x => x.name, (row, value) => row.copy(name = value))
+      override def addresstype = Field[Name, VstorewithaddressesViewRow](_path, "addresstype", None, None, x => x.addresstype, (row, value) => row.copy(addresstype = value))
+      override def addressline1 = Field[/* max 60 chars */ String, VstorewithaddressesViewRow](_path, "addressline1", None, None, x => x.addressline1, (row, value) => row.copy(addressline1 = value))
+      override def addressline2 = OptField[/* max 60 chars */ String, VstorewithaddressesViewRow](_path, "addressline2", None, None, x => x.addressline2, (row, value) => row.copy(addressline2 = value))
+      override def city = Field[/* max 30 chars */ String, VstorewithaddressesViewRow](_path, "city", None, None, x => x.city, (row, value) => row.copy(city = value))
+      override def stateprovincename = Field[Name, VstorewithaddressesViewRow](_path, "stateprovincename", None, None, x => x.stateprovincename, (row, value) => row.copy(stateprovincename = value))
+      override def postalcode = Field[/* max 15 chars */ String, VstorewithaddressesViewRow](_path, "postalcode", None, None, x => x.postalcode, (row, value) => row.copy(postalcode = value))
+      override def countryregionname = Field[Name, VstorewithaddressesViewRow](_path, "countryregionname", None, None, x => x.countryregionname, (row, value) => row.copy(countryregionname = value))
     }
   
-    override val columns: List[FieldLikeNoHkt[?, Row]] =
-      List[FieldLikeNoHkt[?, Row]](fields.businessentityid, fields.name, fields.addresstype, fields.addressline1, fields.addressline2, fields.city, fields.stateprovincename, fields.postalcode, fields.countryregionname)
+    override lazy val columns: List[FieldLikeNoHkt[?, VstorewithaddressesViewRow]] =
+      List[FieldLikeNoHkt[?, VstorewithaddressesViewRow]](fields.businessentityid, fields.name, fields.addresstype, fields.addressline1, fields.addressline2, fields.city, fields.stateprovincename, fields.postalcode, fields.countryregionname)
   
-    override def copy[NewRow](prefix: Option[String], extract: NewRow => VstorewithaddressesViewRow, merge: (NewRow, VstorewithaddressesViewRow) => NewRow): Impl[NewRow] =
-      new Impl(prefix, extract, merge)
+    override def copy(path: List[Path]): Impl =
+      new Impl(path)
   }
   
 }

--- a/typo-tester-doobie/generated-and-checked-in/adventureworks/sales/vstorewithcontacts/VstorewithcontactsViewFields.scala
+++ b/typo-tester-doobie/generated-and-checked-in/adventureworks/sales/vstorewithcontacts/VstorewithcontactsViewFields.scala
@@ -11,53 +11,54 @@ import adventureworks.person.businessentity.BusinessentityId
 import adventureworks.public.Name
 import adventureworks.public.Phone
 import adventureworks.userdefined.FirstName
+import typo.dsl.Path
 import typo.dsl.SqlExpr.Field
 import typo.dsl.SqlExpr.FieldLikeNoHkt
 import typo.dsl.SqlExpr.OptField
 import typo.dsl.Structure.Relation
 
-trait VstorewithcontactsViewFields[Row] {
-  val businessentityid: Field[BusinessentityId, Row]
-  val name: Field[Name, Row]
-  val contacttype: Field[Name, Row]
-  val title: OptField[/* max 8 chars */ String, Row]
-  val firstname: Field[/* user-picked */ FirstName, Row]
-  val middlename: OptField[Name, Row]
-  val lastname: Field[Name, Row]
-  val suffix: OptField[/* max 10 chars */ String, Row]
-  val phonenumber: OptField[Phone, Row]
-  val phonenumbertype: OptField[Name, Row]
-  val emailaddress: OptField[/* max 50 chars */ String, Row]
-  val emailpromotion: Field[Int, Row]
+trait VstorewithcontactsViewFields {
+  def businessentityid: Field[BusinessentityId, VstorewithcontactsViewRow]
+  def name: Field[Name, VstorewithcontactsViewRow]
+  def contacttype: Field[Name, VstorewithcontactsViewRow]
+  def title: OptField[/* max 8 chars */ String, VstorewithcontactsViewRow]
+  def firstname: Field[/* user-picked */ FirstName, VstorewithcontactsViewRow]
+  def middlename: OptField[Name, VstorewithcontactsViewRow]
+  def lastname: Field[Name, VstorewithcontactsViewRow]
+  def suffix: OptField[/* max 10 chars */ String, VstorewithcontactsViewRow]
+  def phonenumber: OptField[Phone, VstorewithcontactsViewRow]
+  def phonenumbertype: OptField[Name, VstorewithcontactsViewRow]
+  def emailaddress: OptField[/* max 50 chars */ String, VstorewithcontactsViewRow]
+  def emailpromotion: Field[Int, VstorewithcontactsViewRow]
 }
 
 object VstorewithcontactsViewFields {
-  val structure: Relation[VstorewithcontactsViewFields, VstorewithcontactsViewRow, VstorewithcontactsViewRow] = 
-    new Impl(None, identity, (_, x) => x)
+  lazy val structure: Relation[VstorewithcontactsViewFields, VstorewithcontactsViewRow] =
+    new Impl(Nil)
     
-  private final class Impl[Row](val prefix: Option[String], val extract: Row => VstorewithcontactsViewRow, val merge: (Row, VstorewithcontactsViewRow) => Row)
-    extends Relation[VstorewithcontactsViewFields, VstorewithcontactsViewRow, Row] { 
+  private final class Impl(val _path: List[Path])
+    extends Relation[VstorewithcontactsViewFields, VstorewithcontactsViewRow] {
   
-    override val fields: VstorewithcontactsViewFields[Row] = new VstorewithcontactsViewFields[Row] {
-      override val businessentityid = new Field[BusinessentityId, Row](prefix, "businessentityid", None, None)(x => extract(x).businessentityid, (row, value) => merge(row, extract(row).copy(businessentityid = value)))
-      override val name = new Field[Name, Row](prefix, "name", None, None)(x => extract(x).name, (row, value) => merge(row, extract(row).copy(name = value)))
-      override val contacttype = new Field[Name, Row](prefix, "contacttype", None, None)(x => extract(x).contacttype, (row, value) => merge(row, extract(row).copy(contacttype = value)))
-      override val title = new OptField[/* max 8 chars */ String, Row](prefix, "title", None, None)(x => extract(x).title, (row, value) => merge(row, extract(row).copy(title = value)))
-      override val firstname = new Field[/* user-picked */ FirstName, Row](prefix, "firstname", None, None)(x => extract(x).firstname, (row, value) => merge(row, extract(row).copy(firstname = value)))
-      override val middlename = new OptField[Name, Row](prefix, "middlename", None, None)(x => extract(x).middlename, (row, value) => merge(row, extract(row).copy(middlename = value)))
-      override val lastname = new Field[Name, Row](prefix, "lastname", None, None)(x => extract(x).lastname, (row, value) => merge(row, extract(row).copy(lastname = value)))
-      override val suffix = new OptField[/* max 10 chars */ String, Row](prefix, "suffix", None, None)(x => extract(x).suffix, (row, value) => merge(row, extract(row).copy(suffix = value)))
-      override val phonenumber = new OptField[Phone, Row](prefix, "phonenumber", None, None)(x => extract(x).phonenumber, (row, value) => merge(row, extract(row).copy(phonenumber = value)))
-      override val phonenumbertype = new OptField[Name, Row](prefix, "phonenumbertype", None, None)(x => extract(x).phonenumbertype, (row, value) => merge(row, extract(row).copy(phonenumbertype = value)))
-      override val emailaddress = new OptField[/* max 50 chars */ String, Row](prefix, "emailaddress", None, None)(x => extract(x).emailaddress, (row, value) => merge(row, extract(row).copy(emailaddress = value)))
-      override val emailpromotion = new Field[Int, Row](prefix, "emailpromotion", None, None)(x => extract(x).emailpromotion, (row, value) => merge(row, extract(row).copy(emailpromotion = value)))
+    override lazy val fields: VstorewithcontactsViewFields = new VstorewithcontactsViewFields {
+      override def businessentityid = Field[BusinessentityId, VstorewithcontactsViewRow](_path, "businessentityid", None, None, x => x.businessentityid, (row, value) => row.copy(businessentityid = value))
+      override def name = Field[Name, VstorewithcontactsViewRow](_path, "name", None, None, x => x.name, (row, value) => row.copy(name = value))
+      override def contacttype = Field[Name, VstorewithcontactsViewRow](_path, "contacttype", None, None, x => x.contacttype, (row, value) => row.copy(contacttype = value))
+      override def title = OptField[/* max 8 chars */ String, VstorewithcontactsViewRow](_path, "title", None, None, x => x.title, (row, value) => row.copy(title = value))
+      override def firstname = Field[/* user-picked */ FirstName, VstorewithcontactsViewRow](_path, "firstname", None, None, x => x.firstname, (row, value) => row.copy(firstname = value))
+      override def middlename = OptField[Name, VstorewithcontactsViewRow](_path, "middlename", None, None, x => x.middlename, (row, value) => row.copy(middlename = value))
+      override def lastname = Field[Name, VstorewithcontactsViewRow](_path, "lastname", None, None, x => x.lastname, (row, value) => row.copy(lastname = value))
+      override def suffix = OptField[/* max 10 chars */ String, VstorewithcontactsViewRow](_path, "suffix", None, None, x => x.suffix, (row, value) => row.copy(suffix = value))
+      override def phonenumber = OptField[Phone, VstorewithcontactsViewRow](_path, "phonenumber", None, None, x => x.phonenumber, (row, value) => row.copy(phonenumber = value))
+      override def phonenumbertype = OptField[Name, VstorewithcontactsViewRow](_path, "phonenumbertype", None, None, x => x.phonenumbertype, (row, value) => row.copy(phonenumbertype = value))
+      override def emailaddress = OptField[/* max 50 chars */ String, VstorewithcontactsViewRow](_path, "emailaddress", None, None, x => x.emailaddress, (row, value) => row.copy(emailaddress = value))
+      override def emailpromotion = Field[Int, VstorewithcontactsViewRow](_path, "emailpromotion", None, None, x => x.emailpromotion, (row, value) => row.copy(emailpromotion = value))
     }
   
-    override val columns: List[FieldLikeNoHkt[?, Row]] =
-      List[FieldLikeNoHkt[?, Row]](fields.businessentityid, fields.name, fields.contacttype, fields.title, fields.firstname, fields.middlename, fields.lastname, fields.suffix, fields.phonenumber, fields.phonenumbertype, fields.emailaddress, fields.emailpromotion)
+    override lazy val columns: List[FieldLikeNoHkt[?, VstorewithcontactsViewRow]] =
+      List[FieldLikeNoHkt[?, VstorewithcontactsViewRow]](fields.businessentityid, fields.name, fields.contacttype, fields.title, fields.firstname, fields.middlename, fields.lastname, fields.suffix, fields.phonenumber, fields.phonenumbertype, fields.emailaddress, fields.emailpromotion)
   
-    override def copy[NewRow](prefix: Option[String], extract: NewRow => VstorewithcontactsViewRow, merge: (NewRow, VstorewithcontactsViewRow) => NewRow): Impl[NewRow] =
-      new Impl(prefix, extract, merge)
+    override def copy(path: List[Path]): Impl =
+      new Impl(path)
   }
   
 }

--- a/typo-tester-doobie/generated-and-checked-in/adventureworks/sales/vstorewithdemographics/VstorewithdemographicsViewFields.scala
+++ b/typo-tester-doobie/generated-and-checked-in/adventureworks/sales/vstorewithdemographics/VstorewithdemographicsViewFields.scala
@@ -10,53 +10,54 @@ package vstorewithdemographics
 import adventureworks.customtypes.TypoMoney
 import adventureworks.person.businessentity.BusinessentityId
 import adventureworks.public.Name
+import typo.dsl.Path
 import typo.dsl.SqlExpr.Field
 import typo.dsl.SqlExpr.FieldLikeNoHkt
 import typo.dsl.SqlExpr.OptField
 import typo.dsl.Structure.Relation
 
-trait VstorewithdemographicsViewFields[Row] {
-  val businessentityid: Field[BusinessentityId, Row]
-  val name: Field[Name, Row]
-  val AnnualSales: OptField[TypoMoney, Row]
-  val AnnualRevenue: OptField[TypoMoney, Row]
-  val BankName: OptField[/* max 50 chars */ String, Row]
-  val BusinessType: OptField[/* max 5 chars */ String, Row]
-  val YearOpened: OptField[Int, Row]
-  val Specialty: OptField[/* max 50 chars */ String, Row]
-  val SquareFeet: OptField[Int, Row]
-  val Brands: OptField[/* max 30 chars */ String, Row]
-  val Internet: OptField[/* max 30 chars */ String, Row]
-  val NumberEmployees: OptField[Int, Row]
+trait VstorewithdemographicsViewFields {
+  def businessentityid: Field[BusinessentityId, VstorewithdemographicsViewRow]
+  def name: Field[Name, VstorewithdemographicsViewRow]
+  def AnnualSales: OptField[TypoMoney, VstorewithdemographicsViewRow]
+  def AnnualRevenue: OptField[TypoMoney, VstorewithdemographicsViewRow]
+  def BankName: OptField[/* max 50 chars */ String, VstorewithdemographicsViewRow]
+  def BusinessType: OptField[/* max 5 chars */ String, VstorewithdemographicsViewRow]
+  def YearOpened: OptField[Int, VstorewithdemographicsViewRow]
+  def Specialty: OptField[/* max 50 chars */ String, VstorewithdemographicsViewRow]
+  def SquareFeet: OptField[Int, VstorewithdemographicsViewRow]
+  def Brands: OptField[/* max 30 chars */ String, VstorewithdemographicsViewRow]
+  def Internet: OptField[/* max 30 chars */ String, VstorewithdemographicsViewRow]
+  def NumberEmployees: OptField[Int, VstorewithdemographicsViewRow]
 }
 
 object VstorewithdemographicsViewFields {
-  val structure: Relation[VstorewithdemographicsViewFields, VstorewithdemographicsViewRow, VstorewithdemographicsViewRow] = 
-    new Impl(None, identity, (_, x) => x)
+  lazy val structure: Relation[VstorewithdemographicsViewFields, VstorewithdemographicsViewRow] =
+    new Impl(Nil)
     
-  private final class Impl[Row](val prefix: Option[String], val extract: Row => VstorewithdemographicsViewRow, val merge: (Row, VstorewithdemographicsViewRow) => Row)
-    extends Relation[VstorewithdemographicsViewFields, VstorewithdemographicsViewRow, Row] { 
+  private final class Impl(val _path: List[Path])
+    extends Relation[VstorewithdemographicsViewFields, VstorewithdemographicsViewRow] {
   
-    override val fields: VstorewithdemographicsViewFields[Row] = new VstorewithdemographicsViewFields[Row] {
-      override val businessentityid = new Field[BusinessentityId, Row](prefix, "businessentityid", None, None)(x => extract(x).businessentityid, (row, value) => merge(row, extract(row).copy(businessentityid = value)))
-      override val name = new Field[Name, Row](prefix, "name", None, None)(x => extract(x).name, (row, value) => merge(row, extract(row).copy(name = value)))
-      override val AnnualSales = new OptField[TypoMoney, Row](prefix, "AnnualSales", Some("numeric"), None)(x => extract(x).AnnualSales, (row, value) => merge(row, extract(row).copy(AnnualSales = value)))
-      override val AnnualRevenue = new OptField[TypoMoney, Row](prefix, "AnnualRevenue", Some("numeric"), None)(x => extract(x).AnnualRevenue, (row, value) => merge(row, extract(row).copy(AnnualRevenue = value)))
-      override val BankName = new OptField[/* max 50 chars */ String, Row](prefix, "BankName", None, None)(x => extract(x).BankName, (row, value) => merge(row, extract(row).copy(BankName = value)))
-      override val BusinessType = new OptField[/* max 5 chars */ String, Row](prefix, "BusinessType", None, None)(x => extract(x).BusinessType, (row, value) => merge(row, extract(row).copy(BusinessType = value)))
-      override val YearOpened = new OptField[Int, Row](prefix, "YearOpened", None, None)(x => extract(x).YearOpened, (row, value) => merge(row, extract(row).copy(YearOpened = value)))
-      override val Specialty = new OptField[/* max 50 chars */ String, Row](prefix, "Specialty", None, None)(x => extract(x).Specialty, (row, value) => merge(row, extract(row).copy(Specialty = value)))
-      override val SquareFeet = new OptField[Int, Row](prefix, "SquareFeet", None, None)(x => extract(x).SquareFeet, (row, value) => merge(row, extract(row).copy(SquareFeet = value)))
-      override val Brands = new OptField[/* max 30 chars */ String, Row](prefix, "Brands", None, None)(x => extract(x).Brands, (row, value) => merge(row, extract(row).copy(Brands = value)))
-      override val Internet = new OptField[/* max 30 chars */ String, Row](prefix, "Internet", None, None)(x => extract(x).Internet, (row, value) => merge(row, extract(row).copy(Internet = value)))
-      override val NumberEmployees = new OptField[Int, Row](prefix, "NumberEmployees", None, None)(x => extract(x).NumberEmployees, (row, value) => merge(row, extract(row).copy(NumberEmployees = value)))
+    override lazy val fields: VstorewithdemographicsViewFields = new VstorewithdemographicsViewFields {
+      override def businessentityid = Field[BusinessentityId, VstorewithdemographicsViewRow](_path, "businessentityid", None, None, x => x.businessentityid, (row, value) => row.copy(businessentityid = value))
+      override def name = Field[Name, VstorewithdemographicsViewRow](_path, "name", None, None, x => x.name, (row, value) => row.copy(name = value))
+      override def AnnualSales = OptField[TypoMoney, VstorewithdemographicsViewRow](_path, "AnnualSales", Some("numeric"), None, x => x.AnnualSales, (row, value) => row.copy(AnnualSales = value))
+      override def AnnualRevenue = OptField[TypoMoney, VstorewithdemographicsViewRow](_path, "AnnualRevenue", Some("numeric"), None, x => x.AnnualRevenue, (row, value) => row.copy(AnnualRevenue = value))
+      override def BankName = OptField[/* max 50 chars */ String, VstorewithdemographicsViewRow](_path, "BankName", None, None, x => x.BankName, (row, value) => row.copy(BankName = value))
+      override def BusinessType = OptField[/* max 5 chars */ String, VstorewithdemographicsViewRow](_path, "BusinessType", None, None, x => x.BusinessType, (row, value) => row.copy(BusinessType = value))
+      override def YearOpened = OptField[Int, VstorewithdemographicsViewRow](_path, "YearOpened", None, None, x => x.YearOpened, (row, value) => row.copy(YearOpened = value))
+      override def Specialty = OptField[/* max 50 chars */ String, VstorewithdemographicsViewRow](_path, "Specialty", None, None, x => x.Specialty, (row, value) => row.copy(Specialty = value))
+      override def SquareFeet = OptField[Int, VstorewithdemographicsViewRow](_path, "SquareFeet", None, None, x => x.SquareFeet, (row, value) => row.copy(SquareFeet = value))
+      override def Brands = OptField[/* max 30 chars */ String, VstorewithdemographicsViewRow](_path, "Brands", None, None, x => x.Brands, (row, value) => row.copy(Brands = value))
+      override def Internet = OptField[/* max 30 chars */ String, VstorewithdemographicsViewRow](_path, "Internet", None, None, x => x.Internet, (row, value) => row.copy(Internet = value))
+      override def NumberEmployees = OptField[Int, VstorewithdemographicsViewRow](_path, "NumberEmployees", None, None, x => x.NumberEmployees, (row, value) => row.copy(NumberEmployees = value))
     }
   
-    override val columns: List[FieldLikeNoHkt[?, Row]] =
-      List[FieldLikeNoHkt[?, Row]](fields.businessentityid, fields.name, fields.AnnualSales, fields.AnnualRevenue, fields.BankName, fields.BusinessType, fields.YearOpened, fields.Specialty, fields.SquareFeet, fields.Brands, fields.Internet, fields.NumberEmployees)
+    override lazy val columns: List[FieldLikeNoHkt[?, VstorewithdemographicsViewRow]] =
+      List[FieldLikeNoHkt[?, VstorewithdemographicsViewRow]](fields.businessentityid, fields.name, fields.AnnualSales, fields.AnnualRevenue, fields.BankName, fields.BusinessType, fields.YearOpened, fields.Specialty, fields.SquareFeet, fields.Brands, fields.Internet, fields.NumberEmployees)
   
-    override def copy[NewRow](prefix: Option[String], extract: NewRow => VstorewithdemographicsViewRow, merge: (NewRow, VstorewithdemographicsViewRow) => NewRow): Impl[NewRow] =
-      new Impl(prefix, extract, merge)
+    override def copy(path: List[Path]): Impl =
+      new Impl(path)
   }
   
 }

--- a/typo-tester-doobie/src/scala/adventureworks/PaginationQueryCirce.scala
+++ b/typo-tester-doobie/src/scala/adventureworks/PaginationQueryCirce.scala
@@ -5,11 +5,11 @@ import io.circe.*
 import typo.dsl.pagination.*
 import typo.dsl.{SelectBuilder, SortOrder, SqlExpr}
 
-class PaginationQueryCirce[Fields[_], Row](underlying: PaginationQuery[Fields, Row, Json]) {
-  def andOn[T, N[_]](v: Fields[Row] => SortOrder[T, N, Row])(implicit
+class PaginationQueryCirce[Fields, Row](underlying: PaginationQuery[Fields, Row, Json]) {
+  def andOn[T, N[_]](v: Fields => SortOrder[T, N])(implicit
       e: Encoder[N[T]],
       d: Decoder[N[T]],
-      asConst: SqlExpr.Const.As[T, N, Row]
+      asConst: SqlExpr.Const.As[T, N]
   ): PaginationQueryCirce[Fields, Row] =
     new PaginationQueryCirce(underlying.andOn(v)(PaginationQueryCirce.abstractCodec)(asConst))
 
@@ -31,11 +31,11 @@ object PaginationQueryCirce {
   implicit val clientCursorDecoder: Decoder[ClientCursor[Json]] =
     Decoder[Map[String, Json]].map(parts => ClientCursor(parts.map { case (k, v) => (SortOrderRepr(k), v) }))
 
-  implicit class PaginationQuerySyntax[Fields[_], Row](private val query: SelectBuilder[Fields, Row]) extends AnyVal {
-    def seekPaginationOn[T, N[_]](v: Fields[Row] => SortOrder[T, N, Row])(implicit
+  implicit class PaginationQuerySyntax[Fields, Row](private val query: SelectBuilder[Fields, Row]) extends AnyVal {
+    def seekPaginationOn[T, N[_]](v: Fields => SortOrder[T, N])(implicit
         e: Encoder[N[T]],
         d: Decoder[N[T]],
-        asConst: SqlExpr.Const.As[T, N, Row]
+        asConst: SqlExpr.Const.As[T, N]
     ): PaginationQueryCirce[Fields, Row] =
       new PaginationQueryCirce(new PaginationQuery(query, Nil).andOn(v)(PaginationQueryCirce.abstractCodec))
   }

--- a/typo-tester-doobie/src/scala/adventureworks/PaginationTest.scala
+++ b/typo-tester-doobie/src/scala/adventureworks/PaginationTest.scala
@@ -40,7 +40,7 @@ class PaginationTest extends AnyFunSuite with TypeCheckedTripleEquals {
     def patch(c: ClientCursor[Json]): ClientCursor[Json] =
       businessentityRepo match {
         case _: BusinessentityRepoMock =>
-          c.copy(parts = c.parts.map { case (k, v) => (SortOrderRepr(k.expr.replace("businessentity1.", "")), v) })
+          c.copy(parts = c.parts.map { case (k, v) => (SortOrderRepr(k.expr.replace("businessentity0.", "")), v) })
         case _ => c
       }
 
@@ -77,8 +77,8 @@ class PaginationTest extends AnyFunSuite with TypeCheckedTripleEquals {
               patch(
                 ClientCursor(
                   Map(
-                    SortOrderRepr("businessentity1.modifieddate") -> Json.fromString("2020-12-29T00:00:00"),
-                    SortOrderRepr("(businessentity1.businessentityid - ? ) :2") -> Json.fromInt(1)
+                    SortOrderRepr("businessentity0.modifieddate") -> Json.fromString("2020-12-29T00:00:00"),
+                    SortOrderRepr("(businessentity0.businessentityid - ? ) :2") -> Json.fromInt(1)
                   )
                 )
               )
@@ -96,8 +96,8 @@ class PaginationTest extends AnyFunSuite with TypeCheckedTripleEquals {
               patch(
                 ClientCursor(
                   Map(
-                    SortOrderRepr("businessentity1.modifieddate") -> Json.fromString("2020-12-25T00:00:00"),
-                    SortOrderRepr("(businessentity1.businessentityid - ? ) :2") -> Json.fromInt(15)
+                    SortOrderRepr("businessentity0.modifieddate") -> Json.fromString("2020-12-25T00:00:00"),
+                    SortOrderRepr("(businessentity0.businessentityid - ? ) :2") -> Json.fromInt(15)
                   )
                 )
               )

--- a/typo-tester-doobie/src/scala/adventureworks/production/product/ProductTest.scala
+++ b/typo-tester-doobie/src/scala/adventureworks/production/product/ProductTest.scala
@@ -90,6 +90,7 @@ class ProductTest extends AnyFunSuite with TypeCheckedTripleEquals {
         }
         _ <- delay(assert(saved3.modifieddate == newModifiedDate))
         _ <- productRepo.update(saved3.copy(size = None)).map(res => assert(res))
+
         query = productRepo.select
           .where(_.`class` === "H ")
           .where(x => (x.daystomanufacture > 25).or(x.daystomanufacture <= 0))

--- a/typo-tester-doobie/src/scala/adventureworks/production/product/SeekTest.scala
+++ b/typo-tester-doobie/src/scala/adventureworks/production/product/SeekTest.scala
@@ -14,7 +14,7 @@ class SeekTest extends AnyFunSuite with TypeCheckedTripleEquals {
       .seek(_.weight.asc)(SqlExpr.asConstOpt(Some(BigDecimal(22.2))))
       .seek(_.listprice.asc)(BigDecimal(33.3))
     assertResult(query.sql.get.toString)(
-      s"""Fragment("select "productid", "name", "productnumber", "makeflag", "finishedgoodsflag", "color", "safetystocklevel", "reorderpoint", "standardcost", "listprice", "size", "sizeunitmeasurecode", "weightunitmeasurecode", "weight", "daystomanufacture", "productline", "class", "style", "productsubcategoryid", "productmodelid", "sellstartdate"::text, "sellenddate"::text, "discontinueddate"::text, "rowguid", "modifieddate"::text from production.product WHERE ((name, weight, listprice)  > (? , ? , ? ) ) ORDER BY name  ASC   , weight  ASC   , listprice  ASC   ")"""
+      s"""Fragment("select "productid", "name", "productnumber", "makeflag", "finishedgoodsflag", "color", "safetystocklevel", "reorderpoint", "standardcost", "listprice", "size", "sizeunitmeasurecode", "weightunitmeasurecode", "weight", "daystomanufacture", "productline", "class", "style", "productsubcategoryid", "productmodelid", "sellstartdate"::text, "sellenddate"::text, "discontinueddate"::text, "rowguid", "modifieddate"::text from production.product product0 WHERE ((product0.name, product0.weight, product0.listprice)  > (? , ? , ? ) ) ORDER BY product0.name  ASC   , product0.weight  ASC   , product0.listprice  ASC   ")"""
     )
   }
 
@@ -24,7 +24,7 @@ class SeekTest extends AnyFunSuite with TypeCheckedTripleEquals {
       .seek(_.weight.desc)(Some(BigDecimal(22.2)))
       .seek(_.listprice.desc)(BigDecimal(33.3))
     assertResult(query.sql.get.toString)(
-      s"""Fragment("select "productid", "name", "productnumber", "makeflag", "finishedgoodsflag", "color", "safetystocklevel", "reorderpoint", "standardcost", "listprice", "size", "sizeunitmeasurecode", "weightunitmeasurecode", "weight", "daystomanufacture", "productline", "class", "style", "productsubcategoryid", "productmodelid", "sellstartdate"::text, "sellenddate"::text, "discontinueddate"::text, "rowguid", "modifieddate"::text from production.product WHERE ((name, weight, listprice)  < (? , ? , ? ) ) ORDER BY name  DESC   , weight  DESC   , listprice  DESC   ")"""
+      s"""Fragment("select "productid", "name", "productnumber", "makeflag", "finishedgoodsflag", "color", "safetystocklevel", "reorderpoint", "standardcost", "listprice", "size", "sizeunitmeasurecode", "weightunitmeasurecode", "weight", "daystomanufacture", "productline", "class", "style", "productsubcategoryid", "productmodelid", "sellstartdate"::text, "sellenddate"::text, "discontinueddate"::text, "rowguid", "modifieddate"::text from production.product product0 WHERE ((product0.name, product0.weight, product0.listprice)  < (? , ? , ? ) ) ORDER BY product0.name  DESC   , product0.weight  DESC   , product0.listprice  DESC   ")"""
     )
   }
 
@@ -34,7 +34,7 @@ class SeekTest extends AnyFunSuite with TypeCheckedTripleEquals {
       .seek(_.weight.desc)(Some(BigDecimal(22.2)))
       .seek(_.listprice.desc)(BigDecimal(33.3))
     assertResult(query.sql.get.toString)(
-      s"""Fragment("select "productid", "name", "productnumber", "makeflag", "finishedgoodsflag", "color", "safetystocklevel", "reorderpoint", "standardcost", "listprice", "size", "sizeunitmeasurecode", "weightunitmeasurecode", "weight", "daystomanufacture", "productline", "class", "style", "productsubcategoryid", "productmodelid", "sellstartdate"::text, "sellenddate"::text, "discontinueddate"::text, "rowguid", "modifieddate"::text from production.product WHERE (((name > ? )  OR ((name = ? )  AND (weight < ? ) ) )  OR (((name = ? )  AND (weight = ? ) )  AND (listprice < ? ) ) ) ORDER BY name  ASC   , weight  DESC   , listprice  DESC   ")"""
+      s"""Fragment("select "productid", "name", "productnumber", "makeflag", "finishedgoodsflag", "color", "safetystocklevel", "reorderpoint", "standardcost", "listprice", "size", "sizeunitmeasurecode", "weightunitmeasurecode", "weight", "daystomanufacture", "productline", "class", "style", "productsubcategoryid", "productmodelid", "sellstartdate"::text, "sellenddate"::text, "discontinueddate"::text, "rowguid", "modifieddate"::text from production.product product0 WHERE (((product0.name > ? )  OR ((product0.name = ? )  AND (product0.weight < ? ) ) )  OR (((product0.name = ? )  AND (product0.weight = ? ) )  AND (product0.listprice < ? ) ) ) ORDER BY product0.name  ASC   , product0.weight  DESC   , product0.listprice  DESC   ")"""
     )
   }
 }

--- a/typo-tester-zio-jdbc/generated-and-checked-in/adventureworks/customtypes/TypoShort.scala
+++ b/typo-tester-zio-jdbc/generated-and-checked-in/adventureworks/customtypes/TypoShort.scala
@@ -9,7 +9,6 @@ package customtypes
 import adventureworks.Text
 import java.sql.ResultSet
 import java.sql.Types
-import scala.math.Numeric
 import typo.dsl.Bijection
 import typo.dsl.ParameterMetaData
 import zio.jdbc.JdbcDecoder

--- a/typo-tester-zio-jdbc/generated-and-checked-in/adventureworks/hr/d/DViewFields.scala
+++ b/typo-tester-zio-jdbc/generated-and-checked-in/adventureworks/hr/d/DViewFields.scala
@@ -10,38 +10,39 @@ package d
 import adventureworks.customtypes.TypoLocalDateTime
 import adventureworks.humanresources.department.DepartmentId
 import adventureworks.public.Name
+import typo.dsl.Path
 import typo.dsl.SqlExpr.Field
 import typo.dsl.SqlExpr.FieldLikeNoHkt
 import typo.dsl.Structure.Relation
 
-trait DViewFields[Row] {
-  val id: Field[DepartmentId, Row]
-  val departmentid: Field[DepartmentId, Row]
-  val name: Field[Name, Row]
-  val groupname: Field[Name, Row]
-  val modifieddate: Field[TypoLocalDateTime, Row]
+trait DViewFields {
+  def id: Field[DepartmentId, DViewRow]
+  def departmentid: Field[DepartmentId, DViewRow]
+  def name: Field[Name, DViewRow]
+  def groupname: Field[Name, DViewRow]
+  def modifieddate: Field[TypoLocalDateTime, DViewRow]
 }
 
 object DViewFields {
-  val structure: Relation[DViewFields, DViewRow, DViewRow] = 
-    new Impl(None, identity, (_, x) => x)
+  lazy val structure: Relation[DViewFields, DViewRow] =
+    new Impl(Nil)
     
-  private final class Impl[Row](val prefix: Option[String], val extract: Row => DViewRow, val merge: (Row, DViewRow) => Row)
-    extends Relation[DViewFields, DViewRow, Row] { 
+  private final class Impl(val _path: List[Path])
+    extends Relation[DViewFields, DViewRow] {
   
-    override val fields: DViewFields[Row] = new DViewFields[Row] {
-      override val id = new Field[DepartmentId, Row](prefix, "id", None, None)(x => extract(x).id, (row, value) => merge(row, extract(row).copy(id = value)))
-      override val departmentid = new Field[DepartmentId, Row](prefix, "departmentid", None, None)(x => extract(x).departmentid, (row, value) => merge(row, extract(row).copy(departmentid = value)))
-      override val name = new Field[Name, Row](prefix, "name", None, None)(x => extract(x).name, (row, value) => merge(row, extract(row).copy(name = value)))
-      override val groupname = new Field[Name, Row](prefix, "groupname", None, None)(x => extract(x).groupname, (row, value) => merge(row, extract(row).copy(groupname = value)))
-      override val modifieddate = new Field[TypoLocalDateTime, Row](prefix, "modifieddate", Some("text"), None)(x => extract(x).modifieddate, (row, value) => merge(row, extract(row).copy(modifieddate = value)))
+    override lazy val fields: DViewFields = new DViewFields {
+      override def id = Field[DepartmentId, DViewRow](_path, "id", None, None, x => x.id, (row, value) => row.copy(id = value))
+      override def departmentid = Field[DepartmentId, DViewRow](_path, "departmentid", None, None, x => x.departmentid, (row, value) => row.copy(departmentid = value))
+      override def name = Field[Name, DViewRow](_path, "name", None, None, x => x.name, (row, value) => row.copy(name = value))
+      override def groupname = Field[Name, DViewRow](_path, "groupname", None, None, x => x.groupname, (row, value) => row.copy(groupname = value))
+      override def modifieddate = Field[TypoLocalDateTime, DViewRow](_path, "modifieddate", Some("text"), None, x => x.modifieddate, (row, value) => row.copy(modifieddate = value))
     }
   
-    override val columns: List[FieldLikeNoHkt[?, Row]] =
-      List[FieldLikeNoHkt[?, Row]](fields.id, fields.departmentid, fields.name, fields.groupname, fields.modifieddate)
+    override lazy val columns: List[FieldLikeNoHkt[?, DViewRow]] =
+      List[FieldLikeNoHkt[?, DViewRow]](fields.id, fields.departmentid, fields.name, fields.groupname, fields.modifieddate)
   
-    override def copy[NewRow](prefix: Option[String], extract: NewRow => DViewRow, merge: (NewRow, DViewRow) => NewRow): Impl[NewRow] =
-      new Impl(prefix, extract, merge)
+    override def copy(path: List[Path]): Impl =
+      new Impl(path)
   }
   
 }

--- a/typo-tester-zio-jdbc/generated-and-checked-in/adventureworks/hr/e/EViewFields.scala
+++ b/typo-tester-zio-jdbc/generated-and-checked-in/adventureworks/hr/e/EViewFields.scala
@@ -13,61 +13,62 @@ import adventureworks.customtypes.TypoShort
 import adventureworks.customtypes.TypoUUID
 import adventureworks.person.businessentity.BusinessentityId
 import adventureworks.public.Flag
+import typo.dsl.Path
 import typo.dsl.SqlExpr.Field
 import typo.dsl.SqlExpr.FieldLikeNoHkt
 import typo.dsl.SqlExpr.OptField
 import typo.dsl.Structure.Relation
 
-trait EViewFields[Row] {
-  val id: Field[BusinessentityId, Row]
-  val businessentityid: Field[BusinessentityId, Row]
-  val nationalidnumber: Field[/* max 15 chars */ String, Row]
-  val loginid: Field[/* max 256 chars */ String, Row]
-  val jobtitle: Field[/* max 50 chars */ String, Row]
-  val birthdate: Field[TypoLocalDate, Row]
-  val maritalstatus: Field[/* bpchar, max 1 chars */ String, Row]
-  val gender: Field[/* bpchar, max 1 chars */ String, Row]
-  val hiredate: Field[TypoLocalDate, Row]
-  val salariedflag: Field[Flag, Row]
-  val vacationhours: Field[TypoShort, Row]
-  val sickleavehours: Field[TypoShort, Row]
-  val currentflag: Field[Flag, Row]
-  val rowguid: Field[TypoUUID, Row]
-  val modifieddate: Field[TypoLocalDateTime, Row]
-  val organizationnode: OptField[String, Row]
+trait EViewFields {
+  def id: Field[BusinessentityId, EViewRow]
+  def businessentityid: Field[BusinessentityId, EViewRow]
+  def nationalidnumber: Field[/* max 15 chars */ String, EViewRow]
+  def loginid: Field[/* max 256 chars */ String, EViewRow]
+  def jobtitle: Field[/* max 50 chars */ String, EViewRow]
+  def birthdate: Field[TypoLocalDate, EViewRow]
+  def maritalstatus: Field[/* bpchar, max 1 chars */ String, EViewRow]
+  def gender: Field[/* bpchar, max 1 chars */ String, EViewRow]
+  def hiredate: Field[TypoLocalDate, EViewRow]
+  def salariedflag: Field[Flag, EViewRow]
+  def vacationhours: Field[TypoShort, EViewRow]
+  def sickleavehours: Field[TypoShort, EViewRow]
+  def currentflag: Field[Flag, EViewRow]
+  def rowguid: Field[TypoUUID, EViewRow]
+  def modifieddate: Field[TypoLocalDateTime, EViewRow]
+  def organizationnode: OptField[String, EViewRow]
 }
 
 object EViewFields {
-  val structure: Relation[EViewFields, EViewRow, EViewRow] = 
-    new Impl(None, identity, (_, x) => x)
+  lazy val structure: Relation[EViewFields, EViewRow] =
+    new Impl(Nil)
     
-  private final class Impl[Row](val prefix: Option[String], val extract: Row => EViewRow, val merge: (Row, EViewRow) => Row)
-    extends Relation[EViewFields, EViewRow, Row] { 
+  private final class Impl(val _path: List[Path])
+    extends Relation[EViewFields, EViewRow] {
   
-    override val fields: EViewFields[Row] = new EViewFields[Row] {
-      override val id = new Field[BusinessentityId, Row](prefix, "id", None, None)(x => extract(x).id, (row, value) => merge(row, extract(row).copy(id = value)))
-      override val businessentityid = new Field[BusinessentityId, Row](prefix, "businessentityid", None, None)(x => extract(x).businessentityid, (row, value) => merge(row, extract(row).copy(businessentityid = value)))
-      override val nationalidnumber = new Field[/* max 15 chars */ String, Row](prefix, "nationalidnumber", None, None)(x => extract(x).nationalidnumber, (row, value) => merge(row, extract(row).copy(nationalidnumber = value)))
-      override val loginid = new Field[/* max 256 chars */ String, Row](prefix, "loginid", None, None)(x => extract(x).loginid, (row, value) => merge(row, extract(row).copy(loginid = value)))
-      override val jobtitle = new Field[/* max 50 chars */ String, Row](prefix, "jobtitle", None, None)(x => extract(x).jobtitle, (row, value) => merge(row, extract(row).copy(jobtitle = value)))
-      override val birthdate = new Field[TypoLocalDate, Row](prefix, "birthdate", Some("text"), None)(x => extract(x).birthdate, (row, value) => merge(row, extract(row).copy(birthdate = value)))
-      override val maritalstatus = new Field[/* bpchar, max 1 chars */ String, Row](prefix, "maritalstatus", None, None)(x => extract(x).maritalstatus, (row, value) => merge(row, extract(row).copy(maritalstatus = value)))
-      override val gender = new Field[/* bpchar, max 1 chars */ String, Row](prefix, "gender", None, None)(x => extract(x).gender, (row, value) => merge(row, extract(row).copy(gender = value)))
-      override val hiredate = new Field[TypoLocalDate, Row](prefix, "hiredate", Some("text"), None)(x => extract(x).hiredate, (row, value) => merge(row, extract(row).copy(hiredate = value)))
-      override val salariedflag = new Field[Flag, Row](prefix, "salariedflag", None, None)(x => extract(x).salariedflag, (row, value) => merge(row, extract(row).copy(salariedflag = value)))
-      override val vacationhours = new Field[TypoShort, Row](prefix, "vacationhours", None, None)(x => extract(x).vacationhours, (row, value) => merge(row, extract(row).copy(vacationhours = value)))
-      override val sickleavehours = new Field[TypoShort, Row](prefix, "sickleavehours", None, None)(x => extract(x).sickleavehours, (row, value) => merge(row, extract(row).copy(sickleavehours = value)))
-      override val currentflag = new Field[Flag, Row](prefix, "currentflag", None, None)(x => extract(x).currentflag, (row, value) => merge(row, extract(row).copy(currentflag = value)))
-      override val rowguid = new Field[TypoUUID, Row](prefix, "rowguid", None, None)(x => extract(x).rowguid, (row, value) => merge(row, extract(row).copy(rowguid = value)))
-      override val modifieddate = new Field[TypoLocalDateTime, Row](prefix, "modifieddate", Some("text"), None)(x => extract(x).modifieddate, (row, value) => merge(row, extract(row).copy(modifieddate = value)))
-      override val organizationnode = new OptField[String, Row](prefix, "organizationnode", None, None)(x => extract(x).organizationnode, (row, value) => merge(row, extract(row).copy(organizationnode = value)))
+    override lazy val fields: EViewFields = new EViewFields {
+      override def id = Field[BusinessentityId, EViewRow](_path, "id", None, None, x => x.id, (row, value) => row.copy(id = value))
+      override def businessentityid = Field[BusinessentityId, EViewRow](_path, "businessentityid", None, None, x => x.businessentityid, (row, value) => row.copy(businessentityid = value))
+      override def nationalidnumber = Field[/* max 15 chars */ String, EViewRow](_path, "nationalidnumber", None, None, x => x.nationalidnumber, (row, value) => row.copy(nationalidnumber = value))
+      override def loginid = Field[/* max 256 chars */ String, EViewRow](_path, "loginid", None, None, x => x.loginid, (row, value) => row.copy(loginid = value))
+      override def jobtitle = Field[/* max 50 chars */ String, EViewRow](_path, "jobtitle", None, None, x => x.jobtitle, (row, value) => row.copy(jobtitle = value))
+      override def birthdate = Field[TypoLocalDate, EViewRow](_path, "birthdate", Some("text"), None, x => x.birthdate, (row, value) => row.copy(birthdate = value))
+      override def maritalstatus = Field[/* bpchar, max 1 chars */ String, EViewRow](_path, "maritalstatus", None, None, x => x.maritalstatus, (row, value) => row.copy(maritalstatus = value))
+      override def gender = Field[/* bpchar, max 1 chars */ String, EViewRow](_path, "gender", None, None, x => x.gender, (row, value) => row.copy(gender = value))
+      override def hiredate = Field[TypoLocalDate, EViewRow](_path, "hiredate", Some("text"), None, x => x.hiredate, (row, value) => row.copy(hiredate = value))
+      override def salariedflag = Field[Flag, EViewRow](_path, "salariedflag", None, None, x => x.salariedflag, (row, value) => row.copy(salariedflag = value))
+      override def vacationhours = Field[TypoShort, EViewRow](_path, "vacationhours", None, None, x => x.vacationhours, (row, value) => row.copy(vacationhours = value))
+      override def sickleavehours = Field[TypoShort, EViewRow](_path, "sickleavehours", None, None, x => x.sickleavehours, (row, value) => row.copy(sickleavehours = value))
+      override def currentflag = Field[Flag, EViewRow](_path, "currentflag", None, None, x => x.currentflag, (row, value) => row.copy(currentflag = value))
+      override def rowguid = Field[TypoUUID, EViewRow](_path, "rowguid", None, None, x => x.rowguid, (row, value) => row.copy(rowguid = value))
+      override def modifieddate = Field[TypoLocalDateTime, EViewRow](_path, "modifieddate", Some("text"), None, x => x.modifieddate, (row, value) => row.copy(modifieddate = value))
+      override def organizationnode = OptField[String, EViewRow](_path, "organizationnode", None, None, x => x.organizationnode, (row, value) => row.copy(organizationnode = value))
     }
   
-    override val columns: List[FieldLikeNoHkt[?, Row]] =
-      List[FieldLikeNoHkt[?, Row]](fields.id, fields.businessentityid, fields.nationalidnumber, fields.loginid, fields.jobtitle, fields.birthdate, fields.maritalstatus, fields.gender, fields.hiredate, fields.salariedflag, fields.vacationhours, fields.sickleavehours, fields.currentflag, fields.rowguid, fields.modifieddate, fields.organizationnode)
+    override lazy val columns: List[FieldLikeNoHkt[?, EViewRow]] =
+      List[FieldLikeNoHkt[?, EViewRow]](fields.id, fields.businessentityid, fields.nationalidnumber, fields.loginid, fields.jobtitle, fields.birthdate, fields.maritalstatus, fields.gender, fields.hiredate, fields.salariedflag, fields.vacationhours, fields.sickleavehours, fields.currentflag, fields.rowguid, fields.modifieddate, fields.organizationnode)
   
-    override def copy[NewRow](prefix: Option[String], extract: NewRow => EViewRow, merge: (NewRow, EViewRow) => NewRow): Impl[NewRow] =
-      new Impl(prefix, extract, merge)
+    override def copy(path: List[Path]): Impl =
+      new Impl(path)
   }
   
 }

--- a/typo-tester-zio-jdbc/generated-and-checked-in/adventureworks/hr/edh/EdhViewFields.scala
+++ b/typo-tester-zio-jdbc/generated-and-checked-in/adventureworks/hr/edh/EdhViewFields.scala
@@ -12,43 +12,44 @@ import adventureworks.customtypes.TypoLocalDateTime
 import adventureworks.humanresources.department.DepartmentId
 import adventureworks.humanresources.shift.ShiftId
 import adventureworks.person.businessentity.BusinessentityId
+import typo.dsl.Path
 import typo.dsl.SqlExpr.Field
 import typo.dsl.SqlExpr.FieldLikeNoHkt
 import typo.dsl.SqlExpr.OptField
 import typo.dsl.Structure.Relation
 
-trait EdhViewFields[Row] {
-  val id: Field[BusinessentityId, Row]
-  val businessentityid: Field[BusinessentityId, Row]
-  val departmentid: Field[DepartmentId, Row]
-  val shiftid: Field[ShiftId, Row]
-  val startdate: Field[TypoLocalDate, Row]
-  val enddate: OptField[TypoLocalDate, Row]
-  val modifieddate: Field[TypoLocalDateTime, Row]
+trait EdhViewFields {
+  def id: Field[BusinessentityId, EdhViewRow]
+  def businessentityid: Field[BusinessentityId, EdhViewRow]
+  def departmentid: Field[DepartmentId, EdhViewRow]
+  def shiftid: Field[ShiftId, EdhViewRow]
+  def startdate: Field[TypoLocalDate, EdhViewRow]
+  def enddate: OptField[TypoLocalDate, EdhViewRow]
+  def modifieddate: Field[TypoLocalDateTime, EdhViewRow]
 }
 
 object EdhViewFields {
-  val structure: Relation[EdhViewFields, EdhViewRow, EdhViewRow] = 
-    new Impl(None, identity, (_, x) => x)
+  lazy val structure: Relation[EdhViewFields, EdhViewRow] =
+    new Impl(Nil)
     
-  private final class Impl[Row](val prefix: Option[String], val extract: Row => EdhViewRow, val merge: (Row, EdhViewRow) => Row)
-    extends Relation[EdhViewFields, EdhViewRow, Row] { 
+  private final class Impl(val _path: List[Path])
+    extends Relation[EdhViewFields, EdhViewRow] {
   
-    override val fields: EdhViewFields[Row] = new EdhViewFields[Row] {
-      override val id = new Field[BusinessentityId, Row](prefix, "id", None, None)(x => extract(x).id, (row, value) => merge(row, extract(row).copy(id = value)))
-      override val businessentityid = new Field[BusinessentityId, Row](prefix, "businessentityid", None, None)(x => extract(x).businessentityid, (row, value) => merge(row, extract(row).copy(businessentityid = value)))
-      override val departmentid = new Field[DepartmentId, Row](prefix, "departmentid", None, None)(x => extract(x).departmentid, (row, value) => merge(row, extract(row).copy(departmentid = value)))
-      override val shiftid = new Field[ShiftId, Row](prefix, "shiftid", None, None)(x => extract(x).shiftid, (row, value) => merge(row, extract(row).copy(shiftid = value)))
-      override val startdate = new Field[TypoLocalDate, Row](prefix, "startdate", Some("text"), None)(x => extract(x).startdate, (row, value) => merge(row, extract(row).copy(startdate = value)))
-      override val enddate = new OptField[TypoLocalDate, Row](prefix, "enddate", Some("text"), None)(x => extract(x).enddate, (row, value) => merge(row, extract(row).copy(enddate = value)))
-      override val modifieddate = new Field[TypoLocalDateTime, Row](prefix, "modifieddate", Some("text"), None)(x => extract(x).modifieddate, (row, value) => merge(row, extract(row).copy(modifieddate = value)))
+    override lazy val fields: EdhViewFields = new EdhViewFields {
+      override def id = Field[BusinessentityId, EdhViewRow](_path, "id", None, None, x => x.id, (row, value) => row.copy(id = value))
+      override def businessentityid = Field[BusinessentityId, EdhViewRow](_path, "businessentityid", None, None, x => x.businessentityid, (row, value) => row.copy(businessentityid = value))
+      override def departmentid = Field[DepartmentId, EdhViewRow](_path, "departmentid", None, None, x => x.departmentid, (row, value) => row.copy(departmentid = value))
+      override def shiftid = Field[ShiftId, EdhViewRow](_path, "shiftid", None, None, x => x.shiftid, (row, value) => row.copy(shiftid = value))
+      override def startdate = Field[TypoLocalDate, EdhViewRow](_path, "startdate", Some("text"), None, x => x.startdate, (row, value) => row.copy(startdate = value))
+      override def enddate = OptField[TypoLocalDate, EdhViewRow](_path, "enddate", Some("text"), None, x => x.enddate, (row, value) => row.copy(enddate = value))
+      override def modifieddate = Field[TypoLocalDateTime, EdhViewRow](_path, "modifieddate", Some("text"), None, x => x.modifieddate, (row, value) => row.copy(modifieddate = value))
     }
   
-    override val columns: List[FieldLikeNoHkt[?, Row]] =
-      List[FieldLikeNoHkt[?, Row]](fields.id, fields.businessentityid, fields.departmentid, fields.shiftid, fields.startdate, fields.enddate, fields.modifieddate)
+    override lazy val columns: List[FieldLikeNoHkt[?, EdhViewRow]] =
+      List[FieldLikeNoHkt[?, EdhViewRow]](fields.id, fields.businessentityid, fields.departmentid, fields.shiftid, fields.startdate, fields.enddate, fields.modifieddate)
   
-    override def copy[NewRow](prefix: Option[String], extract: NewRow => EdhViewRow, merge: (NewRow, EdhViewRow) => NewRow): Impl[NewRow] =
-      new Impl(prefix, extract, merge)
+    override def copy(path: List[Path]): Impl =
+      new Impl(path)
   }
   
 }

--- a/typo-tester-zio-jdbc/generated-and-checked-in/adventureworks/hr/eph/EphViewFields.scala
+++ b/typo-tester-zio-jdbc/generated-and-checked-in/adventureworks/hr/eph/EphViewFields.scala
@@ -10,40 +10,41 @@ package eph
 import adventureworks.customtypes.TypoLocalDateTime
 import adventureworks.customtypes.TypoShort
 import adventureworks.person.businessentity.BusinessentityId
+import typo.dsl.Path
 import typo.dsl.SqlExpr.Field
 import typo.dsl.SqlExpr.FieldLikeNoHkt
 import typo.dsl.Structure.Relation
 
-trait EphViewFields[Row] {
-  val id: Field[BusinessentityId, Row]
-  val businessentityid: Field[BusinessentityId, Row]
-  val ratechangedate: Field[TypoLocalDateTime, Row]
-  val rate: Field[BigDecimal, Row]
-  val payfrequency: Field[TypoShort, Row]
-  val modifieddate: Field[TypoLocalDateTime, Row]
+trait EphViewFields {
+  def id: Field[BusinessentityId, EphViewRow]
+  def businessentityid: Field[BusinessentityId, EphViewRow]
+  def ratechangedate: Field[TypoLocalDateTime, EphViewRow]
+  def rate: Field[BigDecimal, EphViewRow]
+  def payfrequency: Field[TypoShort, EphViewRow]
+  def modifieddate: Field[TypoLocalDateTime, EphViewRow]
 }
 
 object EphViewFields {
-  val structure: Relation[EphViewFields, EphViewRow, EphViewRow] = 
-    new Impl(None, identity, (_, x) => x)
+  lazy val structure: Relation[EphViewFields, EphViewRow] =
+    new Impl(Nil)
     
-  private final class Impl[Row](val prefix: Option[String], val extract: Row => EphViewRow, val merge: (Row, EphViewRow) => Row)
-    extends Relation[EphViewFields, EphViewRow, Row] { 
+  private final class Impl(val _path: List[Path])
+    extends Relation[EphViewFields, EphViewRow] {
   
-    override val fields: EphViewFields[Row] = new EphViewFields[Row] {
-      override val id = new Field[BusinessentityId, Row](prefix, "id", None, None)(x => extract(x).id, (row, value) => merge(row, extract(row).copy(id = value)))
-      override val businessentityid = new Field[BusinessentityId, Row](prefix, "businessentityid", None, None)(x => extract(x).businessentityid, (row, value) => merge(row, extract(row).copy(businessentityid = value)))
-      override val ratechangedate = new Field[TypoLocalDateTime, Row](prefix, "ratechangedate", Some("text"), None)(x => extract(x).ratechangedate, (row, value) => merge(row, extract(row).copy(ratechangedate = value)))
-      override val rate = new Field[BigDecimal, Row](prefix, "rate", None, None)(x => extract(x).rate, (row, value) => merge(row, extract(row).copy(rate = value)))
-      override val payfrequency = new Field[TypoShort, Row](prefix, "payfrequency", None, None)(x => extract(x).payfrequency, (row, value) => merge(row, extract(row).copy(payfrequency = value)))
-      override val modifieddate = new Field[TypoLocalDateTime, Row](prefix, "modifieddate", Some("text"), None)(x => extract(x).modifieddate, (row, value) => merge(row, extract(row).copy(modifieddate = value)))
+    override lazy val fields: EphViewFields = new EphViewFields {
+      override def id = Field[BusinessentityId, EphViewRow](_path, "id", None, None, x => x.id, (row, value) => row.copy(id = value))
+      override def businessentityid = Field[BusinessentityId, EphViewRow](_path, "businessentityid", None, None, x => x.businessentityid, (row, value) => row.copy(businessentityid = value))
+      override def ratechangedate = Field[TypoLocalDateTime, EphViewRow](_path, "ratechangedate", Some("text"), None, x => x.ratechangedate, (row, value) => row.copy(ratechangedate = value))
+      override def rate = Field[BigDecimal, EphViewRow](_path, "rate", None, None, x => x.rate, (row, value) => row.copy(rate = value))
+      override def payfrequency = Field[TypoShort, EphViewRow](_path, "payfrequency", None, None, x => x.payfrequency, (row, value) => row.copy(payfrequency = value))
+      override def modifieddate = Field[TypoLocalDateTime, EphViewRow](_path, "modifieddate", Some("text"), None, x => x.modifieddate, (row, value) => row.copy(modifieddate = value))
     }
   
-    override val columns: List[FieldLikeNoHkt[?, Row]] =
-      List[FieldLikeNoHkt[?, Row]](fields.id, fields.businessentityid, fields.ratechangedate, fields.rate, fields.payfrequency, fields.modifieddate)
+    override lazy val columns: List[FieldLikeNoHkt[?, EphViewRow]] =
+      List[FieldLikeNoHkt[?, EphViewRow]](fields.id, fields.businessentityid, fields.ratechangedate, fields.rate, fields.payfrequency, fields.modifieddate)
   
-    override def copy[NewRow](prefix: Option[String], extract: NewRow => EphViewRow, merge: (NewRow, EphViewRow) => NewRow): Impl[NewRow] =
-      new Impl(prefix, extract, merge)
+    override def copy(path: List[Path]): Impl =
+      new Impl(path)
   }
   
 }

--- a/typo-tester-zio-jdbc/generated-and-checked-in/adventureworks/hr/jc/JcViewFields.scala
+++ b/typo-tester-zio-jdbc/generated-and-checked-in/adventureworks/hr/jc/JcViewFields.scala
@@ -11,39 +11,40 @@ import adventureworks.customtypes.TypoLocalDateTime
 import adventureworks.customtypes.TypoXml
 import adventureworks.humanresources.jobcandidate.JobcandidateId
 import adventureworks.person.businessentity.BusinessentityId
+import typo.dsl.Path
 import typo.dsl.SqlExpr.Field
 import typo.dsl.SqlExpr.FieldLikeNoHkt
 import typo.dsl.SqlExpr.OptField
 import typo.dsl.Structure.Relation
 
-trait JcViewFields[Row] {
-  val id: Field[JobcandidateId, Row]
-  val jobcandidateid: Field[JobcandidateId, Row]
-  val businessentityid: OptField[BusinessentityId, Row]
-  val resume: OptField[TypoXml, Row]
-  val modifieddate: Field[TypoLocalDateTime, Row]
+trait JcViewFields {
+  def id: Field[JobcandidateId, JcViewRow]
+  def jobcandidateid: Field[JobcandidateId, JcViewRow]
+  def businessentityid: OptField[BusinessentityId, JcViewRow]
+  def resume: OptField[TypoXml, JcViewRow]
+  def modifieddate: Field[TypoLocalDateTime, JcViewRow]
 }
 
 object JcViewFields {
-  val structure: Relation[JcViewFields, JcViewRow, JcViewRow] = 
-    new Impl(None, identity, (_, x) => x)
+  lazy val structure: Relation[JcViewFields, JcViewRow] =
+    new Impl(Nil)
     
-  private final class Impl[Row](val prefix: Option[String], val extract: Row => JcViewRow, val merge: (Row, JcViewRow) => Row)
-    extends Relation[JcViewFields, JcViewRow, Row] { 
+  private final class Impl(val _path: List[Path])
+    extends Relation[JcViewFields, JcViewRow] {
   
-    override val fields: JcViewFields[Row] = new JcViewFields[Row] {
-      override val id = new Field[JobcandidateId, Row](prefix, "id", None, None)(x => extract(x).id, (row, value) => merge(row, extract(row).copy(id = value)))
-      override val jobcandidateid = new Field[JobcandidateId, Row](prefix, "jobcandidateid", None, None)(x => extract(x).jobcandidateid, (row, value) => merge(row, extract(row).copy(jobcandidateid = value)))
-      override val businessentityid = new OptField[BusinessentityId, Row](prefix, "businessentityid", None, None)(x => extract(x).businessentityid, (row, value) => merge(row, extract(row).copy(businessentityid = value)))
-      override val resume = new OptField[TypoXml, Row](prefix, "resume", None, None)(x => extract(x).resume, (row, value) => merge(row, extract(row).copy(resume = value)))
-      override val modifieddate = new Field[TypoLocalDateTime, Row](prefix, "modifieddate", Some("text"), None)(x => extract(x).modifieddate, (row, value) => merge(row, extract(row).copy(modifieddate = value)))
+    override lazy val fields: JcViewFields = new JcViewFields {
+      override def id = Field[JobcandidateId, JcViewRow](_path, "id", None, None, x => x.id, (row, value) => row.copy(id = value))
+      override def jobcandidateid = Field[JobcandidateId, JcViewRow](_path, "jobcandidateid", None, None, x => x.jobcandidateid, (row, value) => row.copy(jobcandidateid = value))
+      override def businessentityid = OptField[BusinessentityId, JcViewRow](_path, "businessentityid", None, None, x => x.businessentityid, (row, value) => row.copy(businessentityid = value))
+      override def resume = OptField[TypoXml, JcViewRow](_path, "resume", None, None, x => x.resume, (row, value) => row.copy(resume = value))
+      override def modifieddate = Field[TypoLocalDateTime, JcViewRow](_path, "modifieddate", Some("text"), None, x => x.modifieddate, (row, value) => row.copy(modifieddate = value))
     }
   
-    override val columns: List[FieldLikeNoHkt[?, Row]] =
-      List[FieldLikeNoHkt[?, Row]](fields.id, fields.jobcandidateid, fields.businessentityid, fields.resume, fields.modifieddate)
+    override lazy val columns: List[FieldLikeNoHkt[?, JcViewRow]] =
+      List[FieldLikeNoHkt[?, JcViewRow]](fields.id, fields.jobcandidateid, fields.businessentityid, fields.resume, fields.modifieddate)
   
-    override def copy[NewRow](prefix: Option[String], extract: NewRow => JcViewRow, merge: (NewRow, JcViewRow) => NewRow): Impl[NewRow] =
-      new Impl(prefix, extract, merge)
+    override def copy(path: List[Path]): Impl =
+      new Impl(path)
   }
   
 }

--- a/typo-tester-zio-jdbc/generated-and-checked-in/adventureworks/hr/s/SViewFields.scala
+++ b/typo-tester-zio-jdbc/generated-and-checked-in/adventureworks/hr/s/SViewFields.scala
@@ -11,40 +11,41 @@ import adventureworks.customtypes.TypoLocalDateTime
 import adventureworks.customtypes.TypoLocalTime
 import adventureworks.humanresources.shift.ShiftId
 import adventureworks.public.Name
+import typo.dsl.Path
 import typo.dsl.SqlExpr.Field
 import typo.dsl.SqlExpr.FieldLikeNoHkt
 import typo.dsl.Structure.Relation
 
-trait SViewFields[Row] {
-  val id: Field[ShiftId, Row]
-  val shiftid: Field[ShiftId, Row]
-  val name: Field[Name, Row]
-  val starttime: Field[TypoLocalTime, Row]
-  val endtime: Field[TypoLocalTime, Row]
-  val modifieddate: Field[TypoLocalDateTime, Row]
+trait SViewFields {
+  def id: Field[ShiftId, SViewRow]
+  def shiftid: Field[ShiftId, SViewRow]
+  def name: Field[Name, SViewRow]
+  def starttime: Field[TypoLocalTime, SViewRow]
+  def endtime: Field[TypoLocalTime, SViewRow]
+  def modifieddate: Field[TypoLocalDateTime, SViewRow]
 }
 
 object SViewFields {
-  val structure: Relation[SViewFields, SViewRow, SViewRow] = 
-    new Impl(None, identity, (_, x) => x)
+  lazy val structure: Relation[SViewFields, SViewRow] =
+    new Impl(Nil)
     
-  private final class Impl[Row](val prefix: Option[String], val extract: Row => SViewRow, val merge: (Row, SViewRow) => Row)
-    extends Relation[SViewFields, SViewRow, Row] { 
+  private final class Impl(val _path: List[Path])
+    extends Relation[SViewFields, SViewRow] {
   
-    override val fields: SViewFields[Row] = new SViewFields[Row] {
-      override val id = new Field[ShiftId, Row](prefix, "id", None, None)(x => extract(x).id, (row, value) => merge(row, extract(row).copy(id = value)))
-      override val shiftid = new Field[ShiftId, Row](prefix, "shiftid", None, None)(x => extract(x).shiftid, (row, value) => merge(row, extract(row).copy(shiftid = value)))
-      override val name = new Field[Name, Row](prefix, "name", None, None)(x => extract(x).name, (row, value) => merge(row, extract(row).copy(name = value)))
-      override val starttime = new Field[TypoLocalTime, Row](prefix, "starttime", Some("text"), None)(x => extract(x).starttime, (row, value) => merge(row, extract(row).copy(starttime = value)))
-      override val endtime = new Field[TypoLocalTime, Row](prefix, "endtime", Some("text"), None)(x => extract(x).endtime, (row, value) => merge(row, extract(row).copy(endtime = value)))
-      override val modifieddate = new Field[TypoLocalDateTime, Row](prefix, "modifieddate", Some("text"), None)(x => extract(x).modifieddate, (row, value) => merge(row, extract(row).copy(modifieddate = value)))
+    override lazy val fields: SViewFields = new SViewFields {
+      override def id = Field[ShiftId, SViewRow](_path, "id", None, None, x => x.id, (row, value) => row.copy(id = value))
+      override def shiftid = Field[ShiftId, SViewRow](_path, "shiftid", None, None, x => x.shiftid, (row, value) => row.copy(shiftid = value))
+      override def name = Field[Name, SViewRow](_path, "name", None, None, x => x.name, (row, value) => row.copy(name = value))
+      override def starttime = Field[TypoLocalTime, SViewRow](_path, "starttime", Some("text"), None, x => x.starttime, (row, value) => row.copy(starttime = value))
+      override def endtime = Field[TypoLocalTime, SViewRow](_path, "endtime", Some("text"), None, x => x.endtime, (row, value) => row.copy(endtime = value))
+      override def modifieddate = Field[TypoLocalDateTime, SViewRow](_path, "modifieddate", Some("text"), None, x => x.modifieddate, (row, value) => row.copy(modifieddate = value))
     }
   
-    override val columns: List[FieldLikeNoHkt[?, Row]] =
-      List[FieldLikeNoHkt[?, Row]](fields.id, fields.shiftid, fields.name, fields.starttime, fields.endtime, fields.modifieddate)
+    override lazy val columns: List[FieldLikeNoHkt[?, SViewRow]] =
+      List[FieldLikeNoHkt[?, SViewRow]](fields.id, fields.shiftid, fields.name, fields.starttime, fields.endtime, fields.modifieddate)
   
-    override def copy[NewRow](prefix: Option[String], extract: NewRow => SViewRow, merge: (NewRow, SViewRow) => NewRow): Impl[NewRow] =
-      new Impl(prefix, extract, merge)
+    override def copy(path: List[Path]): Impl =
+      new Impl(path)
   }
   
 }

--- a/typo-tester-zio-jdbc/generated-and-checked-in/adventureworks/humanresources/department/DepartmentFields.scala
+++ b/typo-tester-zio-jdbc/generated-and-checked-in/adventureworks/humanresources/department/DepartmentFields.scala
@@ -9,37 +9,38 @@ package department
 
 import adventureworks.customtypes.TypoLocalDateTime
 import adventureworks.public.Name
+import typo.dsl.Path
 import typo.dsl.SqlExpr.Field
 import typo.dsl.SqlExpr.FieldLikeNoHkt
 import typo.dsl.SqlExpr.IdField
 import typo.dsl.Structure.Relation
 
-trait DepartmentFields[Row] {
-  val departmentid: IdField[DepartmentId, Row]
-  val name: Field[Name, Row]
-  val groupname: Field[Name, Row]
-  val modifieddate: Field[TypoLocalDateTime, Row]
+trait DepartmentFields {
+  def departmentid: IdField[DepartmentId, DepartmentRow]
+  def name: Field[Name, DepartmentRow]
+  def groupname: Field[Name, DepartmentRow]
+  def modifieddate: Field[TypoLocalDateTime, DepartmentRow]
 }
 
 object DepartmentFields {
-  val structure: Relation[DepartmentFields, DepartmentRow, DepartmentRow] = 
-    new Impl(None, identity, (_, x) => x)
+  lazy val structure: Relation[DepartmentFields, DepartmentRow] =
+    new Impl(Nil)
     
-  private final class Impl[Row](val prefix: Option[String], val extract: Row => DepartmentRow, val merge: (Row, DepartmentRow) => Row)
-    extends Relation[DepartmentFields, DepartmentRow, Row] { 
+  private final class Impl(val _path: List[Path])
+    extends Relation[DepartmentFields, DepartmentRow] {
   
-    override val fields: DepartmentFields[Row] = new DepartmentFields[Row] {
-      override val departmentid = new IdField[DepartmentId, Row](prefix, "departmentid", None, Some("int4"))(x => extract(x).departmentid, (row, value) => merge(row, extract(row).copy(departmentid = value)))
-      override val name = new Field[Name, Row](prefix, "name", None, Some("varchar"))(x => extract(x).name, (row, value) => merge(row, extract(row).copy(name = value)))
-      override val groupname = new Field[Name, Row](prefix, "groupname", None, Some("varchar"))(x => extract(x).groupname, (row, value) => merge(row, extract(row).copy(groupname = value)))
-      override val modifieddate = new Field[TypoLocalDateTime, Row](prefix, "modifieddate", Some("text"), Some("timestamp"))(x => extract(x).modifieddate, (row, value) => merge(row, extract(row).copy(modifieddate = value)))
+    override lazy val fields: DepartmentFields = new DepartmentFields {
+      override def departmentid = IdField[DepartmentId, DepartmentRow](_path, "departmentid", None, Some("int4"), x => x.departmentid, (row, value) => row.copy(departmentid = value))
+      override def name = Field[Name, DepartmentRow](_path, "name", None, Some("varchar"), x => x.name, (row, value) => row.copy(name = value))
+      override def groupname = Field[Name, DepartmentRow](_path, "groupname", None, Some("varchar"), x => x.groupname, (row, value) => row.copy(groupname = value))
+      override def modifieddate = Field[TypoLocalDateTime, DepartmentRow](_path, "modifieddate", Some("text"), Some("timestamp"), x => x.modifieddate, (row, value) => row.copy(modifieddate = value))
     }
   
-    override val columns: List[FieldLikeNoHkt[?, Row]] =
-      List[FieldLikeNoHkt[?, Row]](fields.departmentid, fields.name, fields.groupname, fields.modifieddate)
+    override lazy val columns: List[FieldLikeNoHkt[?, DepartmentRow]] =
+      List[FieldLikeNoHkt[?, DepartmentRow]](fields.departmentid, fields.name, fields.groupname, fields.modifieddate)
   
-    override def copy[NewRow](prefix: Option[String], extract: NewRow => DepartmentRow, merge: (NewRow, DepartmentRow) => NewRow): Impl[NewRow] =
-      new Impl(prefix, extract, merge)
+    override def copy(path: List[Path]): Impl =
+      new Impl(path)
   }
   
 }

--- a/typo-tester-zio-jdbc/generated-and-checked-in/adventureworks/humanresources/department/DepartmentRepoMock.scala
+++ b/typo-tester-zio-jdbc/generated-and-checked-in/adventureworks/humanresources/department/DepartmentRepoMock.scala
@@ -26,7 +26,7 @@ import zio.stream.ZStream
 class DepartmentRepoMock(toRow: Function1[DepartmentRowUnsaved, DepartmentRow],
                          map: scala.collection.mutable.Map[DepartmentId, DepartmentRow] = scala.collection.mutable.Map.empty) extends DepartmentRepo {
   override def delete: DeleteBuilder[DepartmentFields, DepartmentRow] = {
-    DeleteBuilderMock(DeleteParams.empty, DepartmentFields.structure.fields, map)
+    DeleteBuilderMock(DeleteParams.empty, DepartmentFields.structure, map)
   }
   override def deleteById(departmentid: DepartmentId): ZIO[ZConnection, Throwable, Boolean] = {
     ZIO.succeed(map.remove(departmentid).isDefined)
@@ -85,7 +85,7 @@ class DepartmentRepoMock(toRow: Function1[DepartmentRowUnsaved, DepartmentRow],
     }
   }
   override def update: UpdateBuilder[DepartmentFields, DepartmentRow] = {
-    UpdateBuilderMock(UpdateParams.empty, DepartmentFields.structure.fields, map)
+    UpdateBuilderMock(UpdateParams.empty, DepartmentFields.structure, map)
   }
   override def update(row: DepartmentRow): ZIO[ZConnection, Throwable, Boolean] = {
     ZIO.succeed {

--- a/typo-tester-zio-jdbc/generated-and-checked-in/adventureworks/humanresources/employee/EmployeeFields.scala
+++ b/typo-tester-zio-jdbc/generated-and-checked-in/adventureworks/humanresources/employee/EmployeeFields.scala
@@ -13,60 +13,61 @@ import adventureworks.customtypes.TypoShort
 import adventureworks.customtypes.TypoUUID
 import adventureworks.person.businessentity.BusinessentityId
 import adventureworks.public.Flag
+import typo.dsl.Path
 import typo.dsl.SqlExpr.Field
 import typo.dsl.SqlExpr.FieldLikeNoHkt
 import typo.dsl.SqlExpr.IdField
 import typo.dsl.SqlExpr.OptField
 import typo.dsl.Structure.Relation
 
-trait EmployeeFields[Row] {
-  val businessentityid: IdField[BusinessentityId, Row]
-  val nationalidnumber: Field[/* max 15 chars */ String, Row]
-  val loginid: Field[/* max 256 chars */ String, Row]
-  val jobtitle: Field[/* max 50 chars */ String, Row]
-  val birthdate: Field[TypoLocalDate, Row]
-  val maritalstatus: Field[/* bpchar, max 1 chars */ String, Row]
-  val gender: Field[/* bpchar, max 1 chars */ String, Row]
-  val hiredate: Field[TypoLocalDate, Row]
-  val salariedflag: Field[Flag, Row]
-  val vacationhours: Field[TypoShort, Row]
-  val sickleavehours: Field[TypoShort, Row]
-  val currentflag: Field[Flag, Row]
-  val rowguid: Field[TypoUUID, Row]
-  val modifieddate: Field[TypoLocalDateTime, Row]
-  val organizationnode: OptField[String, Row]
+trait EmployeeFields {
+  def businessentityid: IdField[BusinessentityId, EmployeeRow]
+  def nationalidnumber: Field[/* max 15 chars */ String, EmployeeRow]
+  def loginid: Field[/* max 256 chars */ String, EmployeeRow]
+  def jobtitle: Field[/* max 50 chars */ String, EmployeeRow]
+  def birthdate: Field[TypoLocalDate, EmployeeRow]
+  def maritalstatus: Field[/* bpchar, max 1 chars */ String, EmployeeRow]
+  def gender: Field[/* bpchar, max 1 chars */ String, EmployeeRow]
+  def hiredate: Field[TypoLocalDate, EmployeeRow]
+  def salariedflag: Field[Flag, EmployeeRow]
+  def vacationhours: Field[TypoShort, EmployeeRow]
+  def sickleavehours: Field[TypoShort, EmployeeRow]
+  def currentflag: Field[Flag, EmployeeRow]
+  def rowguid: Field[TypoUUID, EmployeeRow]
+  def modifieddate: Field[TypoLocalDateTime, EmployeeRow]
+  def organizationnode: OptField[String, EmployeeRow]
 }
 
 object EmployeeFields {
-  val structure: Relation[EmployeeFields, EmployeeRow, EmployeeRow] = 
-    new Impl(None, identity, (_, x) => x)
+  lazy val structure: Relation[EmployeeFields, EmployeeRow] =
+    new Impl(Nil)
     
-  private final class Impl[Row](val prefix: Option[String], val extract: Row => EmployeeRow, val merge: (Row, EmployeeRow) => Row)
-    extends Relation[EmployeeFields, EmployeeRow, Row] { 
+  private final class Impl(val _path: List[Path])
+    extends Relation[EmployeeFields, EmployeeRow] {
   
-    override val fields: EmployeeFields[Row] = new EmployeeFields[Row] {
-      override val businessentityid = new IdField[BusinessentityId, Row](prefix, "businessentityid", None, Some("int4"))(x => extract(x).businessentityid, (row, value) => merge(row, extract(row).copy(businessentityid = value)))
-      override val nationalidnumber = new Field[/* max 15 chars */ String, Row](prefix, "nationalidnumber", None, None)(x => extract(x).nationalidnumber, (row, value) => merge(row, extract(row).copy(nationalidnumber = value)))
-      override val loginid = new Field[/* max 256 chars */ String, Row](prefix, "loginid", None, None)(x => extract(x).loginid, (row, value) => merge(row, extract(row).copy(loginid = value)))
-      override val jobtitle = new Field[/* max 50 chars */ String, Row](prefix, "jobtitle", None, None)(x => extract(x).jobtitle, (row, value) => merge(row, extract(row).copy(jobtitle = value)))
-      override val birthdate = new Field[TypoLocalDate, Row](prefix, "birthdate", Some("text"), Some("date"))(x => extract(x).birthdate, (row, value) => merge(row, extract(row).copy(birthdate = value)))
-      override val maritalstatus = new Field[/* bpchar, max 1 chars */ String, Row](prefix, "maritalstatus", None, Some("bpchar"))(x => extract(x).maritalstatus, (row, value) => merge(row, extract(row).copy(maritalstatus = value)))
-      override val gender = new Field[/* bpchar, max 1 chars */ String, Row](prefix, "gender", None, Some("bpchar"))(x => extract(x).gender, (row, value) => merge(row, extract(row).copy(gender = value)))
-      override val hiredate = new Field[TypoLocalDate, Row](prefix, "hiredate", Some("text"), Some("date"))(x => extract(x).hiredate, (row, value) => merge(row, extract(row).copy(hiredate = value)))
-      override val salariedflag = new Field[Flag, Row](prefix, "salariedflag", None, Some("bool"))(x => extract(x).salariedflag, (row, value) => merge(row, extract(row).copy(salariedflag = value)))
-      override val vacationhours = new Field[TypoShort, Row](prefix, "vacationhours", None, Some("int2"))(x => extract(x).vacationhours, (row, value) => merge(row, extract(row).copy(vacationhours = value)))
-      override val sickleavehours = new Field[TypoShort, Row](prefix, "sickleavehours", None, Some("int2"))(x => extract(x).sickleavehours, (row, value) => merge(row, extract(row).copy(sickleavehours = value)))
-      override val currentflag = new Field[Flag, Row](prefix, "currentflag", None, Some("bool"))(x => extract(x).currentflag, (row, value) => merge(row, extract(row).copy(currentflag = value)))
-      override val rowguid = new Field[TypoUUID, Row](prefix, "rowguid", None, Some("uuid"))(x => extract(x).rowguid, (row, value) => merge(row, extract(row).copy(rowguid = value)))
-      override val modifieddate = new Field[TypoLocalDateTime, Row](prefix, "modifieddate", Some("text"), Some("timestamp"))(x => extract(x).modifieddate, (row, value) => merge(row, extract(row).copy(modifieddate = value)))
-      override val organizationnode = new OptField[String, Row](prefix, "organizationnode", None, None)(x => extract(x).organizationnode, (row, value) => merge(row, extract(row).copy(organizationnode = value)))
+    override lazy val fields: EmployeeFields = new EmployeeFields {
+      override def businessentityid = IdField[BusinessentityId, EmployeeRow](_path, "businessentityid", None, Some("int4"), x => x.businessentityid, (row, value) => row.copy(businessentityid = value))
+      override def nationalidnumber = Field[/* max 15 chars */ String, EmployeeRow](_path, "nationalidnumber", None, None, x => x.nationalidnumber, (row, value) => row.copy(nationalidnumber = value))
+      override def loginid = Field[/* max 256 chars */ String, EmployeeRow](_path, "loginid", None, None, x => x.loginid, (row, value) => row.copy(loginid = value))
+      override def jobtitle = Field[/* max 50 chars */ String, EmployeeRow](_path, "jobtitle", None, None, x => x.jobtitle, (row, value) => row.copy(jobtitle = value))
+      override def birthdate = Field[TypoLocalDate, EmployeeRow](_path, "birthdate", Some("text"), Some("date"), x => x.birthdate, (row, value) => row.copy(birthdate = value))
+      override def maritalstatus = Field[/* bpchar, max 1 chars */ String, EmployeeRow](_path, "maritalstatus", None, Some("bpchar"), x => x.maritalstatus, (row, value) => row.copy(maritalstatus = value))
+      override def gender = Field[/* bpchar, max 1 chars */ String, EmployeeRow](_path, "gender", None, Some("bpchar"), x => x.gender, (row, value) => row.copy(gender = value))
+      override def hiredate = Field[TypoLocalDate, EmployeeRow](_path, "hiredate", Some("text"), Some("date"), x => x.hiredate, (row, value) => row.copy(hiredate = value))
+      override def salariedflag = Field[Flag, EmployeeRow](_path, "salariedflag", None, Some("bool"), x => x.salariedflag, (row, value) => row.copy(salariedflag = value))
+      override def vacationhours = Field[TypoShort, EmployeeRow](_path, "vacationhours", None, Some("int2"), x => x.vacationhours, (row, value) => row.copy(vacationhours = value))
+      override def sickleavehours = Field[TypoShort, EmployeeRow](_path, "sickleavehours", None, Some("int2"), x => x.sickleavehours, (row, value) => row.copy(sickleavehours = value))
+      override def currentflag = Field[Flag, EmployeeRow](_path, "currentflag", None, Some("bool"), x => x.currentflag, (row, value) => row.copy(currentflag = value))
+      override def rowguid = Field[TypoUUID, EmployeeRow](_path, "rowguid", None, Some("uuid"), x => x.rowguid, (row, value) => row.copy(rowguid = value))
+      override def modifieddate = Field[TypoLocalDateTime, EmployeeRow](_path, "modifieddate", Some("text"), Some("timestamp"), x => x.modifieddate, (row, value) => row.copy(modifieddate = value))
+      override def organizationnode = OptField[String, EmployeeRow](_path, "organizationnode", None, None, x => x.organizationnode, (row, value) => row.copy(organizationnode = value))
     }
   
-    override val columns: List[FieldLikeNoHkt[?, Row]] =
-      List[FieldLikeNoHkt[?, Row]](fields.businessentityid, fields.nationalidnumber, fields.loginid, fields.jobtitle, fields.birthdate, fields.maritalstatus, fields.gender, fields.hiredate, fields.salariedflag, fields.vacationhours, fields.sickleavehours, fields.currentflag, fields.rowguid, fields.modifieddate, fields.organizationnode)
+    override lazy val columns: List[FieldLikeNoHkt[?, EmployeeRow]] =
+      List[FieldLikeNoHkt[?, EmployeeRow]](fields.businessentityid, fields.nationalidnumber, fields.loginid, fields.jobtitle, fields.birthdate, fields.maritalstatus, fields.gender, fields.hiredate, fields.salariedflag, fields.vacationhours, fields.sickleavehours, fields.currentflag, fields.rowguid, fields.modifieddate, fields.organizationnode)
   
-    override def copy[NewRow](prefix: Option[String], extract: NewRow => EmployeeRow, merge: (NewRow, EmployeeRow) => NewRow): Impl[NewRow] =
-      new Impl(prefix, extract, merge)
+    override def copy(path: List[Path]): Impl =
+      new Impl(path)
   }
   
 }

--- a/typo-tester-zio-jdbc/generated-and-checked-in/adventureworks/humanresources/employee/EmployeeRepoMock.scala
+++ b/typo-tester-zio-jdbc/generated-and-checked-in/adventureworks/humanresources/employee/EmployeeRepoMock.scala
@@ -27,7 +27,7 @@ import zio.stream.ZStream
 class EmployeeRepoMock(toRow: Function1[EmployeeRowUnsaved, EmployeeRow],
                        map: scala.collection.mutable.Map[BusinessentityId, EmployeeRow] = scala.collection.mutable.Map.empty) extends EmployeeRepo {
   override def delete: DeleteBuilder[EmployeeFields, EmployeeRow] = {
-    DeleteBuilderMock(DeleteParams.empty, EmployeeFields.structure.fields, map)
+    DeleteBuilderMock(DeleteParams.empty, EmployeeFields.structure, map)
   }
   override def deleteById(businessentityid: BusinessentityId): ZIO[ZConnection, Throwable, Boolean] = {
     ZIO.succeed(map.remove(businessentityid).isDefined)
@@ -86,7 +86,7 @@ class EmployeeRepoMock(toRow: Function1[EmployeeRowUnsaved, EmployeeRow],
     }
   }
   override def update: UpdateBuilder[EmployeeFields, EmployeeRow] = {
-    UpdateBuilderMock(UpdateParams.empty, EmployeeFields.structure.fields, map)
+    UpdateBuilderMock(UpdateParams.empty, EmployeeFields.structure, map)
   }
   override def update(row: EmployeeRow): ZIO[ZConnection, Throwable, Boolean] = {
     ZIO.succeed {

--- a/typo-tester-zio-jdbc/generated-and-checked-in/adventureworks/humanresources/employeedepartmenthistory/EmployeedepartmenthistoryFields.scala
+++ b/typo-tester-zio-jdbc/generated-and-checked-in/adventureworks/humanresources/employeedepartmenthistory/EmployeedepartmenthistoryFields.scala
@@ -12,42 +12,43 @@ import adventureworks.customtypes.TypoLocalDateTime
 import adventureworks.humanresources.department.DepartmentId
 import adventureworks.humanresources.shift.ShiftId
 import adventureworks.person.businessentity.BusinessentityId
+import typo.dsl.Path
 import typo.dsl.SqlExpr.Field
 import typo.dsl.SqlExpr.FieldLikeNoHkt
 import typo.dsl.SqlExpr.IdField
 import typo.dsl.SqlExpr.OptField
 import typo.dsl.Structure.Relation
 
-trait EmployeedepartmenthistoryFields[Row] {
-  val businessentityid: IdField[BusinessentityId, Row]
-  val departmentid: IdField[DepartmentId, Row]
-  val shiftid: IdField[ShiftId, Row]
-  val startdate: IdField[TypoLocalDate, Row]
-  val enddate: OptField[TypoLocalDate, Row]
-  val modifieddate: Field[TypoLocalDateTime, Row]
+trait EmployeedepartmenthistoryFields {
+  def businessentityid: IdField[BusinessentityId, EmployeedepartmenthistoryRow]
+  def departmentid: IdField[DepartmentId, EmployeedepartmenthistoryRow]
+  def shiftid: IdField[ShiftId, EmployeedepartmenthistoryRow]
+  def startdate: IdField[TypoLocalDate, EmployeedepartmenthistoryRow]
+  def enddate: OptField[TypoLocalDate, EmployeedepartmenthistoryRow]
+  def modifieddate: Field[TypoLocalDateTime, EmployeedepartmenthistoryRow]
 }
 
 object EmployeedepartmenthistoryFields {
-  val structure: Relation[EmployeedepartmenthistoryFields, EmployeedepartmenthistoryRow, EmployeedepartmenthistoryRow] = 
-    new Impl(None, identity, (_, x) => x)
+  lazy val structure: Relation[EmployeedepartmenthistoryFields, EmployeedepartmenthistoryRow] =
+    new Impl(Nil)
     
-  private final class Impl[Row](val prefix: Option[String], val extract: Row => EmployeedepartmenthistoryRow, val merge: (Row, EmployeedepartmenthistoryRow) => Row)
-    extends Relation[EmployeedepartmenthistoryFields, EmployeedepartmenthistoryRow, Row] { 
+  private final class Impl(val _path: List[Path])
+    extends Relation[EmployeedepartmenthistoryFields, EmployeedepartmenthistoryRow] {
   
-    override val fields: EmployeedepartmenthistoryFields[Row] = new EmployeedepartmenthistoryFields[Row] {
-      override val businessentityid = new IdField[BusinessentityId, Row](prefix, "businessentityid", None, Some("int4"))(x => extract(x).businessentityid, (row, value) => merge(row, extract(row).copy(businessentityid = value)))
-      override val departmentid = new IdField[DepartmentId, Row](prefix, "departmentid", None, Some("int2"))(x => extract(x).departmentid, (row, value) => merge(row, extract(row).copy(departmentid = value)))
-      override val shiftid = new IdField[ShiftId, Row](prefix, "shiftid", None, Some("int2"))(x => extract(x).shiftid, (row, value) => merge(row, extract(row).copy(shiftid = value)))
-      override val startdate = new IdField[TypoLocalDate, Row](prefix, "startdate", Some("text"), Some("date"))(x => extract(x).startdate, (row, value) => merge(row, extract(row).copy(startdate = value)))
-      override val enddate = new OptField[TypoLocalDate, Row](prefix, "enddate", Some("text"), Some("date"))(x => extract(x).enddate, (row, value) => merge(row, extract(row).copy(enddate = value)))
-      override val modifieddate = new Field[TypoLocalDateTime, Row](prefix, "modifieddate", Some("text"), Some("timestamp"))(x => extract(x).modifieddate, (row, value) => merge(row, extract(row).copy(modifieddate = value)))
+    override lazy val fields: EmployeedepartmenthistoryFields = new EmployeedepartmenthistoryFields {
+      override def businessentityid = IdField[BusinessentityId, EmployeedepartmenthistoryRow](_path, "businessentityid", None, Some("int4"), x => x.businessentityid, (row, value) => row.copy(businessentityid = value))
+      override def departmentid = IdField[DepartmentId, EmployeedepartmenthistoryRow](_path, "departmentid", None, Some("int2"), x => x.departmentid, (row, value) => row.copy(departmentid = value))
+      override def shiftid = IdField[ShiftId, EmployeedepartmenthistoryRow](_path, "shiftid", None, Some("int2"), x => x.shiftid, (row, value) => row.copy(shiftid = value))
+      override def startdate = IdField[TypoLocalDate, EmployeedepartmenthistoryRow](_path, "startdate", Some("text"), Some("date"), x => x.startdate, (row, value) => row.copy(startdate = value))
+      override def enddate = OptField[TypoLocalDate, EmployeedepartmenthistoryRow](_path, "enddate", Some("text"), Some("date"), x => x.enddate, (row, value) => row.copy(enddate = value))
+      override def modifieddate = Field[TypoLocalDateTime, EmployeedepartmenthistoryRow](_path, "modifieddate", Some("text"), Some("timestamp"), x => x.modifieddate, (row, value) => row.copy(modifieddate = value))
     }
   
-    override val columns: List[FieldLikeNoHkt[?, Row]] =
-      List[FieldLikeNoHkt[?, Row]](fields.businessentityid, fields.departmentid, fields.shiftid, fields.startdate, fields.enddate, fields.modifieddate)
+    override lazy val columns: List[FieldLikeNoHkt[?, EmployeedepartmenthistoryRow]] =
+      List[FieldLikeNoHkt[?, EmployeedepartmenthistoryRow]](fields.businessentityid, fields.departmentid, fields.shiftid, fields.startdate, fields.enddate, fields.modifieddate)
   
-    override def copy[NewRow](prefix: Option[String], extract: NewRow => EmployeedepartmenthistoryRow, merge: (NewRow, EmployeedepartmenthistoryRow) => NewRow): Impl[NewRow] =
-      new Impl(prefix, extract, merge)
+    override def copy(path: List[Path]): Impl =
+      new Impl(path)
   }
   
 }

--- a/typo-tester-zio-jdbc/generated-and-checked-in/adventureworks/humanresources/employeedepartmenthistory/EmployeedepartmenthistoryRepoMock.scala
+++ b/typo-tester-zio-jdbc/generated-and-checked-in/adventureworks/humanresources/employeedepartmenthistory/EmployeedepartmenthistoryRepoMock.scala
@@ -26,7 +26,7 @@ import zio.stream.ZStream
 class EmployeedepartmenthistoryRepoMock(toRow: Function1[EmployeedepartmenthistoryRowUnsaved, EmployeedepartmenthistoryRow],
                                         map: scala.collection.mutable.Map[EmployeedepartmenthistoryId, EmployeedepartmenthistoryRow] = scala.collection.mutable.Map.empty) extends EmployeedepartmenthistoryRepo {
   override def delete: DeleteBuilder[EmployeedepartmenthistoryFields, EmployeedepartmenthistoryRow] = {
-    DeleteBuilderMock(DeleteParams.empty, EmployeedepartmenthistoryFields.structure.fields, map)
+    DeleteBuilderMock(DeleteParams.empty, EmployeedepartmenthistoryFields.structure, map)
   }
   override def deleteById(compositeId: EmployeedepartmenthistoryId): ZIO[ZConnection, Throwable, Boolean] = {
     ZIO.succeed(map.remove(compositeId).isDefined)
@@ -85,7 +85,7 @@ class EmployeedepartmenthistoryRepoMock(toRow: Function1[Employeedepartmenthisto
     }
   }
   override def update: UpdateBuilder[EmployeedepartmenthistoryFields, EmployeedepartmenthistoryRow] = {
-    UpdateBuilderMock(UpdateParams.empty, EmployeedepartmenthistoryFields.structure.fields, map)
+    UpdateBuilderMock(UpdateParams.empty, EmployeedepartmenthistoryFields.structure, map)
   }
   override def update(row: EmployeedepartmenthistoryRow): ZIO[ZConnection, Throwable, Boolean] = {
     ZIO.succeed {

--- a/typo-tester-zio-jdbc/generated-and-checked-in/adventureworks/humanresources/employeepayhistory/EmployeepayhistoryFields.scala
+++ b/typo-tester-zio-jdbc/generated-and-checked-in/adventureworks/humanresources/employeepayhistory/EmployeepayhistoryFields.scala
@@ -10,39 +10,40 @@ package employeepayhistory
 import adventureworks.customtypes.TypoLocalDateTime
 import adventureworks.customtypes.TypoShort
 import adventureworks.person.businessentity.BusinessentityId
+import typo.dsl.Path
 import typo.dsl.SqlExpr.Field
 import typo.dsl.SqlExpr.FieldLikeNoHkt
 import typo.dsl.SqlExpr.IdField
 import typo.dsl.Structure.Relation
 
-trait EmployeepayhistoryFields[Row] {
-  val businessentityid: IdField[BusinessentityId, Row]
-  val ratechangedate: IdField[TypoLocalDateTime, Row]
-  val rate: Field[BigDecimal, Row]
-  val payfrequency: Field[TypoShort, Row]
-  val modifieddate: Field[TypoLocalDateTime, Row]
+trait EmployeepayhistoryFields {
+  def businessentityid: IdField[BusinessentityId, EmployeepayhistoryRow]
+  def ratechangedate: IdField[TypoLocalDateTime, EmployeepayhistoryRow]
+  def rate: Field[BigDecimal, EmployeepayhistoryRow]
+  def payfrequency: Field[TypoShort, EmployeepayhistoryRow]
+  def modifieddate: Field[TypoLocalDateTime, EmployeepayhistoryRow]
 }
 
 object EmployeepayhistoryFields {
-  val structure: Relation[EmployeepayhistoryFields, EmployeepayhistoryRow, EmployeepayhistoryRow] = 
-    new Impl(None, identity, (_, x) => x)
+  lazy val structure: Relation[EmployeepayhistoryFields, EmployeepayhistoryRow] =
+    new Impl(Nil)
     
-  private final class Impl[Row](val prefix: Option[String], val extract: Row => EmployeepayhistoryRow, val merge: (Row, EmployeepayhistoryRow) => Row)
-    extends Relation[EmployeepayhistoryFields, EmployeepayhistoryRow, Row] { 
+  private final class Impl(val _path: List[Path])
+    extends Relation[EmployeepayhistoryFields, EmployeepayhistoryRow] {
   
-    override val fields: EmployeepayhistoryFields[Row] = new EmployeepayhistoryFields[Row] {
-      override val businessentityid = new IdField[BusinessentityId, Row](prefix, "businessentityid", None, Some("int4"))(x => extract(x).businessentityid, (row, value) => merge(row, extract(row).copy(businessentityid = value)))
-      override val ratechangedate = new IdField[TypoLocalDateTime, Row](prefix, "ratechangedate", Some("text"), Some("timestamp"))(x => extract(x).ratechangedate, (row, value) => merge(row, extract(row).copy(ratechangedate = value)))
-      override val rate = new Field[BigDecimal, Row](prefix, "rate", None, Some("numeric"))(x => extract(x).rate, (row, value) => merge(row, extract(row).copy(rate = value)))
-      override val payfrequency = new Field[TypoShort, Row](prefix, "payfrequency", None, Some("int2"))(x => extract(x).payfrequency, (row, value) => merge(row, extract(row).copy(payfrequency = value)))
-      override val modifieddate = new Field[TypoLocalDateTime, Row](prefix, "modifieddate", Some("text"), Some("timestamp"))(x => extract(x).modifieddate, (row, value) => merge(row, extract(row).copy(modifieddate = value)))
+    override lazy val fields: EmployeepayhistoryFields = new EmployeepayhistoryFields {
+      override def businessentityid = IdField[BusinessentityId, EmployeepayhistoryRow](_path, "businessentityid", None, Some("int4"), x => x.businessentityid, (row, value) => row.copy(businessentityid = value))
+      override def ratechangedate = IdField[TypoLocalDateTime, EmployeepayhistoryRow](_path, "ratechangedate", Some("text"), Some("timestamp"), x => x.ratechangedate, (row, value) => row.copy(ratechangedate = value))
+      override def rate = Field[BigDecimal, EmployeepayhistoryRow](_path, "rate", None, Some("numeric"), x => x.rate, (row, value) => row.copy(rate = value))
+      override def payfrequency = Field[TypoShort, EmployeepayhistoryRow](_path, "payfrequency", None, Some("int2"), x => x.payfrequency, (row, value) => row.copy(payfrequency = value))
+      override def modifieddate = Field[TypoLocalDateTime, EmployeepayhistoryRow](_path, "modifieddate", Some("text"), Some("timestamp"), x => x.modifieddate, (row, value) => row.copy(modifieddate = value))
     }
   
-    override val columns: List[FieldLikeNoHkt[?, Row]] =
-      List[FieldLikeNoHkt[?, Row]](fields.businessentityid, fields.ratechangedate, fields.rate, fields.payfrequency, fields.modifieddate)
+    override lazy val columns: List[FieldLikeNoHkt[?, EmployeepayhistoryRow]] =
+      List[FieldLikeNoHkt[?, EmployeepayhistoryRow]](fields.businessentityid, fields.ratechangedate, fields.rate, fields.payfrequency, fields.modifieddate)
   
-    override def copy[NewRow](prefix: Option[String], extract: NewRow => EmployeepayhistoryRow, merge: (NewRow, EmployeepayhistoryRow) => NewRow): Impl[NewRow] =
-      new Impl(prefix, extract, merge)
+    override def copy(path: List[Path]): Impl =
+      new Impl(path)
   }
   
 }

--- a/typo-tester-zio-jdbc/generated-and-checked-in/adventureworks/humanresources/employeepayhistory/EmployeepayhistoryRepoMock.scala
+++ b/typo-tester-zio-jdbc/generated-and-checked-in/adventureworks/humanresources/employeepayhistory/EmployeepayhistoryRepoMock.scala
@@ -26,7 +26,7 @@ import zio.stream.ZStream
 class EmployeepayhistoryRepoMock(toRow: Function1[EmployeepayhistoryRowUnsaved, EmployeepayhistoryRow],
                                  map: scala.collection.mutable.Map[EmployeepayhistoryId, EmployeepayhistoryRow] = scala.collection.mutable.Map.empty) extends EmployeepayhistoryRepo {
   override def delete: DeleteBuilder[EmployeepayhistoryFields, EmployeepayhistoryRow] = {
-    DeleteBuilderMock(DeleteParams.empty, EmployeepayhistoryFields.structure.fields, map)
+    DeleteBuilderMock(DeleteParams.empty, EmployeepayhistoryFields.structure, map)
   }
   override def deleteById(compositeId: EmployeepayhistoryId): ZIO[ZConnection, Throwable, Boolean] = {
     ZIO.succeed(map.remove(compositeId).isDefined)
@@ -85,7 +85,7 @@ class EmployeepayhistoryRepoMock(toRow: Function1[EmployeepayhistoryRowUnsaved, 
     }
   }
   override def update: UpdateBuilder[EmployeepayhistoryFields, EmployeepayhistoryRow] = {
-    UpdateBuilderMock(UpdateParams.empty, EmployeepayhistoryFields.structure.fields, map)
+    UpdateBuilderMock(UpdateParams.empty, EmployeepayhistoryFields.structure, map)
   }
   override def update(row: EmployeepayhistoryRow): ZIO[ZConnection, Throwable, Boolean] = {
     ZIO.succeed {

--- a/typo-tester-zio-jdbc/generated-and-checked-in/adventureworks/humanresources/jobcandidate/JobcandidateFields.scala
+++ b/typo-tester-zio-jdbc/generated-and-checked-in/adventureworks/humanresources/jobcandidate/JobcandidateFields.scala
@@ -10,38 +10,39 @@ package jobcandidate
 import adventureworks.customtypes.TypoLocalDateTime
 import adventureworks.customtypes.TypoXml
 import adventureworks.person.businessentity.BusinessentityId
+import typo.dsl.Path
 import typo.dsl.SqlExpr.Field
 import typo.dsl.SqlExpr.FieldLikeNoHkt
 import typo.dsl.SqlExpr.IdField
 import typo.dsl.SqlExpr.OptField
 import typo.dsl.Structure.Relation
 
-trait JobcandidateFields[Row] {
-  val jobcandidateid: IdField[JobcandidateId, Row]
-  val businessentityid: OptField[BusinessentityId, Row]
-  val resume: OptField[TypoXml, Row]
-  val modifieddate: Field[TypoLocalDateTime, Row]
+trait JobcandidateFields {
+  def jobcandidateid: IdField[JobcandidateId, JobcandidateRow]
+  def businessentityid: OptField[BusinessentityId, JobcandidateRow]
+  def resume: OptField[TypoXml, JobcandidateRow]
+  def modifieddate: Field[TypoLocalDateTime, JobcandidateRow]
 }
 
 object JobcandidateFields {
-  val structure: Relation[JobcandidateFields, JobcandidateRow, JobcandidateRow] = 
-    new Impl(None, identity, (_, x) => x)
+  lazy val structure: Relation[JobcandidateFields, JobcandidateRow] =
+    new Impl(Nil)
     
-  private final class Impl[Row](val prefix: Option[String], val extract: Row => JobcandidateRow, val merge: (Row, JobcandidateRow) => Row)
-    extends Relation[JobcandidateFields, JobcandidateRow, Row] { 
+  private final class Impl(val _path: List[Path])
+    extends Relation[JobcandidateFields, JobcandidateRow] {
   
-    override val fields: JobcandidateFields[Row] = new JobcandidateFields[Row] {
-      override val jobcandidateid = new IdField[JobcandidateId, Row](prefix, "jobcandidateid", None, Some("int4"))(x => extract(x).jobcandidateid, (row, value) => merge(row, extract(row).copy(jobcandidateid = value)))
-      override val businessentityid = new OptField[BusinessentityId, Row](prefix, "businessentityid", None, Some("int4"))(x => extract(x).businessentityid, (row, value) => merge(row, extract(row).copy(businessentityid = value)))
-      override val resume = new OptField[TypoXml, Row](prefix, "resume", None, Some("xml"))(x => extract(x).resume, (row, value) => merge(row, extract(row).copy(resume = value)))
-      override val modifieddate = new Field[TypoLocalDateTime, Row](prefix, "modifieddate", Some("text"), Some("timestamp"))(x => extract(x).modifieddate, (row, value) => merge(row, extract(row).copy(modifieddate = value)))
+    override lazy val fields: JobcandidateFields = new JobcandidateFields {
+      override def jobcandidateid = IdField[JobcandidateId, JobcandidateRow](_path, "jobcandidateid", None, Some("int4"), x => x.jobcandidateid, (row, value) => row.copy(jobcandidateid = value))
+      override def businessentityid = OptField[BusinessentityId, JobcandidateRow](_path, "businessentityid", None, Some("int4"), x => x.businessentityid, (row, value) => row.copy(businessentityid = value))
+      override def resume = OptField[TypoXml, JobcandidateRow](_path, "resume", None, Some("xml"), x => x.resume, (row, value) => row.copy(resume = value))
+      override def modifieddate = Field[TypoLocalDateTime, JobcandidateRow](_path, "modifieddate", Some("text"), Some("timestamp"), x => x.modifieddate, (row, value) => row.copy(modifieddate = value))
     }
   
-    override val columns: List[FieldLikeNoHkt[?, Row]] =
-      List[FieldLikeNoHkt[?, Row]](fields.jobcandidateid, fields.businessentityid, fields.resume, fields.modifieddate)
+    override lazy val columns: List[FieldLikeNoHkt[?, JobcandidateRow]] =
+      List[FieldLikeNoHkt[?, JobcandidateRow]](fields.jobcandidateid, fields.businessentityid, fields.resume, fields.modifieddate)
   
-    override def copy[NewRow](prefix: Option[String], extract: NewRow => JobcandidateRow, merge: (NewRow, JobcandidateRow) => NewRow): Impl[NewRow] =
-      new Impl(prefix, extract, merge)
+    override def copy(path: List[Path]): Impl =
+      new Impl(path)
   }
   
 }

--- a/typo-tester-zio-jdbc/generated-and-checked-in/adventureworks/humanresources/jobcandidate/JobcandidateRepoMock.scala
+++ b/typo-tester-zio-jdbc/generated-and-checked-in/adventureworks/humanresources/jobcandidate/JobcandidateRepoMock.scala
@@ -26,7 +26,7 @@ import zio.stream.ZStream
 class JobcandidateRepoMock(toRow: Function1[JobcandidateRowUnsaved, JobcandidateRow],
                            map: scala.collection.mutable.Map[JobcandidateId, JobcandidateRow] = scala.collection.mutable.Map.empty) extends JobcandidateRepo {
   override def delete: DeleteBuilder[JobcandidateFields, JobcandidateRow] = {
-    DeleteBuilderMock(DeleteParams.empty, JobcandidateFields.structure.fields, map)
+    DeleteBuilderMock(DeleteParams.empty, JobcandidateFields.structure, map)
   }
   override def deleteById(jobcandidateid: JobcandidateId): ZIO[ZConnection, Throwable, Boolean] = {
     ZIO.succeed(map.remove(jobcandidateid).isDefined)
@@ -85,7 +85,7 @@ class JobcandidateRepoMock(toRow: Function1[JobcandidateRowUnsaved, Jobcandidate
     }
   }
   override def update: UpdateBuilder[JobcandidateFields, JobcandidateRow] = {
-    UpdateBuilderMock(UpdateParams.empty, JobcandidateFields.structure.fields, map)
+    UpdateBuilderMock(UpdateParams.empty, JobcandidateFields.structure, map)
   }
   override def update(row: JobcandidateRow): ZIO[ZConnection, Throwable, Boolean] = {
     ZIO.succeed {

--- a/typo-tester-zio-jdbc/generated-and-checked-in/adventureworks/humanresources/shift/ShiftFields.scala
+++ b/typo-tester-zio-jdbc/generated-and-checked-in/adventureworks/humanresources/shift/ShiftFields.scala
@@ -10,39 +10,40 @@ package shift
 import adventureworks.customtypes.TypoLocalDateTime
 import adventureworks.customtypes.TypoLocalTime
 import adventureworks.public.Name
+import typo.dsl.Path
 import typo.dsl.SqlExpr.Field
 import typo.dsl.SqlExpr.FieldLikeNoHkt
 import typo.dsl.SqlExpr.IdField
 import typo.dsl.Structure.Relation
 
-trait ShiftFields[Row] {
-  val shiftid: IdField[ShiftId, Row]
-  val name: Field[Name, Row]
-  val starttime: Field[TypoLocalTime, Row]
-  val endtime: Field[TypoLocalTime, Row]
-  val modifieddate: Field[TypoLocalDateTime, Row]
+trait ShiftFields {
+  def shiftid: IdField[ShiftId, ShiftRow]
+  def name: Field[Name, ShiftRow]
+  def starttime: Field[TypoLocalTime, ShiftRow]
+  def endtime: Field[TypoLocalTime, ShiftRow]
+  def modifieddate: Field[TypoLocalDateTime, ShiftRow]
 }
 
 object ShiftFields {
-  val structure: Relation[ShiftFields, ShiftRow, ShiftRow] = 
-    new Impl(None, identity, (_, x) => x)
+  lazy val structure: Relation[ShiftFields, ShiftRow] =
+    new Impl(Nil)
     
-  private final class Impl[Row](val prefix: Option[String], val extract: Row => ShiftRow, val merge: (Row, ShiftRow) => Row)
-    extends Relation[ShiftFields, ShiftRow, Row] { 
+  private final class Impl(val _path: List[Path])
+    extends Relation[ShiftFields, ShiftRow] {
   
-    override val fields: ShiftFields[Row] = new ShiftFields[Row] {
-      override val shiftid = new IdField[ShiftId, Row](prefix, "shiftid", None, Some("int4"))(x => extract(x).shiftid, (row, value) => merge(row, extract(row).copy(shiftid = value)))
-      override val name = new Field[Name, Row](prefix, "name", None, Some("varchar"))(x => extract(x).name, (row, value) => merge(row, extract(row).copy(name = value)))
-      override val starttime = new Field[TypoLocalTime, Row](prefix, "starttime", Some("text"), Some("time"))(x => extract(x).starttime, (row, value) => merge(row, extract(row).copy(starttime = value)))
-      override val endtime = new Field[TypoLocalTime, Row](prefix, "endtime", Some("text"), Some("time"))(x => extract(x).endtime, (row, value) => merge(row, extract(row).copy(endtime = value)))
-      override val modifieddate = new Field[TypoLocalDateTime, Row](prefix, "modifieddate", Some("text"), Some("timestamp"))(x => extract(x).modifieddate, (row, value) => merge(row, extract(row).copy(modifieddate = value)))
+    override lazy val fields: ShiftFields = new ShiftFields {
+      override def shiftid = IdField[ShiftId, ShiftRow](_path, "shiftid", None, Some("int4"), x => x.shiftid, (row, value) => row.copy(shiftid = value))
+      override def name = Field[Name, ShiftRow](_path, "name", None, Some("varchar"), x => x.name, (row, value) => row.copy(name = value))
+      override def starttime = Field[TypoLocalTime, ShiftRow](_path, "starttime", Some("text"), Some("time"), x => x.starttime, (row, value) => row.copy(starttime = value))
+      override def endtime = Field[TypoLocalTime, ShiftRow](_path, "endtime", Some("text"), Some("time"), x => x.endtime, (row, value) => row.copy(endtime = value))
+      override def modifieddate = Field[TypoLocalDateTime, ShiftRow](_path, "modifieddate", Some("text"), Some("timestamp"), x => x.modifieddate, (row, value) => row.copy(modifieddate = value))
     }
   
-    override val columns: List[FieldLikeNoHkt[?, Row]] =
-      List[FieldLikeNoHkt[?, Row]](fields.shiftid, fields.name, fields.starttime, fields.endtime, fields.modifieddate)
+    override lazy val columns: List[FieldLikeNoHkt[?, ShiftRow]] =
+      List[FieldLikeNoHkt[?, ShiftRow]](fields.shiftid, fields.name, fields.starttime, fields.endtime, fields.modifieddate)
   
-    override def copy[NewRow](prefix: Option[String], extract: NewRow => ShiftRow, merge: (NewRow, ShiftRow) => NewRow): Impl[NewRow] =
-      new Impl(prefix, extract, merge)
+    override def copy(path: List[Path]): Impl =
+      new Impl(path)
   }
   
 }

--- a/typo-tester-zio-jdbc/generated-and-checked-in/adventureworks/humanresources/shift/ShiftRepoMock.scala
+++ b/typo-tester-zio-jdbc/generated-and-checked-in/adventureworks/humanresources/shift/ShiftRepoMock.scala
@@ -26,7 +26,7 @@ import zio.stream.ZStream
 class ShiftRepoMock(toRow: Function1[ShiftRowUnsaved, ShiftRow],
                     map: scala.collection.mutable.Map[ShiftId, ShiftRow] = scala.collection.mutable.Map.empty) extends ShiftRepo {
   override def delete: DeleteBuilder[ShiftFields, ShiftRow] = {
-    DeleteBuilderMock(DeleteParams.empty, ShiftFields.structure.fields, map)
+    DeleteBuilderMock(DeleteParams.empty, ShiftFields.structure, map)
   }
   override def deleteById(shiftid: ShiftId): ZIO[ZConnection, Throwable, Boolean] = {
     ZIO.succeed(map.remove(shiftid).isDefined)
@@ -85,7 +85,7 @@ class ShiftRepoMock(toRow: Function1[ShiftRowUnsaved, ShiftRow],
     }
   }
   override def update: UpdateBuilder[ShiftFields, ShiftRow] = {
-    UpdateBuilderMock(UpdateParams.empty, ShiftFields.structure.fields, map)
+    UpdateBuilderMock(UpdateParams.empty, ShiftFields.structure, map)
   }
   override def update(row: ShiftRow): ZIO[ZConnection, Throwable, Boolean] = {
     ZIO.succeed {

--- a/typo-tester-zio-jdbc/generated-and-checked-in/adventureworks/humanresources/vemployee/VemployeeViewFields.scala
+++ b/typo-tester-zio-jdbc/generated-and-checked-in/adventureworks/humanresources/vemployee/VemployeeViewFields.scala
@@ -12,65 +12,66 @@ import adventureworks.person.businessentity.BusinessentityId
 import adventureworks.public.Name
 import adventureworks.public.Phone
 import adventureworks.userdefined.FirstName
+import typo.dsl.Path
 import typo.dsl.SqlExpr.Field
 import typo.dsl.SqlExpr.FieldLikeNoHkt
 import typo.dsl.SqlExpr.OptField
 import typo.dsl.Structure.Relation
 
-trait VemployeeViewFields[Row] {
-  val businessentityid: Field[BusinessentityId, Row]
-  val title: OptField[/* max 8 chars */ String, Row]
-  val firstname: Field[/* user-picked */ FirstName, Row]
-  val middlename: OptField[Name, Row]
-  val lastname: Field[Name, Row]
-  val suffix: OptField[/* max 10 chars */ String, Row]
-  val jobtitle: Field[/* max 50 chars */ String, Row]
-  val phonenumber: OptField[Phone, Row]
-  val phonenumbertype: OptField[Name, Row]
-  val emailaddress: OptField[/* max 50 chars */ String, Row]
-  val emailpromotion: Field[Int, Row]
-  val addressline1: Field[/* max 60 chars */ String, Row]
-  val addressline2: OptField[/* max 60 chars */ String, Row]
-  val city: Field[/* max 30 chars */ String, Row]
-  val stateprovincename: Field[Name, Row]
-  val postalcode: Field[/* max 15 chars */ String, Row]
-  val countryregionname: Field[Name, Row]
-  val additionalcontactinfo: OptField[TypoXml, Row]
+trait VemployeeViewFields {
+  def businessentityid: Field[BusinessentityId, VemployeeViewRow]
+  def title: OptField[/* max 8 chars */ String, VemployeeViewRow]
+  def firstname: Field[/* user-picked */ FirstName, VemployeeViewRow]
+  def middlename: OptField[Name, VemployeeViewRow]
+  def lastname: Field[Name, VemployeeViewRow]
+  def suffix: OptField[/* max 10 chars */ String, VemployeeViewRow]
+  def jobtitle: Field[/* max 50 chars */ String, VemployeeViewRow]
+  def phonenumber: OptField[Phone, VemployeeViewRow]
+  def phonenumbertype: OptField[Name, VemployeeViewRow]
+  def emailaddress: OptField[/* max 50 chars */ String, VemployeeViewRow]
+  def emailpromotion: Field[Int, VemployeeViewRow]
+  def addressline1: Field[/* max 60 chars */ String, VemployeeViewRow]
+  def addressline2: OptField[/* max 60 chars */ String, VemployeeViewRow]
+  def city: Field[/* max 30 chars */ String, VemployeeViewRow]
+  def stateprovincename: Field[Name, VemployeeViewRow]
+  def postalcode: Field[/* max 15 chars */ String, VemployeeViewRow]
+  def countryregionname: Field[Name, VemployeeViewRow]
+  def additionalcontactinfo: OptField[TypoXml, VemployeeViewRow]
 }
 
 object VemployeeViewFields {
-  val structure: Relation[VemployeeViewFields, VemployeeViewRow, VemployeeViewRow] = 
-    new Impl(None, identity, (_, x) => x)
+  lazy val structure: Relation[VemployeeViewFields, VemployeeViewRow] =
+    new Impl(Nil)
     
-  private final class Impl[Row](val prefix: Option[String], val extract: Row => VemployeeViewRow, val merge: (Row, VemployeeViewRow) => Row)
-    extends Relation[VemployeeViewFields, VemployeeViewRow, Row] { 
+  private final class Impl(val _path: List[Path])
+    extends Relation[VemployeeViewFields, VemployeeViewRow] {
   
-    override val fields: VemployeeViewFields[Row] = new VemployeeViewFields[Row] {
-      override val businessentityid = new Field[BusinessentityId, Row](prefix, "businessentityid", None, None)(x => extract(x).businessentityid, (row, value) => merge(row, extract(row).copy(businessentityid = value)))
-      override val title = new OptField[/* max 8 chars */ String, Row](prefix, "title", None, None)(x => extract(x).title, (row, value) => merge(row, extract(row).copy(title = value)))
-      override val firstname = new Field[/* user-picked */ FirstName, Row](prefix, "firstname", None, None)(x => extract(x).firstname, (row, value) => merge(row, extract(row).copy(firstname = value)))
-      override val middlename = new OptField[Name, Row](prefix, "middlename", None, None)(x => extract(x).middlename, (row, value) => merge(row, extract(row).copy(middlename = value)))
-      override val lastname = new Field[Name, Row](prefix, "lastname", None, None)(x => extract(x).lastname, (row, value) => merge(row, extract(row).copy(lastname = value)))
-      override val suffix = new OptField[/* max 10 chars */ String, Row](prefix, "suffix", None, None)(x => extract(x).suffix, (row, value) => merge(row, extract(row).copy(suffix = value)))
-      override val jobtitle = new Field[/* max 50 chars */ String, Row](prefix, "jobtitle", None, None)(x => extract(x).jobtitle, (row, value) => merge(row, extract(row).copy(jobtitle = value)))
-      override val phonenumber = new OptField[Phone, Row](prefix, "phonenumber", None, None)(x => extract(x).phonenumber, (row, value) => merge(row, extract(row).copy(phonenumber = value)))
-      override val phonenumbertype = new OptField[Name, Row](prefix, "phonenumbertype", None, None)(x => extract(x).phonenumbertype, (row, value) => merge(row, extract(row).copy(phonenumbertype = value)))
-      override val emailaddress = new OptField[/* max 50 chars */ String, Row](prefix, "emailaddress", None, None)(x => extract(x).emailaddress, (row, value) => merge(row, extract(row).copy(emailaddress = value)))
-      override val emailpromotion = new Field[Int, Row](prefix, "emailpromotion", None, None)(x => extract(x).emailpromotion, (row, value) => merge(row, extract(row).copy(emailpromotion = value)))
-      override val addressline1 = new Field[/* max 60 chars */ String, Row](prefix, "addressline1", None, None)(x => extract(x).addressline1, (row, value) => merge(row, extract(row).copy(addressline1 = value)))
-      override val addressline2 = new OptField[/* max 60 chars */ String, Row](prefix, "addressline2", None, None)(x => extract(x).addressline2, (row, value) => merge(row, extract(row).copy(addressline2 = value)))
-      override val city = new Field[/* max 30 chars */ String, Row](prefix, "city", None, None)(x => extract(x).city, (row, value) => merge(row, extract(row).copy(city = value)))
-      override val stateprovincename = new Field[Name, Row](prefix, "stateprovincename", None, None)(x => extract(x).stateprovincename, (row, value) => merge(row, extract(row).copy(stateprovincename = value)))
-      override val postalcode = new Field[/* max 15 chars */ String, Row](prefix, "postalcode", None, None)(x => extract(x).postalcode, (row, value) => merge(row, extract(row).copy(postalcode = value)))
-      override val countryregionname = new Field[Name, Row](prefix, "countryregionname", None, None)(x => extract(x).countryregionname, (row, value) => merge(row, extract(row).copy(countryregionname = value)))
-      override val additionalcontactinfo = new OptField[TypoXml, Row](prefix, "additionalcontactinfo", None, None)(x => extract(x).additionalcontactinfo, (row, value) => merge(row, extract(row).copy(additionalcontactinfo = value)))
+    override lazy val fields: VemployeeViewFields = new VemployeeViewFields {
+      override def businessentityid = Field[BusinessentityId, VemployeeViewRow](_path, "businessentityid", None, None, x => x.businessentityid, (row, value) => row.copy(businessentityid = value))
+      override def title = OptField[/* max 8 chars */ String, VemployeeViewRow](_path, "title", None, None, x => x.title, (row, value) => row.copy(title = value))
+      override def firstname = Field[/* user-picked */ FirstName, VemployeeViewRow](_path, "firstname", None, None, x => x.firstname, (row, value) => row.copy(firstname = value))
+      override def middlename = OptField[Name, VemployeeViewRow](_path, "middlename", None, None, x => x.middlename, (row, value) => row.copy(middlename = value))
+      override def lastname = Field[Name, VemployeeViewRow](_path, "lastname", None, None, x => x.lastname, (row, value) => row.copy(lastname = value))
+      override def suffix = OptField[/* max 10 chars */ String, VemployeeViewRow](_path, "suffix", None, None, x => x.suffix, (row, value) => row.copy(suffix = value))
+      override def jobtitle = Field[/* max 50 chars */ String, VemployeeViewRow](_path, "jobtitle", None, None, x => x.jobtitle, (row, value) => row.copy(jobtitle = value))
+      override def phonenumber = OptField[Phone, VemployeeViewRow](_path, "phonenumber", None, None, x => x.phonenumber, (row, value) => row.copy(phonenumber = value))
+      override def phonenumbertype = OptField[Name, VemployeeViewRow](_path, "phonenumbertype", None, None, x => x.phonenumbertype, (row, value) => row.copy(phonenumbertype = value))
+      override def emailaddress = OptField[/* max 50 chars */ String, VemployeeViewRow](_path, "emailaddress", None, None, x => x.emailaddress, (row, value) => row.copy(emailaddress = value))
+      override def emailpromotion = Field[Int, VemployeeViewRow](_path, "emailpromotion", None, None, x => x.emailpromotion, (row, value) => row.copy(emailpromotion = value))
+      override def addressline1 = Field[/* max 60 chars */ String, VemployeeViewRow](_path, "addressline1", None, None, x => x.addressline1, (row, value) => row.copy(addressline1 = value))
+      override def addressline2 = OptField[/* max 60 chars */ String, VemployeeViewRow](_path, "addressline2", None, None, x => x.addressline2, (row, value) => row.copy(addressline2 = value))
+      override def city = Field[/* max 30 chars */ String, VemployeeViewRow](_path, "city", None, None, x => x.city, (row, value) => row.copy(city = value))
+      override def stateprovincename = Field[Name, VemployeeViewRow](_path, "stateprovincename", None, None, x => x.stateprovincename, (row, value) => row.copy(stateprovincename = value))
+      override def postalcode = Field[/* max 15 chars */ String, VemployeeViewRow](_path, "postalcode", None, None, x => x.postalcode, (row, value) => row.copy(postalcode = value))
+      override def countryregionname = Field[Name, VemployeeViewRow](_path, "countryregionname", None, None, x => x.countryregionname, (row, value) => row.copy(countryregionname = value))
+      override def additionalcontactinfo = OptField[TypoXml, VemployeeViewRow](_path, "additionalcontactinfo", None, None, x => x.additionalcontactinfo, (row, value) => row.copy(additionalcontactinfo = value))
     }
   
-    override val columns: List[FieldLikeNoHkt[?, Row]] =
-      List[FieldLikeNoHkt[?, Row]](fields.businessentityid, fields.title, fields.firstname, fields.middlename, fields.lastname, fields.suffix, fields.jobtitle, fields.phonenumber, fields.phonenumbertype, fields.emailaddress, fields.emailpromotion, fields.addressline1, fields.addressline2, fields.city, fields.stateprovincename, fields.postalcode, fields.countryregionname, fields.additionalcontactinfo)
+    override lazy val columns: List[FieldLikeNoHkt[?, VemployeeViewRow]] =
+      List[FieldLikeNoHkt[?, VemployeeViewRow]](fields.businessentityid, fields.title, fields.firstname, fields.middlename, fields.lastname, fields.suffix, fields.jobtitle, fields.phonenumber, fields.phonenumbertype, fields.emailaddress, fields.emailpromotion, fields.addressline1, fields.addressline2, fields.city, fields.stateprovincename, fields.postalcode, fields.countryregionname, fields.additionalcontactinfo)
   
-    override def copy[NewRow](prefix: Option[String], extract: NewRow => VemployeeViewRow, merge: (NewRow, VemployeeViewRow) => NewRow): Impl[NewRow] =
-      new Impl(prefix, extract, merge)
+    override def copy(path: List[Path]): Impl =
+      new Impl(path)
   }
   
 }

--- a/typo-tester-zio-jdbc/generated-and-checked-in/adventureworks/humanresources/vemployeedepartment/VemployeedepartmentViewFields.scala
+++ b/typo-tester-zio-jdbc/generated-and-checked-in/adventureworks/humanresources/vemployeedepartment/VemployeedepartmentViewFields.scala
@@ -11,49 +11,50 @@ import adventureworks.customtypes.TypoLocalDate
 import adventureworks.person.businessentity.BusinessentityId
 import adventureworks.public.Name
 import adventureworks.userdefined.FirstName
+import typo.dsl.Path
 import typo.dsl.SqlExpr.Field
 import typo.dsl.SqlExpr.FieldLikeNoHkt
 import typo.dsl.SqlExpr.OptField
 import typo.dsl.Structure.Relation
 
-trait VemployeedepartmentViewFields[Row] {
-  val businessentityid: Field[BusinessentityId, Row]
-  val title: OptField[/* max 8 chars */ String, Row]
-  val firstname: Field[/* user-picked */ FirstName, Row]
-  val middlename: OptField[Name, Row]
-  val lastname: Field[Name, Row]
-  val suffix: OptField[/* max 10 chars */ String, Row]
-  val jobtitle: Field[/* max 50 chars */ String, Row]
-  val department: Field[Name, Row]
-  val groupname: Field[Name, Row]
-  val startdate: Field[TypoLocalDate, Row]
+trait VemployeedepartmentViewFields {
+  def businessentityid: Field[BusinessentityId, VemployeedepartmentViewRow]
+  def title: OptField[/* max 8 chars */ String, VemployeedepartmentViewRow]
+  def firstname: Field[/* user-picked */ FirstName, VemployeedepartmentViewRow]
+  def middlename: OptField[Name, VemployeedepartmentViewRow]
+  def lastname: Field[Name, VemployeedepartmentViewRow]
+  def suffix: OptField[/* max 10 chars */ String, VemployeedepartmentViewRow]
+  def jobtitle: Field[/* max 50 chars */ String, VemployeedepartmentViewRow]
+  def department: Field[Name, VemployeedepartmentViewRow]
+  def groupname: Field[Name, VemployeedepartmentViewRow]
+  def startdate: Field[TypoLocalDate, VemployeedepartmentViewRow]
 }
 
 object VemployeedepartmentViewFields {
-  val structure: Relation[VemployeedepartmentViewFields, VemployeedepartmentViewRow, VemployeedepartmentViewRow] = 
-    new Impl(None, identity, (_, x) => x)
+  lazy val structure: Relation[VemployeedepartmentViewFields, VemployeedepartmentViewRow] =
+    new Impl(Nil)
     
-  private final class Impl[Row](val prefix: Option[String], val extract: Row => VemployeedepartmentViewRow, val merge: (Row, VemployeedepartmentViewRow) => Row)
-    extends Relation[VemployeedepartmentViewFields, VemployeedepartmentViewRow, Row] { 
+  private final class Impl(val _path: List[Path])
+    extends Relation[VemployeedepartmentViewFields, VemployeedepartmentViewRow] {
   
-    override val fields: VemployeedepartmentViewFields[Row] = new VemployeedepartmentViewFields[Row] {
-      override val businessentityid = new Field[BusinessentityId, Row](prefix, "businessentityid", None, None)(x => extract(x).businessentityid, (row, value) => merge(row, extract(row).copy(businessentityid = value)))
-      override val title = new OptField[/* max 8 chars */ String, Row](prefix, "title", None, None)(x => extract(x).title, (row, value) => merge(row, extract(row).copy(title = value)))
-      override val firstname = new Field[/* user-picked */ FirstName, Row](prefix, "firstname", None, None)(x => extract(x).firstname, (row, value) => merge(row, extract(row).copy(firstname = value)))
-      override val middlename = new OptField[Name, Row](prefix, "middlename", None, None)(x => extract(x).middlename, (row, value) => merge(row, extract(row).copy(middlename = value)))
-      override val lastname = new Field[Name, Row](prefix, "lastname", None, None)(x => extract(x).lastname, (row, value) => merge(row, extract(row).copy(lastname = value)))
-      override val suffix = new OptField[/* max 10 chars */ String, Row](prefix, "suffix", None, None)(x => extract(x).suffix, (row, value) => merge(row, extract(row).copy(suffix = value)))
-      override val jobtitle = new Field[/* max 50 chars */ String, Row](prefix, "jobtitle", None, None)(x => extract(x).jobtitle, (row, value) => merge(row, extract(row).copy(jobtitle = value)))
-      override val department = new Field[Name, Row](prefix, "department", None, None)(x => extract(x).department, (row, value) => merge(row, extract(row).copy(department = value)))
-      override val groupname = new Field[Name, Row](prefix, "groupname", None, None)(x => extract(x).groupname, (row, value) => merge(row, extract(row).copy(groupname = value)))
-      override val startdate = new Field[TypoLocalDate, Row](prefix, "startdate", Some("text"), None)(x => extract(x).startdate, (row, value) => merge(row, extract(row).copy(startdate = value)))
+    override lazy val fields: VemployeedepartmentViewFields = new VemployeedepartmentViewFields {
+      override def businessentityid = Field[BusinessentityId, VemployeedepartmentViewRow](_path, "businessentityid", None, None, x => x.businessentityid, (row, value) => row.copy(businessentityid = value))
+      override def title = OptField[/* max 8 chars */ String, VemployeedepartmentViewRow](_path, "title", None, None, x => x.title, (row, value) => row.copy(title = value))
+      override def firstname = Field[/* user-picked */ FirstName, VemployeedepartmentViewRow](_path, "firstname", None, None, x => x.firstname, (row, value) => row.copy(firstname = value))
+      override def middlename = OptField[Name, VemployeedepartmentViewRow](_path, "middlename", None, None, x => x.middlename, (row, value) => row.copy(middlename = value))
+      override def lastname = Field[Name, VemployeedepartmentViewRow](_path, "lastname", None, None, x => x.lastname, (row, value) => row.copy(lastname = value))
+      override def suffix = OptField[/* max 10 chars */ String, VemployeedepartmentViewRow](_path, "suffix", None, None, x => x.suffix, (row, value) => row.copy(suffix = value))
+      override def jobtitle = Field[/* max 50 chars */ String, VemployeedepartmentViewRow](_path, "jobtitle", None, None, x => x.jobtitle, (row, value) => row.copy(jobtitle = value))
+      override def department = Field[Name, VemployeedepartmentViewRow](_path, "department", None, None, x => x.department, (row, value) => row.copy(department = value))
+      override def groupname = Field[Name, VemployeedepartmentViewRow](_path, "groupname", None, None, x => x.groupname, (row, value) => row.copy(groupname = value))
+      override def startdate = Field[TypoLocalDate, VemployeedepartmentViewRow](_path, "startdate", Some("text"), None, x => x.startdate, (row, value) => row.copy(startdate = value))
     }
   
-    override val columns: List[FieldLikeNoHkt[?, Row]] =
-      List[FieldLikeNoHkt[?, Row]](fields.businessentityid, fields.title, fields.firstname, fields.middlename, fields.lastname, fields.suffix, fields.jobtitle, fields.department, fields.groupname, fields.startdate)
+    override lazy val columns: List[FieldLikeNoHkt[?, VemployeedepartmentViewRow]] =
+      List[FieldLikeNoHkt[?, VemployeedepartmentViewRow]](fields.businessentityid, fields.title, fields.firstname, fields.middlename, fields.lastname, fields.suffix, fields.jobtitle, fields.department, fields.groupname, fields.startdate)
   
-    override def copy[NewRow](prefix: Option[String], extract: NewRow => VemployeedepartmentViewRow, merge: (NewRow, VemployeedepartmentViewRow) => NewRow): Impl[NewRow] =
-      new Impl(prefix, extract, merge)
+    override def copy(path: List[Path]): Impl =
+      new Impl(path)
   }
   
 }

--- a/typo-tester-zio-jdbc/generated-and-checked-in/adventureworks/humanresources/vemployeedepartmenthistory/VemployeedepartmenthistoryViewFields.scala
+++ b/typo-tester-zio-jdbc/generated-and-checked-in/adventureworks/humanresources/vemployeedepartmenthistory/VemployeedepartmenthistoryViewFields.scala
@@ -11,51 +11,52 @@ import adventureworks.customtypes.TypoLocalDate
 import adventureworks.person.businessentity.BusinessentityId
 import adventureworks.public.Name
 import adventureworks.userdefined.FirstName
+import typo.dsl.Path
 import typo.dsl.SqlExpr.Field
 import typo.dsl.SqlExpr.FieldLikeNoHkt
 import typo.dsl.SqlExpr.OptField
 import typo.dsl.Structure.Relation
 
-trait VemployeedepartmenthistoryViewFields[Row] {
-  val businessentityid: Field[BusinessentityId, Row]
-  val title: OptField[/* max 8 chars */ String, Row]
-  val firstname: Field[/* user-picked */ FirstName, Row]
-  val middlename: OptField[Name, Row]
-  val lastname: Field[Name, Row]
-  val suffix: OptField[/* max 10 chars */ String, Row]
-  val shift: Field[Name, Row]
-  val department: Field[Name, Row]
-  val groupname: Field[Name, Row]
-  val startdate: Field[TypoLocalDate, Row]
-  val enddate: OptField[TypoLocalDate, Row]
+trait VemployeedepartmenthistoryViewFields {
+  def businessentityid: Field[BusinessentityId, VemployeedepartmenthistoryViewRow]
+  def title: OptField[/* max 8 chars */ String, VemployeedepartmenthistoryViewRow]
+  def firstname: Field[/* user-picked */ FirstName, VemployeedepartmenthistoryViewRow]
+  def middlename: OptField[Name, VemployeedepartmenthistoryViewRow]
+  def lastname: Field[Name, VemployeedepartmenthistoryViewRow]
+  def suffix: OptField[/* max 10 chars */ String, VemployeedepartmenthistoryViewRow]
+  def shift: Field[Name, VemployeedepartmenthistoryViewRow]
+  def department: Field[Name, VemployeedepartmenthistoryViewRow]
+  def groupname: Field[Name, VemployeedepartmenthistoryViewRow]
+  def startdate: Field[TypoLocalDate, VemployeedepartmenthistoryViewRow]
+  def enddate: OptField[TypoLocalDate, VemployeedepartmenthistoryViewRow]
 }
 
 object VemployeedepartmenthistoryViewFields {
-  val structure: Relation[VemployeedepartmenthistoryViewFields, VemployeedepartmenthistoryViewRow, VemployeedepartmenthistoryViewRow] = 
-    new Impl(None, identity, (_, x) => x)
+  lazy val structure: Relation[VemployeedepartmenthistoryViewFields, VemployeedepartmenthistoryViewRow] =
+    new Impl(Nil)
     
-  private final class Impl[Row](val prefix: Option[String], val extract: Row => VemployeedepartmenthistoryViewRow, val merge: (Row, VemployeedepartmenthistoryViewRow) => Row)
-    extends Relation[VemployeedepartmenthistoryViewFields, VemployeedepartmenthistoryViewRow, Row] { 
+  private final class Impl(val _path: List[Path])
+    extends Relation[VemployeedepartmenthistoryViewFields, VemployeedepartmenthistoryViewRow] {
   
-    override val fields: VemployeedepartmenthistoryViewFields[Row] = new VemployeedepartmenthistoryViewFields[Row] {
-      override val businessentityid = new Field[BusinessentityId, Row](prefix, "businessentityid", None, None)(x => extract(x).businessentityid, (row, value) => merge(row, extract(row).copy(businessentityid = value)))
-      override val title = new OptField[/* max 8 chars */ String, Row](prefix, "title", None, None)(x => extract(x).title, (row, value) => merge(row, extract(row).copy(title = value)))
-      override val firstname = new Field[/* user-picked */ FirstName, Row](prefix, "firstname", None, None)(x => extract(x).firstname, (row, value) => merge(row, extract(row).copy(firstname = value)))
-      override val middlename = new OptField[Name, Row](prefix, "middlename", None, None)(x => extract(x).middlename, (row, value) => merge(row, extract(row).copy(middlename = value)))
-      override val lastname = new Field[Name, Row](prefix, "lastname", None, None)(x => extract(x).lastname, (row, value) => merge(row, extract(row).copy(lastname = value)))
-      override val suffix = new OptField[/* max 10 chars */ String, Row](prefix, "suffix", None, None)(x => extract(x).suffix, (row, value) => merge(row, extract(row).copy(suffix = value)))
-      override val shift = new Field[Name, Row](prefix, "shift", None, None)(x => extract(x).shift, (row, value) => merge(row, extract(row).copy(shift = value)))
-      override val department = new Field[Name, Row](prefix, "department", None, None)(x => extract(x).department, (row, value) => merge(row, extract(row).copy(department = value)))
-      override val groupname = new Field[Name, Row](prefix, "groupname", None, None)(x => extract(x).groupname, (row, value) => merge(row, extract(row).copy(groupname = value)))
-      override val startdate = new Field[TypoLocalDate, Row](prefix, "startdate", Some("text"), None)(x => extract(x).startdate, (row, value) => merge(row, extract(row).copy(startdate = value)))
-      override val enddate = new OptField[TypoLocalDate, Row](prefix, "enddate", Some("text"), None)(x => extract(x).enddate, (row, value) => merge(row, extract(row).copy(enddate = value)))
+    override lazy val fields: VemployeedepartmenthistoryViewFields = new VemployeedepartmenthistoryViewFields {
+      override def businessentityid = Field[BusinessentityId, VemployeedepartmenthistoryViewRow](_path, "businessentityid", None, None, x => x.businessentityid, (row, value) => row.copy(businessentityid = value))
+      override def title = OptField[/* max 8 chars */ String, VemployeedepartmenthistoryViewRow](_path, "title", None, None, x => x.title, (row, value) => row.copy(title = value))
+      override def firstname = Field[/* user-picked */ FirstName, VemployeedepartmenthistoryViewRow](_path, "firstname", None, None, x => x.firstname, (row, value) => row.copy(firstname = value))
+      override def middlename = OptField[Name, VemployeedepartmenthistoryViewRow](_path, "middlename", None, None, x => x.middlename, (row, value) => row.copy(middlename = value))
+      override def lastname = Field[Name, VemployeedepartmenthistoryViewRow](_path, "lastname", None, None, x => x.lastname, (row, value) => row.copy(lastname = value))
+      override def suffix = OptField[/* max 10 chars */ String, VemployeedepartmenthistoryViewRow](_path, "suffix", None, None, x => x.suffix, (row, value) => row.copy(suffix = value))
+      override def shift = Field[Name, VemployeedepartmenthistoryViewRow](_path, "shift", None, None, x => x.shift, (row, value) => row.copy(shift = value))
+      override def department = Field[Name, VemployeedepartmenthistoryViewRow](_path, "department", None, None, x => x.department, (row, value) => row.copy(department = value))
+      override def groupname = Field[Name, VemployeedepartmenthistoryViewRow](_path, "groupname", None, None, x => x.groupname, (row, value) => row.copy(groupname = value))
+      override def startdate = Field[TypoLocalDate, VemployeedepartmenthistoryViewRow](_path, "startdate", Some("text"), None, x => x.startdate, (row, value) => row.copy(startdate = value))
+      override def enddate = OptField[TypoLocalDate, VemployeedepartmenthistoryViewRow](_path, "enddate", Some("text"), None, x => x.enddate, (row, value) => row.copy(enddate = value))
     }
   
-    override val columns: List[FieldLikeNoHkt[?, Row]] =
-      List[FieldLikeNoHkt[?, Row]](fields.businessentityid, fields.title, fields.firstname, fields.middlename, fields.lastname, fields.suffix, fields.shift, fields.department, fields.groupname, fields.startdate, fields.enddate)
+    override lazy val columns: List[FieldLikeNoHkt[?, VemployeedepartmenthistoryViewRow]] =
+      List[FieldLikeNoHkt[?, VemployeedepartmenthistoryViewRow]](fields.businessentityid, fields.title, fields.firstname, fields.middlename, fields.lastname, fields.suffix, fields.shift, fields.department, fields.groupname, fields.startdate, fields.enddate)
   
-    override def copy[NewRow](prefix: Option[String], extract: NewRow => VemployeedepartmenthistoryViewRow, merge: (NewRow, VemployeedepartmenthistoryViewRow) => NewRow): Impl[NewRow] =
-      new Impl(prefix, extract, merge)
+    override def copy(path: List[Path]): Impl =
+      new Impl(path)
   }
   
 }

--- a/typo-tester-zio-jdbc/generated-and-checked-in/adventureworks/humanresources/vjobcandidate/VjobcandidateViewFields.scala
+++ b/typo-tester-zio-jdbc/generated-and-checked-in/adventureworks/humanresources/vjobcandidate/VjobcandidateViewFields.scala
@@ -10,61 +10,62 @@ package vjobcandidate
 import adventureworks.customtypes.TypoLocalDateTime
 import adventureworks.humanresources.jobcandidate.JobcandidateId
 import adventureworks.person.businessentity.BusinessentityId
+import typo.dsl.Path
 import typo.dsl.SqlExpr.Field
 import typo.dsl.SqlExpr.FieldLikeNoHkt
 import typo.dsl.SqlExpr.OptField
 import typo.dsl.Structure.Relation
 
-trait VjobcandidateViewFields[Row] {
-  val jobcandidateid: Field[JobcandidateId, Row]
-  val businessentityid: OptField[BusinessentityId, Row]
-  val NamePrefix: OptField[/* max 30 chars */ String, Row]
-  val NameFirst: OptField[/* max 30 chars */ String, Row]
-  val NameMiddle: OptField[/* max 30 chars */ String, Row]
-  val NameLast: OptField[/* max 30 chars */ String, Row]
-  val NameSuffix: OptField[/* max 30 chars */ String, Row]
-  val Skills: OptField[String, Row]
-  val AddrType: OptField[/* max 30 chars */ String, Row]
-  val AddrLocCountryRegion: OptField[/* max 100 chars */ String, Row]
-  val AddrLocState: OptField[/* max 100 chars */ String, Row]
-  val AddrLocCity: OptField[/* max 100 chars */ String, Row]
-  val AddrPostalCode: OptField[/* max 20 chars */ String, Row]
-  val EMail: OptField[String, Row]
-  val WebSite: OptField[String, Row]
-  val modifieddate: Field[TypoLocalDateTime, Row]
+trait VjobcandidateViewFields {
+  def jobcandidateid: Field[JobcandidateId, VjobcandidateViewRow]
+  def businessentityid: OptField[BusinessentityId, VjobcandidateViewRow]
+  def NamePrefix: OptField[/* max 30 chars */ String, VjobcandidateViewRow]
+  def NameFirst: OptField[/* max 30 chars */ String, VjobcandidateViewRow]
+  def NameMiddle: OptField[/* max 30 chars */ String, VjobcandidateViewRow]
+  def NameLast: OptField[/* max 30 chars */ String, VjobcandidateViewRow]
+  def NameSuffix: OptField[/* max 30 chars */ String, VjobcandidateViewRow]
+  def Skills: OptField[String, VjobcandidateViewRow]
+  def AddrType: OptField[/* max 30 chars */ String, VjobcandidateViewRow]
+  def AddrLocCountryRegion: OptField[/* max 100 chars */ String, VjobcandidateViewRow]
+  def AddrLocState: OptField[/* max 100 chars */ String, VjobcandidateViewRow]
+  def AddrLocCity: OptField[/* max 100 chars */ String, VjobcandidateViewRow]
+  def AddrPostalCode: OptField[/* max 20 chars */ String, VjobcandidateViewRow]
+  def EMail: OptField[String, VjobcandidateViewRow]
+  def WebSite: OptField[String, VjobcandidateViewRow]
+  def modifieddate: Field[TypoLocalDateTime, VjobcandidateViewRow]
 }
 
 object VjobcandidateViewFields {
-  val structure: Relation[VjobcandidateViewFields, VjobcandidateViewRow, VjobcandidateViewRow] = 
-    new Impl(None, identity, (_, x) => x)
+  lazy val structure: Relation[VjobcandidateViewFields, VjobcandidateViewRow] =
+    new Impl(Nil)
     
-  private final class Impl[Row](val prefix: Option[String], val extract: Row => VjobcandidateViewRow, val merge: (Row, VjobcandidateViewRow) => Row)
-    extends Relation[VjobcandidateViewFields, VjobcandidateViewRow, Row] { 
+  private final class Impl(val _path: List[Path])
+    extends Relation[VjobcandidateViewFields, VjobcandidateViewRow] {
   
-    override val fields: VjobcandidateViewFields[Row] = new VjobcandidateViewFields[Row] {
-      override val jobcandidateid = new Field[JobcandidateId, Row](prefix, "jobcandidateid", None, None)(x => extract(x).jobcandidateid, (row, value) => merge(row, extract(row).copy(jobcandidateid = value)))
-      override val businessentityid = new OptField[BusinessentityId, Row](prefix, "businessentityid", None, None)(x => extract(x).businessentityid, (row, value) => merge(row, extract(row).copy(businessentityid = value)))
-      override val NamePrefix = new OptField[/* max 30 chars */ String, Row](prefix, "Name.Prefix", None, None)(x => extract(x).NamePrefix, (row, value) => merge(row, extract(row).copy(NamePrefix = value)))
-      override val NameFirst = new OptField[/* max 30 chars */ String, Row](prefix, "Name.First", None, None)(x => extract(x).NameFirst, (row, value) => merge(row, extract(row).copy(NameFirst = value)))
-      override val NameMiddle = new OptField[/* max 30 chars */ String, Row](prefix, "Name.Middle", None, None)(x => extract(x).NameMiddle, (row, value) => merge(row, extract(row).copy(NameMiddle = value)))
-      override val NameLast = new OptField[/* max 30 chars */ String, Row](prefix, "Name.Last", None, None)(x => extract(x).NameLast, (row, value) => merge(row, extract(row).copy(NameLast = value)))
-      override val NameSuffix = new OptField[/* max 30 chars */ String, Row](prefix, "Name.Suffix", None, None)(x => extract(x).NameSuffix, (row, value) => merge(row, extract(row).copy(NameSuffix = value)))
-      override val Skills = new OptField[String, Row](prefix, "Skills", None, None)(x => extract(x).Skills, (row, value) => merge(row, extract(row).copy(Skills = value)))
-      override val AddrType = new OptField[/* max 30 chars */ String, Row](prefix, "Addr.Type", None, None)(x => extract(x).AddrType, (row, value) => merge(row, extract(row).copy(AddrType = value)))
-      override val AddrLocCountryRegion = new OptField[/* max 100 chars */ String, Row](prefix, "Addr.Loc.CountryRegion", None, None)(x => extract(x).AddrLocCountryRegion, (row, value) => merge(row, extract(row).copy(AddrLocCountryRegion = value)))
-      override val AddrLocState = new OptField[/* max 100 chars */ String, Row](prefix, "Addr.Loc.State", None, None)(x => extract(x).AddrLocState, (row, value) => merge(row, extract(row).copy(AddrLocState = value)))
-      override val AddrLocCity = new OptField[/* max 100 chars */ String, Row](prefix, "Addr.Loc.City", None, None)(x => extract(x).AddrLocCity, (row, value) => merge(row, extract(row).copy(AddrLocCity = value)))
-      override val AddrPostalCode = new OptField[/* max 20 chars */ String, Row](prefix, "Addr.PostalCode", None, None)(x => extract(x).AddrPostalCode, (row, value) => merge(row, extract(row).copy(AddrPostalCode = value)))
-      override val EMail = new OptField[String, Row](prefix, "EMail", None, None)(x => extract(x).EMail, (row, value) => merge(row, extract(row).copy(EMail = value)))
-      override val WebSite = new OptField[String, Row](prefix, "WebSite", None, None)(x => extract(x).WebSite, (row, value) => merge(row, extract(row).copy(WebSite = value)))
-      override val modifieddate = new Field[TypoLocalDateTime, Row](prefix, "modifieddate", Some("text"), None)(x => extract(x).modifieddate, (row, value) => merge(row, extract(row).copy(modifieddate = value)))
+    override lazy val fields: VjobcandidateViewFields = new VjobcandidateViewFields {
+      override def jobcandidateid = Field[JobcandidateId, VjobcandidateViewRow](_path, "jobcandidateid", None, None, x => x.jobcandidateid, (row, value) => row.copy(jobcandidateid = value))
+      override def businessentityid = OptField[BusinessentityId, VjobcandidateViewRow](_path, "businessentityid", None, None, x => x.businessentityid, (row, value) => row.copy(businessentityid = value))
+      override def NamePrefix = OptField[/* max 30 chars */ String, VjobcandidateViewRow](_path, "Name.Prefix", None, None, x => x.NamePrefix, (row, value) => row.copy(NamePrefix = value))
+      override def NameFirst = OptField[/* max 30 chars */ String, VjobcandidateViewRow](_path, "Name.First", None, None, x => x.NameFirst, (row, value) => row.copy(NameFirst = value))
+      override def NameMiddle = OptField[/* max 30 chars */ String, VjobcandidateViewRow](_path, "Name.Middle", None, None, x => x.NameMiddle, (row, value) => row.copy(NameMiddle = value))
+      override def NameLast = OptField[/* max 30 chars */ String, VjobcandidateViewRow](_path, "Name.Last", None, None, x => x.NameLast, (row, value) => row.copy(NameLast = value))
+      override def NameSuffix = OptField[/* max 30 chars */ String, VjobcandidateViewRow](_path, "Name.Suffix", None, None, x => x.NameSuffix, (row, value) => row.copy(NameSuffix = value))
+      override def Skills = OptField[String, VjobcandidateViewRow](_path, "Skills", None, None, x => x.Skills, (row, value) => row.copy(Skills = value))
+      override def AddrType = OptField[/* max 30 chars */ String, VjobcandidateViewRow](_path, "Addr.Type", None, None, x => x.AddrType, (row, value) => row.copy(AddrType = value))
+      override def AddrLocCountryRegion = OptField[/* max 100 chars */ String, VjobcandidateViewRow](_path, "Addr.Loc.CountryRegion", None, None, x => x.AddrLocCountryRegion, (row, value) => row.copy(AddrLocCountryRegion = value))
+      override def AddrLocState = OptField[/* max 100 chars */ String, VjobcandidateViewRow](_path, "Addr.Loc.State", None, None, x => x.AddrLocState, (row, value) => row.copy(AddrLocState = value))
+      override def AddrLocCity = OptField[/* max 100 chars */ String, VjobcandidateViewRow](_path, "Addr.Loc.City", None, None, x => x.AddrLocCity, (row, value) => row.copy(AddrLocCity = value))
+      override def AddrPostalCode = OptField[/* max 20 chars */ String, VjobcandidateViewRow](_path, "Addr.PostalCode", None, None, x => x.AddrPostalCode, (row, value) => row.copy(AddrPostalCode = value))
+      override def EMail = OptField[String, VjobcandidateViewRow](_path, "EMail", None, None, x => x.EMail, (row, value) => row.copy(EMail = value))
+      override def WebSite = OptField[String, VjobcandidateViewRow](_path, "WebSite", None, None, x => x.WebSite, (row, value) => row.copy(WebSite = value))
+      override def modifieddate = Field[TypoLocalDateTime, VjobcandidateViewRow](_path, "modifieddate", Some("text"), None, x => x.modifieddate, (row, value) => row.copy(modifieddate = value))
     }
   
-    override val columns: List[FieldLikeNoHkt[?, Row]] =
-      List[FieldLikeNoHkt[?, Row]](fields.jobcandidateid, fields.businessentityid, fields.NamePrefix, fields.NameFirst, fields.NameMiddle, fields.NameLast, fields.NameSuffix, fields.Skills, fields.AddrType, fields.AddrLocCountryRegion, fields.AddrLocState, fields.AddrLocCity, fields.AddrPostalCode, fields.EMail, fields.WebSite, fields.modifieddate)
+    override lazy val columns: List[FieldLikeNoHkt[?, VjobcandidateViewRow]] =
+      List[FieldLikeNoHkt[?, VjobcandidateViewRow]](fields.jobcandidateid, fields.businessentityid, fields.NamePrefix, fields.NameFirst, fields.NameMiddle, fields.NameLast, fields.NameSuffix, fields.Skills, fields.AddrType, fields.AddrLocCountryRegion, fields.AddrLocState, fields.AddrLocCity, fields.AddrPostalCode, fields.EMail, fields.WebSite, fields.modifieddate)
   
-    override def copy[NewRow](prefix: Option[String], extract: NewRow => VjobcandidateViewRow, merge: (NewRow, VjobcandidateViewRow) => NewRow): Impl[NewRow] =
-      new Impl(prefix, extract, merge)
+    override def copy(path: List[Path]): Impl =
+      new Impl(path)
   }
   
 }

--- a/typo-tester-zio-jdbc/generated-and-checked-in/adventureworks/humanresources/vjobcandidateeducation/VjobcandidateeducationViewFields.scala
+++ b/typo-tester-zio-jdbc/generated-and-checked-in/adventureworks/humanresources/vjobcandidateeducation/VjobcandidateeducationViewFields.scala
@@ -9,55 +9,56 @@ package vjobcandidateeducation
 
 import adventureworks.customtypes.TypoLocalDate
 import adventureworks.humanresources.jobcandidate.JobcandidateId
+import typo.dsl.Path
 import typo.dsl.SqlExpr.Field
 import typo.dsl.SqlExpr.FieldLikeNoHkt
 import typo.dsl.SqlExpr.OptField
 import typo.dsl.Structure.Relation
 
-trait VjobcandidateeducationViewFields[Row] {
-  val jobcandidateid: Field[JobcandidateId, Row]
-  val EduLevel: OptField[/* max 50 chars */ String, Row]
-  val EduStartDate: OptField[TypoLocalDate, Row]
-  val EduEndDate: OptField[TypoLocalDate, Row]
-  val EduDegree: OptField[/* max 50 chars */ String, Row]
-  val EduMajor: OptField[/* max 50 chars */ String, Row]
-  val EduMinor: OptField[/* max 50 chars */ String, Row]
-  val EduGPA: OptField[/* max 5 chars */ String, Row]
-  val EduGPAScale: OptField[/* max 5 chars */ String, Row]
-  val EduSchool: OptField[/* max 100 chars */ String, Row]
-  val EduLocCountryRegion: OptField[/* max 100 chars */ String, Row]
-  val EduLocState: OptField[/* max 100 chars */ String, Row]
-  val EduLocCity: OptField[/* max 100 chars */ String, Row]
+trait VjobcandidateeducationViewFields {
+  def jobcandidateid: Field[JobcandidateId, VjobcandidateeducationViewRow]
+  def EduLevel: OptField[/* max 50 chars */ String, VjobcandidateeducationViewRow]
+  def EduStartDate: OptField[TypoLocalDate, VjobcandidateeducationViewRow]
+  def EduEndDate: OptField[TypoLocalDate, VjobcandidateeducationViewRow]
+  def EduDegree: OptField[/* max 50 chars */ String, VjobcandidateeducationViewRow]
+  def EduMajor: OptField[/* max 50 chars */ String, VjobcandidateeducationViewRow]
+  def EduMinor: OptField[/* max 50 chars */ String, VjobcandidateeducationViewRow]
+  def EduGPA: OptField[/* max 5 chars */ String, VjobcandidateeducationViewRow]
+  def EduGPAScale: OptField[/* max 5 chars */ String, VjobcandidateeducationViewRow]
+  def EduSchool: OptField[/* max 100 chars */ String, VjobcandidateeducationViewRow]
+  def EduLocCountryRegion: OptField[/* max 100 chars */ String, VjobcandidateeducationViewRow]
+  def EduLocState: OptField[/* max 100 chars */ String, VjobcandidateeducationViewRow]
+  def EduLocCity: OptField[/* max 100 chars */ String, VjobcandidateeducationViewRow]
 }
 
 object VjobcandidateeducationViewFields {
-  val structure: Relation[VjobcandidateeducationViewFields, VjobcandidateeducationViewRow, VjobcandidateeducationViewRow] = 
-    new Impl(None, identity, (_, x) => x)
+  lazy val structure: Relation[VjobcandidateeducationViewFields, VjobcandidateeducationViewRow] =
+    new Impl(Nil)
     
-  private final class Impl[Row](val prefix: Option[String], val extract: Row => VjobcandidateeducationViewRow, val merge: (Row, VjobcandidateeducationViewRow) => Row)
-    extends Relation[VjobcandidateeducationViewFields, VjobcandidateeducationViewRow, Row] { 
+  private final class Impl(val _path: List[Path])
+    extends Relation[VjobcandidateeducationViewFields, VjobcandidateeducationViewRow] {
   
-    override val fields: VjobcandidateeducationViewFields[Row] = new VjobcandidateeducationViewFields[Row] {
-      override val jobcandidateid = new Field[JobcandidateId, Row](prefix, "jobcandidateid", None, None)(x => extract(x).jobcandidateid, (row, value) => merge(row, extract(row).copy(jobcandidateid = value)))
-      override val EduLevel = new OptField[/* max 50 chars */ String, Row](prefix, "Edu.Level", None, None)(x => extract(x).EduLevel, (row, value) => merge(row, extract(row).copy(EduLevel = value)))
-      override val EduStartDate = new OptField[TypoLocalDate, Row](prefix, "Edu.StartDate", Some("text"), None)(x => extract(x).EduStartDate, (row, value) => merge(row, extract(row).copy(EduStartDate = value)))
-      override val EduEndDate = new OptField[TypoLocalDate, Row](prefix, "Edu.EndDate", Some("text"), None)(x => extract(x).EduEndDate, (row, value) => merge(row, extract(row).copy(EduEndDate = value)))
-      override val EduDegree = new OptField[/* max 50 chars */ String, Row](prefix, "Edu.Degree", None, None)(x => extract(x).EduDegree, (row, value) => merge(row, extract(row).copy(EduDegree = value)))
-      override val EduMajor = new OptField[/* max 50 chars */ String, Row](prefix, "Edu.Major", None, None)(x => extract(x).EduMajor, (row, value) => merge(row, extract(row).copy(EduMajor = value)))
-      override val EduMinor = new OptField[/* max 50 chars */ String, Row](prefix, "Edu.Minor", None, None)(x => extract(x).EduMinor, (row, value) => merge(row, extract(row).copy(EduMinor = value)))
-      override val EduGPA = new OptField[/* max 5 chars */ String, Row](prefix, "Edu.GPA", None, None)(x => extract(x).EduGPA, (row, value) => merge(row, extract(row).copy(EduGPA = value)))
-      override val EduGPAScale = new OptField[/* max 5 chars */ String, Row](prefix, "Edu.GPAScale", None, None)(x => extract(x).EduGPAScale, (row, value) => merge(row, extract(row).copy(EduGPAScale = value)))
-      override val EduSchool = new OptField[/* max 100 chars */ String, Row](prefix, "Edu.School", None, None)(x => extract(x).EduSchool, (row, value) => merge(row, extract(row).copy(EduSchool = value)))
-      override val EduLocCountryRegion = new OptField[/* max 100 chars */ String, Row](prefix, "Edu.Loc.CountryRegion", None, None)(x => extract(x).EduLocCountryRegion, (row, value) => merge(row, extract(row).copy(EduLocCountryRegion = value)))
-      override val EduLocState = new OptField[/* max 100 chars */ String, Row](prefix, "Edu.Loc.State", None, None)(x => extract(x).EduLocState, (row, value) => merge(row, extract(row).copy(EduLocState = value)))
-      override val EduLocCity = new OptField[/* max 100 chars */ String, Row](prefix, "Edu.Loc.City", None, None)(x => extract(x).EduLocCity, (row, value) => merge(row, extract(row).copy(EduLocCity = value)))
+    override lazy val fields: VjobcandidateeducationViewFields = new VjobcandidateeducationViewFields {
+      override def jobcandidateid = Field[JobcandidateId, VjobcandidateeducationViewRow](_path, "jobcandidateid", None, None, x => x.jobcandidateid, (row, value) => row.copy(jobcandidateid = value))
+      override def EduLevel = OptField[/* max 50 chars */ String, VjobcandidateeducationViewRow](_path, "Edu.Level", None, None, x => x.EduLevel, (row, value) => row.copy(EduLevel = value))
+      override def EduStartDate = OptField[TypoLocalDate, VjobcandidateeducationViewRow](_path, "Edu.StartDate", Some("text"), None, x => x.EduStartDate, (row, value) => row.copy(EduStartDate = value))
+      override def EduEndDate = OptField[TypoLocalDate, VjobcandidateeducationViewRow](_path, "Edu.EndDate", Some("text"), None, x => x.EduEndDate, (row, value) => row.copy(EduEndDate = value))
+      override def EduDegree = OptField[/* max 50 chars */ String, VjobcandidateeducationViewRow](_path, "Edu.Degree", None, None, x => x.EduDegree, (row, value) => row.copy(EduDegree = value))
+      override def EduMajor = OptField[/* max 50 chars */ String, VjobcandidateeducationViewRow](_path, "Edu.Major", None, None, x => x.EduMajor, (row, value) => row.copy(EduMajor = value))
+      override def EduMinor = OptField[/* max 50 chars */ String, VjobcandidateeducationViewRow](_path, "Edu.Minor", None, None, x => x.EduMinor, (row, value) => row.copy(EduMinor = value))
+      override def EduGPA = OptField[/* max 5 chars */ String, VjobcandidateeducationViewRow](_path, "Edu.GPA", None, None, x => x.EduGPA, (row, value) => row.copy(EduGPA = value))
+      override def EduGPAScale = OptField[/* max 5 chars */ String, VjobcandidateeducationViewRow](_path, "Edu.GPAScale", None, None, x => x.EduGPAScale, (row, value) => row.copy(EduGPAScale = value))
+      override def EduSchool = OptField[/* max 100 chars */ String, VjobcandidateeducationViewRow](_path, "Edu.School", None, None, x => x.EduSchool, (row, value) => row.copy(EduSchool = value))
+      override def EduLocCountryRegion = OptField[/* max 100 chars */ String, VjobcandidateeducationViewRow](_path, "Edu.Loc.CountryRegion", None, None, x => x.EduLocCountryRegion, (row, value) => row.copy(EduLocCountryRegion = value))
+      override def EduLocState = OptField[/* max 100 chars */ String, VjobcandidateeducationViewRow](_path, "Edu.Loc.State", None, None, x => x.EduLocState, (row, value) => row.copy(EduLocState = value))
+      override def EduLocCity = OptField[/* max 100 chars */ String, VjobcandidateeducationViewRow](_path, "Edu.Loc.City", None, None, x => x.EduLocCity, (row, value) => row.copy(EduLocCity = value))
     }
   
-    override val columns: List[FieldLikeNoHkt[?, Row]] =
-      List[FieldLikeNoHkt[?, Row]](fields.jobcandidateid, fields.EduLevel, fields.EduStartDate, fields.EduEndDate, fields.EduDegree, fields.EduMajor, fields.EduMinor, fields.EduGPA, fields.EduGPAScale, fields.EduSchool, fields.EduLocCountryRegion, fields.EduLocState, fields.EduLocCity)
+    override lazy val columns: List[FieldLikeNoHkt[?, VjobcandidateeducationViewRow]] =
+      List[FieldLikeNoHkt[?, VjobcandidateeducationViewRow]](fields.jobcandidateid, fields.EduLevel, fields.EduStartDate, fields.EduEndDate, fields.EduDegree, fields.EduMajor, fields.EduMinor, fields.EduGPA, fields.EduGPAScale, fields.EduSchool, fields.EduLocCountryRegion, fields.EduLocState, fields.EduLocCity)
   
-    override def copy[NewRow](prefix: Option[String], extract: NewRow => VjobcandidateeducationViewRow, merge: (NewRow, VjobcandidateeducationViewRow) => NewRow): Impl[NewRow] =
-      new Impl(prefix, extract, merge)
+    override def copy(path: List[Path]): Impl =
+      new Impl(path)
   }
   
 }

--- a/typo-tester-zio-jdbc/generated-and-checked-in/adventureworks/humanresources/vjobcandidateemployment/VjobcandidateemploymentViewFields.scala
+++ b/typo-tester-zio-jdbc/generated-and-checked-in/adventureworks/humanresources/vjobcandidateemployment/VjobcandidateemploymentViewFields.scala
@@ -9,51 +9,52 @@ package vjobcandidateemployment
 
 import adventureworks.customtypes.TypoLocalDate
 import adventureworks.humanresources.jobcandidate.JobcandidateId
+import typo.dsl.Path
 import typo.dsl.SqlExpr.Field
 import typo.dsl.SqlExpr.FieldLikeNoHkt
 import typo.dsl.SqlExpr.OptField
 import typo.dsl.Structure.Relation
 
-trait VjobcandidateemploymentViewFields[Row] {
-  val jobcandidateid: Field[JobcandidateId, Row]
-  val EmpStartDate: OptField[TypoLocalDate, Row]
-  val EmpEndDate: OptField[TypoLocalDate, Row]
-  val EmpOrgName: OptField[/* max 100 chars */ String, Row]
-  val EmpJobTitle: OptField[/* max 100 chars */ String, Row]
-  val EmpResponsibility: OptField[String, Row]
-  val EmpFunctionCategory: OptField[String, Row]
-  val EmpIndustryCategory: OptField[String, Row]
-  val EmpLocCountryRegion: OptField[String, Row]
-  val EmpLocState: OptField[String, Row]
-  val EmpLocCity: OptField[String, Row]
+trait VjobcandidateemploymentViewFields {
+  def jobcandidateid: Field[JobcandidateId, VjobcandidateemploymentViewRow]
+  def EmpStartDate: OptField[TypoLocalDate, VjobcandidateemploymentViewRow]
+  def EmpEndDate: OptField[TypoLocalDate, VjobcandidateemploymentViewRow]
+  def EmpOrgName: OptField[/* max 100 chars */ String, VjobcandidateemploymentViewRow]
+  def EmpJobTitle: OptField[/* max 100 chars */ String, VjobcandidateemploymentViewRow]
+  def EmpResponsibility: OptField[String, VjobcandidateemploymentViewRow]
+  def EmpFunctionCategory: OptField[String, VjobcandidateemploymentViewRow]
+  def EmpIndustryCategory: OptField[String, VjobcandidateemploymentViewRow]
+  def EmpLocCountryRegion: OptField[String, VjobcandidateemploymentViewRow]
+  def EmpLocState: OptField[String, VjobcandidateemploymentViewRow]
+  def EmpLocCity: OptField[String, VjobcandidateemploymentViewRow]
 }
 
 object VjobcandidateemploymentViewFields {
-  val structure: Relation[VjobcandidateemploymentViewFields, VjobcandidateemploymentViewRow, VjobcandidateemploymentViewRow] = 
-    new Impl(None, identity, (_, x) => x)
+  lazy val structure: Relation[VjobcandidateemploymentViewFields, VjobcandidateemploymentViewRow] =
+    new Impl(Nil)
     
-  private final class Impl[Row](val prefix: Option[String], val extract: Row => VjobcandidateemploymentViewRow, val merge: (Row, VjobcandidateemploymentViewRow) => Row)
-    extends Relation[VjobcandidateemploymentViewFields, VjobcandidateemploymentViewRow, Row] { 
+  private final class Impl(val _path: List[Path])
+    extends Relation[VjobcandidateemploymentViewFields, VjobcandidateemploymentViewRow] {
   
-    override val fields: VjobcandidateemploymentViewFields[Row] = new VjobcandidateemploymentViewFields[Row] {
-      override val jobcandidateid = new Field[JobcandidateId, Row](prefix, "jobcandidateid", None, None)(x => extract(x).jobcandidateid, (row, value) => merge(row, extract(row).copy(jobcandidateid = value)))
-      override val EmpStartDate = new OptField[TypoLocalDate, Row](prefix, "Emp.StartDate", Some("text"), None)(x => extract(x).EmpStartDate, (row, value) => merge(row, extract(row).copy(EmpStartDate = value)))
-      override val EmpEndDate = new OptField[TypoLocalDate, Row](prefix, "Emp.EndDate", Some("text"), None)(x => extract(x).EmpEndDate, (row, value) => merge(row, extract(row).copy(EmpEndDate = value)))
-      override val EmpOrgName = new OptField[/* max 100 chars */ String, Row](prefix, "Emp.OrgName", None, None)(x => extract(x).EmpOrgName, (row, value) => merge(row, extract(row).copy(EmpOrgName = value)))
-      override val EmpJobTitle = new OptField[/* max 100 chars */ String, Row](prefix, "Emp.JobTitle", None, None)(x => extract(x).EmpJobTitle, (row, value) => merge(row, extract(row).copy(EmpJobTitle = value)))
-      override val EmpResponsibility = new OptField[String, Row](prefix, "Emp.Responsibility", None, None)(x => extract(x).EmpResponsibility, (row, value) => merge(row, extract(row).copy(EmpResponsibility = value)))
-      override val EmpFunctionCategory = new OptField[String, Row](prefix, "Emp.FunctionCategory", None, None)(x => extract(x).EmpFunctionCategory, (row, value) => merge(row, extract(row).copy(EmpFunctionCategory = value)))
-      override val EmpIndustryCategory = new OptField[String, Row](prefix, "Emp.IndustryCategory", None, None)(x => extract(x).EmpIndustryCategory, (row, value) => merge(row, extract(row).copy(EmpIndustryCategory = value)))
-      override val EmpLocCountryRegion = new OptField[String, Row](prefix, "Emp.Loc.CountryRegion", None, None)(x => extract(x).EmpLocCountryRegion, (row, value) => merge(row, extract(row).copy(EmpLocCountryRegion = value)))
-      override val EmpLocState = new OptField[String, Row](prefix, "Emp.Loc.State", None, None)(x => extract(x).EmpLocState, (row, value) => merge(row, extract(row).copy(EmpLocState = value)))
-      override val EmpLocCity = new OptField[String, Row](prefix, "Emp.Loc.City", None, None)(x => extract(x).EmpLocCity, (row, value) => merge(row, extract(row).copy(EmpLocCity = value)))
+    override lazy val fields: VjobcandidateemploymentViewFields = new VjobcandidateemploymentViewFields {
+      override def jobcandidateid = Field[JobcandidateId, VjobcandidateemploymentViewRow](_path, "jobcandidateid", None, None, x => x.jobcandidateid, (row, value) => row.copy(jobcandidateid = value))
+      override def EmpStartDate = OptField[TypoLocalDate, VjobcandidateemploymentViewRow](_path, "Emp.StartDate", Some("text"), None, x => x.EmpStartDate, (row, value) => row.copy(EmpStartDate = value))
+      override def EmpEndDate = OptField[TypoLocalDate, VjobcandidateemploymentViewRow](_path, "Emp.EndDate", Some("text"), None, x => x.EmpEndDate, (row, value) => row.copy(EmpEndDate = value))
+      override def EmpOrgName = OptField[/* max 100 chars */ String, VjobcandidateemploymentViewRow](_path, "Emp.OrgName", None, None, x => x.EmpOrgName, (row, value) => row.copy(EmpOrgName = value))
+      override def EmpJobTitle = OptField[/* max 100 chars */ String, VjobcandidateemploymentViewRow](_path, "Emp.JobTitle", None, None, x => x.EmpJobTitle, (row, value) => row.copy(EmpJobTitle = value))
+      override def EmpResponsibility = OptField[String, VjobcandidateemploymentViewRow](_path, "Emp.Responsibility", None, None, x => x.EmpResponsibility, (row, value) => row.copy(EmpResponsibility = value))
+      override def EmpFunctionCategory = OptField[String, VjobcandidateemploymentViewRow](_path, "Emp.FunctionCategory", None, None, x => x.EmpFunctionCategory, (row, value) => row.copy(EmpFunctionCategory = value))
+      override def EmpIndustryCategory = OptField[String, VjobcandidateemploymentViewRow](_path, "Emp.IndustryCategory", None, None, x => x.EmpIndustryCategory, (row, value) => row.copy(EmpIndustryCategory = value))
+      override def EmpLocCountryRegion = OptField[String, VjobcandidateemploymentViewRow](_path, "Emp.Loc.CountryRegion", None, None, x => x.EmpLocCountryRegion, (row, value) => row.copy(EmpLocCountryRegion = value))
+      override def EmpLocState = OptField[String, VjobcandidateemploymentViewRow](_path, "Emp.Loc.State", None, None, x => x.EmpLocState, (row, value) => row.copy(EmpLocState = value))
+      override def EmpLocCity = OptField[String, VjobcandidateemploymentViewRow](_path, "Emp.Loc.City", None, None, x => x.EmpLocCity, (row, value) => row.copy(EmpLocCity = value))
     }
   
-    override val columns: List[FieldLikeNoHkt[?, Row]] =
-      List[FieldLikeNoHkt[?, Row]](fields.jobcandidateid, fields.EmpStartDate, fields.EmpEndDate, fields.EmpOrgName, fields.EmpJobTitle, fields.EmpResponsibility, fields.EmpFunctionCategory, fields.EmpIndustryCategory, fields.EmpLocCountryRegion, fields.EmpLocState, fields.EmpLocCity)
+    override lazy val columns: List[FieldLikeNoHkt[?, VjobcandidateemploymentViewRow]] =
+      List[FieldLikeNoHkt[?, VjobcandidateemploymentViewRow]](fields.jobcandidateid, fields.EmpStartDate, fields.EmpEndDate, fields.EmpOrgName, fields.EmpJobTitle, fields.EmpResponsibility, fields.EmpFunctionCategory, fields.EmpIndustryCategory, fields.EmpLocCountryRegion, fields.EmpLocState, fields.EmpLocCity)
   
-    override def copy[NewRow](prefix: Option[String], extract: NewRow => VjobcandidateemploymentViewRow, merge: (NewRow, VjobcandidateemploymentViewRow) => NewRow): Impl[NewRow] =
-      new Impl(prefix, extract, merge)
+    override def copy(path: List[Path]): Impl =
+      new Impl(path)
   }
   
 }

--- a/typo-tester-zio-jdbc/generated-and-checked-in/adventureworks/pe/a/AViewFields.scala
+++ b/typo-tester-zio-jdbc/generated-and-checked-in/adventureworks/pe/a/AViewFields.scala
@@ -12,49 +12,50 @@ import adventureworks.customtypes.TypoLocalDateTime
 import adventureworks.customtypes.TypoUUID
 import adventureworks.person.address.AddressId
 import adventureworks.person.stateprovince.StateprovinceId
+import typo.dsl.Path
 import typo.dsl.SqlExpr.Field
 import typo.dsl.SqlExpr.FieldLikeNoHkt
 import typo.dsl.SqlExpr.OptField
 import typo.dsl.Structure.Relation
 
-trait AViewFields[Row] {
-  val id: Field[AddressId, Row]
-  val addressid: Field[AddressId, Row]
-  val addressline1: Field[/* max 60 chars */ String, Row]
-  val addressline2: OptField[/* max 60 chars */ String, Row]
-  val city: Field[/* max 30 chars */ String, Row]
-  val stateprovinceid: Field[StateprovinceId, Row]
-  val postalcode: Field[/* max 15 chars */ String, Row]
-  val spatiallocation: OptField[TypoBytea, Row]
-  val rowguid: Field[TypoUUID, Row]
-  val modifieddate: Field[TypoLocalDateTime, Row]
+trait AViewFields {
+  def id: Field[AddressId, AViewRow]
+  def addressid: Field[AddressId, AViewRow]
+  def addressline1: Field[/* max 60 chars */ String, AViewRow]
+  def addressline2: OptField[/* max 60 chars */ String, AViewRow]
+  def city: Field[/* max 30 chars */ String, AViewRow]
+  def stateprovinceid: Field[StateprovinceId, AViewRow]
+  def postalcode: Field[/* max 15 chars */ String, AViewRow]
+  def spatiallocation: OptField[TypoBytea, AViewRow]
+  def rowguid: Field[TypoUUID, AViewRow]
+  def modifieddate: Field[TypoLocalDateTime, AViewRow]
 }
 
 object AViewFields {
-  val structure: Relation[AViewFields, AViewRow, AViewRow] = 
-    new Impl(None, identity, (_, x) => x)
+  lazy val structure: Relation[AViewFields, AViewRow] =
+    new Impl(Nil)
     
-  private final class Impl[Row](val prefix: Option[String], val extract: Row => AViewRow, val merge: (Row, AViewRow) => Row)
-    extends Relation[AViewFields, AViewRow, Row] { 
+  private final class Impl(val _path: List[Path])
+    extends Relation[AViewFields, AViewRow] {
   
-    override val fields: AViewFields[Row] = new AViewFields[Row] {
-      override val id = new Field[AddressId, Row](prefix, "id", None, None)(x => extract(x).id, (row, value) => merge(row, extract(row).copy(id = value)))
-      override val addressid = new Field[AddressId, Row](prefix, "addressid", None, None)(x => extract(x).addressid, (row, value) => merge(row, extract(row).copy(addressid = value)))
-      override val addressline1 = new Field[/* max 60 chars */ String, Row](prefix, "addressline1", None, None)(x => extract(x).addressline1, (row, value) => merge(row, extract(row).copy(addressline1 = value)))
-      override val addressline2 = new OptField[/* max 60 chars */ String, Row](prefix, "addressline2", None, None)(x => extract(x).addressline2, (row, value) => merge(row, extract(row).copy(addressline2 = value)))
-      override val city = new Field[/* max 30 chars */ String, Row](prefix, "city", None, None)(x => extract(x).city, (row, value) => merge(row, extract(row).copy(city = value)))
-      override val stateprovinceid = new Field[StateprovinceId, Row](prefix, "stateprovinceid", None, None)(x => extract(x).stateprovinceid, (row, value) => merge(row, extract(row).copy(stateprovinceid = value)))
-      override val postalcode = new Field[/* max 15 chars */ String, Row](prefix, "postalcode", None, None)(x => extract(x).postalcode, (row, value) => merge(row, extract(row).copy(postalcode = value)))
-      override val spatiallocation = new OptField[TypoBytea, Row](prefix, "spatiallocation", None, None)(x => extract(x).spatiallocation, (row, value) => merge(row, extract(row).copy(spatiallocation = value)))
-      override val rowguid = new Field[TypoUUID, Row](prefix, "rowguid", None, None)(x => extract(x).rowguid, (row, value) => merge(row, extract(row).copy(rowguid = value)))
-      override val modifieddate = new Field[TypoLocalDateTime, Row](prefix, "modifieddate", Some("text"), None)(x => extract(x).modifieddate, (row, value) => merge(row, extract(row).copy(modifieddate = value)))
+    override lazy val fields: AViewFields = new AViewFields {
+      override def id = Field[AddressId, AViewRow](_path, "id", None, None, x => x.id, (row, value) => row.copy(id = value))
+      override def addressid = Field[AddressId, AViewRow](_path, "addressid", None, None, x => x.addressid, (row, value) => row.copy(addressid = value))
+      override def addressline1 = Field[/* max 60 chars */ String, AViewRow](_path, "addressline1", None, None, x => x.addressline1, (row, value) => row.copy(addressline1 = value))
+      override def addressline2 = OptField[/* max 60 chars */ String, AViewRow](_path, "addressline2", None, None, x => x.addressline2, (row, value) => row.copy(addressline2 = value))
+      override def city = Field[/* max 30 chars */ String, AViewRow](_path, "city", None, None, x => x.city, (row, value) => row.copy(city = value))
+      override def stateprovinceid = Field[StateprovinceId, AViewRow](_path, "stateprovinceid", None, None, x => x.stateprovinceid, (row, value) => row.copy(stateprovinceid = value))
+      override def postalcode = Field[/* max 15 chars */ String, AViewRow](_path, "postalcode", None, None, x => x.postalcode, (row, value) => row.copy(postalcode = value))
+      override def spatiallocation = OptField[TypoBytea, AViewRow](_path, "spatiallocation", None, None, x => x.spatiallocation, (row, value) => row.copy(spatiallocation = value))
+      override def rowguid = Field[TypoUUID, AViewRow](_path, "rowguid", None, None, x => x.rowguid, (row, value) => row.copy(rowguid = value))
+      override def modifieddate = Field[TypoLocalDateTime, AViewRow](_path, "modifieddate", Some("text"), None, x => x.modifieddate, (row, value) => row.copy(modifieddate = value))
     }
   
-    override val columns: List[FieldLikeNoHkt[?, Row]] =
-      List[FieldLikeNoHkt[?, Row]](fields.id, fields.addressid, fields.addressline1, fields.addressline2, fields.city, fields.stateprovinceid, fields.postalcode, fields.spatiallocation, fields.rowguid, fields.modifieddate)
+    override lazy val columns: List[FieldLikeNoHkt[?, AViewRow]] =
+      List[FieldLikeNoHkt[?, AViewRow]](fields.id, fields.addressid, fields.addressline1, fields.addressline2, fields.city, fields.stateprovinceid, fields.postalcode, fields.spatiallocation, fields.rowguid, fields.modifieddate)
   
-    override def copy[NewRow](prefix: Option[String], extract: NewRow => AViewRow, merge: (NewRow, AViewRow) => NewRow): Impl[NewRow] =
-      new Impl(prefix, extract, merge)
+    override def copy(path: List[Path]): Impl =
+      new Impl(path)
   }
   
 }

--- a/typo-tester-zio-jdbc/generated-and-checked-in/adventureworks/pe/at/AtViewFields.scala
+++ b/typo-tester-zio-jdbc/generated-and-checked-in/adventureworks/pe/at/AtViewFields.scala
@@ -11,38 +11,39 @@ import adventureworks.customtypes.TypoLocalDateTime
 import adventureworks.customtypes.TypoUUID
 import adventureworks.person.addresstype.AddresstypeId
 import adventureworks.public.Name
+import typo.dsl.Path
 import typo.dsl.SqlExpr.Field
 import typo.dsl.SqlExpr.FieldLikeNoHkt
 import typo.dsl.Structure.Relation
 
-trait AtViewFields[Row] {
-  val id: Field[AddresstypeId, Row]
-  val addresstypeid: Field[AddresstypeId, Row]
-  val name: Field[Name, Row]
-  val rowguid: Field[TypoUUID, Row]
-  val modifieddate: Field[TypoLocalDateTime, Row]
+trait AtViewFields {
+  def id: Field[AddresstypeId, AtViewRow]
+  def addresstypeid: Field[AddresstypeId, AtViewRow]
+  def name: Field[Name, AtViewRow]
+  def rowguid: Field[TypoUUID, AtViewRow]
+  def modifieddate: Field[TypoLocalDateTime, AtViewRow]
 }
 
 object AtViewFields {
-  val structure: Relation[AtViewFields, AtViewRow, AtViewRow] = 
-    new Impl(None, identity, (_, x) => x)
+  lazy val structure: Relation[AtViewFields, AtViewRow] =
+    new Impl(Nil)
     
-  private final class Impl[Row](val prefix: Option[String], val extract: Row => AtViewRow, val merge: (Row, AtViewRow) => Row)
-    extends Relation[AtViewFields, AtViewRow, Row] { 
+  private final class Impl(val _path: List[Path])
+    extends Relation[AtViewFields, AtViewRow] {
   
-    override val fields: AtViewFields[Row] = new AtViewFields[Row] {
-      override val id = new Field[AddresstypeId, Row](prefix, "id", None, None)(x => extract(x).id, (row, value) => merge(row, extract(row).copy(id = value)))
-      override val addresstypeid = new Field[AddresstypeId, Row](prefix, "addresstypeid", None, None)(x => extract(x).addresstypeid, (row, value) => merge(row, extract(row).copy(addresstypeid = value)))
-      override val name = new Field[Name, Row](prefix, "name", None, None)(x => extract(x).name, (row, value) => merge(row, extract(row).copy(name = value)))
-      override val rowguid = new Field[TypoUUID, Row](prefix, "rowguid", None, None)(x => extract(x).rowguid, (row, value) => merge(row, extract(row).copy(rowguid = value)))
-      override val modifieddate = new Field[TypoLocalDateTime, Row](prefix, "modifieddate", Some("text"), None)(x => extract(x).modifieddate, (row, value) => merge(row, extract(row).copy(modifieddate = value)))
+    override lazy val fields: AtViewFields = new AtViewFields {
+      override def id = Field[AddresstypeId, AtViewRow](_path, "id", None, None, x => x.id, (row, value) => row.copy(id = value))
+      override def addresstypeid = Field[AddresstypeId, AtViewRow](_path, "addresstypeid", None, None, x => x.addresstypeid, (row, value) => row.copy(addresstypeid = value))
+      override def name = Field[Name, AtViewRow](_path, "name", None, None, x => x.name, (row, value) => row.copy(name = value))
+      override def rowguid = Field[TypoUUID, AtViewRow](_path, "rowguid", None, None, x => x.rowguid, (row, value) => row.copy(rowguid = value))
+      override def modifieddate = Field[TypoLocalDateTime, AtViewRow](_path, "modifieddate", Some("text"), None, x => x.modifieddate, (row, value) => row.copy(modifieddate = value))
     }
   
-    override val columns: List[FieldLikeNoHkt[?, Row]] =
-      List[FieldLikeNoHkt[?, Row]](fields.id, fields.addresstypeid, fields.name, fields.rowguid, fields.modifieddate)
+    override lazy val columns: List[FieldLikeNoHkt[?, AtViewRow]] =
+      List[FieldLikeNoHkt[?, AtViewRow]](fields.id, fields.addresstypeid, fields.name, fields.rowguid, fields.modifieddate)
   
-    override def copy[NewRow](prefix: Option[String], extract: NewRow => AtViewRow, merge: (NewRow, AtViewRow) => NewRow): Impl[NewRow] =
-      new Impl(prefix, extract, merge)
+    override def copy(path: List[Path]): Impl =
+      new Impl(path)
   }
   
 }

--- a/typo-tester-zio-jdbc/generated-and-checked-in/adventureworks/pe/be/BeViewFields.scala
+++ b/typo-tester-zio-jdbc/generated-and-checked-in/adventureworks/pe/be/BeViewFields.scala
@@ -10,36 +10,37 @@ package be
 import adventureworks.customtypes.TypoLocalDateTime
 import adventureworks.customtypes.TypoUUID
 import adventureworks.person.businessentity.BusinessentityId
+import typo.dsl.Path
 import typo.dsl.SqlExpr.Field
 import typo.dsl.SqlExpr.FieldLikeNoHkt
 import typo.dsl.Structure.Relation
 
-trait BeViewFields[Row] {
-  val id: Field[BusinessentityId, Row]
-  val businessentityid: Field[BusinessentityId, Row]
-  val rowguid: Field[TypoUUID, Row]
-  val modifieddate: Field[TypoLocalDateTime, Row]
+trait BeViewFields {
+  def id: Field[BusinessentityId, BeViewRow]
+  def businessentityid: Field[BusinessentityId, BeViewRow]
+  def rowguid: Field[TypoUUID, BeViewRow]
+  def modifieddate: Field[TypoLocalDateTime, BeViewRow]
 }
 
 object BeViewFields {
-  val structure: Relation[BeViewFields, BeViewRow, BeViewRow] = 
-    new Impl(None, identity, (_, x) => x)
+  lazy val structure: Relation[BeViewFields, BeViewRow] =
+    new Impl(Nil)
     
-  private final class Impl[Row](val prefix: Option[String], val extract: Row => BeViewRow, val merge: (Row, BeViewRow) => Row)
-    extends Relation[BeViewFields, BeViewRow, Row] { 
+  private final class Impl(val _path: List[Path])
+    extends Relation[BeViewFields, BeViewRow] {
   
-    override val fields: BeViewFields[Row] = new BeViewFields[Row] {
-      override val id = new Field[BusinessentityId, Row](prefix, "id", None, None)(x => extract(x).id, (row, value) => merge(row, extract(row).copy(id = value)))
-      override val businessentityid = new Field[BusinessentityId, Row](prefix, "businessentityid", None, None)(x => extract(x).businessentityid, (row, value) => merge(row, extract(row).copy(businessentityid = value)))
-      override val rowguid = new Field[TypoUUID, Row](prefix, "rowguid", None, None)(x => extract(x).rowguid, (row, value) => merge(row, extract(row).copy(rowguid = value)))
-      override val modifieddate = new Field[TypoLocalDateTime, Row](prefix, "modifieddate", Some("text"), None)(x => extract(x).modifieddate, (row, value) => merge(row, extract(row).copy(modifieddate = value)))
+    override lazy val fields: BeViewFields = new BeViewFields {
+      override def id = Field[BusinessentityId, BeViewRow](_path, "id", None, None, x => x.id, (row, value) => row.copy(id = value))
+      override def businessentityid = Field[BusinessentityId, BeViewRow](_path, "businessentityid", None, None, x => x.businessentityid, (row, value) => row.copy(businessentityid = value))
+      override def rowguid = Field[TypoUUID, BeViewRow](_path, "rowguid", None, None, x => x.rowguid, (row, value) => row.copy(rowguid = value))
+      override def modifieddate = Field[TypoLocalDateTime, BeViewRow](_path, "modifieddate", Some("text"), None, x => x.modifieddate, (row, value) => row.copy(modifieddate = value))
     }
   
-    override val columns: List[FieldLikeNoHkt[?, Row]] =
-      List[FieldLikeNoHkt[?, Row]](fields.id, fields.businessentityid, fields.rowguid, fields.modifieddate)
+    override lazy val columns: List[FieldLikeNoHkt[?, BeViewRow]] =
+      List[FieldLikeNoHkt[?, BeViewRow]](fields.id, fields.businessentityid, fields.rowguid, fields.modifieddate)
   
-    override def copy[NewRow](prefix: Option[String], extract: NewRow => BeViewRow, merge: (NewRow, BeViewRow) => NewRow): Impl[NewRow] =
-      new Impl(prefix, extract, merge)
+    override def copy(path: List[Path]): Impl =
+      new Impl(path)
   }
   
 }

--- a/typo-tester-zio-jdbc/generated-and-checked-in/adventureworks/pe/bea/BeaViewFields.scala
+++ b/typo-tester-zio-jdbc/generated-and-checked-in/adventureworks/pe/bea/BeaViewFields.scala
@@ -12,40 +12,41 @@ import adventureworks.customtypes.TypoUUID
 import adventureworks.person.address.AddressId
 import adventureworks.person.addresstype.AddresstypeId
 import adventureworks.person.businessentity.BusinessentityId
+import typo.dsl.Path
 import typo.dsl.SqlExpr.Field
 import typo.dsl.SqlExpr.FieldLikeNoHkt
 import typo.dsl.Structure.Relation
 
-trait BeaViewFields[Row] {
-  val id: Field[BusinessentityId, Row]
-  val businessentityid: Field[BusinessentityId, Row]
-  val addressid: Field[AddressId, Row]
-  val addresstypeid: Field[AddresstypeId, Row]
-  val rowguid: Field[TypoUUID, Row]
-  val modifieddate: Field[TypoLocalDateTime, Row]
+trait BeaViewFields {
+  def id: Field[BusinessentityId, BeaViewRow]
+  def businessentityid: Field[BusinessentityId, BeaViewRow]
+  def addressid: Field[AddressId, BeaViewRow]
+  def addresstypeid: Field[AddresstypeId, BeaViewRow]
+  def rowguid: Field[TypoUUID, BeaViewRow]
+  def modifieddate: Field[TypoLocalDateTime, BeaViewRow]
 }
 
 object BeaViewFields {
-  val structure: Relation[BeaViewFields, BeaViewRow, BeaViewRow] = 
-    new Impl(None, identity, (_, x) => x)
+  lazy val structure: Relation[BeaViewFields, BeaViewRow] =
+    new Impl(Nil)
     
-  private final class Impl[Row](val prefix: Option[String], val extract: Row => BeaViewRow, val merge: (Row, BeaViewRow) => Row)
-    extends Relation[BeaViewFields, BeaViewRow, Row] { 
+  private final class Impl(val _path: List[Path])
+    extends Relation[BeaViewFields, BeaViewRow] {
   
-    override val fields: BeaViewFields[Row] = new BeaViewFields[Row] {
-      override val id = new Field[BusinessentityId, Row](prefix, "id", None, None)(x => extract(x).id, (row, value) => merge(row, extract(row).copy(id = value)))
-      override val businessentityid = new Field[BusinessentityId, Row](prefix, "businessentityid", None, None)(x => extract(x).businessentityid, (row, value) => merge(row, extract(row).copy(businessentityid = value)))
-      override val addressid = new Field[AddressId, Row](prefix, "addressid", None, None)(x => extract(x).addressid, (row, value) => merge(row, extract(row).copy(addressid = value)))
-      override val addresstypeid = new Field[AddresstypeId, Row](prefix, "addresstypeid", None, None)(x => extract(x).addresstypeid, (row, value) => merge(row, extract(row).copy(addresstypeid = value)))
-      override val rowguid = new Field[TypoUUID, Row](prefix, "rowguid", None, None)(x => extract(x).rowguid, (row, value) => merge(row, extract(row).copy(rowguid = value)))
-      override val modifieddate = new Field[TypoLocalDateTime, Row](prefix, "modifieddate", Some("text"), None)(x => extract(x).modifieddate, (row, value) => merge(row, extract(row).copy(modifieddate = value)))
+    override lazy val fields: BeaViewFields = new BeaViewFields {
+      override def id = Field[BusinessentityId, BeaViewRow](_path, "id", None, None, x => x.id, (row, value) => row.copy(id = value))
+      override def businessentityid = Field[BusinessentityId, BeaViewRow](_path, "businessentityid", None, None, x => x.businessentityid, (row, value) => row.copy(businessentityid = value))
+      override def addressid = Field[AddressId, BeaViewRow](_path, "addressid", None, None, x => x.addressid, (row, value) => row.copy(addressid = value))
+      override def addresstypeid = Field[AddresstypeId, BeaViewRow](_path, "addresstypeid", None, None, x => x.addresstypeid, (row, value) => row.copy(addresstypeid = value))
+      override def rowguid = Field[TypoUUID, BeaViewRow](_path, "rowguid", None, None, x => x.rowguid, (row, value) => row.copy(rowguid = value))
+      override def modifieddate = Field[TypoLocalDateTime, BeaViewRow](_path, "modifieddate", Some("text"), None, x => x.modifieddate, (row, value) => row.copy(modifieddate = value))
     }
   
-    override val columns: List[FieldLikeNoHkt[?, Row]] =
-      List[FieldLikeNoHkt[?, Row]](fields.id, fields.businessentityid, fields.addressid, fields.addresstypeid, fields.rowguid, fields.modifieddate)
+    override lazy val columns: List[FieldLikeNoHkt[?, BeaViewRow]] =
+      List[FieldLikeNoHkt[?, BeaViewRow]](fields.id, fields.businessentityid, fields.addressid, fields.addresstypeid, fields.rowguid, fields.modifieddate)
   
-    override def copy[NewRow](prefix: Option[String], extract: NewRow => BeaViewRow, merge: (NewRow, BeaViewRow) => NewRow): Impl[NewRow] =
-      new Impl(prefix, extract, merge)
+    override def copy(path: List[Path]): Impl =
+      new Impl(path)
   }
   
 }

--- a/typo-tester-zio-jdbc/generated-and-checked-in/adventureworks/pe/bec/BecViewFields.scala
+++ b/typo-tester-zio-jdbc/generated-and-checked-in/adventureworks/pe/bec/BecViewFields.scala
@@ -11,40 +11,41 @@ import adventureworks.customtypes.TypoLocalDateTime
 import adventureworks.customtypes.TypoUUID
 import adventureworks.person.businessentity.BusinessentityId
 import adventureworks.person.contacttype.ContacttypeId
+import typo.dsl.Path
 import typo.dsl.SqlExpr.Field
 import typo.dsl.SqlExpr.FieldLikeNoHkt
 import typo.dsl.Structure.Relation
 
-trait BecViewFields[Row] {
-  val id: Field[BusinessentityId, Row]
-  val businessentityid: Field[BusinessentityId, Row]
-  val personid: Field[BusinessentityId, Row]
-  val contacttypeid: Field[ContacttypeId, Row]
-  val rowguid: Field[TypoUUID, Row]
-  val modifieddate: Field[TypoLocalDateTime, Row]
+trait BecViewFields {
+  def id: Field[BusinessentityId, BecViewRow]
+  def businessentityid: Field[BusinessentityId, BecViewRow]
+  def personid: Field[BusinessentityId, BecViewRow]
+  def contacttypeid: Field[ContacttypeId, BecViewRow]
+  def rowguid: Field[TypoUUID, BecViewRow]
+  def modifieddate: Field[TypoLocalDateTime, BecViewRow]
 }
 
 object BecViewFields {
-  val structure: Relation[BecViewFields, BecViewRow, BecViewRow] = 
-    new Impl(None, identity, (_, x) => x)
+  lazy val structure: Relation[BecViewFields, BecViewRow] =
+    new Impl(Nil)
     
-  private final class Impl[Row](val prefix: Option[String], val extract: Row => BecViewRow, val merge: (Row, BecViewRow) => Row)
-    extends Relation[BecViewFields, BecViewRow, Row] { 
+  private final class Impl(val _path: List[Path])
+    extends Relation[BecViewFields, BecViewRow] {
   
-    override val fields: BecViewFields[Row] = new BecViewFields[Row] {
-      override val id = new Field[BusinessentityId, Row](prefix, "id", None, None)(x => extract(x).id, (row, value) => merge(row, extract(row).copy(id = value)))
-      override val businessentityid = new Field[BusinessentityId, Row](prefix, "businessentityid", None, None)(x => extract(x).businessentityid, (row, value) => merge(row, extract(row).copy(businessentityid = value)))
-      override val personid = new Field[BusinessentityId, Row](prefix, "personid", None, None)(x => extract(x).personid, (row, value) => merge(row, extract(row).copy(personid = value)))
-      override val contacttypeid = new Field[ContacttypeId, Row](prefix, "contacttypeid", None, None)(x => extract(x).contacttypeid, (row, value) => merge(row, extract(row).copy(contacttypeid = value)))
-      override val rowguid = new Field[TypoUUID, Row](prefix, "rowguid", None, None)(x => extract(x).rowguid, (row, value) => merge(row, extract(row).copy(rowguid = value)))
-      override val modifieddate = new Field[TypoLocalDateTime, Row](prefix, "modifieddate", Some("text"), None)(x => extract(x).modifieddate, (row, value) => merge(row, extract(row).copy(modifieddate = value)))
+    override lazy val fields: BecViewFields = new BecViewFields {
+      override def id = Field[BusinessentityId, BecViewRow](_path, "id", None, None, x => x.id, (row, value) => row.copy(id = value))
+      override def businessentityid = Field[BusinessentityId, BecViewRow](_path, "businessentityid", None, None, x => x.businessentityid, (row, value) => row.copy(businessentityid = value))
+      override def personid = Field[BusinessentityId, BecViewRow](_path, "personid", None, None, x => x.personid, (row, value) => row.copy(personid = value))
+      override def contacttypeid = Field[ContacttypeId, BecViewRow](_path, "contacttypeid", None, None, x => x.contacttypeid, (row, value) => row.copy(contacttypeid = value))
+      override def rowguid = Field[TypoUUID, BecViewRow](_path, "rowguid", None, None, x => x.rowguid, (row, value) => row.copy(rowguid = value))
+      override def modifieddate = Field[TypoLocalDateTime, BecViewRow](_path, "modifieddate", Some("text"), None, x => x.modifieddate, (row, value) => row.copy(modifieddate = value))
     }
   
-    override val columns: List[FieldLikeNoHkt[?, Row]] =
-      List[FieldLikeNoHkt[?, Row]](fields.id, fields.businessentityid, fields.personid, fields.contacttypeid, fields.rowguid, fields.modifieddate)
+    override lazy val columns: List[FieldLikeNoHkt[?, BecViewRow]] =
+      List[FieldLikeNoHkt[?, BecViewRow]](fields.id, fields.businessentityid, fields.personid, fields.contacttypeid, fields.rowguid, fields.modifieddate)
   
-    override def copy[NewRow](prefix: Option[String], extract: NewRow => BecViewRow, merge: (NewRow, BecViewRow) => NewRow): Impl[NewRow] =
-      new Impl(prefix, extract, merge)
+    override def copy(path: List[Path]): Impl =
+      new Impl(path)
   }
   
 }

--- a/typo-tester-zio-jdbc/generated-and-checked-in/adventureworks/pe/ct/CtViewFields.scala
+++ b/typo-tester-zio-jdbc/generated-and-checked-in/adventureworks/pe/ct/CtViewFields.scala
@@ -10,36 +10,37 @@ package ct
 import adventureworks.customtypes.TypoLocalDateTime
 import adventureworks.person.contacttype.ContacttypeId
 import adventureworks.public.Name
+import typo.dsl.Path
 import typo.dsl.SqlExpr.Field
 import typo.dsl.SqlExpr.FieldLikeNoHkt
 import typo.dsl.Structure.Relation
 
-trait CtViewFields[Row] {
-  val id: Field[ContacttypeId, Row]
-  val contacttypeid: Field[ContacttypeId, Row]
-  val name: Field[Name, Row]
-  val modifieddate: Field[TypoLocalDateTime, Row]
+trait CtViewFields {
+  def id: Field[ContacttypeId, CtViewRow]
+  def contacttypeid: Field[ContacttypeId, CtViewRow]
+  def name: Field[Name, CtViewRow]
+  def modifieddate: Field[TypoLocalDateTime, CtViewRow]
 }
 
 object CtViewFields {
-  val structure: Relation[CtViewFields, CtViewRow, CtViewRow] = 
-    new Impl(None, identity, (_, x) => x)
+  lazy val structure: Relation[CtViewFields, CtViewRow] =
+    new Impl(Nil)
     
-  private final class Impl[Row](val prefix: Option[String], val extract: Row => CtViewRow, val merge: (Row, CtViewRow) => Row)
-    extends Relation[CtViewFields, CtViewRow, Row] { 
+  private final class Impl(val _path: List[Path])
+    extends Relation[CtViewFields, CtViewRow] {
   
-    override val fields: CtViewFields[Row] = new CtViewFields[Row] {
-      override val id = new Field[ContacttypeId, Row](prefix, "id", None, None)(x => extract(x).id, (row, value) => merge(row, extract(row).copy(id = value)))
-      override val contacttypeid = new Field[ContacttypeId, Row](prefix, "contacttypeid", None, None)(x => extract(x).contacttypeid, (row, value) => merge(row, extract(row).copy(contacttypeid = value)))
-      override val name = new Field[Name, Row](prefix, "name", None, None)(x => extract(x).name, (row, value) => merge(row, extract(row).copy(name = value)))
-      override val modifieddate = new Field[TypoLocalDateTime, Row](prefix, "modifieddate", Some("text"), None)(x => extract(x).modifieddate, (row, value) => merge(row, extract(row).copy(modifieddate = value)))
+    override lazy val fields: CtViewFields = new CtViewFields {
+      override def id = Field[ContacttypeId, CtViewRow](_path, "id", None, None, x => x.id, (row, value) => row.copy(id = value))
+      override def contacttypeid = Field[ContacttypeId, CtViewRow](_path, "contacttypeid", None, None, x => x.contacttypeid, (row, value) => row.copy(contacttypeid = value))
+      override def name = Field[Name, CtViewRow](_path, "name", None, None, x => x.name, (row, value) => row.copy(name = value))
+      override def modifieddate = Field[TypoLocalDateTime, CtViewRow](_path, "modifieddate", Some("text"), None, x => x.modifieddate, (row, value) => row.copy(modifieddate = value))
     }
   
-    override val columns: List[FieldLikeNoHkt[?, Row]] =
-      List[FieldLikeNoHkt[?, Row]](fields.id, fields.contacttypeid, fields.name, fields.modifieddate)
+    override lazy val columns: List[FieldLikeNoHkt[?, CtViewRow]] =
+      List[FieldLikeNoHkt[?, CtViewRow]](fields.id, fields.contacttypeid, fields.name, fields.modifieddate)
   
-    override def copy[NewRow](prefix: Option[String], extract: NewRow => CtViewRow, merge: (NewRow, CtViewRow) => NewRow): Impl[NewRow] =
-      new Impl(prefix, extract, merge)
+    override def copy(path: List[Path]): Impl =
+      new Impl(path)
   }
   
 }

--- a/typo-tester-zio-jdbc/generated-and-checked-in/adventureworks/pe/e/EViewFields.scala
+++ b/typo-tester-zio-jdbc/generated-and-checked-in/adventureworks/pe/e/EViewFields.scala
@@ -10,41 +10,42 @@ package e
 import adventureworks.customtypes.TypoLocalDateTime
 import adventureworks.customtypes.TypoUUID
 import adventureworks.person.businessentity.BusinessentityId
+import typo.dsl.Path
 import typo.dsl.SqlExpr.Field
 import typo.dsl.SqlExpr.FieldLikeNoHkt
 import typo.dsl.SqlExpr.OptField
 import typo.dsl.Structure.Relation
 
-trait EViewFields[Row] {
-  val id: Field[Int, Row]
-  val businessentityid: Field[BusinessentityId, Row]
-  val emailaddressid: Field[Int, Row]
-  val emailaddress: OptField[/* max 50 chars */ String, Row]
-  val rowguid: Field[TypoUUID, Row]
-  val modifieddate: Field[TypoLocalDateTime, Row]
+trait EViewFields {
+  def id: Field[Int, EViewRow]
+  def businessentityid: Field[BusinessentityId, EViewRow]
+  def emailaddressid: Field[Int, EViewRow]
+  def emailaddress: OptField[/* max 50 chars */ String, EViewRow]
+  def rowguid: Field[TypoUUID, EViewRow]
+  def modifieddate: Field[TypoLocalDateTime, EViewRow]
 }
 
 object EViewFields {
-  val structure: Relation[EViewFields, EViewRow, EViewRow] = 
-    new Impl(None, identity, (_, x) => x)
+  lazy val structure: Relation[EViewFields, EViewRow] =
+    new Impl(Nil)
     
-  private final class Impl[Row](val prefix: Option[String], val extract: Row => EViewRow, val merge: (Row, EViewRow) => Row)
-    extends Relation[EViewFields, EViewRow, Row] { 
+  private final class Impl(val _path: List[Path])
+    extends Relation[EViewFields, EViewRow] {
   
-    override val fields: EViewFields[Row] = new EViewFields[Row] {
-      override val id = new Field[Int, Row](prefix, "id", None, None)(x => extract(x).id, (row, value) => merge(row, extract(row).copy(id = value)))
-      override val businessentityid = new Field[BusinessentityId, Row](prefix, "businessentityid", None, None)(x => extract(x).businessentityid, (row, value) => merge(row, extract(row).copy(businessentityid = value)))
-      override val emailaddressid = new Field[Int, Row](prefix, "emailaddressid", None, None)(x => extract(x).emailaddressid, (row, value) => merge(row, extract(row).copy(emailaddressid = value)))
-      override val emailaddress = new OptField[/* max 50 chars */ String, Row](prefix, "emailaddress", None, None)(x => extract(x).emailaddress, (row, value) => merge(row, extract(row).copy(emailaddress = value)))
-      override val rowguid = new Field[TypoUUID, Row](prefix, "rowguid", None, None)(x => extract(x).rowguid, (row, value) => merge(row, extract(row).copy(rowguid = value)))
-      override val modifieddate = new Field[TypoLocalDateTime, Row](prefix, "modifieddate", Some("text"), None)(x => extract(x).modifieddate, (row, value) => merge(row, extract(row).copy(modifieddate = value)))
+    override lazy val fields: EViewFields = new EViewFields {
+      override def id = Field[Int, EViewRow](_path, "id", None, None, x => x.id, (row, value) => row.copy(id = value))
+      override def businessentityid = Field[BusinessentityId, EViewRow](_path, "businessentityid", None, None, x => x.businessentityid, (row, value) => row.copy(businessentityid = value))
+      override def emailaddressid = Field[Int, EViewRow](_path, "emailaddressid", None, None, x => x.emailaddressid, (row, value) => row.copy(emailaddressid = value))
+      override def emailaddress = OptField[/* max 50 chars */ String, EViewRow](_path, "emailaddress", None, None, x => x.emailaddress, (row, value) => row.copy(emailaddress = value))
+      override def rowguid = Field[TypoUUID, EViewRow](_path, "rowguid", None, None, x => x.rowguid, (row, value) => row.copy(rowguid = value))
+      override def modifieddate = Field[TypoLocalDateTime, EViewRow](_path, "modifieddate", Some("text"), None, x => x.modifieddate, (row, value) => row.copy(modifieddate = value))
     }
   
-    override val columns: List[FieldLikeNoHkt[?, Row]] =
-      List[FieldLikeNoHkt[?, Row]](fields.id, fields.businessentityid, fields.emailaddressid, fields.emailaddress, fields.rowguid, fields.modifieddate)
+    override lazy val columns: List[FieldLikeNoHkt[?, EViewRow]] =
+      List[FieldLikeNoHkt[?, EViewRow]](fields.id, fields.businessentityid, fields.emailaddressid, fields.emailaddress, fields.rowguid, fields.modifieddate)
   
-    override def copy[NewRow](prefix: Option[String], extract: NewRow => EViewRow, merge: (NewRow, EViewRow) => NewRow): Impl[NewRow] =
-      new Impl(prefix, extract, merge)
+    override def copy(path: List[Path]): Impl =
+      new Impl(path)
   }
   
 }

--- a/typo-tester-zio-jdbc/generated-and-checked-in/adventureworks/pe/p/PViewFields.scala
+++ b/typo-tester-zio-jdbc/generated-and-checked-in/adventureworks/pe/p/PViewFields.scala
@@ -14,57 +14,58 @@ import adventureworks.person.businessentity.BusinessentityId
 import adventureworks.public.Name
 import adventureworks.public.NameStyle
 import adventureworks.userdefined.FirstName
+import typo.dsl.Path
 import typo.dsl.SqlExpr.Field
 import typo.dsl.SqlExpr.FieldLikeNoHkt
 import typo.dsl.SqlExpr.OptField
 import typo.dsl.Structure.Relation
 
-trait PViewFields[Row] {
-  val id: Field[BusinessentityId, Row]
-  val businessentityid: Field[BusinessentityId, Row]
-  val persontype: Field[/* bpchar, max 2 chars */ String, Row]
-  val namestyle: Field[NameStyle, Row]
-  val title: OptField[/* max 8 chars */ String, Row]
-  val firstname: Field[/* user-picked */ FirstName, Row]
-  val middlename: OptField[Name, Row]
-  val lastname: Field[Name, Row]
-  val suffix: OptField[/* max 10 chars */ String, Row]
-  val emailpromotion: Field[Int, Row]
-  val additionalcontactinfo: OptField[TypoXml, Row]
-  val demographics: OptField[TypoXml, Row]
-  val rowguid: Field[TypoUUID, Row]
-  val modifieddate: Field[TypoLocalDateTime, Row]
+trait PViewFields {
+  def id: Field[BusinessentityId, PViewRow]
+  def businessentityid: Field[BusinessentityId, PViewRow]
+  def persontype: Field[/* bpchar, max 2 chars */ String, PViewRow]
+  def namestyle: Field[NameStyle, PViewRow]
+  def title: OptField[/* max 8 chars */ String, PViewRow]
+  def firstname: Field[/* user-picked */ FirstName, PViewRow]
+  def middlename: OptField[Name, PViewRow]
+  def lastname: Field[Name, PViewRow]
+  def suffix: OptField[/* max 10 chars */ String, PViewRow]
+  def emailpromotion: Field[Int, PViewRow]
+  def additionalcontactinfo: OptField[TypoXml, PViewRow]
+  def demographics: OptField[TypoXml, PViewRow]
+  def rowguid: Field[TypoUUID, PViewRow]
+  def modifieddate: Field[TypoLocalDateTime, PViewRow]
 }
 
 object PViewFields {
-  val structure: Relation[PViewFields, PViewRow, PViewRow] = 
-    new Impl(None, identity, (_, x) => x)
+  lazy val structure: Relation[PViewFields, PViewRow] =
+    new Impl(Nil)
     
-  private final class Impl[Row](val prefix: Option[String], val extract: Row => PViewRow, val merge: (Row, PViewRow) => Row)
-    extends Relation[PViewFields, PViewRow, Row] { 
+  private final class Impl(val _path: List[Path])
+    extends Relation[PViewFields, PViewRow] {
   
-    override val fields: PViewFields[Row] = new PViewFields[Row] {
-      override val id = new Field[BusinessentityId, Row](prefix, "id", None, None)(x => extract(x).id, (row, value) => merge(row, extract(row).copy(id = value)))
-      override val businessentityid = new Field[BusinessentityId, Row](prefix, "businessentityid", None, None)(x => extract(x).businessentityid, (row, value) => merge(row, extract(row).copy(businessentityid = value)))
-      override val persontype = new Field[/* bpchar, max 2 chars */ String, Row](prefix, "persontype", None, None)(x => extract(x).persontype, (row, value) => merge(row, extract(row).copy(persontype = value)))
-      override val namestyle = new Field[NameStyle, Row](prefix, "namestyle", None, None)(x => extract(x).namestyle, (row, value) => merge(row, extract(row).copy(namestyle = value)))
-      override val title = new OptField[/* max 8 chars */ String, Row](prefix, "title", None, None)(x => extract(x).title, (row, value) => merge(row, extract(row).copy(title = value)))
-      override val firstname = new Field[/* user-picked */ FirstName, Row](prefix, "firstname", None, None)(x => extract(x).firstname, (row, value) => merge(row, extract(row).copy(firstname = value)))
-      override val middlename = new OptField[Name, Row](prefix, "middlename", None, None)(x => extract(x).middlename, (row, value) => merge(row, extract(row).copy(middlename = value)))
-      override val lastname = new Field[Name, Row](prefix, "lastname", None, None)(x => extract(x).lastname, (row, value) => merge(row, extract(row).copy(lastname = value)))
-      override val suffix = new OptField[/* max 10 chars */ String, Row](prefix, "suffix", None, None)(x => extract(x).suffix, (row, value) => merge(row, extract(row).copy(suffix = value)))
-      override val emailpromotion = new Field[Int, Row](prefix, "emailpromotion", None, None)(x => extract(x).emailpromotion, (row, value) => merge(row, extract(row).copy(emailpromotion = value)))
-      override val additionalcontactinfo = new OptField[TypoXml, Row](prefix, "additionalcontactinfo", None, None)(x => extract(x).additionalcontactinfo, (row, value) => merge(row, extract(row).copy(additionalcontactinfo = value)))
-      override val demographics = new OptField[TypoXml, Row](prefix, "demographics", None, None)(x => extract(x).demographics, (row, value) => merge(row, extract(row).copy(demographics = value)))
-      override val rowguid = new Field[TypoUUID, Row](prefix, "rowguid", None, None)(x => extract(x).rowguid, (row, value) => merge(row, extract(row).copy(rowguid = value)))
-      override val modifieddate = new Field[TypoLocalDateTime, Row](prefix, "modifieddate", Some("text"), None)(x => extract(x).modifieddate, (row, value) => merge(row, extract(row).copy(modifieddate = value)))
+    override lazy val fields: PViewFields = new PViewFields {
+      override def id = Field[BusinessentityId, PViewRow](_path, "id", None, None, x => x.id, (row, value) => row.copy(id = value))
+      override def businessentityid = Field[BusinessentityId, PViewRow](_path, "businessentityid", None, None, x => x.businessentityid, (row, value) => row.copy(businessentityid = value))
+      override def persontype = Field[/* bpchar, max 2 chars */ String, PViewRow](_path, "persontype", None, None, x => x.persontype, (row, value) => row.copy(persontype = value))
+      override def namestyle = Field[NameStyle, PViewRow](_path, "namestyle", None, None, x => x.namestyle, (row, value) => row.copy(namestyle = value))
+      override def title = OptField[/* max 8 chars */ String, PViewRow](_path, "title", None, None, x => x.title, (row, value) => row.copy(title = value))
+      override def firstname = Field[/* user-picked */ FirstName, PViewRow](_path, "firstname", None, None, x => x.firstname, (row, value) => row.copy(firstname = value))
+      override def middlename = OptField[Name, PViewRow](_path, "middlename", None, None, x => x.middlename, (row, value) => row.copy(middlename = value))
+      override def lastname = Field[Name, PViewRow](_path, "lastname", None, None, x => x.lastname, (row, value) => row.copy(lastname = value))
+      override def suffix = OptField[/* max 10 chars */ String, PViewRow](_path, "suffix", None, None, x => x.suffix, (row, value) => row.copy(suffix = value))
+      override def emailpromotion = Field[Int, PViewRow](_path, "emailpromotion", None, None, x => x.emailpromotion, (row, value) => row.copy(emailpromotion = value))
+      override def additionalcontactinfo = OptField[TypoXml, PViewRow](_path, "additionalcontactinfo", None, None, x => x.additionalcontactinfo, (row, value) => row.copy(additionalcontactinfo = value))
+      override def demographics = OptField[TypoXml, PViewRow](_path, "demographics", None, None, x => x.demographics, (row, value) => row.copy(demographics = value))
+      override def rowguid = Field[TypoUUID, PViewRow](_path, "rowguid", None, None, x => x.rowguid, (row, value) => row.copy(rowguid = value))
+      override def modifieddate = Field[TypoLocalDateTime, PViewRow](_path, "modifieddate", Some("text"), None, x => x.modifieddate, (row, value) => row.copy(modifieddate = value))
     }
   
-    override val columns: List[FieldLikeNoHkt[?, Row]] =
-      List[FieldLikeNoHkt[?, Row]](fields.id, fields.businessentityid, fields.persontype, fields.namestyle, fields.title, fields.firstname, fields.middlename, fields.lastname, fields.suffix, fields.emailpromotion, fields.additionalcontactinfo, fields.demographics, fields.rowguid, fields.modifieddate)
+    override lazy val columns: List[FieldLikeNoHkt[?, PViewRow]] =
+      List[FieldLikeNoHkt[?, PViewRow]](fields.id, fields.businessentityid, fields.persontype, fields.namestyle, fields.title, fields.firstname, fields.middlename, fields.lastname, fields.suffix, fields.emailpromotion, fields.additionalcontactinfo, fields.demographics, fields.rowguid, fields.modifieddate)
   
-    override def copy[NewRow](prefix: Option[String], extract: NewRow => PViewRow, merge: (NewRow, PViewRow) => NewRow): Impl[NewRow] =
-      new Impl(prefix, extract, merge)
+    override def copy(path: List[Path]): Impl =
+      new Impl(path)
   }
   
 }

--- a/typo-tester-zio-jdbc/generated-and-checked-in/adventureworks/pe/pa/PaViewFields.scala
+++ b/typo-tester-zio-jdbc/generated-and-checked-in/adventureworks/pe/pa/PaViewFields.scala
@@ -10,40 +10,41 @@ package pa
 import adventureworks.customtypes.TypoLocalDateTime
 import adventureworks.customtypes.TypoUUID
 import adventureworks.person.businessentity.BusinessentityId
+import typo.dsl.Path
 import typo.dsl.SqlExpr.Field
 import typo.dsl.SqlExpr.FieldLikeNoHkt
 import typo.dsl.Structure.Relation
 
-trait PaViewFields[Row] {
-  val id: Field[BusinessentityId, Row]
-  val businessentityid: Field[BusinessentityId, Row]
-  val passwordhash: Field[/* max 128 chars */ String, Row]
-  val passwordsalt: Field[/* max 10 chars */ String, Row]
-  val rowguid: Field[TypoUUID, Row]
-  val modifieddate: Field[TypoLocalDateTime, Row]
+trait PaViewFields {
+  def id: Field[BusinessentityId, PaViewRow]
+  def businessentityid: Field[BusinessentityId, PaViewRow]
+  def passwordhash: Field[/* max 128 chars */ String, PaViewRow]
+  def passwordsalt: Field[/* max 10 chars */ String, PaViewRow]
+  def rowguid: Field[TypoUUID, PaViewRow]
+  def modifieddate: Field[TypoLocalDateTime, PaViewRow]
 }
 
 object PaViewFields {
-  val structure: Relation[PaViewFields, PaViewRow, PaViewRow] = 
-    new Impl(None, identity, (_, x) => x)
+  lazy val structure: Relation[PaViewFields, PaViewRow] =
+    new Impl(Nil)
     
-  private final class Impl[Row](val prefix: Option[String], val extract: Row => PaViewRow, val merge: (Row, PaViewRow) => Row)
-    extends Relation[PaViewFields, PaViewRow, Row] { 
+  private final class Impl(val _path: List[Path])
+    extends Relation[PaViewFields, PaViewRow] {
   
-    override val fields: PaViewFields[Row] = new PaViewFields[Row] {
-      override val id = new Field[BusinessentityId, Row](prefix, "id", None, None)(x => extract(x).id, (row, value) => merge(row, extract(row).copy(id = value)))
-      override val businessentityid = new Field[BusinessentityId, Row](prefix, "businessentityid", None, None)(x => extract(x).businessentityid, (row, value) => merge(row, extract(row).copy(businessentityid = value)))
-      override val passwordhash = new Field[/* max 128 chars */ String, Row](prefix, "passwordhash", None, None)(x => extract(x).passwordhash, (row, value) => merge(row, extract(row).copy(passwordhash = value)))
-      override val passwordsalt = new Field[/* max 10 chars */ String, Row](prefix, "passwordsalt", None, None)(x => extract(x).passwordsalt, (row, value) => merge(row, extract(row).copy(passwordsalt = value)))
-      override val rowguid = new Field[TypoUUID, Row](prefix, "rowguid", None, None)(x => extract(x).rowguid, (row, value) => merge(row, extract(row).copy(rowguid = value)))
-      override val modifieddate = new Field[TypoLocalDateTime, Row](prefix, "modifieddate", Some("text"), None)(x => extract(x).modifieddate, (row, value) => merge(row, extract(row).copy(modifieddate = value)))
+    override lazy val fields: PaViewFields = new PaViewFields {
+      override def id = Field[BusinessentityId, PaViewRow](_path, "id", None, None, x => x.id, (row, value) => row.copy(id = value))
+      override def businessentityid = Field[BusinessentityId, PaViewRow](_path, "businessentityid", None, None, x => x.businessentityid, (row, value) => row.copy(businessentityid = value))
+      override def passwordhash = Field[/* max 128 chars */ String, PaViewRow](_path, "passwordhash", None, None, x => x.passwordhash, (row, value) => row.copy(passwordhash = value))
+      override def passwordsalt = Field[/* max 10 chars */ String, PaViewRow](_path, "passwordsalt", None, None, x => x.passwordsalt, (row, value) => row.copy(passwordsalt = value))
+      override def rowguid = Field[TypoUUID, PaViewRow](_path, "rowguid", None, None, x => x.rowguid, (row, value) => row.copy(rowguid = value))
+      override def modifieddate = Field[TypoLocalDateTime, PaViewRow](_path, "modifieddate", Some("text"), None, x => x.modifieddate, (row, value) => row.copy(modifieddate = value))
     }
   
-    override val columns: List[FieldLikeNoHkt[?, Row]] =
-      List[FieldLikeNoHkt[?, Row]](fields.id, fields.businessentityid, fields.passwordhash, fields.passwordsalt, fields.rowguid, fields.modifieddate)
+    override lazy val columns: List[FieldLikeNoHkt[?, PaViewRow]] =
+      List[FieldLikeNoHkt[?, PaViewRow]](fields.id, fields.businessentityid, fields.passwordhash, fields.passwordsalt, fields.rowguid, fields.modifieddate)
   
-    override def copy[NewRow](prefix: Option[String], extract: NewRow => PaViewRow, merge: (NewRow, PaViewRow) => NewRow): Impl[NewRow] =
-      new Impl(prefix, extract, merge)
+    override def copy(path: List[Path]): Impl =
+      new Impl(path)
   }
   
 }

--- a/typo-tester-zio-jdbc/generated-and-checked-in/adventureworks/pe/pnt/PntViewFields.scala
+++ b/typo-tester-zio-jdbc/generated-and-checked-in/adventureworks/pe/pnt/PntViewFields.scala
@@ -10,36 +10,37 @@ package pnt
 import adventureworks.customtypes.TypoLocalDateTime
 import adventureworks.person.phonenumbertype.PhonenumbertypeId
 import adventureworks.public.Name
+import typo.dsl.Path
 import typo.dsl.SqlExpr.Field
 import typo.dsl.SqlExpr.FieldLikeNoHkt
 import typo.dsl.Structure.Relation
 
-trait PntViewFields[Row] {
-  val id: Field[PhonenumbertypeId, Row]
-  val phonenumbertypeid: Field[PhonenumbertypeId, Row]
-  val name: Field[Name, Row]
-  val modifieddate: Field[TypoLocalDateTime, Row]
+trait PntViewFields {
+  def id: Field[PhonenumbertypeId, PntViewRow]
+  def phonenumbertypeid: Field[PhonenumbertypeId, PntViewRow]
+  def name: Field[Name, PntViewRow]
+  def modifieddate: Field[TypoLocalDateTime, PntViewRow]
 }
 
 object PntViewFields {
-  val structure: Relation[PntViewFields, PntViewRow, PntViewRow] = 
-    new Impl(None, identity, (_, x) => x)
+  lazy val structure: Relation[PntViewFields, PntViewRow] =
+    new Impl(Nil)
     
-  private final class Impl[Row](val prefix: Option[String], val extract: Row => PntViewRow, val merge: (Row, PntViewRow) => Row)
-    extends Relation[PntViewFields, PntViewRow, Row] { 
+  private final class Impl(val _path: List[Path])
+    extends Relation[PntViewFields, PntViewRow] {
   
-    override val fields: PntViewFields[Row] = new PntViewFields[Row] {
-      override val id = new Field[PhonenumbertypeId, Row](prefix, "id", None, None)(x => extract(x).id, (row, value) => merge(row, extract(row).copy(id = value)))
-      override val phonenumbertypeid = new Field[PhonenumbertypeId, Row](prefix, "phonenumbertypeid", None, None)(x => extract(x).phonenumbertypeid, (row, value) => merge(row, extract(row).copy(phonenumbertypeid = value)))
-      override val name = new Field[Name, Row](prefix, "name", None, None)(x => extract(x).name, (row, value) => merge(row, extract(row).copy(name = value)))
-      override val modifieddate = new Field[TypoLocalDateTime, Row](prefix, "modifieddate", Some("text"), None)(x => extract(x).modifieddate, (row, value) => merge(row, extract(row).copy(modifieddate = value)))
+    override lazy val fields: PntViewFields = new PntViewFields {
+      override def id = Field[PhonenumbertypeId, PntViewRow](_path, "id", None, None, x => x.id, (row, value) => row.copy(id = value))
+      override def phonenumbertypeid = Field[PhonenumbertypeId, PntViewRow](_path, "phonenumbertypeid", None, None, x => x.phonenumbertypeid, (row, value) => row.copy(phonenumbertypeid = value))
+      override def name = Field[Name, PntViewRow](_path, "name", None, None, x => x.name, (row, value) => row.copy(name = value))
+      override def modifieddate = Field[TypoLocalDateTime, PntViewRow](_path, "modifieddate", Some("text"), None, x => x.modifieddate, (row, value) => row.copy(modifieddate = value))
     }
   
-    override val columns: List[FieldLikeNoHkt[?, Row]] =
-      List[FieldLikeNoHkt[?, Row]](fields.id, fields.phonenumbertypeid, fields.name, fields.modifieddate)
+    override lazy val columns: List[FieldLikeNoHkt[?, PntViewRow]] =
+      List[FieldLikeNoHkt[?, PntViewRow]](fields.id, fields.phonenumbertypeid, fields.name, fields.modifieddate)
   
-    override def copy[NewRow](prefix: Option[String], extract: NewRow => PntViewRow, merge: (NewRow, PntViewRow) => NewRow): Impl[NewRow] =
-      new Impl(prefix, extract, merge)
+    override def copy(path: List[Path]): Impl =
+      new Impl(path)
   }
   
 }

--- a/typo-tester-zio-jdbc/generated-and-checked-in/adventureworks/pe/pp/PpViewFields.scala
+++ b/typo-tester-zio-jdbc/generated-and-checked-in/adventureworks/pe/pp/PpViewFields.scala
@@ -11,38 +11,39 @@ import adventureworks.customtypes.TypoLocalDateTime
 import adventureworks.person.businessentity.BusinessentityId
 import adventureworks.person.phonenumbertype.PhonenumbertypeId
 import adventureworks.public.Phone
+import typo.dsl.Path
 import typo.dsl.SqlExpr.Field
 import typo.dsl.SqlExpr.FieldLikeNoHkt
 import typo.dsl.Structure.Relation
 
-trait PpViewFields[Row] {
-  val id: Field[BusinessentityId, Row]
-  val businessentityid: Field[BusinessentityId, Row]
-  val phonenumber: Field[Phone, Row]
-  val phonenumbertypeid: Field[PhonenumbertypeId, Row]
-  val modifieddate: Field[TypoLocalDateTime, Row]
+trait PpViewFields {
+  def id: Field[BusinessentityId, PpViewRow]
+  def businessentityid: Field[BusinessentityId, PpViewRow]
+  def phonenumber: Field[Phone, PpViewRow]
+  def phonenumbertypeid: Field[PhonenumbertypeId, PpViewRow]
+  def modifieddate: Field[TypoLocalDateTime, PpViewRow]
 }
 
 object PpViewFields {
-  val structure: Relation[PpViewFields, PpViewRow, PpViewRow] = 
-    new Impl(None, identity, (_, x) => x)
+  lazy val structure: Relation[PpViewFields, PpViewRow] =
+    new Impl(Nil)
     
-  private final class Impl[Row](val prefix: Option[String], val extract: Row => PpViewRow, val merge: (Row, PpViewRow) => Row)
-    extends Relation[PpViewFields, PpViewRow, Row] { 
+  private final class Impl(val _path: List[Path])
+    extends Relation[PpViewFields, PpViewRow] {
   
-    override val fields: PpViewFields[Row] = new PpViewFields[Row] {
-      override val id = new Field[BusinessentityId, Row](prefix, "id", None, None)(x => extract(x).id, (row, value) => merge(row, extract(row).copy(id = value)))
-      override val businessentityid = new Field[BusinessentityId, Row](prefix, "businessentityid", None, None)(x => extract(x).businessentityid, (row, value) => merge(row, extract(row).copy(businessentityid = value)))
-      override val phonenumber = new Field[Phone, Row](prefix, "phonenumber", None, None)(x => extract(x).phonenumber, (row, value) => merge(row, extract(row).copy(phonenumber = value)))
-      override val phonenumbertypeid = new Field[PhonenumbertypeId, Row](prefix, "phonenumbertypeid", None, None)(x => extract(x).phonenumbertypeid, (row, value) => merge(row, extract(row).copy(phonenumbertypeid = value)))
-      override val modifieddate = new Field[TypoLocalDateTime, Row](prefix, "modifieddate", Some("text"), None)(x => extract(x).modifieddate, (row, value) => merge(row, extract(row).copy(modifieddate = value)))
+    override lazy val fields: PpViewFields = new PpViewFields {
+      override def id = Field[BusinessentityId, PpViewRow](_path, "id", None, None, x => x.id, (row, value) => row.copy(id = value))
+      override def businessentityid = Field[BusinessentityId, PpViewRow](_path, "businessentityid", None, None, x => x.businessentityid, (row, value) => row.copy(businessentityid = value))
+      override def phonenumber = Field[Phone, PpViewRow](_path, "phonenumber", None, None, x => x.phonenumber, (row, value) => row.copy(phonenumber = value))
+      override def phonenumbertypeid = Field[PhonenumbertypeId, PpViewRow](_path, "phonenumbertypeid", None, None, x => x.phonenumbertypeid, (row, value) => row.copy(phonenumbertypeid = value))
+      override def modifieddate = Field[TypoLocalDateTime, PpViewRow](_path, "modifieddate", Some("text"), None, x => x.modifieddate, (row, value) => row.copy(modifieddate = value))
     }
   
-    override val columns: List[FieldLikeNoHkt[?, Row]] =
-      List[FieldLikeNoHkt[?, Row]](fields.id, fields.businessentityid, fields.phonenumber, fields.phonenumbertypeid, fields.modifieddate)
+    override lazy val columns: List[FieldLikeNoHkt[?, PpViewRow]] =
+      List[FieldLikeNoHkt[?, PpViewRow]](fields.id, fields.businessentityid, fields.phonenumber, fields.phonenumbertypeid, fields.modifieddate)
   
-    override def copy[NewRow](prefix: Option[String], extract: NewRow => PpViewRow, merge: (NewRow, PpViewRow) => NewRow): Impl[NewRow] =
-      new Impl(prefix, extract, merge)
+    override def copy(path: List[Path]): Impl =
+      new Impl(path)
   }
   
 }

--- a/typo-tester-zio-jdbc/generated-and-checked-in/adventureworks/pe/sp/SpViewFields.scala
+++ b/typo-tester-zio-jdbc/generated-and-checked-in/adventureworks/pe/sp/SpViewFields.scala
@@ -14,46 +14,47 @@ import adventureworks.person.stateprovince.StateprovinceId
 import adventureworks.public.Flag
 import adventureworks.public.Name
 import adventureworks.sales.salesterritory.SalesterritoryId
+import typo.dsl.Path
 import typo.dsl.SqlExpr.Field
 import typo.dsl.SqlExpr.FieldLikeNoHkt
 import typo.dsl.Structure.Relation
 
-trait SpViewFields[Row] {
-  val id: Field[StateprovinceId, Row]
-  val stateprovinceid: Field[StateprovinceId, Row]
-  val stateprovincecode: Field[/* bpchar, max 3 chars */ String, Row]
-  val countryregioncode: Field[CountryregionId, Row]
-  val isonlystateprovinceflag: Field[Flag, Row]
-  val name: Field[Name, Row]
-  val territoryid: Field[SalesterritoryId, Row]
-  val rowguid: Field[TypoUUID, Row]
-  val modifieddate: Field[TypoLocalDateTime, Row]
+trait SpViewFields {
+  def id: Field[StateprovinceId, SpViewRow]
+  def stateprovinceid: Field[StateprovinceId, SpViewRow]
+  def stateprovincecode: Field[/* bpchar, max 3 chars */ String, SpViewRow]
+  def countryregioncode: Field[CountryregionId, SpViewRow]
+  def isonlystateprovinceflag: Field[Flag, SpViewRow]
+  def name: Field[Name, SpViewRow]
+  def territoryid: Field[SalesterritoryId, SpViewRow]
+  def rowguid: Field[TypoUUID, SpViewRow]
+  def modifieddate: Field[TypoLocalDateTime, SpViewRow]
 }
 
 object SpViewFields {
-  val structure: Relation[SpViewFields, SpViewRow, SpViewRow] = 
-    new Impl(None, identity, (_, x) => x)
+  lazy val structure: Relation[SpViewFields, SpViewRow] =
+    new Impl(Nil)
     
-  private final class Impl[Row](val prefix: Option[String], val extract: Row => SpViewRow, val merge: (Row, SpViewRow) => Row)
-    extends Relation[SpViewFields, SpViewRow, Row] { 
+  private final class Impl(val _path: List[Path])
+    extends Relation[SpViewFields, SpViewRow] {
   
-    override val fields: SpViewFields[Row] = new SpViewFields[Row] {
-      override val id = new Field[StateprovinceId, Row](prefix, "id", None, None)(x => extract(x).id, (row, value) => merge(row, extract(row).copy(id = value)))
-      override val stateprovinceid = new Field[StateprovinceId, Row](prefix, "stateprovinceid", None, None)(x => extract(x).stateprovinceid, (row, value) => merge(row, extract(row).copy(stateprovinceid = value)))
-      override val stateprovincecode = new Field[/* bpchar, max 3 chars */ String, Row](prefix, "stateprovincecode", None, None)(x => extract(x).stateprovincecode, (row, value) => merge(row, extract(row).copy(stateprovincecode = value)))
-      override val countryregioncode = new Field[CountryregionId, Row](prefix, "countryregioncode", None, None)(x => extract(x).countryregioncode, (row, value) => merge(row, extract(row).copy(countryregioncode = value)))
-      override val isonlystateprovinceflag = new Field[Flag, Row](prefix, "isonlystateprovinceflag", None, None)(x => extract(x).isonlystateprovinceflag, (row, value) => merge(row, extract(row).copy(isonlystateprovinceflag = value)))
-      override val name = new Field[Name, Row](prefix, "name", None, None)(x => extract(x).name, (row, value) => merge(row, extract(row).copy(name = value)))
-      override val territoryid = new Field[SalesterritoryId, Row](prefix, "territoryid", None, None)(x => extract(x).territoryid, (row, value) => merge(row, extract(row).copy(territoryid = value)))
-      override val rowguid = new Field[TypoUUID, Row](prefix, "rowguid", None, None)(x => extract(x).rowguid, (row, value) => merge(row, extract(row).copy(rowguid = value)))
-      override val modifieddate = new Field[TypoLocalDateTime, Row](prefix, "modifieddate", Some("text"), None)(x => extract(x).modifieddate, (row, value) => merge(row, extract(row).copy(modifieddate = value)))
+    override lazy val fields: SpViewFields = new SpViewFields {
+      override def id = Field[StateprovinceId, SpViewRow](_path, "id", None, None, x => x.id, (row, value) => row.copy(id = value))
+      override def stateprovinceid = Field[StateprovinceId, SpViewRow](_path, "stateprovinceid", None, None, x => x.stateprovinceid, (row, value) => row.copy(stateprovinceid = value))
+      override def stateprovincecode = Field[/* bpchar, max 3 chars */ String, SpViewRow](_path, "stateprovincecode", None, None, x => x.stateprovincecode, (row, value) => row.copy(stateprovincecode = value))
+      override def countryregioncode = Field[CountryregionId, SpViewRow](_path, "countryregioncode", None, None, x => x.countryregioncode, (row, value) => row.copy(countryregioncode = value))
+      override def isonlystateprovinceflag = Field[Flag, SpViewRow](_path, "isonlystateprovinceflag", None, None, x => x.isonlystateprovinceflag, (row, value) => row.copy(isonlystateprovinceflag = value))
+      override def name = Field[Name, SpViewRow](_path, "name", None, None, x => x.name, (row, value) => row.copy(name = value))
+      override def territoryid = Field[SalesterritoryId, SpViewRow](_path, "territoryid", None, None, x => x.territoryid, (row, value) => row.copy(territoryid = value))
+      override def rowguid = Field[TypoUUID, SpViewRow](_path, "rowguid", None, None, x => x.rowguid, (row, value) => row.copy(rowguid = value))
+      override def modifieddate = Field[TypoLocalDateTime, SpViewRow](_path, "modifieddate", Some("text"), None, x => x.modifieddate, (row, value) => row.copy(modifieddate = value))
     }
   
-    override val columns: List[FieldLikeNoHkt[?, Row]] =
-      List[FieldLikeNoHkt[?, Row]](fields.id, fields.stateprovinceid, fields.stateprovincecode, fields.countryregioncode, fields.isonlystateprovinceflag, fields.name, fields.territoryid, fields.rowguid, fields.modifieddate)
+    override lazy val columns: List[FieldLikeNoHkt[?, SpViewRow]] =
+      List[FieldLikeNoHkt[?, SpViewRow]](fields.id, fields.stateprovinceid, fields.stateprovincecode, fields.countryregioncode, fields.isonlystateprovinceflag, fields.name, fields.territoryid, fields.rowguid, fields.modifieddate)
   
-    override def copy[NewRow](prefix: Option[String], extract: NewRow => SpViewRow, merge: (NewRow, SpViewRow) => NewRow): Impl[NewRow] =
-      new Impl(prefix, extract, merge)
+    override def copy(path: List[Path]): Impl =
+      new Impl(path)
   }
   
 }

--- a/typo-tester-zio-jdbc/generated-and-checked-in/adventureworks/person/address/AddressFields.scala
+++ b/typo-tester-zio-jdbc/generated-and-checked-in/adventureworks/person/address/AddressFields.scala
@@ -11,48 +11,49 @@ import adventureworks.customtypes.TypoBytea
 import adventureworks.customtypes.TypoLocalDateTime
 import adventureworks.customtypes.TypoUUID
 import adventureworks.person.stateprovince.StateprovinceId
+import typo.dsl.Path
 import typo.dsl.SqlExpr.Field
 import typo.dsl.SqlExpr.FieldLikeNoHkt
 import typo.dsl.SqlExpr.IdField
 import typo.dsl.SqlExpr.OptField
 import typo.dsl.Structure.Relation
 
-trait AddressFields[Row] {
-  val addressid: IdField[AddressId, Row]
-  val addressline1: Field[/* max 60 chars */ String, Row]
-  val addressline2: OptField[/* max 60 chars */ String, Row]
-  val city: Field[/* max 30 chars */ String, Row]
-  val stateprovinceid: Field[StateprovinceId, Row]
-  val postalcode: Field[/* max 15 chars */ String, Row]
-  val spatiallocation: OptField[TypoBytea, Row]
-  val rowguid: Field[TypoUUID, Row]
-  val modifieddate: Field[TypoLocalDateTime, Row]
+trait AddressFields {
+  def addressid: IdField[AddressId, AddressRow]
+  def addressline1: Field[/* max 60 chars */ String, AddressRow]
+  def addressline2: OptField[/* max 60 chars */ String, AddressRow]
+  def city: Field[/* max 30 chars */ String, AddressRow]
+  def stateprovinceid: Field[StateprovinceId, AddressRow]
+  def postalcode: Field[/* max 15 chars */ String, AddressRow]
+  def spatiallocation: OptField[TypoBytea, AddressRow]
+  def rowguid: Field[TypoUUID, AddressRow]
+  def modifieddate: Field[TypoLocalDateTime, AddressRow]
 }
 
 object AddressFields {
-  val structure: Relation[AddressFields, AddressRow, AddressRow] = 
-    new Impl(None, identity, (_, x) => x)
+  lazy val structure: Relation[AddressFields, AddressRow] =
+    new Impl(Nil)
     
-  private final class Impl[Row](val prefix: Option[String], val extract: Row => AddressRow, val merge: (Row, AddressRow) => Row)
-    extends Relation[AddressFields, AddressRow, Row] { 
+  private final class Impl(val _path: List[Path])
+    extends Relation[AddressFields, AddressRow] {
   
-    override val fields: AddressFields[Row] = new AddressFields[Row] {
-      override val addressid = new IdField[AddressId, Row](prefix, "addressid", None, Some("int4"))(x => extract(x).addressid, (row, value) => merge(row, extract(row).copy(addressid = value)))
-      override val addressline1 = new Field[/* max 60 chars */ String, Row](prefix, "addressline1", None, None)(x => extract(x).addressline1, (row, value) => merge(row, extract(row).copy(addressline1 = value)))
-      override val addressline2 = new OptField[/* max 60 chars */ String, Row](prefix, "addressline2", None, None)(x => extract(x).addressline2, (row, value) => merge(row, extract(row).copy(addressline2 = value)))
-      override val city = new Field[/* max 30 chars */ String, Row](prefix, "city", None, None)(x => extract(x).city, (row, value) => merge(row, extract(row).copy(city = value)))
-      override val stateprovinceid = new Field[StateprovinceId, Row](prefix, "stateprovinceid", None, Some("int4"))(x => extract(x).stateprovinceid, (row, value) => merge(row, extract(row).copy(stateprovinceid = value)))
-      override val postalcode = new Field[/* max 15 chars */ String, Row](prefix, "postalcode", None, None)(x => extract(x).postalcode, (row, value) => merge(row, extract(row).copy(postalcode = value)))
-      override val spatiallocation = new OptField[TypoBytea, Row](prefix, "spatiallocation", None, Some("bytea"))(x => extract(x).spatiallocation, (row, value) => merge(row, extract(row).copy(spatiallocation = value)))
-      override val rowguid = new Field[TypoUUID, Row](prefix, "rowguid", None, Some("uuid"))(x => extract(x).rowguid, (row, value) => merge(row, extract(row).copy(rowguid = value)))
-      override val modifieddate = new Field[TypoLocalDateTime, Row](prefix, "modifieddate", Some("text"), Some("timestamp"))(x => extract(x).modifieddate, (row, value) => merge(row, extract(row).copy(modifieddate = value)))
+    override lazy val fields: AddressFields = new AddressFields {
+      override def addressid = IdField[AddressId, AddressRow](_path, "addressid", None, Some("int4"), x => x.addressid, (row, value) => row.copy(addressid = value))
+      override def addressline1 = Field[/* max 60 chars */ String, AddressRow](_path, "addressline1", None, None, x => x.addressline1, (row, value) => row.copy(addressline1 = value))
+      override def addressline2 = OptField[/* max 60 chars */ String, AddressRow](_path, "addressline2", None, None, x => x.addressline2, (row, value) => row.copy(addressline2 = value))
+      override def city = Field[/* max 30 chars */ String, AddressRow](_path, "city", None, None, x => x.city, (row, value) => row.copy(city = value))
+      override def stateprovinceid = Field[StateprovinceId, AddressRow](_path, "stateprovinceid", None, Some("int4"), x => x.stateprovinceid, (row, value) => row.copy(stateprovinceid = value))
+      override def postalcode = Field[/* max 15 chars */ String, AddressRow](_path, "postalcode", None, None, x => x.postalcode, (row, value) => row.copy(postalcode = value))
+      override def spatiallocation = OptField[TypoBytea, AddressRow](_path, "spatiallocation", None, Some("bytea"), x => x.spatiallocation, (row, value) => row.copy(spatiallocation = value))
+      override def rowguid = Field[TypoUUID, AddressRow](_path, "rowguid", None, Some("uuid"), x => x.rowguid, (row, value) => row.copy(rowguid = value))
+      override def modifieddate = Field[TypoLocalDateTime, AddressRow](_path, "modifieddate", Some("text"), Some("timestamp"), x => x.modifieddate, (row, value) => row.copy(modifieddate = value))
     }
   
-    override val columns: List[FieldLikeNoHkt[?, Row]] =
-      List[FieldLikeNoHkt[?, Row]](fields.addressid, fields.addressline1, fields.addressline2, fields.city, fields.stateprovinceid, fields.postalcode, fields.spatiallocation, fields.rowguid, fields.modifieddate)
+    override lazy val columns: List[FieldLikeNoHkt[?, AddressRow]] =
+      List[FieldLikeNoHkt[?, AddressRow]](fields.addressid, fields.addressline1, fields.addressline2, fields.city, fields.stateprovinceid, fields.postalcode, fields.spatiallocation, fields.rowguid, fields.modifieddate)
   
-    override def copy[NewRow](prefix: Option[String], extract: NewRow => AddressRow, merge: (NewRow, AddressRow) => NewRow): Impl[NewRow] =
-      new Impl(prefix, extract, merge)
+    override def copy(path: List[Path]): Impl =
+      new Impl(path)
   }
   
 }

--- a/typo-tester-zio-jdbc/generated-and-checked-in/adventureworks/person/address/AddressRepoMock.scala
+++ b/typo-tester-zio-jdbc/generated-and-checked-in/adventureworks/person/address/AddressRepoMock.scala
@@ -26,7 +26,7 @@ import zio.stream.ZStream
 class AddressRepoMock(toRow: Function1[AddressRowUnsaved, AddressRow],
                       map: scala.collection.mutable.Map[AddressId, AddressRow] = scala.collection.mutable.Map.empty) extends AddressRepo {
   override def delete: DeleteBuilder[AddressFields, AddressRow] = {
-    DeleteBuilderMock(DeleteParams.empty, AddressFields.structure.fields, map)
+    DeleteBuilderMock(DeleteParams.empty, AddressFields.structure, map)
   }
   override def deleteById(addressid: AddressId): ZIO[ZConnection, Throwable, Boolean] = {
     ZIO.succeed(map.remove(addressid).isDefined)
@@ -85,7 +85,7 @@ class AddressRepoMock(toRow: Function1[AddressRowUnsaved, AddressRow],
     }
   }
   override def update: UpdateBuilder[AddressFields, AddressRow] = {
-    UpdateBuilderMock(UpdateParams.empty, AddressFields.structure.fields, map)
+    UpdateBuilderMock(UpdateParams.empty, AddressFields.structure, map)
   }
   override def update(row: AddressRow): ZIO[ZConnection, Throwable, Boolean] = {
     ZIO.succeed {

--- a/typo-tester-zio-jdbc/generated-and-checked-in/adventureworks/person/addresstype/AddresstypeFields.scala
+++ b/typo-tester-zio-jdbc/generated-and-checked-in/adventureworks/person/addresstype/AddresstypeFields.scala
@@ -10,37 +10,38 @@ package addresstype
 import adventureworks.customtypes.TypoLocalDateTime
 import adventureworks.customtypes.TypoUUID
 import adventureworks.public.Name
+import typo.dsl.Path
 import typo.dsl.SqlExpr.Field
 import typo.dsl.SqlExpr.FieldLikeNoHkt
 import typo.dsl.SqlExpr.IdField
 import typo.dsl.Structure.Relation
 
-trait AddresstypeFields[Row] {
-  val addresstypeid: IdField[AddresstypeId, Row]
-  val name: Field[Name, Row]
-  val rowguid: Field[TypoUUID, Row]
-  val modifieddate: Field[TypoLocalDateTime, Row]
+trait AddresstypeFields {
+  def addresstypeid: IdField[AddresstypeId, AddresstypeRow]
+  def name: Field[Name, AddresstypeRow]
+  def rowguid: Field[TypoUUID, AddresstypeRow]
+  def modifieddate: Field[TypoLocalDateTime, AddresstypeRow]
 }
 
 object AddresstypeFields {
-  val structure: Relation[AddresstypeFields, AddresstypeRow, AddresstypeRow] = 
-    new Impl(None, identity, (_, x) => x)
+  lazy val structure: Relation[AddresstypeFields, AddresstypeRow] =
+    new Impl(Nil)
     
-  private final class Impl[Row](val prefix: Option[String], val extract: Row => AddresstypeRow, val merge: (Row, AddresstypeRow) => Row)
-    extends Relation[AddresstypeFields, AddresstypeRow, Row] { 
+  private final class Impl(val _path: List[Path])
+    extends Relation[AddresstypeFields, AddresstypeRow] {
   
-    override val fields: AddresstypeFields[Row] = new AddresstypeFields[Row] {
-      override val addresstypeid = new IdField[AddresstypeId, Row](prefix, "addresstypeid", None, Some("int4"))(x => extract(x).addresstypeid, (row, value) => merge(row, extract(row).copy(addresstypeid = value)))
-      override val name = new Field[Name, Row](prefix, "name", None, Some("varchar"))(x => extract(x).name, (row, value) => merge(row, extract(row).copy(name = value)))
-      override val rowguid = new Field[TypoUUID, Row](prefix, "rowguid", None, Some("uuid"))(x => extract(x).rowguid, (row, value) => merge(row, extract(row).copy(rowguid = value)))
-      override val modifieddate = new Field[TypoLocalDateTime, Row](prefix, "modifieddate", Some("text"), Some("timestamp"))(x => extract(x).modifieddate, (row, value) => merge(row, extract(row).copy(modifieddate = value)))
+    override lazy val fields: AddresstypeFields = new AddresstypeFields {
+      override def addresstypeid = IdField[AddresstypeId, AddresstypeRow](_path, "addresstypeid", None, Some("int4"), x => x.addresstypeid, (row, value) => row.copy(addresstypeid = value))
+      override def name = Field[Name, AddresstypeRow](_path, "name", None, Some("varchar"), x => x.name, (row, value) => row.copy(name = value))
+      override def rowguid = Field[TypoUUID, AddresstypeRow](_path, "rowguid", None, Some("uuid"), x => x.rowguid, (row, value) => row.copy(rowguid = value))
+      override def modifieddate = Field[TypoLocalDateTime, AddresstypeRow](_path, "modifieddate", Some("text"), Some("timestamp"), x => x.modifieddate, (row, value) => row.copy(modifieddate = value))
     }
   
-    override val columns: List[FieldLikeNoHkt[?, Row]] =
-      List[FieldLikeNoHkt[?, Row]](fields.addresstypeid, fields.name, fields.rowguid, fields.modifieddate)
+    override lazy val columns: List[FieldLikeNoHkt[?, AddresstypeRow]] =
+      List[FieldLikeNoHkt[?, AddresstypeRow]](fields.addresstypeid, fields.name, fields.rowguid, fields.modifieddate)
   
-    override def copy[NewRow](prefix: Option[String], extract: NewRow => AddresstypeRow, merge: (NewRow, AddresstypeRow) => NewRow): Impl[NewRow] =
-      new Impl(prefix, extract, merge)
+    override def copy(path: List[Path]): Impl =
+      new Impl(path)
   }
   
 }

--- a/typo-tester-zio-jdbc/generated-and-checked-in/adventureworks/person/addresstype/AddresstypeRepoMock.scala
+++ b/typo-tester-zio-jdbc/generated-and-checked-in/adventureworks/person/addresstype/AddresstypeRepoMock.scala
@@ -26,7 +26,7 @@ import zio.stream.ZStream
 class AddresstypeRepoMock(toRow: Function1[AddresstypeRowUnsaved, AddresstypeRow],
                           map: scala.collection.mutable.Map[AddresstypeId, AddresstypeRow] = scala.collection.mutable.Map.empty) extends AddresstypeRepo {
   override def delete: DeleteBuilder[AddresstypeFields, AddresstypeRow] = {
-    DeleteBuilderMock(DeleteParams.empty, AddresstypeFields.structure.fields, map)
+    DeleteBuilderMock(DeleteParams.empty, AddresstypeFields.structure, map)
   }
   override def deleteById(addresstypeid: AddresstypeId): ZIO[ZConnection, Throwable, Boolean] = {
     ZIO.succeed(map.remove(addresstypeid).isDefined)
@@ -85,7 +85,7 @@ class AddresstypeRepoMock(toRow: Function1[AddresstypeRowUnsaved, AddresstypeRow
     }
   }
   override def update: UpdateBuilder[AddresstypeFields, AddresstypeRow] = {
-    UpdateBuilderMock(UpdateParams.empty, AddresstypeFields.structure.fields, map)
+    UpdateBuilderMock(UpdateParams.empty, AddresstypeFields.structure, map)
   }
   override def update(row: AddresstypeRow): ZIO[ZConnection, Throwable, Boolean] = {
     ZIO.succeed {

--- a/typo-tester-zio-jdbc/generated-and-checked-in/adventureworks/person/businessentity/BusinessentityRepoMock.scala
+++ b/typo-tester-zio-jdbc/generated-and-checked-in/adventureworks/person/businessentity/BusinessentityRepoMock.scala
@@ -26,7 +26,7 @@ import zio.stream.ZStream
 class BusinessentityRepoMock(toRow: Function1[BusinessentityRowUnsaved, BusinessentityRow],
                              map: scala.collection.mutable.Map[BusinessentityId, BusinessentityRow] = scala.collection.mutable.Map.empty) extends BusinessentityRepo {
   override def delete: DeleteBuilder[BusinessentityFields, BusinessentityRow] = {
-    DeleteBuilderMock(DeleteParams.empty, BusinessentityFields.structure.fields, map)
+    DeleteBuilderMock(DeleteParams.empty, BusinessentityFields.structure, map)
   }
   override def deleteById(businessentityid: BusinessentityId): ZIO[ZConnection, Throwable, Boolean] = {
     ZIO.succeed(map.remove(businessentityid).isDefined)
@@ -85,7 +85,7 @@ class BusinessentityRepoMock(toRow: Function1[BusinessentityRowUnsaved, Business
     }
   }
   override def update: UpdateBuilder[BusinessentityFields, BusinessentityRow] = {
-    UpdateBuilderMock(UpdateParams.empty, BusinessentityFields.structure.fields, map)
+    UpdateBuilderMock(UpdateParams.empty, BusinessentityFields.structure, map)
   }
   override def update(row: BusinessentityRow): ZIO[ZConnection, Throwable, Boolean] = {
     ZIO.succeed {

--- a/typo-tester-zio-jdbc/generated-and-checked-in/adventureworks/person/businessentityaddress/BusinessentityaddressFields.scala
+++ b/typo-tester-zio-jdbc/generated-and-checked-in/adventureworks/person/businessentityaddress/BusinessentityaddressFields.scala
@@ -12,39 +12,40 @@ import adventureworks.customtypes.TypoUUID
 import adventureworks.person.address.AddressId
 import adventureworks.person.addresstype.AddresstypeId
 import adventureworks.person.businessentity.BusinessentityId
+import typo.dsl.Path
 import typo.dsl.SqlExpr.Field
 import typo.dsl.SqlExpr.FieldLikeNoHkt
 import typo.dsl.SqlExpr.IdField
 import typo.dsl.Structure.Relation
 
-trait BusinessentityaddressFields[Row] {
-  val businessentityid: IdField[BusinessentityId, Row]
-  val addressid: IdField[AddressId, Row]
-  val addresstypeid: IdField[AddresstypeId, Row]
-  val rowguid: Field[TypoUUID, Row]
-  val modifieddate: Field[TypoLocalDateTime, Row]
+trait BusinessentityaddressFields {
+  def businessentityid: IdField[BusinessentityId, BusinessentityaddressRow]
+  def addressid: IdField[AddressId, BusinessentityaddressRow]
+  def addresstypeid: IdField[AddresstypeId, BusinessentityaddressRow]
+  def rowguid: Field[TypoUUID, BusinessentityaddressRow]
+  def modifieddate: Field[TypoLocalDateTime, BusinessentityaddressRow]
 }
 
 object BusinessentityaddressFields {
-  val structure: Relation[BusinessentityaddressFields, BusinessentityaddressRow, BusinessentityaddressRow] = 
-    new Impl(None, identity, (_, x) => x)
+  lazy val structure: Relation[BusinessentityaddressFields, BusinessentityaddressRow] =
+    new Impl(Nil)
     
-  private final class Impl[Row](val prefix: Option[String], val extract: Row => BusinessentityaddressRow, val merge: (Row, BusinessentityaddressRow) => Row)
-    extends Relation[BusinessentityaddressFields, BusinessentityaddressRow, Row] { 
+  private final class Impl(val _path: List[Path])
+    extends Relation[BusinessentityaddressFields, BusinessentityaddressRow] {
   
-    override val fields: BusinessentityaddressFields[Row] = new BusinessentityaddressFields[Row] {
-      override val businessentityid = new IdField[BusinessentityId, Row](prefix, "businessentityid", None, Some("int4"))(x => extract(x).businessentityid, (row, value) => merge(row, extract(row).copy(businessentityid = value)))
-      override val addressid = new IdField[AddressId, Row](prefix, "addressid", None, Some("int4"))(x => extract(x).addressid, (row, value) => merge(row, extract(row).copy(addressid = value)))
-      override val addresstypeid = new IdField[AddresstypeId, Row](prefix, "addresstypeid", None, Some("int4"))(x => extract(x).addresstypeid, (row, value) => merge(row, extract(row).copy(addresstypeid = value)))
-      override val rowguid = new Field[TypoUUID, Row](prefix, "rowguid", None, Some("uuid"))(x => extract(x).rowguid, (row, value) => merge(row, extract(row).copy(rowguid = value)))
-      override val modifieddate = new Field[TypoLocalDateTime, Row](prefix, "modifieddate", Some("text"), Some("timestamp"))(x => extract(x).modifieddate, (row, value) => merge(row, extract(row).copy(modifieddate = value)))
+    override lazy val fields: BusinessentityaddressFields = new BusinessentityaddressFields {
+      override def businessentityid = IdField[BusinessentityId, BusinessentityaddressRow](_path, "businessentityid", None, Some("int4"), x => x.businessentityid, (row, value) => row.copy(businessentityid = value))
+      override def addressid = IdField[AddressId, BusinessentityaddressRow](_path, "addressid", None, Some("int4"), x => x.addressid, (row, value) => row.copy(addressid = value))
+      override def addresstypeid = IdField[AddresstypeId, BusinessentityaddressRow](_path, "addresstypeid", None, Some("int4"), x => x.addresstypeid, (row, value) => row.copy(addresstypeid = value))
+      override def rowguid = Field[TypoUUID, BusinessentityaddressRow](_path, "rowguid", None, Some("uuid"), x => x.rowguid, (row, value) => row.copy(rowguid = value))
+      override def modifieddate = Field[TypoLocalDateTime, BusinessentityaddressRow](_path, "modifieddate", Some("text"), Some("timestamp"), x => x.modifieddate, (row, value) => row.copy(modifieddate = value))
     }
   
-    override val columns: List[FieldLikeNoHkt[?, Row]] =
-      List[FieldLikeNoHkt[?, Row]](fields.businessentityid, fields.addressid, fields.addresstypeid, fields.rowguid, fields.modifieddate)
+    override lazy val columns: List[FieldLikeNoHkt[?, BusinessentityaddressRow]] =
+      List[FieldLikeNoHkt[?, BusinessentityaddressRow]](fields.businessentityid, fields.addressid, fields.addresstypeid, fields.rowguid, fields.modifieddate)
   
-    override def copy[NewRow](prefix: Option[String], extract: NewRow => BusinessentityaddressRow, merge: (NewRow, BusinessentityaddressRow) => NewRow): Impl[NewRow] =
-      new Impl(prefix, extract, merge)
+    override def copy(path: List[Path]): Impl =
+      new Impl(path)
   }
   
 }

--- a/typo-tester-zio-jdbc/generated-and-checked-in/adventureworks/person/businessentityaddress/BusinessentityaddressRepoMock.scala
+++ b/typo-tester-zio-jdbc/generated-and-checked-in/adventureworks/person/businessentityaddress/BusinessentityaddressRepoMock.scala
@@ -26,7 +26,7 @@ import zio.stream.ZStream
 class BusinessentityaddressRepoMock(toRow: Function1[BusinessentityaddressRowUnsaved, BusinessentityaddressRow],
                                     map: scala.collection.mutable.Map[BusinessentityaddressId, BusinessentityaddressRow] = scala.collection.mutable.Map.empty) extends BusinessentityaddressRepo {
   override def delete: DeleteBuilder[BusinessentityaddressFields, BusinessentityaddressRow] = {
-    DeleteBuilderMock(DeleteParams.empty, BusinessentityaddressFields.structure.fields, map)
+    DeleteBuilderMock(DeleteParams.empty, BusinessentityaddressFields.structure, map)
   }
   override def deleteById(compositeId: BusinessentityaddressId): ZIO[ZConnection, Throwable, Boolean] = {
     ZIO.succeed(map.remove(compositeId).isDefined)
@@ -85,7 +85,7 @@ class BusinessentityaddressRepoMock(toRow: Function1[BusinessentityaddressRowUns
     }
   }
   override def update: UpdateBuilder[BusinessentityaddressFields, BusinessentityaddressRow] = {
-    UpdateBuilderMock(UpdateParams.empty, BusinessentityaddressFields.structure.fields, map)
+    UpdateBuilderMock(UpdateParams.empty, BusinessentityaddressFields.structure, map)
   }
   override def update(row: BusinessentityaddressRow): ZIO[ZConnection, Throwable, Boolean] = {
     ZIO.succeed {

--- a/typo-tester-zio-jdbc/generated-and-checked-in/adventureworks/person/businessentitycontact/BusinessentitycontactFields.scala
+++ b/typo-tester-zio-jdbc/generated-and-checked-in/adventureworks/person/businessentitycontact/BusinessentitycontactFields.scala
@@ -11,39 +11,40 @@ import adventureworks.customtypes.TypoLocalDateTime
 import adventureworks.customtypes.TypoUUID
 import adventureworks.person.businessentity.BusinessentityId
 import adventureworks.person.contacttype.ContacttypeId
+import typo.dsl.Path
 import typo.dsl.SqlExpr.Field
 import typo.dsl.SqlExpr.FieldLikeNoHkt
 import typo.dsl.SqlExpr.IdField
 import typo.dsl.Structure.Relation
 
-trait BusinessentitycontactFields[Row] {
-  val businessentityid: IdField[BusinessentityId, Row]
-  val personid: IdField[BusinessentityId, Row]
-  val contacttypeid: IdField[ContacttypeId, Row]
-  val rowguid: Field[TypoUUID, Row]
-  val modifieddate: Field[TypoLocalDateTime, Row]
+trait BusinessentitycontactFields {
+  def businessentityid: IdField[BusinessentityId, BusinessentitycontactRow]
+  def personid: IdField[BusinessentityId, BusinessentitycontactRow]
+  def contacttypeid: IdField[ContacttypeId, BusinessentitycontactRow]
+  def rowguid: Field[TypoUUID, BusinessentitycontactRow]
+  def modifieddate: Field[TypoLocalDateTime, BusinessentitycontactRow]
 }
 
 object BusinessentitycontactFields {
-  val structure: Relation[BusinessentitycontactFields, BusinessentitycontactRow, BusinessentitycontactRow] = 
-    new Impl(None, identity, (_, x) => x)
+  lazy val structure: Relation[BusinessentitycontactFields, BusinessentitycontactRow] =
+    new Impl(Nil)
     
-  private final class Impl[Row](val prefix: Option[String], val extract: Row => BusinessentitycontactRow, val merge: (Row, BusinessentitycontactRow) => Row)
-    extends Relation[BusinessentitycontactFields, BusinessentitycontactRow, Row] { 
+  private final class Impl(val _path: List[Path])
+    extends Relation[BusinessentitycontactFields, BusinessentitycontactRow] {
   
-    override val fields: BusinessentitycontactFields[Row] = new BusinessentitycontactFields[Row] {
-      override val businessentityid = new IdField[BusinessentityId, Row](prefix, "businessentityid", None, Some("int4"))(x => extract(x).businessentityid, (row, value) => merge(row, extract(row).copy(businessentityid = value)))
-      override val personid = new IdField[BusinessentityId, Row](prefix, "personid", None, Some("int4"))(x => extract(x).personid, (row, value) => merge(row, extract(row).copy(personid = value)))
-      override val contacttypeid = new IdField[ContacttypeId, Row](prefix, "contacttypeid", None, Some("int4"))(x => extract(x).contacttypeid, (row, value) => merge(row, extract(row).copy(contacttypeid = value)))
-      override val rowguid = new Field[TypoUUID, Row](prefix, "rowguid", None, Some("uuid"))(x => extract(x).rowguid, (row, value) => merge(row, extract(row).copy(rowguid = value)))
-      override val modifieddate = new Field[TypoLocalDateTime, Row](prefix, "modifieddate", Some("text"), Some("timestamp"))(x => extract(x).modifieddate, (row, value) => merge(row, extract(row).copy(modifieddate = value)))
+    override lazy val fields: BusinessentitycontactFields = new BusinessentitycontactFields {
+      override def businessentityid = IdField[BusinessentityId, BusinessentitycontactRow](_path, "businessentityid", None, Some("int4"), x => x.businessentityid, (row, value) => row.copy(businessentityid = value))
+      override def personid = IdField[BusinessentityId, BusinessentitycontactRow](_path, "personid", None, Some("int4"), x => x.personid, (row, value) => row.copy(personid = value))
+      override def contacttypeid = IdField[ContacttypeId, BusinessentitycontactRow](_path, "contacttypeid", None, Some("int4"), x => x.contacttypeid, (row, value) => row.copy(contacttypeid = value))
+      override def rowguid = Field[TypoUUID, BusinessentitycontactRow](_path, "rowguid", None, Some("uuid"), x => x.rowguid, (row, value) => row.copy(rowguid = value))
+      override def modifieddate = Field[TypoLocalDateTime, BusinessentitycontactRow](_path, "modifieddate", Some("text"), Some("timestamp"), x => x.modifieddate, (row, value) => row.copy(modifieddate = value))
     }
   
-    override val columns: List[FieldLikeNoHkt[?, Row]] =
-      List[FieldLikeNoHkt[?, Row]](fields.businessentityid, fields.personid, fields.contacttypeid, fields.rowguid, fields.modifieddate)
+    override lazy val columns: List[FieldLikeNoHkt[?, BusinessentitycontactRow]] =
+      List[FieldLikeNoHkt[?, BusinessentitycontactRow]](fields.businessentityid, fields.personid, fields.contacttypeid, fields.rowguid, fields.modifieddate)
   
-    override def copy[NewRow](prefix: Option[String], extract: NewRow => BusinessentitycontactRow, merge: (NewRow, BusinessentitycontactRow) => NewRow): Impl[NewRow] =
-      new Impl(prefix, extract, merge)
+    override def copy(path: List[Path]): Impl =
+      new Impl(path)
   }
   
 }

--- a/typo-tester-zio-jdbc/generated-and-checked-in/adventureworks/person/businessentitycontact/BusinessentitycontactRepoMock.scala
+++ b/typo-tester-zio-jdbc/generated-and-checked-in/adventureworks/person/businessentitycontact/BusinessentitycontactRepoMock.scala
@@ -26,7 +26,7 @@ import zio.stream.ZStream
 class BusinessentitycontactRepoMock(toRow: Function1[BusinessentitycontactRowUnsaved, BusinessentitycontactRow],
                                     map: scala.collection.mutable.Map[BusinessentitycontactId, BusinessentitycontactRow] = scala.collection.mutable.Map.empty) extends BusinessentitycontactRepo {
   override def delete: DeleteBuilder[BusinessentitycontactFields, BusinessentitycontactRow] = {
-    DeleteBuilderMock(DeleteParams.empty, BusinessentitycontactFields.structure.fields, map)
+    DeleteBuilderMock(DeleteParams.empty, BusinessentitycontactFields.structure, map)
   }
   override def deleteById(compositeId: BusinessentitycontactId): ZIO[ZConnection, Throwable, Boolean] = {
     ZIO.succeed(map.remove(compositeId).isDefined)
@@ -85,7 +85,7 @@ class BusinessentitycontactRepoMock(toRow: Function1[BusinessentitycontactRowUns
     }
   }
   override def update: UpdateBuilder[BusinessentitycontactFields, BusinessentitycontactRow] = {
-    UpdateBuilderMock(UpdateParams.empty, BusinessentitycontactFields.structure.fields, map)
+    UpdateBuilderMock(UpdateParams.empty, BusinessentitycontactFields.structure, map)
   }
   override def update(row: BusinessentitycontactRow): ZIO[ZConnection, Throwable, Boolean] = {
     ZIO.succeed {

--- a/typo-tester-zio-jdbc/generated-and-checked-in/adventureworks/person/contacttype/ContacttypeFields.scala
+++ b/typo-tester-zio-jdbc/generated-and-checked-in/adventureworks/person/contacttype/ContacttypeFields.scala
@@ -9,35 +9,36 @@ package contacttype
 
 import adventureworks.customtypes.TypoLocalDateTime
 import adventureworks.public.Name
+import typo.dsl.Path
 import typo.dsl.SqlExpr.Field
 import typo.dsl.SqlExpr.FieldLikeNoHkt
 import typo.dsl.SqlExpr.IdField
 import typo.dsl.Structure.Relation
 
-trait ContacttypeFields[Row] {
-  val contacttypeid: IdField[ContacttypeId, Row]
-  val name: Field[Name, Row]
-  val modifieddate: Field[TypoLocalDateTime, Row]
+trait ContacttypeFields {
+  def contacttypeid: IdField[ContacttypeId, ContacttypeRow]
+  def name: Field[Name, ContacttypeRow]
+  def modifieddate: Field[TypoLocalDateTime, ContacttypeRow]
 }
 
 object ContacttypeFields {
-  val structure: Relation[ContacttypeFields, ContacttypeRow, ContacttypeRow] = 
-    new Impl(None, identity, (_, x) => x)
+  lazy val structure: Relation[ContacttypeFields, ContacttypeRow] =
+    new Impl(Nil)
     
-  private final class Impl[Row](val prefix: Option[String], val extract: Row => ContacttypeRow, val merge: (Row, ContacttypeRow) => Row)
-    extends Relation[ContacttypeFields, ContacttypeRow, Row] { 
+  private final class Impl(val _path: List[Path])
+    extends Relation[ContacttypeFields, ContacttypeRow] {
   
-    override val fields: ContacttypeFields[Row] = new ContacttypeFields[Row] {
-      override val contacttypeid = new IdField[ContacttypeId, Row](prefix, "contacttypeid", None, Some("int4"))(x => extract(x).contacttypeid, (row, value) => merge(row, extract(row).copy(contacttypeid = value)))
-      override val name = new Field[Name, Row](prefix, "name", None, Some("varchar"))(x => extract(x).name, (row, value) => merge(row, extract(row).copy(name = value)))
-      override val modifieddate = new Field[TypoLocalDateTime, Row](prefix, "modifieddate", Some("text"), Some("timestamp"))(x => extract(x).modifieddate, (row, value) => merge(row, extract(row).copy(modifieddate = value)))
+    override lazy val fields: ContacttypeFields = new ContacttypeFields {
+      override def contacttypeid = IdField[ContacttypeId, ContacttypeRow](_path, "contacttypeid", None, Some("int4"), x => x.contacttypeid, (row, value) => row.copy(contacttypeid = value))
+      override def name = Field[Name, ContacttypeRow](_path, "name", None, Some("varchar"), x => x.name, (row, value) => row.copy(name = value))
+      override def modifieddate = Field[TypoLocalDateTime, ContacttypeRow](_path, "modifieddate", Some("text"), Some("timestamp"), x => x.modifieddate, (row, value) => row.copy(modifieddate = value))
     }
   
-    override val columns: List[FieldLikeNoHkt[?, Row]] =
-      List[FieldLikeNoHkt[?, Row]](fields.contacttypeid, fields.name, fields.modifieddate)
+    override lazy val columns: List[FieldLikeNoHkt[?, ContacttypeRow]] =
+      List[FieldLikeNoHkt[?, ContacttypeRow]](fields.contacttypeid, fields.name, fields.modifieddate)
   
-    override def copy[NewRow](prefix: Option[String], extract: NewRow => ContacttypeRow, merge: (NewRow, ContacttypeRow) => NewRow): Impl[NewRow] =
-      new Impl(prefix, extract, merge)
+    override def copy(path: List[Path]): Impl =
+      new Impl(path)
   }
   
 }

--- a/typo-tester-zio-jdbc/generated-and-checked-in/adventureworks/person/contacttype/ContacttypeRepoMock.scala
+++ b/typo-tester-zio-jdbc/generated-and-checked-in/adventureworks/person/contacttype/ContacttypeRepoMock.scala
@@ -26,7 +26,7 @@ import zio.stream.ZStream
 class ContacttypeRepoMock(toRow: Function1[ContacttypeRowUnsaved, ContacttypeRow],
                           map: scala.collection.mutable.Map[ContacttypeId, ContacttypeRow] = scala.collection.mutable.Map.empty) extends ContacttypeRepo {
   override def delete: DeleteBuilder[ContacttypeFields, ContacttypeRow] = {
-    DeleteBuilderMock(DeleteParams.empty, ContacttypeFields.structure.fields, map)
+    DeleteBuilderMock(DeleteParams.empty, ContacttypeFields.structure, map)
   }
   override def deleteById(contacttypeid: ContacttypeId): ZIO[ZConnection, Throwable, Boolean] = {
     ZIO.succeed(map.remove(contacttypeid).isDefined)
@@ -85,7 +85,7 @@ class ContacttypeRepoMock(toRow: Function1[ContacttypeRowUnsaved, ContacttypeRow
     }
   }
   override def update: UpdateBuilder[ContacttypeFields, ContacttypeRow] = {
-    UpdateBuilderMock(UpdateParams.empty, ContacttypeFields.structure.fields, map)
+    UpdateBuilderMock(UpdateParams.empty, ContacttypeFields.structure, map)
   }
   override def update(row: ContacttypeRow): ZIO[ZConnection, Throwable, Boolean] = {
     ZIO.succeed {

--- a/typo-tester-zio-jdbc/generated-and-checked-in/adventureworks/person/countryregion/CountryregionFields.scala
+++ b/typo-tester-zio-jdbc/generated-and-checked-in/adventureworks/person/countryregion/CountryregionFields.scala
@@ -9,35 +9,36 @@ package countryregion
 
 import adventureworks.customtypes.TypoLocalDateTime
 import adventureworks.public.Name
+import typo.dsl.Path
 import typo.dsl.SqlExpr.Field
 import typo.dsl.SqlExpr.FieldLikeNoHkt
 import typo.dsl.SqlExpr.IdField
 import typo.dsl.Structure.Relation
 
-trait CountryregionFields[Row] {
-  val countryregioncode: IdField[CountryregionId, Row]
-  val name: Field[Name, Row]
-  val modifieddate: Field[TypoLocalDateTime, Row]
+trait CountryregionFields {
+  def countryregioncode: IdField[CountryregionId, CountryregionRow]
+  def name: Field[Name, CountryregionRow]
+  def modifieddate: Field[TypoLocalDateTime, CountryregionRow]
 }
 
 object CountryregionFields {
-  val structure: Relation[CountryregionFields, CountryregionRow, CountryregionRow] = 
-    new Impl(None, identity, (_, x) => x)
+  lazy val structure: Relation[CountryregionFields, CountryregionRow] =
+    new Impl(Nil)
     
-  private final class Impl[Row](val prefix: Option[String], val extract: Row => CountryregionRow, val merge: (Row, CountryregionRow) => Row)
-    extends Relation[CountryregionFields, CountryregionRow, Row] { 
+  private final class Impl(val _path: List[Path])
+    extends Relation[CountryregionFields, CountryregionRow] {
   
-    override val fields: CountryregionFields[Row] = new CountryregionFields[Row] {
-      override val countryregioncode = new IdField[CountryregionId, Row](prefix, "countryregioncode", None, None)(x => extract(x).countryregioncode, (row, value) => merge(row, extract(row).copy(countryregioncode = value)))
-      override val name = new Field[Name, Row](prefix, "name", None, Some("varchar"))(x => extract(x).name, (row, value) => merge(row, extract(row).copy(name = value)))
-      override val modifieddate = new Field[TypoLocalDateTime, Row](prefix, "modifieddate", Some("text"), Some("timestamp"))(x => extract(x).modifieddate, (row, value) => merge(row, extract(row).copy(modifieddate = value)))
+    override lazy val fields: CountryregionFields = new CountryregionFields {
+      override def countryregioncode = IdField[CountryregionId, CountryregionRow](_path, "countryregioncode", None, None, x => x.countryregioncode, (row, value) => row.copy(countryregioncode = value))
+      override def name = Field[Name, CountryregionRow](_path, "name", None, Some("varchar"), x => x.name, (row, value) => row.copy(name = value))
+      override def modifieddate = Field[TypoLocalDateTime, CountryregionRow](_path, "modifieddate", Some("text"), Some("timestamp"), x => x.modifieddate, (row, value) => row.copy(modifieddate = value))
     }
   
-    override val columns: List[FieldLikeNoHkt[?, Row]] =
-      List[FieldLikeNoHkt[?, Row]](fields.countryregioncode, fields.name, fields.modifieddate)
+    override lazy val columns: List[FieldLikeNoHkt[?, CountryregionRow]] =
+      List[FieldLikeNoHkt[?, CountryregionRow]](fields.countryregioncode, fields.name, fields.modifieddate)
   
-    override def copy[NewRow](prefix: Option[String], extract: NewRow => CountryregionRow, merge: (NewRow, CountryregionRow) => NewRow): Impl[NewRow] =
-      new Impl(prefix, extract, merge)
+    override def copy(path: List[Path]): Impl =
+      new Impl(path)
   }
   
 }

--- a/typo-tester-zio-jdbc/generated-and-checked-in/adventureworks/person/countryregion/CountryregionRepoMock.scala
+++ b/typo-tester-zio-jdbc/generated-and-checked-in/adventureworks/person/countryregion/CountryregionRepoMock.scala
@@ -26,7 +26,7 @@ import zio.stream.ZStream
 class CountryregionRepoMock(toRow: Function1[CountryregionRowUnsaved, CountryregionRow],
                             map: scala.collection.mutable.Map[CountryregionId, CountryregionRow] = scala.collection.mutable.Map.empty) extends CountryregionRepo {
   override def delete: DeleteBuilder[CountryregionFields, CountryregionRow] = {
-    DeleteBuilderMock(DeleteParams.empty, CountryregionFields.structure.fields, map)
+    DeleteBuilderMock(DeleteParams.empty, CountryregionFields.structure, map)
   }
   override def deleteById(countryregioncode: CountryregionId): ZIO[ZConnection, Throwable, Boolean] = {
     ZIO.succeed(map.remove(countryregioncode).isDefined)
@@ -85,7 +85,7 @@ class CountryregionRepoMock(toRow: Function1[CountryregionRowUnsaved, Countryreg
     }
   }
   override def update: UpdateBuilder[CountryregionFields, CountryregionRow] = {
-    UpdateBuilderMock(UpdateParams.empty, CountryregionFields.structure.fields, map)
+    UpdateBuilderMock(UpdateParams.empty, CountryregionFields.structure, map)
   }
   override def update(row: CountryregionRow): ZIO[ZConnection, Throwable, Boolean] = {
     ZIO.succeed {

--- a/typo-tester-zio-jdbc/generated-and-checked-in/adventureworks/person/emailaddress/EmailaddressFields.scala
+++ b/typo-tester-zio-jdbc/generated-and-checked-in/adventureworks/person/emailaddress/EmailaddressFields.scala
@@ -10,40 +10,41 @@ package emailaddress
 import adventureworks.customtypes.TypoLocalDateTime
 import adventureworks.customtypes.TypoUUID
 import adventureworks.person.businessentity.BusinessentityId
+import typo.dsl.Path
 import typo.dsl.SqlExpr.Field
 import typo.dsl.SqlExpr.FieldLikeNoHkt
 import typo.dsl.SqlExpr.IdField
 import typo.dsl.SqlExpr.OptField
 import typo.dsl.Structure.Relation
 
-trait EmailaddressFields[Row] {
-  val businessentityid: IdField[BusinessentityId, Row]
-  val emailaddressid: IdField[Int, Row]
-  val emailaddress: OptField[/* max 50 chars */ String, Row]
-  val rowguid: Field[TypoUUID, Row]
-  val modifieddate: Field[TypoLocalDateTime, Row]
+trait EmailaddressFields {
+  def businessentityid: IdField[BusinessentityId, EmailaddressRow]
+  def emailaddressid: IdField[Int, EmailaddressRow]
+  def emailaddress: OptField[/* max 50 chars */ String, EmailaddressRow]
+  def rowguid: Field[TypoUUID, EmailaddressRow]
+  def modifieddate: Field[TypoLocalDateTime, EmailaddressRow]
 }
 
 object EmailaddressFields {
-  val structure: Relation[EmailaddressFields, EmailaddressRow, EmailaddressRow] = 
-    new Impl(None, identity, (_, x) => x)
+  lazy val structure: Relation[EmailaddressFields, EmailaddressRow] =
+    new Impl(Nil)
     
-  private final class Impl[Row](val prefix: Option[String], val extract: Row => EmailaddressRow, val merge: (Row, EmailaddressRow) => Row)
-    extends Relation[EmailaddressFields, EmailaddressRow, Row] { 
+  private final class Impl(val _path: List[Path])
+    extends Relation[EmailaddressFields, EmailaddressRow] {
   
-    override val fields: EmailaddressFields[Row] = new EmailaddressFields[Row] {
-      override val businessentityid = new IdField[BusinessentityId, Row](prefix, "businessentityid", None, Some("int4"))(x => extract(x).businessentityid, (row, value) => merge(row, extract(row).copy(businessentityid = value)))
-      override val emailaddressid = new IdField[Int, Row](prefix, "emailaddressid", None, Some("int4"))(x => extract(x).emailaddressid, (row, value) => merge(row, extract(row).copy(emailaddressid = value)))
-      override val emailaddress = new OptField[/* max 50 chars */ String, Row](prefix, "emailaddress", None, None)(x => extract(x).emailaddress, (row, value) => merge(row, extract(row).copy(emailaddress = value)))
-      override val rowguid = new Field[TypoUUID, Row](prefix, "rowguid", None, Some("uuid"))(x => extract(x).rowguid, (row, value) => merge(row, extract(row).copy(rowguid = value)))
-      override val modifieddate = new Field[TypoLocalDateTime, Row](prefix, "modifieddate", Some("text"), Some("timestamp"))(x => extract(x).modifieddate, (row, value) => merge(row, extract(row).copy(modifieddate = value)))
+    override lazy val fields: EmailaddressFields = new EmailaddressFields {
+      override def businessentityid = IdField[BusinessentityId, EmailaddressRow](_path, "businessentityid", None, Some("int4"), x => x.businessentityid, (row, value) => row.copy(businessentityid = value))
+      override def emailaddressid = IdField[Int, EmailaddressRow](_path, "emailaddressid", None, Some("int4"), x => x.emailaddressid, (row, value) => row.copy(emailaddressid = value))
+      override def emailaddress = OptField[/* max 50 chars */ String, EmailaddressRow](_path, "emailaddress", None, None, x => x.emailaddress, (row, value) => row.copy(emailaddress = value))
+      override def rowguid = Field[TypoUUID, EmailaddressRow](_path, "rowguid", None, Some("uuid"), x => x.rowguid, (row, value) => row.copy(rowguid = value))
+      override def modifieddate = Field[TypoLocalDateTime, EmailaddressRow](_path, "modifieddate", Some("text"), Some("timestamp"), x => x.modifieddate, (row, value) => row.copy(modifieddate = value))
     }
   
-    override val columns: List[FieldLikeNoHkt[?, Row]] =
-      List[FieldLikeNoHkt[?, Row]](fields.businessentityid, fields.emailaddressid, fields.emailaddress, fields.rowguid, fields.modifieddate)
+    override lazy val columns: List[FieldLikeNoHkt[?, EmailaddressRow]] =
+      List[FieldLikeNoHkt[?, EmailaddressRow]](fields.businessentityid, fields.emailaddressid, fields.emailaddress, fields.rowguid, fields.modifieddate)
   
-    override def copy[NewRow](prefix: Option[String], extract: NewRow => EmailaddressRow, merge: (NewRow, EmailaddressRow) => NewRow): Impl[NewRow] =
-      new Impl(prefix, extract, merge)
+    override def copy(path: List[Path]): Impl =
+      new Impl(path)
   }
   
 }

--- a/typo-tester-zio-jdbc/generated-and-checked-in/adventureworks/person/emailaddress/EmailaddressRepoMock.scala
+++ b/typo-tester-zio-jdbc/generated-and-checked-in/adventureworks/person/emailaddress/EmailaddressRepoMock.scala
@@ -26,7 +26,7 @@ import zio.stream.ZStream
 class EmailaddressRepoMock(toRow: Function1[EmailaddressRowUnsaved, EmailaddressRow],
                            map: scala.collection.mutable.Map[EmailaddressId, EmailaddressRow] = scala.collection.mutable.Map.empty) extends EmailaddressRepo {
   override def delete: DeleteBuilder[EmailaddressFields, EmailaddressRow] = {
-    DeleteBuilderMock(DeleteParams.empty, EmailaddressFields.structure.fields, map)
+    DeleteBuilderMock(DeleteParams.empty, EmailaddressFields.structure, map)
   }
   override def deleteById(compositeId: EmailaddressId): ZIO[ZConnection, Throwable, Boolean] = {
     ZIO.succeed(map.remove(compositeId).isDefined)
@@ -85,7 +85,7 @@ class EmailaddressRepoMock(toRow: Function1[EmailaddressRowUnsaved, Emailaddress
     }
   }
   override def update: UpdateBuilder[EmailaddressFields, EmailaddressRow] = {
-    UpdateBuilderMock(UpdateParams.empty, EmailaddressFields.structure.fields, map)
+    UpdateBuilderMock(UpdateParams.empty, EmailaddressFields.structure, map)
   }
   override def update(row: EmailaddressRow): ZIO[ZConnection, Throwable, Boolean] = {
     ZIO.succeed {

--- a/typo-tester-zio-jdbc/generated-and-checked-in/adventureworks/person/password/PasswordFields.scala
+++ b/typo-tester-zio-jdbc/generated-and-checked-in/adventureworks/person/password/PasswordFields.scala
@@ -10,39 +10,40 @@ package password
 import adventureworks.customtypes.TypoLocalDateTime
 import adventureworks.customtypes.TypoUUID
 import adventureworks.person.businessentity.BusinessentityId
+import typo.dsl.Path
 import typo.dsl.SqlExpr.Field
 import typo.dsl.SqlExpr.FieldLikeNoHkt
 import typo.dsl.SqlExpr.IdField
 import typo.dsl.Structure.Relation
 
-trait PasswordFields[Row] {
-  val businessentityid: IdField[BusinessentityId, Row]
-  val passwordhash: Field[/* max 128 chars */ String, Row]
-  val passwordsalt: Field[/* max 10 chars */ String, Row]
-  val rowguid: Field[TypoUUID, Row]
-  val modifieddate: Field[TypoLocalDateTime, Row]
+trait PasswordFields {
+  def businessentityid: IdField[BusinessentityId, PasswordRow]
+  def passwordhash: Field[/* max 128 chars */ String, PasswordRow]
+  def passwordsalt: Field[/* max 10 chars */ String, PasswordRow]
+  def rowguid: Field[TypoUUID, PasswordRow]
+  def modifieddate: Field[TypoLocalDateTime, PasswordRow]
 }
 
 object PasswordFields {
-  val structure: Relation[PasswordFields, PasswordRow, PasswordRow] = 
-    new Impl(None, identity, (_, x) => x)
+  lazy val structure: Relation[PasswordFields, PasswordRow] =
+    new Impl(Nil)
     
-  private final class Impl[Row](val prefix: Option[String], val extract: Row => PasswordRow, val merge: (Row, PasswordRow) => Row)
-    extends Relation[PasswordFields, PasswordRow, Row] { 
+  private final class Impl(val _path: List[Path])
+    extends Relation[PasswordFields, PasswordRow] {
   
-    override val fields: PasswordFields[Row] = new PasswordFields[Row] {
-      override val businessentityid = new IdField[BusinessentityId, Row](prefix, "businessentityid", None, Some("int4"))(x => extract(x).businessentityid, (row, value) => merge(row, extract(row).copy(businessentityid = value)))
-      override val passwordhash = new Field[/* max 128 chars */ String, Row](prefix, "passwordhash", None, None)(x => extract(x).passwordhash, (row, value) => merge(row, extract(row).copy(passwordhash = value)))
-      override val passwordsalt = new Field[/* max 10 chars */ String, Row](prefix, "passwordsalt", None, None)(x => extract(x).passwordsalt, (row, value) => merge(row, extract(row).copy(passwordsalt = value)))
-      override val rowguid = new Field[TypoUUID, Row](prefix, "rowguid", None, Some("uuid"))(x => extract(x).rowguid, (row, value) => merge(row, extract(row).copy(rowguid = value)))
-      override val modifieddate = new Field[TypoLocalDateTime, Row](prefix, "modifieddate", Some("text"), Some("timestamp"))(x => extract(x).modifieddate, (row, value) => merge(row, extract(row).copy(modifieddate = value)))
+    override lazy val fields: PasswordFields = new PasswordFields {
+      override def businessentityid = IdField[BusinessentityId, PasswordRow](_path, "businessentityid", None, Some("int4"), x => x.businessentityid, (row, value) => row.copy(businessentityid = value))
+      override def passwordhash = Field[/* max 128 chars */ String, PasswordRow](_path, "passwordhash", None, None, x => x.passwordhash, (row, value) => row.copy(passwordhash = value))
+      override def passwordsalt = Field[/* max 10 chars */ String, PasswordRow](_path, "passwordsalt", None, None, x => x.passwordsalt, (row, value) => row.copy(passwordsalt = value))
+      override def rowguid = Field[TypoUUID, PasswordRow](_path, "rowguid", None, Some("uuid"), x => x.rowguid, (row, value) => row.copy(rowguid = value))
+      override def modifieddate = Field[TypoLocalDateTime, PasswordRow](_path, "modifieddate", Some("text"), Some("timestamp"), x => x.modifieddate, (row, value) => row.copy(modifieddate = value))
     }
   
-    override val columns: List[FieldLikeNoHkt[?, Row]] =
-      List[FieldLikeNoHkt[?, Row]](fields.businessentityid, fields.passwordhash, fields.passwordsalt, fields.rowguid, fields.modifieddate)
+    override lazy val columns: List[FieldLikeNoHkt[?, PasswordRow]] =
+      List[FieldLikeNoHkt[?, PasswordRow]](fields.businessentityid, fields.passwordhash, fields.passwordsalt, fields.rowguid, fields.modifieddate)
   
-    override def copy[NewRow](prefix: Option[String], extract: NewRow => PasswordRow, merge: (NewRow, PasswordRow) => NewRow): Impl[NewRow] =
-      new Impl(prefix, extract, merge)
+    override def copy(path: List[Path]): Impl =
+      new Impl(path)
   }
   
 }

--- a/typo-tester-zio-jdbc/generated-and-checked-in/adventureworks/person/password/PasswordRepoMock.scala
+++ b/typo-tester-zio-jdbc/generated-and-checked-in/adventureworks/person/password/PasswordRepoMock.scala
@@ -27,7 +27,7 @@ import zio.stream.ZStream
 class PasswordRepoMock(toRow: Function1[PasswordRowUnsaved, PasswordRow],
                        map: scala.collection.mutable.Map[BusinessentityId, PasswordRow] = scala.collection.mutable.Map.empty) extends PasswordRepo {
   override def delete: DeleteBuilder[PasswordFields, PasswordRow] = {
-    DeleteBuilderMock(DeleteParams.empty, PasswordFields.structure.fields, map)
+    DeleteBuilderMock(DeleteParams.empty, PasswordFields.structure, map)
   }
   override def deleteById(businessentityid: BusinessentityId): ZIO[ZConnection, Throwable, Boolean] = {
     ZIO.succeed(map.remove(businessentityid).isDefined)
@@ -86,7 +86,7 @@ class PasswordRepoMock(toRow: Function1[PasswordRowUnsaved, PasswordRow],
     }
   }
   override def update: UpdateBuilder[PasswordFields, PasswordRow] = {
-    UpdateBuilderMock(UpdateParams.empty, PasswordFields.structure.fields, map)
+    UpdateBuilderMock(UpdateParams.empty, PasswordFields.structure, map)
   }
   override def update(row: PasswordRow): ZIO[ZConnection, Throwable, Boolean] = {
     ZIO.succeed {

--- a/typo-tester-zio-jdbc/generated-and-checked-in/adventureworks/person/person/PersonFields.scala
+++ b/typo-tester-zio-jdbc/generated-and-checked-in/adventureworks/person/person/PersonFields.scala
@@ -14,56 +14,57 @@ import adventureworks.person.businessentity.BusinessentityId
 import adventureworks.public.Name
 import adventureworks.public.NameStyle
 import adventureworks.userdefined.FirstName
+import typo.dsl.Path
 import typo.dsl.SqlExpr.Field
 import typo.dsl.SqlExpr.FieldLikeNoHkt
 import typo.dsl.SqlExpr.IdField
 import typo.dsl.SqlExpr.OptField
 import typo.dsl.Structure.Relation
 
-trait PersonFields[Row] {
-  val businessentityid: IdField[BusinessentityId, Row]
-  val persontype: Field[/* bpchar, max 2 chars */ String, Row]
-  val namestyle: Field[NameStyle, Row]
-  val title: OptField[/* max 8 chars */ String, Row]
-  val firstname: Field[/* user-picked */ FirstName, Row]
-  val middlename: OptField[Name, Row]
-  val lastname: Field[Name, Row]
-  val suffix: OptField[/* max 10 chars */ String, Row]
-  val emailpromotion: Field[Int, Row]
-  val additionalcontactinfo: OptField[TypoXml, Row]
-  val demographics: OptField[TypoXml, Row]
-  val rowguid: Field[TypoUUID, Row]
-  val modifieddate: Field[TypoLocalDateTime, Row]
+trait PersonFields {
+  def businessentityid: IdField[BusinessentityId, PersonRow]
+  def persontype: Field[/* bpchar, max 2 chars */ String, PersonRow]
+  def namestyle: Field[NameStyle, PersonRow]
+  def title: OptField[/* max 8 chars */ String, PersonRow]
+  def firstname: Field[/* user-picked */ FirstName, PersonRow]
+  def middlename: OptField[Name, PersonRow]
+  def lastname: Field[Name, PersonRow]
+  def suffix: OptField[/* max 10 chars */ String, PersonRow]
+  def emailpromotion: Field[Int, PersonRow]
+  def additionalcontactinfo: OptField[TypoXml, PersonRow]
+  def demographics: OptField[TypoXml, PersonRow]
+  def rowguid: Field[TypoUUID, PersonRow]
+  def modifieddate: Field[TypoLocalDateTime, PersonRow]
 }
 
 object PersonFields {
-  val structure: Relation[PersonFields, PersonRow, PersonRow] = 
-    new Impl(None, identity, (_, x) => x)
+  lazy val structure: Relation[PersonFields, PersonRow] =
+    new Impl(Nil)
     
-  private final class Impl[Row](val prefix: Option[String], val extract: Row => PersonRow, val merge: (Row, PersonRow) => Row)
-    extends Relation[PersonFields, PersonRow, Row] { 
+  private final class Impl(val _path: List[Path])
+    extends Relation[PersonFields, PersonRow] {
   
-    override val fields: PersonFields[Row] = new PersonFields[Row] {
-      override val businessentityid = new IdField[BusinessentityId, Row](prefix, "businessentityid", None, Some("int4"))(x => extract(x).businessentityid, (row, value) => merge(row, extract(row).copy(businessentityid = value)))
-      override val persontype = new Field[/* bpchar, max 2 chars */ String, Row](prefix, "persontype", None, Some("bpchar"))(x => extract(x).persontype, (row, value) => merge(row, extract(row).copy(persontype = value)))
-      override val namestyle = new Field[NameStyle, Row](prefix, "namestyle", None, Some("bool"))(x => extract(x).namestyle, (row, value) => merge(row, extract(row).copy(namestyle = value)))
-      override val title = new OptField[/* max 8 chars */ String, Row](prefix, "title", None, None)(x => extract(x).title, (row, value) => merge(row, extract(row).copy(title = value)))
-      override val firstname = new Field[/* user-picked */ FirstName, Row](prefix, "firstname", None, Some("varchar"))(x => extract(x).firstname, (row, value) => merge(row, extract(row).copy(firstname = value)))
-      override val middlename = new OptField[Name, Row](prefix, "middlename", None, Some("varchar"))(x => extract(x).middlename, (row, value) => merge(row, extract(row).copy(middlename = value)))
-      override val lastname = new Field[Name, Row](prefix, "lastname", None, Some("varchar"))(x => extract(x).lastname, (row, value) => merge(row, extract(row).copy(lastname = value)))
-      override val suffix = new OptField[/* max 10 chars */ String, Row](prefix, "suffix", None, None)(x => extract(x).suffix, (row, value) => merge(row, extract(row).copy(suffix = value)))
-      override val emailpromotion = new Field[Int, Row](prefix, "emailpromotion", None, Some("int4"))(x => extract(x).emailpromotion, (row, value) => merge(row, extract(row).copy(emailpromotion = value)))
-      override val additionalcontactinfo = new OptField[TypoXml, Row](prefix, "additionalcontactinfo", None, Some("xml"))(x => extract(x).additionalcontactinfo, (row, value) => merge(row, extract(row).copy(additionalcontactinfo = value)))
-      override val demographics = new OptField[TypoXml, Row](prefix, "demographics", None, Some("xml"))(x => extract(x).demographics, (row, value) => merge(row, extract(row).copy(demographics = value)))
-      override val rowguid = new Field[TypoUUID, Row](prefix, "rowguid", None, Some("uuid"))(x => extract(x).rowguid, (row, value) => merge(row, extract(row).copy(rowguid = value)))
-      override val modifieddate = new Field[TypoLocalDateTime, Row](prefix, "modifieddate", Some("text"), Some("timestamp"))(x => extract(x).modifieddate, (row, value) => merge(row, extract(row).copy(modifieddate = value)))
+    override lazy val fields: PersonFields = new PersonFields {
+      override def businessentityid = IdField[BusinessentityId, PersonRow](_path, "businessentityid", None, Some("int4"), x => x.businessentityid, (row, value) => row.copy(businessentityid = value))
+      override def persontype = Field[/* bpchar, max 2 chars */ String, PersonRow](_path, "persontype", None, Some("bpchar"), x => x.persontype, (row, value) => row.copy(persontype = value))
+      override def namestyle = Field[NameStyle, PersonRow](_path, "namestyle", None, Some("bool"), x => x.namestyle, (row, value) => row.copy(namestyle = value))
+      override def title = OptField[/* max 8 chars */ String, PersonRow](_path, "title", None, None, x => x.title, (row, value) => row.copy(title = value))
+      override def firstname = Field[/* user-picked */ FirstName, PersonRow](_path, "firstname", None, Some("varchar"), x => x.firstname, (row, value) => row.copy(firstname = value))
+      override def middlename = OptField[Name, PersonRow](_path, "middlename", None, Some("varchar"), x => x.middlename, (row, value) => row.copy(middlename = value))
+      override def lastname = Field[Name, PersonRow](_path, "lastname", None, Some("varchar"), x => x.lastname, (row, value) => row.copy(lastname = value))
+      override def suffix = OptField[/* max 10 chars */ String, PersonRow](_path, "suffix", None, None, x => x.suffix, (row, value) => row.copy(suffix = value))
+      override def emailpromotion = Field[Int, PersonRow](_path, "emailpromotion", None, Some("int4"), x => x.emailpromotion, (row, value) => row.copy(emailpromotion = value))
+      override def additionalcontactinfo = OptField[TypoXml, PersonRow](_path, "additionalcontactinfo", None, Some("xml"), x => x.additionalcontactinfo, (row, value) => row.copy(additionalcontactinfo = value))
+      override def demographics = OptField[TypoXml, PersonRow](_path, "demographics", None, Some("xml"), x => x.demographics, (row, value) => row.copy(demographics = value))
+      override def rowguid = Field[TypoUUID, PersonRow](_path, "rowguid", None, Some("uuid"), x => x.rowguid, (row, value) => row.copy(rowguid = value))
+      override def modifieddate = Field[TypoLocalDateTime, PersonRow](_path, "modifieddate", Some("text"), Some("timestamp"), x => x.modifieddate, (row, value) => row.copy(modifieddate = value))
     }
   
-    override val columns: List[FieldLikeNoHkt[?, Row]] =
-      List[FieldLikeNoHkt[?, Row]](fields.businessentityid, fields.persontype, fields.namestyle, fields.title, fields.firstname, fields.middlename, fields.lastname, fields.suffix, fields.emailpromotion, fields.additionalcontactinfo, fields.demographics, fields.rowguid, fields.modifieddate)
+    override lazy val columns: List[FieldLikeNoHkt[?, PersonRow]] =
+      List[FieldLikeNoHkt[?, PersonRow]](fields.businessentityid, fields.persontype, fields.namestyle, fields.title, fields.firstname, fields.middlename, fields.lastname, fields.suffix, fields.emailpromotion, fields.additionalcontactinfo, fields.demographics, fields.rowguid, fields.modifieddate)
   
-    override def copy[NewRow](prefix: Option[String], extract: NewRow => PersonRow, merge: (NewRow, PersonRow) => NewRow): Impl[NewRow] =
-      new Impl(prefix, extract, merge)
+    override def copy(path: List[Path]): Impl =
+      new Impl(path)
   }
   
 }

--- a/typo-tester-zio-jdbc/generated-and-checked-in/adventureworks/person/person/PersonRepoMock.scala
+++ b/typo-tester-zio-jdbc/generated-and-checked-in/adventureworks/person/person/PersonRepoMock.scala
@@ -27,7 +27,7 @@ import zio.stream.ZStream
 class PersonRepoMock(toRow: Function1[PersonRowUnsaved, PersonRow],
                      map: scala.collection.mutable.Map[BusinessentityId, PersonRow] = scala.collection.mutable.Map.empty) extends PersonRepo {
   override def delete: DeleteBuilder[PersonFields, PersonRow] = {
-    DeleteBuilderMock(DeleteParams.empty, PersonFields.structure.fields, map)
+    DeleteBuilderMock(DeleteParams.empty, PersonFields.structure, map)
   }
   override def deleteById(businessentityid: BusinessentityId): ZIO[ZConnection, Throwable, Boolean] = {
     ZIO.succeed(map.remove(businessentityid).isDefined)
@@ -86,7 +86,7 @@ class PersonRepoMock(toRow: Function1[PersonRowUnsaved, PersonRow],
     }
   }
   override def update: UpdateBuilder[PersonFields, PersonRow] = {
-    UpdateBuilderMock(UpdateParams.empty, PersonFields.structure.fields, map)
+    UpdateBuilderMock(UpdateParams.empty, PersonFields.structure, map)
   }
   override def update(row: PersonRow): ZIO[ZConnection, Throwable, Boolean] = {
     ZIO.succeed {

--- a/typo-tester-zio-jdbc/generated-and-checked-in/adventureworks/person/personphone/PersonphoneFields.scala
+++ b/typo-tester-zio-jdbc/generated-and-checked-in/adventureworks/person/personphone/PersonphoneFields.scala
@@ -11,37 +11,38 @@ import adventureworks.customtypes.TypoLocalDateTime
 import adventureworks.person.businessentity.BusinessentityId
 import adventureworks.person.phonenumbertype.PhonenumbertypeId
 import adventureworks.public.Phone
+import typo.dsl.Path
 import typo.dsl.SqlExpr.Field
 import typo.dsl.SqlExpr.FieldLikeNoHkt
 import typo.dsl.SqlExpr.IdField
 import typo.dsl.Structure.Relation
 
-trait PersonphoneFields[Row] {
-  val businessentityid: IdField[BusinessentityId, Row]
-  val phonenumber: IdField[Phone, Row]
-  val phonenumbertypeid: IdField[PhonenumbertypeId, Row]
-  val modifieddate: Field[TypoLocalDateTime, Row]
+trait PersonphoneFields {
+  def businessentityid: IdField[BusinessentityId, PersonphoneRow]
+  def phonenumber: IdField[Phone, PersonphoneRow]
+  def phonenumbertypeid: IdField[PhonenumbertypeId, PersonphoneRow]
+  def modifieddate: Field[TypoLocalDateTime, PersonphoneRow]
 }
 
 object PersonphoneFields {
-  val structure: Relation[PersonphoneFields, PersonphoneRow, PersonphoneRow] = 
-    new Impl(None, identity, (_, x) => x)
+  lazy val structure: Relation[PersonphoneFields, PersonphoneRow] =
+    new Impl(Nil)
     
-  private final class Impl[Row](val prefix: Option[String], val extract: Row => PersonphoneRow, val merge: (Row, PersonphoneRow) => Row)
-    extends Relation[PersonphoneFields, PersonphoneRow, Row] { 
+  private final class Impl(val _path: List[Path])
+    extends Relation[PersonphoneFields, PersonphoneRow] {
   
-    override val fields: PersonphoneFields[Row] = new PersonphoneFields[Row] {
-      override val businessentityid = new IdField[BusinessentityId, Row](prefix, "businessentityid", None, Some("int4"))(x => extract(x).businessentityid, (row, value) => merge(row, extract(row).copy(businessentityid = value)))
-      override val phonenumber = new IdField[Phone, Row](prefix, "phonenumber", None, Some("varchar"))(x => extract(x).phonenumber, (row, value) => merge(row, extract(row).copy(phonenumber = value)))
-      override val phonenumbertypeid = new IdField[PhonenumbertypeId, Row](prefix, "phonenumbertypeid", None, Some("int4"))(x => extract(x).phonenumbertypeid, (row, value) => merge(row, extract(row).copy(phonenumbertypeid = value)))
-      override val modifieddate = new Field[TypoLocalDateTime, Row](prefix, "modifieddate", Some("text"), Some("timestamp"))(x => extract(x).modifieddate, (row, value) => merge(row, extract(row).copy(modifieddate = value)))
+    override lazy val fields: PersonphoneFields = new PersonphoneFields {
+      override def businessentityid = IdField[BusinessentityId, PersonphoneRow](_path, "businessentityid", None, Some("int4"), x => x.businessentityid, (row, value) => row.copy(businessentityid = value))
+      override def phonenumber = IdField[Phone, PersonphoneRow](_path, "phonenumber", None, Some("varchar"), x => x.phonenumber, (row, value) => row.copy(phonenumber = value))
+      override def phonenumbertypeid = IdField[PhonenumbertypeId, PersonphoneRow](_path, "phonenumbertypeid", None, Some("int4"), x => x.phonenumbertypeid, (row, value) => row.copy(phonenumbertypeid = value))
+      override def modifieddate = Field[TypoLocalDateTime, PersonphoneRow](_path, "modifieddate", Some("text"), Some("timestamp"), x => x.modifieddate, (row, value) => row.copy(modifieddate = value))
     }
   
-    override val columns: List[FieldLikeNoHkt[?, Row]] =
-      List[FieldLikeNoHkt[?, Row]](fields.businessentityid, fields.phonenumber, fields.phonenumbertypeid, fields.modifieddate)
+    override lazy val columns: List[FieldLikeNoHkt[?, PersonphoneRow]] =
+      List[FieldLikeNoHkt[?, PersonphoneRow]](fields.businessentityid, fields.phonenumber, fields.phonenumbertypeid, fields.modifieddate)
   
-    override def copy[NewRow](prefix: Option[String], extract: NewRow => PersonphoneRow, merge: (NewRow, PersonphoneRow) => NewRow): Impl[NewRow] =
-      new Impl(prefix, extract, merge)
+    override def copy(path: List[Path]): Impl =
+      new Impl(path)
   }
   
 }

--- a/typo-tester-zio-jdbc/generated-and-checked-in/adventureworks/person/personphone/PersonphoneRepoMock.scala
+++ b/typo-tester-zio-jdbc/generated-and-checked-in/adventureworks/person/personphone/PersonphoneRepoMock.scala
@@ -26,7 +26,7 @@ import zio.stream.ZStream
 class PersonphoneRepoMock(toRow: Function1[PersonphoneRowUnsaved, PersonphoneRow],
                           map: scala.collection.mutable.Map[PersonphoneId, PersonphoneRow] = scala.collection.mutable.Map.empty) extends PersonphoneRepo {
   override def delete: DeleteBuilder[PersonphoneFields, PersonphoneRow] = {
-    DeleteBuilderMock(DeleteParams.empty, PersonphoneFields.structure.fields, map)
+    DeleteBuilderMock(DeleteParams.empty, PersonphoneFields.structure, map)
   }
   override def deleteById(compositeId: PersonphoneId): ZIO[ZConnection, Throwable, Boolean] = {
     ZIO.succeed(map.remove(compositeId).isDefined)
@@ -85,7 +85,7 @@ class PersonphoneRepoMock(toRow: Function1[PersonphoneRowUnsaved, PersonphoneRow
     }
   }
   override def update: UpdateBuilder[PersonphoneFields, PersonphoneRow] = {
-    UpdateBuilderMock(UpdateParams.empty, PersonphoneFields.structure.fields, map)
+    UpdateBuilderMock(UpdateParams.empty, PersonphoneFields.structure, map)
   }
   override def update(row: PersonphoneRow): ZIO[ZConnection, Throwable, Boolean] = {
     ZIO.succeed {

--- a/typo-tester-zio-jdbc/generated-and-checked-in/adventureworks/person/phonenumbertype/PhonenumbertypeFields.scala
+++ b/typo-tester-zio-jdbc/generated-and-checked-in/adventureworks/person/phonenumbertype/PhonenumbertypeFields.scala
@@ -9,35 +9,36 @@ package phonenumbertype
 
 import adventureworks.customtypes.TypoLocalDateTime
 import adventureworks.public.Name
+import typo.dsl.Path
 import typo.dsl.SqlExpr.Field
 import typo.dsl.SqlExpr.FieldLikeNoHkt
 import typo.dsl.SqlExpr.IdField
 import typo.dsl.Structure.Relation
 
-trait PhonenumbertypeFields[Row] {
-  val phonenumbertypeid: IdField[PhonenumbertypeId, Row]
-  val name: Field[Name, Row]
-  val modifieddate: Field[TypoLocalDateTime, Row]
+trait PhonenumbertypeFields {
+  def phonenumbertypeid: IdField[PhonenumbertypeId, PhonenumbertypeRow]
+  def name: Field[Name, PhonenumbertypeRow]
+  def modifieddate: Field[TypoLocalDateTime, PhonenumbertypeRow]
 }
 
 object PhonenumbertypeFields {
-  val structure: Relation[PhonenumbertypeFields, PhonenumbertypeRow, PhonenumbertypeRow] = 
-    new Impl(None, identity, (_, x) => x)
+  lazy val structure: Relation[PhonenumbertypeFields, PhonenumbertypeRow] =
+    new Impl(Nil)
     
-  private final class Impl[Row](val prefix: Option[String], val extract: Row => PhonenumbertypeRow, val merge: (Row, PhonenumbertypeRow) => Row)
-    extends Relation[PhonenumbertypeFields, PhonenumbertypeRow, Row] { 
+  private final class Impl(val _path: List[Path])
+    extends Relation[PhonenumbertypeFields, PhonenumbertypeRow] {
   
-    override val fields: PhonenumbertypeFields[Row] = new PhonenumbertypeFields[Row] {
-      override val phonenumbertypeid = new IdField[PhonenumbertypeId, Row](prefix, "phonenumbertypeid", None, Some("int4"))(x => extract(x).phonenumbertypeid, (row, value) => merge(row, extract(row).copy(phonenumbertypeid = value)))
-      override val name = new Field[Name, Row](prefix, "name", None, Some("varchar"))(x => extract(x).name, (row, value) => merge(row, extract(row).copy(name = value)))
-      override val modifieddate = new Field[TypoLocalDateTime, Row](prefix, "modifieddate", Some("text"), Some("timestamp"))(x => extract(x).modifieddate, (row, value) => merge(row, extract(row).copy(modifieddate = value)))
+    override lazy val fields: PhonenumbertypeFields = new PhonenumbertypeFields {
+      override def phonenumbertypeid = IdField[PhonenumbertypeId, PhonenumbertypeRow](_path, "phonenumbertypeid", None, Some("int4"), x => x.phonenumbertypeid, (row, value) => row.copy(phonenumbertypeid = value))
+      override def name = Field[Name, PhonenumbertypeRow](_path, "name", None, Some("varchar"), x => x.name, (row, value) => row.copy(name = value))
+      override def modifieddate = Field[TypoLocalDateTime, PhonenumbertypeRow](_path, "modifieddate", Some("text"), Some("timestamp"), x => x.modifieddate, (row, value) => row.copy(modifieddate = value))
     }
   
-    override val columns: List[FieldLikeNoHkt[?, Row]] =
-      List[FieldLikeNoHkt[?, Row]](fields.phonenumbertypeid, fields.name, fields.modifieddate)
+    override lazy val columns: List[FieldLikeNoHkt[?, PhonenumbertypeRow]] =
+      List[FieldLikeNoHkt[?, PhonenumbertypeRow]](fields.phonenumbertypeid, fields.name, fields.modifieddate)
   
-    override def copy[NewRow](prefix: Option[String], extract: NewRow => PhonenumbertypeRow, merge: (NewRow, PhonenumbertypeRow) => NewRow): Impl[NewRow] =
-      new Impl(prefix, extract, merge)
+    override def copy(path: List[Path]): Impl =
+      new Impl(path)
   }
   
 }

--- a/typo-tester-zio-jdbc/generated-and-checked-in/adventureworks/person/phonenumbertype/PhonenumbertypeRepoMock.scala
+++ b/typo-tester-zio-jdbc/generated-and-checked-in/adventureworks/person/phonenumbertype/PhonenumbertypeRepoMock.scala
@@ -26,7 +26,7 @@ import zio.stream.ZStream
 class PhonenumbertypeRepoMock(toRow: Function1[PhonenumbertypeRowUnsaved, PhonenumbertypeRow],
                               map: scala.collection.mutable.Map[PhonenumbertypeId, PhonenumbertypeRow] = scala.collection.mutable.Map.empty) extends PhonenumbertypeRepo {
   override def delete: DeleteBuilder[PhonenumbertypeFields, PhonenumbertypeRow] = {
-    DeleteBuilderMock(DeleteParams.empty, PhonenumbertypeFields.structure.fields, map)
+    DeleteBuilderMock(DeleteParams.empty, PhonenumbertypeFields.structure, map)
   }
   override def deleteById(phonenumbertypeid: PhonenumbertypeId): ZIO[ZConnection, Throwable, Boolean] = {
     ZIO.succeed(map.remove(phonenumbertypeid).isDefined)
@@ -85,7 +85,7 @@ class PhonenumbertypeRepoMock(toRow: Function1[PhonenumbertypeRowUnsaved, Phonen
     }
   }
   override def update: UpdateBuilder[PhonenumbertypeFields, PhonenumbertypeRow] = {
-    UpdateBuilderMock(UpdateParams.empty, PhonenumbertypeFields.structure.fields, map)
+    UpdateBuilderMock(UpdateParams.empty, PhonenumbertypeFields.structure, map)
   }
   override def update(row: PhonenumbertypeRow): ZIO[ZConnection, Throwable, Boolean] = {
     ZIO.succeed {

--- a/typo-tester-zio-jdbc/generated-and-checked-in/adventureworks/person/stateprovince/StateprovinceFields.scala
+++ b/typo-tester-zio-jdbc/generated-and-checked-in/adventureworks/person/stateprovince/StateprovinceFields.scala
@@ -13,45 +13,46 @@ import adventureworks.person.countryregion.CountryregionId
 import adventureworks.public.Flag
 import adventureworks.public.Name
 import adventureworks.sales.salesterritory.SalesterritoryId
+import typo.dsl.Path
 import typo.dsl.SqlExpr.Field
 import typo.dsl.SqlExpr.FieldLikeNoHkt
 import typo.dsl.SqlExpr.IdField
 import typo.dsl.Structure.Relation
 
-trait StateprovinceFields[Row] {
-  val stateprovinceid: IdField[StateprovinceId, Row]
-  val stateprovincecode: Field[/* bpchar, max 3 chars */ String, Row]
-  val countryregioncode: Field[CountryregionId, Row]
-  val isonlystateprovinceflag: Field[Flag, Row]
-  val name: Field[Name, Row]
-  val territoryid: Field[SalesterritoryId, Row]
-  val rowguid: Field[TypoUUID, Row]
-  val modifieddate: Field[TypoLocalDateTime, Row]
+trait StateprovinceFields {
+  def stateprovinceid: IdField[StateprovinceId, StateprovinceRow]
+  def stateprovincecode: Field[/* bpchar, max 3 chars */ String, StateprovinceRow]
+  def countryregioncode: Field[CountryregionId, StateprovinceRow]
+  def isonlystateprovinceflag: Field[Flag, StateprovinceRow]
+  def name: Field[Name, StateprovinceRow]
+  def territoryid: Field[SalesterritoryId, StateprovinceRow]
+  def rowguid: Field[TypoUUID, StateprovinceRow]
+  def modifieddate: Field[TypoLocalDateTime, StateprovinceRow]
 }
 
 object StateprovinceFields {
-  val structure: Relation[StateprovinceFields, StateprovinceRow, StateprovinceRow] = 
-    new Impl(None, identity, (_, x) => x)
+  lazy val structure: Relation[StateprovinceFields, StateprovinceRow] =
+    new Impl(Nil)
     
-  private final class Impl[Row](val prefix: Option[String], val extract: Row => StateprovinceRow, val merge: (Row, StateprovinceRow) => Row)
-    extends Relation[StateprovinceFields, StateprovinceRow, Row] { 
+  private final class Impl(val _path: List[Path])
+    extends Relation[StateprovinceFields, StateprovinceRow] {
   
-    override val fields: StateprovinceFields[Row] = new StateprovinceFields[Row] {
-      override val stateprovinceid = new IdField[StateprovinceId, Row](prefix, "stateprovinceid", None, Some("int4"))(x => extract(x).stateprovinceid, (row, value) => merge(row, extract(row).copy(stateprovinceid = value)))
-      override val stateprovincecode = new Field[/* bpchar, max 3 chars */ String, Row](prefix, "stateprovincecode", None, Some("bpchar"))(x => extract(x).stateprovincecode, (row, value) => merge(row, extract(row).copy(stateprovincecode = value)))
-      override val countryregioncode = new Field[CountryregionId, Row](prefix, "countryregioncode", None, None)(x => extract(x).countryregioncode, (row, value) => merge(row, extract(row).copy(countryregioncode = value)))
-      override val isonlystateprovinceflag = new Field[Flag, Row](prefix, "isonlystateprovinceflag", None, Some("bool"))(x => extract(x).isonlystateprovinceflag, (row, value) => merge(row, extract(row).copy(isonlystateprovinceflag = value)))
-      override val name = new Field[Name, Row](prefix, "name", None, Some("varchar"))(x => extract(x).name, (row, value) => merge(row, extract(row).copy(name = value)))
-      override val territoryid = new Field[SalesterritoryId, Row](prefix, "territoryid", None, Some("int4"))(x => extract(x).territoryid, (row, value) => merge(row, extract(row).copy(territoryid = value)))
-      override val rowguid = new Field[TypoUUID, Row](prefix, "rowguid", None, Some("uuid"))(x => extract(x).rowguid, (row, value) => merge(row, extract(row).copy(rowguid = value)))
-      override val modifieddate = new Field[TypoLocalDateTime, Row](prefix, "modifieddate", Some("text"), Some("timestamp"))(x => extract(x).modifieddate, (row, value) => merge(row, extract(row).copy(modifieddate = value)))
+    override lazy val fields: StateprovinceFields = new StateprovinceFields {
+      override def stateprovinceid = IdField[StateprovinceId, StateprovinceRow](_path, "stateprovinceid", None, Some("int4"), x => x.stateprovinceid, (row, value) => row.copy(stateprovinceid = value))
+      override def stateprovincecode = Field[/* bpchar, max 3 chars */ String, StateprovinceRow](_path, "stateprovincecode", None, Some("bpchar"), x => x.stateprovincecode, (row, value) => row.copy(stateprovincecode = value))
+      override def countryregioncode = Field[CountryregionId, StateprovinceRow](_path, "countryregioncode", None, None, x => x.countryregioncode, (row, value) => row.copy(countryregioncode = value))
+      override def isonlystateprovinceflag = Field[Flag, StateprovinceRow](_path, "isonlystateprovinceflag", None, Some("bool"), x => x.isonlystateprovinceflag, (row, value) => row.copy(isonlystateprovinceflag = value))
+      override def name = Field[Name, StateprovinceRow](_path, "name", None, Some("varchar"), x => x.name, (row, value) => row.copy(name = value))
+      override def territoryid = Field[SalesterritoryId, StateprovinceRow](_path, "territoryid", None, Some("int4"), x => x.territoryid, (row, value) => row.copy(territoryid = value))
+      override def rowguid = Field[TypoUUID, StateprovinceRow](_path, "rowguid", None, Some("uuid"), x => x.rowguid, (row, value) => row.copy(rowguid = value))
+      override def modifieddate = Field[TypoLocalDateTime, StateprovinceRow](_path, "modifieddate", Some("text"), Some("timestamp"), x => x.modifieddate, (row, value) => row.copy(modifieddate = value))
     }
   
-    override val columns: List[FieldLikeNoHkt[?, Row]] =
-      List[FieldLikeNoHkt[?, Row]](fields.stateprovinceid, fields.stateprovincecode, fields.countryregioncode, fields.isonlystateprovinceflag, fields.name, fields.territoryid, fields.rowguid, fields.modifieddate)
+    override lazy val columns: List[FieldLikeNoHkt[?, StateprovinceRow]] =
+      List[FieldLikeNoHkt[?, StateprovinceRow]](fields.stateprovinceid, fields.stateprovincecode, fields.countryregioncode, fields.isonlystateprovinceflag, fields.name, fields.territoryid, fields.rowguid, fields.modifieddate)
   
-    override def copy[NewRow](prefix: Option[String], extract: NewRow => StateprovinceRow, merge: (NewRow, StateprovinceRow) => NewRow): Impl[NewRow] =
-      new Impl(prefix, extract, merge)
+    override def copy(path: List[Path]): Impl =
+      new Impl(path)
   }
   
 }

--- a/typo-tester-zio-jdbc/generated-and-checked-in/adventureworks/person/stateprovince/StateprovinceRepoMock.scala
+++ b/typo-tester-zio-jdbc/generated-and-checked-in/adventureworks/person/stateprovince/StateprovinceRepoMock.scala
@@ -26,7 +26,7 @@ import zio.stream.ZStream
 class StateprovinceRepoMock(toRow: Function1[StateprovinceRowUnsaved, StateprovinceRow],
                             map: scala.collection.mutable.Map[StateprovinceId, StateprovinceRow] = scala.collection.mutable.Map.empty) extends StateprovinceRepo {
   override def delete: DeleteBuilder[StateprovinceFields, StateprovinceRow] = {
-    DeleteBuilderMock(DeleteParams.empty, StateprovinceFields.structure.fields, map)
+    DeleteBuilderMock(DeleteParams.empty, StateprovinceFields.structure, map)
   }
   override def deleteById(stateprovinceid: StateprovinceId): ZIO[ZConnection, Throwable, Boolean] = {
     ZIO.succeed(map.remove(stateprovinceid).isDefined)
@@ -85,7 +85,7 @@ class StateprovinceRepoMock(toRow: Function1[StateprovinceRowUnsaved, Stateprovi
     }
   }
   override def update: UpdateBuilder[StateprovinceFields, StateprovinceRow] = {
-    UpdateBuilderMock(UpdateParams.empty, StateprovinceFields.structure.fields, map)
+    UpdateBuilderMock(UpdateParams.empty, StateprovinceFields.structure, map)
   }
   override def update(row: StateprovinceRow): ZIO[ZConnection, Throwable, Boolean] = {
     ZIO.succeed {

--- a/typo-tester-zio-jdbc/generated-and-checked-in/adventureworks/person/vadditionalcontactinfo/VadditionalcontactinfoViewFields.scala
+++ b/typo-tester-zio-jdbc/generated-and-checked-in/adventureworks/person/vadditionalcontactinfo/VadditionalcontactinfoViewFields.scala
@@ -13,63 +13,64 @@ import adventureworks.customtypes.TypoXml
 import adventureworks.person.businessentity.BusinessentityId
 import adventureworks.public.Name
 import adventureworks.userdefined.FirstName
+import typo.dsl.Path
 import typo.dsl.SqlExpr.Field
 import typo.dsl.SqlExpr.FieldLikeNoHkt
 import typo.dsl.SqlExpr.OptField
 import typo.dsl.Structure.Relation
 
-trait VadditionalcontactinfoViewFields[Row] {
-  val businessentityid: Field[BusinessentityId, Row]
-  val firstname: Field[/* user-picked */ FirstName, Row]
-  val middlename: OptField[Name, Row]
-  val lastname: Field[Name, Row]
-  val telephonenumber: OptField[TypoXml, Row]
-  val telephonespecialinstructions: OptField[String, Row]
-  val street: OptField[TypoXml, Row]
-  val city: OptField[TypoXml, Row]
-  val stateprovince: OptField[TypoXml, Row]
-  val postalcode: OptField[TypoXml, Row]
-  val countryregion: OptField[TypoXml, Row]
-  val homeaddressspecialinstructions: OptField[TypoXml, Row]
-  val emailaddress: OptField[TypoXml, Row]
-  val emailspecialinstructions: OptField[String, Row]
-  val emailtelephonenumber: OptField[TypoXml, Row]
-  val rowguid: Field[TypoUUID, Row]
-  val modifieddate: Field[TypoLocalDateTime, Row]
+trait VadditionalcontactinfoViewFields {
+  def businessentityid: Field[BusinessentityId, VadditionalcontactinfoViewRow]
+  def firstname: Field[/* user-picked */ FirstName, VadditionalcontactinfoViewRow]
+  def middlename: OptField[Name, VadditionalcontactinfoViewRow]
+  def lastname: Field[Name, VadditionalcontactinfoViewRow]
+  def telephonenumber: OptField[TypoXml, VadditionalcontactinfoViewRow]
+  def telephonespecialinstructions: OptField[String, VadditionalcontactinfoViewRow]
+  def street: OptField[TypoXml, VadditionalcontactinfoViewRow]
+  def city: OptField[TypoXml, VadditionalcontactinfoViewRow]
+  def stateprovince: OptField[TypoXml, VadditionalcontactinfoViewRow]
+  def postalcode: OptField[TypoXml, VadditionalcontactinfoViewRow]
+  def countryregion: OptField[TypoXml, VadditionalcontactinfoViewRow]
+  def homeaddressspecialinstructions: OptField[TypoXml, VadditionalcontactinfoViewRow]
+  def emailaddress: OptField[TypoXml, VadditionalcontactinfoViewRow]
+  def emailspecialinstructions: OptField[String, VadditionalcontactinfoViewRow]
+  def emailtelephonenumber: OptField[TypoXml, VadditionalcontactinfoViewRow]
+  def rowguid: Field[TypoUUID, VadditionalcontactinfoViewRow]
+  def modifieddate: Field[TypoLocalDateTime, VadditionalcontactinfoViewRow]
 }
 
 object VadditionalcontactinfoViewFields {
-  val structure: Relation[VadditionalcontactinfoViewFields, VadditionalcontactinfoViewRow, VadditionalcontactinfoViewRow] = 
-    new Impl(None, identity, (_, x) => x)
+  lazy val structure: Relation[VadditionalcontactinfoViewFields, VadditionalcontactinfoViewRow] =
+    new Impl(Nil)
     
-  private final class Impl[Row](val prefix: Option[String], val extract: Row => VadditionalcontactinfoViewRow, val merge: (Row, VadditionalcontactinfoViewRow) => Row)
-    extends Relation[VadditionalcontactinfoViewFields, VadditionalcontactinfoViewRow, Row] { 
+  private final class Impl(val _path: List[Path])
+    extends Relation[VadditionalcontactinfoViewFields, VadditionalcontactinfoViewRow] {
   
-    override val fields: VadditionalcontactinfoViewFields[Row] = new VadditionalcontactinfoViewFields[Row] {
-      override val businessentityid = new Field[BusinessentityId, Row](prefix, "businessentityid", None, None)(x => extract(x).businessentityid, (row, value) => merge(row, extract(row).copy(businessentityid = value)))
-      override val firstname = new Field[/* user-picked */ FirstName, Row](prefix, "firstname", None, None)(x => extract(x).firstname, (row, value) => merge(row, extract(row).copy(firstname = value)))
-      override val middlename = new OptField[Name, Row](prefix, "middlename", None, None)(x => extract(x).middlename, (row, value) => merge(row, extract(row).copy(middlename = value)))
-      override val lastname = new Field[Name, Row](prefix, "lastname", None, None)(x => extract(x).lastname, (row, value) => merge(row, extract(row).copy(lastname = value)))
-      override val telephonenumber = new OptField[TypoXml, Row](prefix, "telephonenumber", None, None)(x => extract(x).telephonenumber, (row, value) => merge(row, extract(row).copy(telephonenumber = value)))
-      override val telephonespecialinstructions = new OptField[String, Row](prefix, "telephonespecialinstructions", None, None)(x => extract(x).telephonespecialinstructions, (row, value) => merge(row, extract(row).copy(telephonespecialinstructions = value)))
-      override val street = new OptField[TypoXml, Row](prefix, "street", None, None)(x => extract(x).street, (row, value) => merge(row, extract(row).copy(street = value)))
-      override val city = new OptField[TypoXml, Row](prefix, "city", None, None)(x => extract(x).city, (row, value) => merge(row, extract(row).copy(city = value)))
-      override val stateprovince = new OptField[TypoXml, Row](prefix, "stateprovince", None, None)(x => extract(x).stateprovince, (row, value) => merge(row, extract(row).copy(stateprovince = value)))
-      override val postalcode = new OptField[TypoXml, Row](prefix, "postalcode", None, None)(x => extract(x).postalcode, (row, value) => merge(row, extract(row).copy(postalcode = value)))
-      override val countryregion = new OptField[TypoXml, Row](prefix, "countryregion", None, None)(x => extract(x).countryregion, (row, value) => merge(row, extract(row).copy(countryregion = value)))
-      override val homeaddressspecialinstructions = new OptField[TypoXml, Row](prefix, "homeaddressspecialinstructions", None, None)(x => extract(x).homeaddressspecialinstructions, (row, value) => merge(row, extract(row).copy(homeaddressspecialinstructions = value)))
-      override val emailaddress = new OptField[TypoXml, Row](prefix, "emailaddress", None, None)(x => extract(x).emailaddress, (row, value) => merge(row, extract(row).copy(emailaddress = value)))
-      override val emailspecialinstructions = new OptField[String, Row](prefix, "emailspecialinstructions", None, None)(x => extract(x).emailspecialinstructions, (row, value) => merge(row, extract(row).copy(emailspecialinstructions = value)))
-      override val emailtelephonenumber = new OptField[TypoXml, Row](prefix, "emailtelephonenumber", None, None)(x => extract(x).emailtelephonenumber, (row, value) => merge(row, extract(row).copy(emailtelephonenumber = value)))
-      override val rowguid = new Field[TypoUUID, Row](prefix, "rowguid", None, None)(x => extract(x).rowguid, (row, value) => merge(row, extract(row).copy(rowguid = value)))
-      override val modifieddate = new Field[TypoLocalDateTime, Row](prefix, "modifieddate", Some("text"), None)(x => extract(x).modifieddate, (row, value) => merge(row, extract(row).copy(modifieddate = value)))
+    override lazy val fields: VadditionalcontactinfoViewFields = new VadditionalcontactinfoViewFields {
+      override def businessentityid = Field[BusinessentityId, VadditionalcontactinfoViewRow](_path, "businessentityid", None, None, x => x.businessentityid, (row, value) => row.copy(businessentityid = value))
+      override def firstname = Field[/* user-picked */ FirstName, VadditionalcontactinfoViewRow](_path, "firstname", None, None, x => x.firstname, (row, value) => row.copy(firstname = value))
+      override def middlename = OptField[Name, VadditionalcontactinfoViewRow](_path, "middlename", None, None, x => x.middlename, (row, value) => row.copy(middlename = value))
+      override def lastname = Field[Name, VadditionalcontactinfoViewRow](_path, "lastname", None, None, x => x.lastname, (row, value) => row.copy(lastname = value))
+      override def telephonenumber = OptField[TypoXml, VadditionalcontactinfoViewRow](_path, "telephonenumber", None, None, x => x.telephonenumber, (row, value) => row.copy(telephonenumber = value))
+      override def telephonespecialinstructions = OptField[String, VadditionalcontactinfoViewRow](_path, "telephonespecialinstructions", None, None, x => x.telephonespecialinstructions, (row, value) => row.copy(telephonespecialinstructions = value))
+      override def street = OptField[TypoXml, VadditionalcontactinfoViewRow](_path, "street", None, None, x => x.street, (row, value) => row.copy(street = value))
+      override def city = OptField[TypoXml, VadditionalcontactinfoViewRow](_path, "city", None, None, x => x.city, (row, value) => row.copy(city = value))
+      override def stateprovince = OptField[TypoXml, VadditionalcontactinfoViewRow](_path, "stateprovince", None, None, x => x.stateprovince, (row, value) => row.copy(stateprovince = value))
+      override def postalcode = OptField[TypoXml, VadditionalcontactinfoViewRow](_path, "postalcode", None, None, x => x.postalcode, (row, value) => row.copy(postalcode = value))
+      override def countryregion = OptField[TypoXml, VadditionalcontactinfoViewRow](_path, "countryregion", None, None, x => x.countryregion, (row, value) => row.copy(countryregion = value))
+      override def homeaddressspecialinstructions = OptField[TypoXml, VadditionalcontactinfoViewRow](_path, "homeaddressspecialinstructions", None, None, x => x.homeaddressspecialinstructions, (row, value) => row.copy(homeaddressspecialinstructions = value))
+      override def emailaddress = OptField[TypoXml, VadditionalcontactinfoViewRow](_path, "emailaddress", None, None, x => x.emailaddress, (row, value) => row.copy(emailaddress = value))
+      override def emailspecialinstructions = OptField[String, VadditionalcontactinfoViewRow](_path, "emailspecialinstructions", None, None, x => x.emailspecialinstructions, (row, value) => row.copy(emailspecialinstructions = value))
+      override def emailtelephonenumber = OptField[TypoXml, VadditionalcontactinfoViewRow](_path, "emailtelephonenumber", None, None, x => x.emailtelephonenumber, (row, value) => row.copy(emailtelephonenumber = value))
+      override def rowguid = Field[TypoUUID, VadditionalcontactinfoViewRow](_path, "rowguid", None, None, x => x.rowguid, (row, value) => row.copy(rowguid = value))
+      override def modifieddate = Field[TypoLocalDateTime, VadditionalcontactinfoViewRow](_path, "modifieddate", Some("text"), None, x => x.modifieddate, (row, value) => row.copy(modifieddate = value))
     }
   
-    override val columns: List[FieldLikeNoHkt[?, Row]] =
-      List[FieldLikeNoHkt[?, Row]](fields.businessentityid, fields.firstname, fields.middlename, fields.lastname, fields.telephonenumber, fields.telephonespecialinstructions, fields.street, fields.city, fields.stateprovince, fields.postalcode, fields.countryregion, fields.homeaddressspecialinstructions, fields.emailaddress, fields.emailspecialinstructions, fields.emailtelephonenumber, fields.rowguid, fields.modifieddate)
+    override lazy val columns: List[FieldLikeNoHkt[?, VadditionalcontactinfoViewRow]] =
+      List[FieldLikeNoHkt[?, VadditionalcontactinfoViewRow]](fields.businessentityid, fields.firstname, fields.middlename, fields.lastname, fields.telephonenumber, fields.telephonespecialinstructions, fields.street, fields.city, fields.stateprovince, fields.postalcode, fields.countryregion, fields.homeaddressspecialinstructions, fields.emailaddress, fields.emailspecialinstructions, fields.emailtelephonenumber, fields.rowguid, fields.modifieddate)
   
-    override def copy[NewRow](prefix: Option[String], extract: NewRow => VadditionalcontactinfoViewRow, merge: (NewRow, VadditionalcontactinfoViewRow) => NewRow): Impl[NewRow] =
-      new Impl(prefix, extract, merge)
+    override def copy(path: List[Path]): Impl =
+      new Impl(path)
   }
   
 }

--- a/typo-tester-zio-jdbc/generated-and-checked-in/adventureworks/person/vstateprovincecountryregion/VstateprovincecountryregionMVFields.scala
+++ b/typo-tester-zio-jdbc/generated-and-checked-in/adventureworks/person/vstateprovincecountryregion/VstateprovincecountryregionMVFields.scala
@@ -12,42 +12,43 @@ import adventureworks.person.stateprovince.StateprovinceId
 import adventureworks.public.Flag
 import adventureworks.public.Name
 import adventureworks.sales.salesterritory.SalesterritoryId
+import typo.dsl.Path
 import typo.dsl.SqlExpr.Field
 import typo.dsl.SqlExpr.FieldLikeNoHkt
 import typo.dsl.Structure.Relation
 
-trait VstateprovincecountryregionMVFields[Row] {
-  val stateprovinceid: Field[StateprovinceId, Row]
-  val stateprovincecode: Field[/* bpchar, max 3 chars */ String, Row]
-  val isonlystateprovinceflag: Field[Flag, Row]
-  val stateprovincename: Field[Name, Row]
-  val territoryid: Field[SalesterritoryId, Row]
-  val countryregioncode: Field[CountryregionId, Row]
-  val countryregionname: Field[Name, Row]
+trait VstateprovincecountryregionMVFields {
+  def stateprovinceid: Field[StateprovinceId, VstateprovincecountryregionMVRow]
+  def stateprovincecode: Field[/* bpchar, max 3 chars */ String, VstateprovincecountryregionMVRow]
+  def isonlystateprovinceflag: Field[Flag, VstateprovincecountryregionMVRow]
+  def stateprovincename: Field[Name, VstateprovincecountryregionMVRow]
+  def territoryid: Field[SalesterritoryId, VstateprovincecountryregionMVRow]
+  def countryregioncode: Field[CountryregionId, VstateprovincecountryregionMVRow]
+  def countryregionname: Field[Name, VstateprovincecountryregionMVRow]
 }
 
 object VstateprovincecountryregionMVFields {
-  val structure: Relation[VstateprovincecountryregionMVFields, VstateprovincecountryregionMVRow, VstateprovincecountryregionMVRow] = 
-    new Impl(None, identity, (_, x) => x)
+  lazy val structure: Relation[VstateprovincecountryregionMVFields, VstateprovincecountryregionMVRow] =
+    new Impl(Nil)
     
-  private final class Impl[Row](val prefix: Option[String], val extract: Row => VstateprovincecountryregionMVRow, val merge: (Row, VstateprovincecountryregionMVRow) => Row)
-    extends Relation[VstateprovincecountryregionMVFields, VstateprovincecountryregionMVRow, Row] { 
+  private final class Impl(val _path: List[Path])
+    extends Relation[VstateprovincecountryregionMVFields, VstateprovincecountryregionMVRow] {
   
-    override val fields: VstateprovincecountryregionMVFields[Row] = new VstateprovincecountryregionMVFields[Row] {
-      override val stateprovinceid = new Field[StateprovinceId, Row](prefix, "stateprovinceid", None, None)(x => extract(x).stateprovinceid, (row, value) => merge(row, extract(row).copy(stateprovinceid = value)))
-      override val stateprovincecode = new Field[/* bpchar, max 3 chars */ String, Row](prefix, "stateprovincecode", None, None)(x => extract(x).stateprovincecode, (row, value) => merge(row, extract(row).copy(stateprovincecode = value)))
-      override val isonlystateprovinceflag = new Field[Flag, Row](prefix, "isonlystateprovinceflag", None, None)(x => extract(x).isonlystateprovinceflag, (row, value) => merge(row, extract(row).copy(isonlystateprovinceflag = value)))
-      override val stateprovincename = new Field[Name, Row](prefix, "stateprovincename", None, None)(x => extract(x).stateprovincename, (row, value) => merge(row, extract(row).copy(stateprovincename = value)))
-      override val territoryid = new Field[SalesterritoryId, Row](prefix, "territoryid", None, None)(x => extract(x).territoryid, (row, value) => merge(row, extract(row).copy(territoryid = value)))
-      override val countryregioncode = new Field[CountryregionId, Row](prefix, "countryregioncode", None, None)(x => extract(x).countryregioncode, (row, value) => merge(row, extract(row).copy(countryregioncode = value)))
-      override val countryregionname = new Field[Name, Row](prefix, "countryregionname", None, None)(x => extract(x).countryregionname, (row, value) => merge(row, extract(row).copy(countryregionname = value)))
+    override lazy val fields: VstateprovincecountryregionMVFields = new VstateprovincecountryregionMVFields {
+      override def stateprovinceid = Field[StateprovinceId, VstateprovincecountryregionMVRow](_path, "stateprovinceid", None, None, x => x.stateprovinceid, (row, value) => row.copy(stateprovinceid = value))
+      override def stateprovincecode = Field[/* bpchar, max 3 chars */ String, VstateprovincecountryregionMVRow](_path, "stateprovincecode", None, None, x => x.stateprovincecode, (row, value) => row.copy(stateprovincecode = value))
+      override def isonlystateprovinceflag = Field[Flag, VstateprovincecountryregionMVRow](_path, "isonlystateprovinceflag", None, None, x => x.isonlystateprovinceflag, (row, value) => row.copy(isonlystateprovinceflag = value))
+      override def stateprovincename = Field[Name, VstateprovincecountryregionMVRow](_path, "stateprovincename", None, None, x => x.stateprovincename, (row, value) => row.copy(stateprovincename = value))
+      override def territoryid = Field[SalesterritoryId, VstateprovincecountryregionMVRow](_path, "territoryid", None, None, x => x.territoryid, (row, value) => row.copy(territoryid = value))
+      override def countryregioncode = Field[CountryregionId, VstateprovincecountryregionMVRow](_path, "countryregioncode", None, None, x => x.countryregioncode, (row, value) => row.copy(countryregioncode = value))
+      override def countryregionname = Field[Name, VstateprovincecountryregionMVRow](_path, "countryregionname", None, None, x => x.countryregionname, (row, value) => row.copy(countryregionname = value))
     }
   
-    override val columns: List[FieldLikeNoHkt[?, Row]] =
-      List[FieldLikeNoHkt[?, Row]](fields.stateprovinceid, fields.stateprovincecode, fields.isonlystateprovinceflag, fields.stateprovincename, fields.territoryid, fields.countryregioncode, fields.countryregionname)
+    override lazy val columns: List[FieldLikeNoHkt[?, VstateprovincecountryregionMVRow]] =
+      List[FieldLikeNoHkt[?, VstateprovincecountryregionMVRow]](fields.stateprovinceid, fields.stateprovincecode, fields.isonlystateprovinceflag, fields.stateprovincename, fields.territoryid, fields.countryregioncode, fields.countryregionname)
   
-    override def copy[NewRow](prefix: Option[String], extract: NewRow => VstateprovincecountryregionMVRow, merge: (NewRow, VstateprovincecountryregionMVRow) => NewRow): Impl[NewRow] =
-      new Impl(prefix, extract, merge)
+    override def copy(path: List[Path]): Impl =
+      new Impl(path)
   }
   
 }

--- a/typo-tester-zio-jdbc/generated-and-checked-in/adventureworks/pr/bom/BomViewFields.scala
+++ b/typo-tester-zio-jdbc/generated-and-checked-in/adventureworks/pr/bom/BomViewFields.scala
@@ -11,49 +11,50 @@ import adventureworks.customtypes.TypoLocalDateTime
 import adventureworks.customtypes.TypoShort
 import adventureworks.production.product.ProductId
 import adventureworks.production.unitmeasure.UnitmeasureId
+import typo.dsl.Path
 import typo.dsl.SqlExpr.Field
 import typo.dsl.SqlExpr.FieldLikeNoHkt
 import typo.dsl.SqlExpr.OptField
 import typo.dsl.Structure.Relation
 
-trait BomViewFields[Row] {
-  val id: Field[Int, Row]
-  val billofmaterialsid: Field[Int, Row]
-  val productassemblyid: OptField[ProductId, Row]
-  val componentid: Field[ProductId, Row]
-  val startdate: Field[TypoLocalDateTime, Row]
-  val enddate: OptField[TypoLocalDateTime, Row]
-  val unitmeasurecode: Field[UnitmeasureId, Row]
-  val bomlevel: Field[TypoShort, Row]
-  val perassemblyqty: Field[BigDecimal, Row]
-  val modifieddate: Field[TypoLocalDateTime, Row]
+trait BomViewFields {
+  def id: Field[Int, BomViewRow]
+  def billofmaterialsid: Field[Int, BomViewRow]
+  def productassemblyid: OptField[ProductId, BomViewRow]
+  def componentid: Field[ProductId, BomViewRow]
+  def startdate: Field[TypoLocalDateTime, BomViewRow]
+  def enddate: OptField[TypoLocalDateTime, BomViewRow]
+  def unitmeasurecode: Field[UnitmeasureId, BomViewRow]
+  def bomlevel: Field[TypoShort, BomViewRow]
+  def perassemblyqty: Field[BigDecimal, BomViewRow]
+  def modifieddate: Field[TypoLocalDateTime, BomViewRow]
 }
 
 object BomViewFields {
-  val structure: Relation[BomViewFields, BomViewRow, BomViewRow] = 
-    new Impl(None, identity, (_, x) => x)
+  lazy val structure: Relation[BomViewFields, BomViewRow] =
+    new Impl(Nil)
     
-  private final class Impl[Row](val prefix: Option[String], val extract: Row => BomViewRow, val merge: (Row, BomViewRow) => Row)
-    extends Relation[BomViewFields, BomViewRow, Row] { 
+  private final class Impl(val _path: List[Path])
+    extends Relation[BomViewFields, BomViewRow] {
   
-    override val fields: BomViewFields[Row] = new BomViewFields[Row] {
-      override val id = new Field[Int, Row](prefix, "id", None, None)(x => extract(x).id, (row, value) => merge(row, extract(row).copy(id = value)))
-      override val billofmaterialsid = new Field[Int, Row](prefix, "billofmaterialsid", None, None)(x => extract(x).billofmaterialsid, (row, value) => merge(row, extract(row).copy(billofmaterialsid = value)))
-      override val productassemblyid = new OptField[ProductId, Row](prefix, "productassemblyid", None, None)(x => extract(x).productassemblyid, (row, value) => merge(row, extract(row).copy(productassemblyid = value)))
-      override val componentid = new Field[ProductId, Row](prefix, "componentid", None, None)(x => extract(x).componentid, (row, value) => merge(row, extract(row).copy(componentid = value)))
-      override val startdate = new Field[TypoLocalDateTime, Row](prefix, "startdate", Some("text"), None)(x => extract(x).startdate, (row, value) => merge(row, extract(row).copy(startdate = value)))
-      override val enddate = new OptField[TypoLocalDateTime, Row](prefix, "enddate", Some("text"), None)(x => extract(x).enddate, (row, value) => merge(row, extract(row).copy(enddate = value)))
-      override val unitmeasurecode = new Field[UnitmeasureId, Row](prefix, "unitmeasurecode", None, None)(x => extract(x).unitmeasurecode, (row, value) => merge(row, extract(row).copy(unitmeasurecode = value)))
-      override val bomlevel = new Field[TypoShort, Row](prefix, "bomlevel", None, None)(x => extract(x).bomlevel, (row, value) => merge(row, extract(row).copy(bomlevel = value)))
-      override val perassemblyqty = new Field[BigDecimal, Row](prefix, "perassemblyqty", None, None)(x => extract(x).perassemblyqty, (row, value) => merge(row, extract(row).copy(perassemblyqty = value)))
-      override val modifieddate = new Field[TypoLocalDateTime, Row](prefix, "modifieddate", Some("text"), None)(x => extract(x).modifieddate, (row, value) => merge(row, extract(row).copy(modifieddate = value)))
+    override lazy val fields: BomViewFields = new BomViewFields {
+      override def id = Field[Int, BomViewRow](_path, "id", None, None, x => x.id, (row, value) => row.copy(id = value))
+      override def billofmaterialsid = Field[Int, BomViewRow](_path, "billofmaterialsid", None, None, x => x.billofmaterialsid, (row, value) => row.copy(billofmaterialsid = value))
+      override def productassemblyid = OptField[ProductId, BomViewRow](_path, "productassemblyid", None, None, x => x.productassemblyid, (row, value) => row.copy(productassemblyid = value))
+      override def componentid = Field[ProductId, BomViewRow](_path, "componentid", None, None, x => x.componentid, (row, value) => row.copy(componentid = value))
+      override def startdate = Field[TypoLocalDateTime, BomViewRow](_path, "startdate", Some("text"), None, x => x.startdate, (row, value) => row.copy(startdate = value))
+      override def enddate = OptField[TypoLocalDateTime, BomViewRow](_path, "enddate", Some("text"), None, x => x.enddate, (row, value) => row.copy(enddate = value))
+      override def unitmeasurecode = Field[UnitmeasureId, BomViewRow](_path, "unitmeasurecode", None, None, x => x.unitmeasurecode, (row, value) => row.copy(unitmeasurecode = value))
+      override def bomlevel = Field[TypoShort, BomViewRow](_path, "bomlevel", None, None, x => x.bomlevel, (row, value) => row.copy(bomlevel = value))
+      override def perassemblyqty = Field[BigDecimal, BomViewRow](_path, "perassemblyqty", None, None, x => x.perassemblyqty, (row, value) => row.copy(perassemblyqty = value))
+      override def modifieddate = Field[TypoLocalDateTime, BomViewRow](_path, "modifieddate", Some("text"), None, x => x.modifieddate, (row, value) => row.copy(modifieddate = value))
     }
   
-    override val columns: List[FieldLikeNoHkt[?, Row]] =
-      List[FieldLikeNoHkt[?, Row]](fields.id, fields.billofmaterialsid, fields.productassemblyid, fields.componentid, fields.startdate, fields.enddate, fields.unitmeasurecode, fields.bomlevel, fields.perassemblyqty, fields.modifieddate)
+    override lazy val columns: List[FieldLikeNoHkt[?, BomViewRow]] =
+      List[FieldLikeNoHkt[?, BomViewRow]](fields.id, fields.billofmaterialsid, fields.productassemblyid, fields.componentid, fields.startdate, fields.enddate, fields.unitmeasurecode, fields.bomlevel, fields.perassemblyqty, fields.modifieddate)
   
-    override def copy[NewRow](prefix: Option[String], extract: NewRow => BomViewRow, merge: (NewRow, BomViewRow) => NewRow): Impl[NewRow] =
-      new Impl(prefix, extract, merge)
+    override def copy(path: List[Path]): Impl =
+      new Impl(path)
   }
   
 }

--- a/typo-tester-zio-jdbc/generated-and-checked-in/adventureworks/pr/d/DViewFields.scala
+++ b/typo-tester-zio-jdbc/generated-and-checked-in/adventureworks/pr/d/DViewFields.scala
@@ -14,55 +14,56 @@ import adventureworks.customtypes.TypoUUID
 import adventureworks.person.businessentity.BusinessentityId
 import adventureworks.production.document.DocumentId
 import adventureworks.public.Flag
+import typo.dsl.Path
 import typo.dsl.SqlExpr.Field
 import typo.dsl.SqlExpr.FieldLikeNoHkt
 import typo.dsl.SqlExpr.OptField
 import typo.dsl.Structure.Relation
 
-trait DViewFields[Row] {
-  val title: Field[/* max 50 chars */ String, Row]
-  val owner: Field[BusinessentityId, Row]
-  val folderflag: Field[Flag, Row]
-  val filename: Field[/* max 400 chars */ String, Row]
-  val fileextension: OptField[/* max 8 chars */ String, Row]
-  val revision: Field[/* bpchar, max 5 chars */ String, Row]
-  val changenumber: Field[Int, Row]
-  val status: Field[TypoShort, Row]
-  val documentsummary: OptField[String, Row]
-  val document: OptField[TypoBytea, Row]
-  val rowguid: Field[TypoUUID, Row]
-  val modifieddate: Field[TypoLocalDateTime, Row]
-  val documentnode: Field[DocumentId, Row]
+trait DViewFields {
+  def title: Field[/* max 50 chars */ String, DViewRow]
+  def owner: Field[BusinessentityId, DViewRow]
+  def folderflag: Field[Flag, DViewRow]
+  def filename: Field[/* max 400 chars */ String, DViewRow]
+  def fileextension: OptField[/* max 8 chars */ String, DViewRow]
+  def revision: Field[/* bpchar, max 5 chars */ String, DViewRow]
+  def changenumber: Field[Int, DViewRow]
+  def status: Field[TypoShort, DViewRow]
+  def documentsummary: OptField[String, DViewRow]
+  def document: OptField[TypoBytea, DViewRow]
+  def rowguid: Field[TypoUUID, DViewRow]
+  def modifieddate: Field[TypoLocalDateTime, DViewRow]
+  def documentnode: Field[DocumentId, DViewRow]
 }
 
 object DViewFields {
-  val structure: Relation[DViewFields, DViewRow, DViewRow] = 
-    new Impl(None, identity, (_, x) => x)
+  lazy val structure: Relation[DViewFields, DViewRow] =
+    new Impl(Nil)
     
-  private final class Impl[Row](val prefix: Option[String], val extract: Row => DViewRow, val merge: (Row, DViewRow) => Row)
-    extends Relation[DViewFields, DViewRow, Row] { 
+  private final class Impl(val _path: List[Path])
+    extends Relation[DViewFields, DViewRow] {
   
-    override val fields: DViewFields[Row] = new DViewFields[Row] {
-      override val title = new Field[/* max 50 chars */ String, Row](prefix, "title", None, None)(x => extract(x).title, (row, value) => merge(row, extract(row).copy(title = value)))
-      override val owner = new Field[BusinessentityId, Row](prefix, "owner", None, None)(x => extract(x).owner, (row, value) => merge(row, extract(row).copy(owner = value)))
-      override val folderflag = new Field[Flag, Row](prefix, "folderflag", None, None)(x => extract(x).folderflag, (row, value) => merge(row, extract(row).copy(folderflag = value)))
-      override val filename = new Field[/* max 400 chars */ String, Row](prefix, "filename", None, None)(x => extract(x).filename, (row, value) => merge(row, extract(row).copy(filename = value)))
-      override val fileextension = new OptField[/* max 8 chars */ String, Row](prefix, "fileextension", None, None)(x => extract(x).fileextension, (row, value) => merge(row, extract(row).copy(fileextension = value)))
-      override val revision = new Field[/* bpchar, max 5 chars */ String, Row](prefix, "revision", None, None)(x => extract(x).revision, (row, value) => merge(row, extract(row).copy(revision = value)))
-      override val changenumber = new Field[Int, Row](prefix, "changenumber", None, None)(x => extract(x).changenumber, (row, value) => merge(row, extract(row).copy(changenumber = value)))
-      override val status = new Field[TypoShort, Row](prefix, "status", None, None)(x => extract(x).status, (row, value) => merge(row, extract(row).copy(status = value)))
-      override val documentsummary = new OptField[String, Row](prefix, "documentsummary", None, None)(x => extract(x).documentsummary, (row, value) => merge(row, extract(row).copy(documentsummary = value)))
-      override val document = new OptField[TypoBytea, Row](prefix, "document", None, None)(x => extract(x).document, (row, value) => merge(row, extract(row).copy(document = value)))
-      override val rowguid = new Field[TypoUUID, Row](prefix, "rowguid", None, None)(x => extract(x).rowguid, (row, value) => merge(row, extract(row).copy(rowguid = value)))
-      override val modifieddate = new Field[TypoLocalDateTime, Row](prefix, "modifieddate", Some("text"), None)(x => extract(x).modifieddate, (row, value) => merge(row, extract(row).copy(modifieddate = value)))
-      override val documentnode = new Field[DocumentId, Row](prefix, "documentnode", None, None)(x => extract(x).documentnode, (row, value) => merge(row, extract(row).copy(documentnode = value)))
+    override lazy val fields: DViewFields = new DViewFields {
+      override def title = Field[/* max 50 chars */ String, DViewRow](_path, "title", None, None, x => x.title, (row, value) => row.copy(title = value))
+      override def owner = Field[BusinessentityId, DViewRow](_path, "owner", None, None, x => x.owner, (row, value) => row.copy(owner = value))
+      override def folderflag = Field[Flag, DViewRow](_path, "folderflag", None, None, x => x.folderflag, (row, value) => row.copy(folderflag = value))
+      override def filename = Field[/* max 400 chars */ String, DViewRow](_path, "filename", None, None, x => x.filename, (row, value) => row.copy(filename = value))
+      override def fileextension = OptField[/* max 8 chars */ String, DViewRow](_path, "fileextension", None, None, x => x.fileextension, (row, value) => row.copy(fileextension = value))
+      override def revision = Field[/* bpchar, max 5 chars */ String, DViewRow](_path, "revision", None, None, x => x.revision, (row, value) => row.copy(revision = value))
+      override def changenumber = Field[Int, DViewRow](_path, "changenumber", None, None, x => x.changenumber, (row, value) => row.copy(changenumber = value))
+      override def status = Field[TypoShort, DViewRow](_path, "status", None, None, x => x.status, (row, value) => row.copy(status = value))
+      override def documentsummary = OptField[String, DViewRow](_path, "documentsummary", None, None, x => x.documentsummary, (row, value) => row.copy(documentsummary = value))
+      override def document = OptField[TypoBytea, DViewRow](_path, "document", None, None, x => x.document, (row, value) => row.copy(document = value))
+      override def rowguid = Field[TypoUUID, DViewRow](_path, "rowguid", None, None, x => x.rowguid, (row, value) => row.copy(rowguid = value))
+      override def modifieddate = Field[TypoLocalDateTime, DViewRow](_path, "modifieddate", Some("text"), None, x => x.modifieddate, (row, value) => row.copy(modifieddate = value))
+      override def documentnode = Field[DocumentId, DViewRow](_path, "documentnode", None, None, x => x.documentnode, (row, value) => row.copy(documentnode = value))
     }
   
-    override val columns: List[FieldLikeNoHkt[?, Row]] =
-      List[FieldLikeNoHkt[?, Row]](fields.title, fields.owner, fields.folderflag, fields.filename, fields.fileextension, fields.revision, fields.changenumber, fields.status, fields.documentsummary, fields.document, fields.rowguid, fields.modifieddate, fields.documentnode)
+    override lazy val columns: List[FieldLikeNoHkt[?, DViewRow]] =
+      List[FieldLikeNoHkt[?, DViewRow]](fields.title, fields.owner, fields.folderflag, fields.filename, fields.fileextension, fields.revision, fields.changenumber, fields.status, fields.documentsummary, fields.document, fields.rowguid, fields.modifieddate, fields.documentnode)
   
-    override def copy[NewRow](prefix: Option[String], extract: NewRow => DViewRow, merge: (NewRow, DViewRow) => NewRow): Impl[NewRow] =
-      new Impl(prefix, extract, merge)
+    override def copy(path: List[Path]): Impl =
+      new Impl(path)
   }
   
 }

--- a/typo-tester-zio-jdbc/generated-and-checked-in/adventureworks/pr/l/LViewFields.scala
+++ b/typo-tester-zio-jdbc/generated-and-checked-in/adventureworks/pr/l/LViewFields.scala
@@ -10,40 +10,41 @@ package l
 import adventureworks.customtypes.TypoLocalDateTime
 import adventureworks.production.location.LocationId
 import adventureworks.public.Name
+import typo.dsl.Path
 import typo.dsl.SqlExpr.Field
 import typo.dsl.SqlExpr.FieldLikeNoHkt
 import typo.dsl.Structure.Relation
 
-trait LViewFields[Row] {
-  val id: Field[LocationId, Row]
-  val locationid: Field[LocationId, Row]
-  val name: Field[Name, Row]
-  val costrate: Field[BigDecimal, Row]
-  val availability: Field[BigDecimal, Row]
-  val modifieddate: Field[TypoLocalDateTime, Row]
+trait LViewFields {
+  def id: Field[LocationId, LViewRow]
+  def locationid: Field[LocationId, LViewRow]
+  def name: Field[Name, LViewRow]
+  def costrate: Field[BigDecimal, LViewRow]
+  def availability: Field[BigDecimal, LViewRow]
+  def modifieddate: Field[TypoLocalDateTime, LViewRow]
 }
 
 object LViewFields {
-  val structure: Relation[LViewFields, LViewRow, LViewRow] = 
-    new Impl(None, identity, (_, x) => x)
+  lazy val structure: Relation[LViewFields, LViewRow] =
+    new Impl(Nil)
     
-  private final class Impl[Row](val prefix: Option[String], val extract: Row => LViewRow, val merge: (Row, LViewRow) => Row)
-    extends Relation[LViewFields, LViewRow, Row] { 
+  private final class Impl(val _path: List[Path])
+    extends Relation[LViewFields, LViewRow] {
   
-    override val fields: LViewFields[Row] = new LViewFields[Row] {
-      override val id = new Field[LocationId, Row](prefix, "id", None, None)(x => extract(x).id, (row, value) => merge(row, extract(row).copy(id = value)))
-      override val locationid = new Field[LocationId, Row](prefix, "locationid", None, None)(x => extract(x).locationid, (row, value) => merge(row, extract(row).copy(locationid = value)))
-      override val name = new Field[Name, Row](prefix, "name", None, None)(x => extract(x).name, (row, value) => merge(row, extract(row).copy(name = value)))
-      override val costrate = new Field[BigDecimal, Row](prefix, "costrate", None, None)(x => extract(x).costrate, (row, value) => merge(row, extract(row).copy(costrate = value)))
-      override val availability = new Field[BigDecimal, Row](prefix, "availability", None, None)(x => extract(x).availability, (row, value) => merge(row, extract(row).copy(availability = value)))
-      override val modifieddate = new Field[TypoLocalDateTime, Row](prefix, "modifieddate", Some("text"), None)(x => extract(x).modifieddate, (row, value) => merge(row, extract(row).copy(modifieddate = value)))
+    override lazy val fields: LViewFields = new LViewFields {
+      override def id = Field[LocationId, LViewRow](_path, "id", None, None, x => x.id, (row, value) => row.copy(id = value))
+      override def locationid = Field[LocationId, LViewRow](_path, "locationid", None, None, x => x.locationid, (row, value) => row.copy(locationid = value))
+      override def name = Field[Name, LViewRow](_path, "name", None, None, x => x.name, (row, value) => row.copy(name = value))
+      override def costrate = Field[BigDecimal, LViewRow](_path, "costrate", None, None, x => x.costrate, (row, value) => row.copy(costrate = value))
+      override def availability = Field[BigDecimal, LViewRow](_path, "availability", None, None, x => x.availability, (row, value) => row.copy(availability = value))
+      override def modifieddate = Field[TypoLocalDateTime, LViewRow](_path, "modifieddate", Some("text"), None, x => x.modifieddate, (row, value) => row.copy(modifieddate = value))
     }
   
-    override val columns: List[FieldLikeNoHkt[?, Row]] =
-      List[FieldLikeNoHkt[?, Row]](fields.id, fields.locationid, fields.name, fields.costrate, fields.availability, fields.modifieddate)
+    override lazy val columns: List[FieldLikeNoHkt[?, LViewRow]] =
+      List[FieldLikeNoHkt[?, LViewRow]](fields.id, fields.locationid, fields.name, fields.costrate, fields.availability, fields.modifieddate)
   
-    override def copy[NewRow](prefix: Option[String], extract: NewRow => LViewRow, merge: (NewRow, LViewRow) => NewRow): Impl[NewRow] =
-      new Impl(prefix, extract, merge)
+    override def copy(path: List[Path]): Impl =
+      new Impl(path)
   }
   
 }

--- a/typo-tester-zio-jdbc/generated-and-checked-in/adventureworks/pr/p/PViewFields.scala
+++ b/typo-tester-zio-jdbc/generated-and-checked-in/adventureworks/pr/p/PViewFields.scala
@@ -16,81 +16,82 @@ import adventureworks.production.productsubcategory.ProductsubcategoryId
 import adventureworks.production.unitmeasure.UnitmeasureId
 import adventureworks.public.Flag
 import adventureworks.public.Name
+import typo.dsl.Path
 import typo.dsl.SqlExpr.Field
 import typo.dsl.SqlExpr.FieldLikeNoHkt
 import typo.dsl.SqlExpr.OptField
 import typo.dsl.Structure.Relation
 
-trait PViewFields[Row] {
-  val id: Field[ProductId, Row]
-  val productid: Field[ProductId, Row]
-  val name: Field[Name, Row]
-  val productnumber: Field[/* max 25 chars */ String, Row]
-  val makeflag: Field[Flag, Row]
-  val finishedgoodsflag: Field[Flag, Row]
-  val color: OptField[/* max 15 chars */ String, Row]
-  val safetystocklevel: Field[TypoShort, Row]
-  val reorderpoint: Field[TypoShort, Row]
-  val standardcost: Field[BigDecimal, Row]
-  val listprice: Field[BigDecimal, Row]
-  val size: OptField[/* max 5 chars */ String, Row]
-  val sizeunitmeasurecode: OptField[UnitmeasureId, Row]
-  val weightunitmeasurecode: OptField[UnitmeasureId, Row]
-  val weight: OptField[BigDecimal, Row]
-  val daystomanufacture: Field[Int, Row]
-  val productline: OptField[/* bpchar, max 2 chars */ String, Row]
-  val `class`: OptField[/* bpchar, max 2 chars */ String, Row]
-  val style: OptField[/* bpchar, max 2 chars */ String, Row]
-  val productsubcategoryid: OptField[ProductsubcategoryId, Row]
-  val productmodelid: OptField[ProductmodelId, Row]
-  val sellstartdate: Field[TypoLocalDateTime, Row]
-  val sellenddate: OptField[TypoLocalDateTime, Row]
-  val discontinueddate: OptField[TypoLocalDateTime, Row]
-  val rowguid: Field[TypoUUID, Row]
-  val modifieddate: Field[TypoLocalDateTime, Row]
+trait PViewFields {
+  def id: Field[ProductId, PViewRow]
+  def productid: Field[ProductId, PViewRow]
+  def name: Field[Name, PViewRow]
+  def productnumber: Field[/* max 25 chars */ String, PViewRow]
+  def makeflag: Field[Flag, PViewRow]
+  def finishedgoodsflag: Field[Flag, PViewRow]
+  def color: OptField[/* max 15 chars */ String, PViewRow]
+  def safetystocklevel: Field[TypoShort, PViewRow]
+  def reorderpoint: Field[TypoShort, PViewRow]
+  def standardcost: Field[BigDecimal, PViewRow]
+  def listprice: Field[BigDecimal, PViewRow]
+  def size: OptField[/* max 5 chars */ String, PViewRow]
+  def sizeunitmeasurecode: OptField[UnitmeasureId, PViewRow]
+  def weightunitmeasurecode: OptField[UnitmeasureId, PViewRow]
+  def weight: OptField[BigDecimal, PViewRow]
+  def daystomanufacture: Field[Int, PViewRow]
+  def productline: OptField[/* bpchar, max 2 chars */ String, PViewRow]
+  def `class`: OptField[/* bpchar, max 2 chars */ String, PViewRow]
+  def style: OptField[/* bpchar, max 2 chars */ String, PViewRow]
+  def productsubcategoryid: OptField[ProductsubcategoryId, PViewRow]
+  def productmodelid: OptField[ProductmodelId, PViewRow]
+  def sellstartdate: Field[TypoLocalDateTime, PViewRow]
+  def sellenddate: OptField[TypoLocalDateTime, PViewRow]
+  def discontinueddate: OptField[TypoLocalDateTime, PViewRow]
+  def rowguid: Field[TypoUUID, PViewRow]
+  def modifieddate: Field[TypoLocalDateTime, PViewRow]
 }
 
 object PViewFields {
-  val structure: Relation[PViewFields, PViewRow, PViewRow] = 
-    new Impl(None, identity, (_, x) => x)
+  lazy val structure: Relation[PViewFields, PViewRow] =
+    new Impl(Nil)
     
-  private final class Impl[Row](val prefix: Option[String], val extract: Row => PViewRow, val merge: (Row, PViewRow) => Row)
-    extends Relation[PViewFields, PViewRow, Row] { 
+  private final class Impl(val _path: List[Path])
+    extends Relation[PViewFields, PViewRow] {
   
-    override val fields: PViewFields[Row] = new PViewFields[Row] {
-      override val id = new Field[ProductId, Row](prefix, "id", None, None)(x => extract(x).id, (row, value) => merge(row, extract(row).copy(id = value)))
-      override val productid = new Field[ProductId, Row](prefix, "productid", None, None)(x => extract(x).productid, (row, value) => merge(row, extract(row).copy(productid = value)))
-      override val name = new Field[Name, Row](prefix, "name", None, None)(x => extract(x).name, (row, value) => merge(row, extract(row).copy(name = value)))
-      override val productnumber = new Field[/* max 25 chars */ String, Row](prefix, "productnumber", None, None)(x => extract(x).productnumber, (row, value) => merge(row, extract(row).copy(productnumber = value)))
-      override val makeflag = new Field[Flag, Row](prefix, "makeflag", None, None)(x => extract(x).makeflag, (row, value) => merge(row, extract(row).copy(makeflag = value)))
-      override val finishedgoodsflag = new Field[Flag, Row](prefix, "finishedgoodsflag", None, None)(x => extract(x).finishedgoodsflag, (row, value) => merge(row, extract(row).copy(finishedgoodsflag = value)))
-      override val color = new OptField[/* max 15 chars */ String, Row](prefix, "color", None, None)(x => extract(x).color, (row, value) => merge(row, extract(row).copy(color = value)))
-      override val safetystocklevel = new Field[TypoShort, Row](prefix, "safetystocklevel", None, None)(x => extract(x).safetystocklevel, (row, value) => merge(row, extract(row).copy(safetystocklevel = value)))
-      override val reorderpoint = new Field[TypoShort, Row](prefix, "reorderpoint", None, None)(x => extract(x).reorderpoint, (row, value) => merge(row, extract(row).copy(reorderpoint = value)))
-      override val standardcost = new Field[BigDecimal, Row](prefix, "standardcost", None, None)(x => extract(x).standardcost, (row, value) => merge(row, extract(row).copy(standardcost = value)))
-      override val listprice = new Field[BigDecimal, Row](prefix, "listprice", None, None)(x => extract(x).listprice, (row, value) => merge(row, extract(row).copy(listprice = value)))
-      override val size = new OptField[/* max 5 chars */ String, Row](prefix, "size", None, None)(x => extract(x).size, (row, value) => merge(row, extract(row).copy(size = value)))
-      override val sizeunitmeasurecode = new OptField[UnitmeasureId, Row](prefix, "sizeunitmeasurecode", None, None)(x => extract(x).sizeunitmeasurecode, (row, value) => merge(row, extract(row).copy(sizeunitmeasurecode = value)))
-      override val weightunitmeasurecode = new OptField[UnitmeasureId, Row](prefix, "weightunitmeasurecode", None, None)(x => extract(x).weightunitmeasurecode, (row, value) => merge(row, extract(row).copy(weightunitmeasurecode = value)))
-      override val weight = new OptField[BigDecimal, Row](prefix, "weight", None, None)(x => extract(x).weight, (row, value) => merge(row, extract(row).copy(weight = value)))
-      override val daystomanufacture = new Field[Int, Row](prefix, "daystomanufacture", None, None)(x => extract(x).daystomanufacture, (row, value) => merge(row, extract(row).copy(daystomanufacture = value)))
-      override val productline = new OptField[/* bpchar, max 2 chars */ String, Row](prefix, "productline", None, None)(x => extract(x).productline, (row, value) => merge(row, extract(row).copy(productline = value)))
-      override val `class` = new OptField[/* bpchar, max 2 chars */ String, Row](prefix, "class", None, None)(x => extract(x).`class`, (row, value) => merge(row, extract(row).copy(`class` = value)))
-      override val style = new OptField[/* bpchar, max 2 chars */ String, Row](prefix, "style", None, None)(x => extract(x).style, (row, value) => merge(row, extract(row).copy(style = value)))
-      override val productsubcategoryid = new OptField[ProductsubcategoryId, Row](prefix, "productsubcategoryid", None, None)(x => extract(x).productsubcategoryid, (row, value) => merge(row, extract(row).copy(productsubcategoryid = value)))
-      override val productmodelid = new OptField[ProductmodelId, Row](prefix, "productmodelid", None, None)(x => extract(x).productmodelid, (row, value) => merge(row, extract(row).copy(productmodelid = value)))
-      override val sellstartdate = new Field[TypoLocalDateTime, Row](prefix, "sellstartdate", Some("text"), None)(x => extract(x).sellstartdate, (row, value) => merge(row, extract(row).copy(sellstartdate = value)))
-      override val sellenddate = new OptField[TypoLocalDateTime, Row](prefix, "sellenddate", Some("text"), None)(x => extract(x).sellenddate, (row, value) => merge(row, extract(row).copy(sellenddate = value)))
-      override val discontinueddate = new OptField[TypoLocalDateTime, Row](prefix, "discontinueddate", Some("text"), None)(x => extract(x).discontinueddate, (row, value) => merge(row, extract(row).copy(discontinueddate = value)))
-      override val rowguid = new Field[TypoUUID, Row](prefix, "rowguid", None, None)(x => extract(x).rowguid, (row, value) => merge(row, extract(row).copy(rowguid = value)))
-      override val modifieddate = new Field[TypoLocalDateTime, Row](prefix, "modifieddate", Some("text"), None)(x => extract(x).modifieddate, (row, value) => merge(row, extract(row).copy(modifieddate = value)))
+    override lazy val fields: PViewFields = new PViewFields {
+      override def id = Field[ProductId, PViewRow](_path, "id", None, None, x => x.id, (row, value) => row.copy(id = value))
+      override def productid = Field[ProductId, PViewRow](_path, "productid", None, None, x => x.productid, (row, value) => row.copy(productid = value))
+      override def name = Field[Name, PViewRow](_path, "name", None, None, x => x.name, (row, value) => row.copy(name = value))
+      override def productnumber = Field[/* max 25 chars */ String, PViewRow](_path, "productnumber", None, None, x => x.productnumber, (row, value) => row.copy(productnumber = value))
+      override def makeflag = Field[Flag, PViewRow](_path, "makeflag", None, None, x => x.makeflag, (row, value) => row.copy(makeflag = value))
+      override def finishedgoodsflag = Field[Flag, PViewRow](_path, "finishedgoodsflag", None, None, x => x.finishedgoodsflag, (row, value) => row.copy(finishedgoodsflag = value))
+      override def color = OptField[/* max 15 chars */ String, PViewRow](_path, "color", None, None, x => x.color, (row, value) => row.copy(color = value))
+      override def safetystocklevel = Field[TypoShort, PViewRow](_path, "safetystocklevel", None, None, x => x.safetystocklevel, (row, value) => row.copy(safetystocklevel = value))
+      override def reorderpoint = Field[TypoShort, PViewRow](_path, "reorderpoint", None, None, x => x.reorderpoint, (row, value) => row.copy(reorderpoint = value))
+      override def standardcost = Field[BigDecimal, PViewRow](_path, "standardcost", None, None, x => x.standardcost, (row, value) => row.copy(standardcost = value))
+      override def listprice = Field[BigDecimal, PViewRow](_path, "listprice", None, None, x => x.listprice, (row, value) => row.copy(listprice = value))
+      override def size = OptField[/* max 5 chars */ String, PViewRow](_path, "size", None, None, x => x.size, (row, value) => row.copy(size = value))
+      override def sizeunitmeasurecode = OptField[UnitmeasureId, PViewRow](_path, "sizeunitmeasurecode", None, None, x => x.sizeunitmeasurecode, (row, value) => row.copy(sizeunitmeasurecode = value))
+      override def weightunitmeasurecode = OptField[UnitmeasureId, PViewRow](_path, "weightunitmeasurecode", None, None, x => x.weightunitmeasurecode, (row, value) => row.copy(weightunitmeasurecode = value))
+      override def weight = OptField[BigDecimal, PViewRow](_path, "weight", None, None, x => x.weight, (row, value) => row.copy(weight = value))
+      override def daystomanufacture = Field[Int, PViewRow](_path, "daystomanufacture", None, None, x => x.daystomanufacture, (row, value) => row.copy(daystomanufacture = value))
+      override def productline = OptField[/* bpchar, max 2 chars */ String, PViewRow](_path, "productline", None, None, x => x.productline, (row, value) => row.copy(productline = value))
+      override def `class` = OptField[/* bpchar, max 2 chars */ String, PViewRow](_path, "class", None, None, x => x.`class`, (row, value) => row.copy(`class` = value))
+      override def style = OptField[/* bpchar, max 2 chars */ String, PViewRow](_path, "style", None, None, x => x.style, (row, value) => row.copy(style = value))
+      override def productsubcategoryid = OptField[ProductsubcategoryId, PViewRow](_path, "productsubcategoryid", None, None, x => x.productsubcategoryid, (row, value) => row.copy(productsubcategoryid = value))
+      override def productmodelid = OptField[ProductmodelId, PViewRow](_path, "productmodelid", None, None, x => x.productmodelid, (row, value) => row.copy(productmodelid = value))
+      override def sellstartdate = Field[TypoLocalDateTime, PViewRow](_path, "sellstartdate", Some("text"), None, x => x.sellstartdate, (row, value) => row.copy(sellstartdate = value))
+      override def sellenddate = OptField[TypoLocalDateTime, PViewRow](_path, "sellenddate", Some("text"), None, x => x.sellenddate, (row, value) => row.copy(sellenddate = value))
+      override def discontinueddate = OptField[TypoLocalDateTime, PViewRow](_path, "discontinueddate", Some("text"), None, x => x.discontinueddate, (row, value) => row.copy(discontinueddate = value))
+      override def rowguid = Field[TypoUUID, PViewRow](_path, "rowguid", None, None, x => x.rowguid, (row, value) => row.copy(rowguid = value))
+      override def modifieddate = Field[TypoLocalDateTime, PViewRow](_path, "modifieddate", Some("text"), None, x => x.modifieddate, (row, value) => row.copy(modifieddate = value))
     }
   
-    override val columns: List[FieldLikeNoHkt[?, Row]] =
-      List[FieldLikeNoHkt[?, Row]](fields.id, fields.productid, fields.name, fields.productnumber, fields.makeflag, fields.finishedgoodsflag, fields.color, fields.safetystocklevel, fields.reorderpoint, fields.standardcost, fields.listprice, fields.size, fields.sizeunitmeasurecode, fields.weightunitmeasurecode, fields.weight, fields.daystomanufacture, fields.productline, fields.`class`, fields.style, fields.productsubcategoryid, fields.productmodelid, fields.sellstartdate, fields.sellenddate, fields.discontinueddate, fields.rowguid, fields.modifieddate)
+    override lazy val columns: List[FieldLikeNoHkt[?, PViewRow]] =
+      List[FieldLikeNoHkt[?, PViewRow]](fields.id, fields.productid, fields.name, fields.productnumber, fields.makeflag, fields.finishedgoodsflag, fields.color, fields.safetystocklevel, fields.reorderpoint, fields.standardcost, fields.listprice, fields.size, fields.sizeunitmeasurecode, fields.weightunitmeasurecode, fields.weight, fields.daystomanufacture, fields.productline, fields.`class`, fields.style, fields.productsubcategoryid, fields.productmodelid, fields.sellstartdate, fields.sellenddate, fields.discontinueddate, fields.rowguid, fields.modifieddate)
   
-    override def copy[NewRow](prefix: Option[String], extract: NewRow => PViewRow, merge: (NewRow, PViewRow) => NewRow): Impl[NewRow] =
-      new Impl(prefix, extract, merge)
+    override def copy(path: List[Path]): Impl =
+      new Impl(path)
   }
   
 }

--- a/typo-tester-zio-jdbc/generated-and-checked-in/adventureworks/pr/pc/PcViewFields.scala
+++ b/typo-tester-zio-jdbc/generated-and-checked-in/adventureworks/pr/pc/PcViewFields.scala
@@ -11,38 +11,39 @@ import adventureworks.customtypes.TypoLocalDateTime
 import adventureworks.customtypes.TypoUUID
 import adventureworks.production.productcategory.ProductcategoryId
 import adventureworks.public.Name
+import typo.dsl.Path
 import typo.dsl.SqlExpr.Field
 import typo.dsl.SqlExpr.FieldLikeNoHkt
 import typo.dsl.Structure.Relation
 
-trait PcViewFields[Row] {
-  val id: Field[ProductcategoryId, Row]
-  val productcategoryid: Field[ProductcategoryId, Row]
-  val name: Field[Name, Row]
-  val rowguid: Field[TypoUUID, Row]
-  val modifieddate: Field[TypoLocalDateTime, Row]
+trait PcViewFields {
+  def id: Field[ProductcategoryId, PcViewRow]
+  def productcategoryid: Field[ProductcategoryId, PcViewRow]
+  def name: Field[Name, PcViewRow]
+  def rowguid: Field[TypoUUID, PcViewRow]
+  def modifieddate: Field[TypoLocalDateTime, PcViewRow]
 }
 
 object PcViewFields {
-  val structure: Relation[PcViewFields, PcViewRow, PcViewRow] = 
-    new Impl(None, identity, (_, x) => x)
+  lazy val structure: Relation[PcViewFields, PcViewRow] =
+    new Impl(Nil)
     
-  private final class Impl[Row](val prefix: Option[String], val extract: Row => PcViewRow, val merge: (Row, PcViewRow) => Row)
-    extends Relation[PcViewFields, PcViewRow, Row] { 
+  private final class Impl(val _path: List[Path])
+    extends Relation[PcViewFields, PcViewRow] {
   
-    override val fields: PcViewFields[Row] = new PcViewFields[Row] {
-      override val id = new Field[ProductcategoryId, Row](prefix, "id", None, None)(x => extract(x).id, (row, value) => merge(row, extract(row).copy(id = value)))
-      override val productcategoryid = new Field[ProductcategoryId, Row](prefix, "productcategoryid", None, None)(x => extract(x).productcategoryid, (row, value) => merge(row, extract(row).copy(productcategoryid = value)))
-      override val name = new Field[Name, Row](prefix, "name", None, None)(x => extract(x).name, (row, value) => merge(row, extract(row).copy(name = value)))
-      override val rowguid = new Field[TypoUUID, Row](prefix, "rowguid", None, None)(x => extract(x).rowguid, (row, value) => merge(row, extract(row).copy(rowguid = value)))
-      override val modifieddate = new Field[TypoLocalDateTime, Row](prefix, "modifieddate", Some("text"), None)(x => extract(x).modifieddate, (row, value) => merge(row, extract(row).copy(modifieddate = value)))
+    override lazy val fields: PcViewFields = new PcViewFields {
+      override def id = Field[ProductcategoryId, PcViewRow](_path, "id", None, None, x => x.id, (row, value) => row.copy(id = value))
+      override def productcategoryid = Field[ProductcategoryId, PcViewRow](_path, "productcategoryid", None, None, x => x.productcategoryid, (row, value) => row.copy(productcategoryid = value))
+      override def name = Field[Name, PcViewRow](_path, "name", None, None, x => x.name, (row, value) => row.copy(name = value))
+      override def rowguid = Field[TypoUUID, PcViewRow](_path, "rowguid", None, None, x => x.rowguid, (row, value) => row.copy(rowguid = value))
+      override def modifieddate = Field[TypoLocalDateTime, PcViewRow](_path, "modifieddate", Some("text"), None, x => x.modifieddate, (row, value) => row.copy(modifieddate = value))
     }
   
-    override val columns: List[FieldLikeNoHkt[?, Row]] =
-      List[FieldLikeNoHkt[?, Row]](fields.id, fields.productcategoryid, fields.name, fields.rowguid, fields.modifieddate)
+    override lazy val columns: List[FieldLikeNoHkt[?, PcViewRow]] =
+      List[FieldLikeNoHkt[?, PcViewRow]](fields.id, fields.productcategoryid, fields.name, fields.rowguid, fields.modifieddate)
   
-    override def copy[NewRow](prefix: Option[String], extract: NewRow => PcViewRow, merge: (NewRow, PcViewRow) => NewRow): Impl[NewRow] =
-      new Impl(prefix, extract, merge)
+    override def copy(path: List[Path]): Impl =
+      new Impl(path)
   }
   
 }

--- a/typo-tester-zio-jdbc/generated-and-checked-in/adventureworks/pr/pch/PchViewFields.scala
+++ b/typo-tester-zio-jdbc/generated-and-checked-in/adventureworks/pr/pch/PchViewFields.scala
@@ -9,41 +9,42 @@ package pch
 
 import adventureworks.customtypes.TypoLocalDateTime
 import adventureworks.production.product.ProductId
+import typo.dsl.Path
 import typo.dsl.SqlExpr.Field
 import typo.dsl.SqlExpr.FieldLikeNoHkt
 import typo.dsl.SqlExpr.OptField
 import typo.dsl.Structure.Relation
 
-trait PchViewFields[Row] {
-  val id: Field[ProductId, Row]
-  val productid: Field[ProductId, Row]
-  val startdate: Field[TypoLocalDateTime, Row]
-  val enddate: OptField[TypoLocalDateTime, Row]
-  val standardcost: Field[BigDecimal, Row]
-  val modifieddate: Field[TypoLocalDateTime, Row]
+trait PchViewFields {
+  def id: Field[ProductId, PchViewRow]
+  def productid: Field[ProductId, PchViewRow]
+  def startdate: Field[TypoLocalDateTime, PchViewRow]
+  def enddate: OptField[TypoLocalDateTime, PchViewRow]
+  def standardcost: Field[BigDecimal, PchViewRow]
+  def modifieddate: Field[TypoLocalDateTime, PchViewRow]
 }
 
 object PchViewFields {
-  val structure: Relation[PchViewFields, PchViewRow, PchViewRow] = 
-    new Impl(None, identity, (_, x) => x)
+  lazy val structure: Relation[PchViewFields, PchViewRow] =
+    new Impl(Nil)
     
-  private final class Impl[Row](val prefix: Option[String], val extract: Row => PchViewRow, val merge: (Row, PchViewRow) => Row)
-    extends Relation[PchViewFields, PchViewRow, Row] { 
+  private final class Impl(val _path: List[Path])
+    extends Relation[PchViewFields, PchViewRow] {
   
-    override val fields: PchViewFields[Row] = new PchViewFields[Row] {
-      override val id = new Field[ProductId, Row](prefix, "id", None, None)(x => extract(x).id, (row, value) => merge(row, extract(row).copy(id = value)))
-      override val productid = new Field[ProductId, Row](prefix, "productid", None, None)(x => extract(x).productid, (row, value) => merge(row, extract(row).copy(productid = value)))
-      override val startdate = new Field[TypoLocalDateTime, Row](prefix, "startdate", Some("text"), None)(x => extract(x).startdate, (row, value) => merge(row, extract(row).copy(startdate = value)))
-      override val enddate = new OptField[TypoLocalDateTime, Row](prefix, "enddate", Some("text"), None)(x => extract(x).enddate, (row, value) => merge(row, extract(row).copy(enddate = value)))
-      override val standardcost = new Field[BigDecimal, Row](prefix, "standardcost", None, None)(x => extract(x).standardcost, (row, value) => merge(row, extract(row).copy(standardcost = value)))
-      override val modifieddate = new Field[TypoLocalDateTime, Row](prefix, "modifieddate", Some("text"), None)(x => extract(x).modifieddate, (row, value) => merge(row, extract(row).copy(modifieddate = value)))
+    override lazy val fields: PchViewFields = new PchViewFields {
+      override def id = Field[ProductId, PchViewRow](_path, "id", None, None, x => x.id, (row, value) => row.copy(id = value))
+      override def productid = Field[ProductId, PchViewRow](_path, "productid", None, None, x => x.productid, (row, value) => row.copy(productid = value))
+      override def startdate = Field[TypoLocalDateTime, PchViewRow](_path, "startdate", Some("text"), None, x => x.startdate, (row, value) => row.copy(startdate = value))
+      override def enddate = OptField[TypoLocalDateTime, PchViewRow](_path, "enddate", Some("text"), None, x => x.enddate, (row, value) => row.copy(enddate = value))
+      override def standardcost = Field[BigDecimal, PchViewRow](_path, "standardcost", None, None, x => x.standardcost, (row, value) => row.copy(standardcost = value))
+      override def modifieddate = Field[TypoLocalDateTime, PchViewRow](_path, "modifieddate", Some("text"), None, x => x.modifieddate, (row, value) => row.copy(modifieddate = value))
     }
   
-    override val columns: List[FieldLikeNoHkt[?, Row]] =
-      List[FieldLikeNoHkt[?, Row]](fields.id, fields.productid, fields.startdate, fields.enddate, fields.standardcost, fields.modifieddate)
+    override lazy val columns: List[FieldLikeNoHkt[?, PchViewRow]] =
+      List[FieldLikeNoHkt[?, PchViewRow]](fields.id, fields.productid, fields.startdate, fields.enddate, fields.standardcost, fields.modifieddate)
   
-    override def copy[NewRow](prefix: Option[String], extract: NewRow => PchViewRow, merge: (NewRow, PchViewRow) => NewRow): Impl[NewRow] =
-      new Impl(prefix, extract, merge)
+    override def copy(path: List[Path]): Impl =
+      new Impl(path)
   }
   
 }

--- a/typo-tester-zio-jdbc/generated-and-checked-in/adventureworks/pr/pd/PdViewFields.scala
+++ b/typo-tester-zio-jdbc/generated-and-checked-in/adventureworks/pr/pd/PdViewFields.scala
@@ -10,38 +10,39 @@ package pd
 import adventureworks.customtypes.TypoLocalDateTime
 import adventureworks.customtypes.TypoUUID
 import adventureworks.production.productdescription.ProductdescriptionId
+import typo.dsl.Path
 import typo.dsl.SqlExpr.Field
 import typo.dsl.SqlExpr.FieldLikeNoHkt
 import typo.dsl.Structure.Relation
 
-trait PdViewFields[Row] {
-  val id: Field[ProductdescriptionId, Row]
-  val productdescriptionid: Field[ProductdescriptionId, Row]
-  val description: Field[/* max 400 chars */ String, Row]
-  val rowguid: Field[TypoUUID, Row]
-  val modifieddate: Field[TypoLocalDateTime, Row]
+trait PdViewFields {
+  def id: Field[ProductdescriptionId, PdViewRow]
+  def productdescriptionid: Field[ProductdescriptionId, PdViewRow]
+  def description: Field[/* max 400 chars */ String, PdViewRow]
+  def rowguid: Field[TypoUUID, PdViewRow]
+  def modifieddate: Field[TypoLocalDateTime, PdViewRow]
 }
 
 object PdViewFields {
-  val structure: Relation[PdViewFields, PdViewRow, PdViewRow] = 
-    new Impl(None, identity, (_, x) => x)
+  lazy val structure: Relation[PdViewFields, PdViewRow] =
+    new Impl(Nil)
     
-  private final class Impl[Row](val prefix: Option[String], val extract: Row => PdViewRow, val merge: (Row, PdViewRow) => Row)
-    extends Relation[PdViewFields, PdViewRow, Row] { 
+  private final class Impl(val _path: List[Path])
+    extends Relation[PdViewFields, PdViewRow] {
   
-    override val fields: PdViewFields[Row] = new PdViewFields[Row] {
-      override val id = new Field[ProductdescriptionId, Row](prefix, "id", None, None)(x => extract(x).id, (row, value) => merge(row, extract(row).copy(id = value)))
-      override val productdescriptionid = new Field[ProductdescriptionId, Row](prefix, "productdescriptionid", None, None)(x => extract(x).productdescriptionid, (row, value) => merge(row, extract(row).copy(productdescriptionid = value)))
-      override val description = new Field[/* max 400 chars */ String, Row](prefix, "description", None, None)(x => extract(x).description, (row, value) => merge(row, extract(row).copy(description = value)))
-      override val rowguid = new Field[TypoUUID, Row](prefix, "rowguid", None, None)(x => extract(x).rowguid, (row, value) => merge(row, extract(row).copy(rowguid = value)))
-      override val modifieddate = new Field[TypoLocalDateTime, Row](prefix, "modifieddate", Some("text"), None)(x => extract(x).modifieddate, (row, value) => merge(row, extract(row).copy(modifieddate = value)))
+    override lazy val fields: PdViewFields = new PdViewFields {
+      override def id = Field[ProductdescriptionId, PdViewRow](_path, "id", None, None, x => x.id, (row, value) => row.copy(id = value))
+      override def productdescriptionid = Field[ProductdescriptionId, PdViewRow](_path, "productdescriptionid", None, None, x => x.productdescriptionid, (row, value) => row.copy(productdescriptionid = value))
+      override def description = Field[/* max 400 chars */ String, PdViewRow](_path, "description", None, None, x => x.description, (row, value) => row.copy(description = value))
+      override def rowguid = Field[TypoUUID, PdViewRow](_path, "rowguid", None, None, x => x.rowguid, (row, value) => row.copy(rowguid = value))
+      override def modifieddate = Field[TypoLocalDateTime, PdViewRow](_path, "modifieddate", Some("text"), None, x => x.modifieddate, (row, value) => row.copy(modifieddate = value))
     }
   
-    override val columns: List[FieldLikeNoHkt[?, Row]] =
-      List[FieldLikeNoHkt[?, Row]](fields.id, fields.productdescriptionid, fields.description, fields.rowguid, fields.modifieddate)
+    override lazy val columns: List[FieldLikeNoHkt[?, PdViewRow]] =
+      List[FieldLikeNoHkt[?, PdViewRow]](fields.id, fields.productdescriptionid, fields.description, fields.rowguid, fields.modifieddate)
   
-    override def copy[NewRow](prefix: Option[String], extract: NewRow => PdViewRow, merge: (NewRow, PdViewRow) => NewRow): Impl[NewRow] =
-      new Impl(prefix, extract, merge)
+    override def copy(path: List[Path]): Impl =
+      new Impl(path)
   }
   
 }

--- a/typo-tester-zio-jdbc/generated-and-checked-in/adventureworks/pr/pi/PiViewFields.scala
+++ b/typo-tester-zio-jdbc/generated-and-checked-in/adventureworks/pr/pi/PiViewFields.scala
@@ -12,44 +12,45 @@ import adventureworks.customtypes.TypoShort
 import adventureworks.customtypes.TypoUUID
 import adventureworks.production.location.LocationId
 import adventureworks.production.product.ProductId
+import typo.dsl.Path
 import typo.dsl.SqlExpr.Field
 import typo.dsl.SqlExpr.FieldLikeNoHkt
 import typo.dsl.Structure.Relation
 
-trait PiViewFields[Row] {
-  val id: Field[ProductId, Row]
-  val productid: Field[ProductId, Row]
-  val locationid: Field[LocationId, Row]
-  val shelf: Field[/* max 10 chars */ String, Row]
-  val bin: Field[TypoShort, Row]
-  val quantity: Field[TypoShort, Row]
-  val rowguid: Field[TypoUUID, Row]
-  val modifieddate: Field[TypoLocalDateTime, Row]
+trait PiViewFields {
+  def id: Field[ProductId, PiViewRow]
+  def productid: Field[ProductId, PiViewRow]
+  def locationid: Field[LocationId, PiViewRow]
+  def shelf: Field[/* max 10 chars */ String, PiViewRow]
+  def bin: Field[TypoShort, PiViewRow]
+  def quantity: Field[TypoShort, PiViewRow]
+  def rowguid: Field[TypoUUID, PiViewRow]
+  def modifieddate: Field[TypoLocalDateTime, PiViewRow]
 }
 
 object PiViewFields {
-  val structure: Relation[PiViewFields, PiViewRow, PiViewRow] = 
-    new Impl(None, identity, (_, x) => x)
+  lazy val structure: Relation[PiViewFields, PiViewRow] =
+    new Impl(Nil)
     
-  private final class Impl[Row](val prefix: Option[String], val extract: Row => PiViewRow, val merge: (Row, PiViewRow) => Row)
-    extends Relation[PiViewFields, PiViewRow, Row] { 
+  private final class Impl(val _path: List[Path])
+    extends Relation[PiViewFields, PiViewRow] {
   
-    override val fields: PiViewFields[Row] = new PiViewFields[Row] {
-      override val id = new Field[ProductId, Row](prefix, "id", None, None)(x => extract(x).id, (row, value) => merge(row, extract(row).copy(id = value)))
-      override val productid = new Field[ProductId, Row](prefix, "productid", None, None)(x => extract(x).productid, (row, value) => merge(row, extract(row).copy(productid = value)))
-      override val locationid = new Field[LocationId, Row](prefix, "locationid", None, None)(x => extract(x).locationid, (row, value) => merge(row, extract(row).copy(locationid = value)))
-      override val shelf = new Field[/* max 10 chars */ String, Row](prefix, "shelf", None, None)(x => extract(x).shelf, (row, value) => merge(row, extract(row).copy(shelf = value)))
-      override val bin = new Field[TypoShort, Row](prefix, "bin", None, None)(x => extract(x).bin, (row, value) => merge(row, extract(row).copy(bin = value)))
-      override val quantity = new Field[TypoShort, Row](prefix, "quantity", None, None)(x => extract(x).quantity, (row, value) => merge(row, extract(row).copy(quantity = value)))
-      override val rowguid = new Field[TypoUUID, Row](prefix, "rowguid", None, None)(x => extract(x).rowguid, (row, value) => merge(row, extract(row).copy(rowguid = value)))
-      override val modifieddate = new Field[TypoLocalDateTime, Row](prefix, "modifieddate", Some("text"), None)(x => extract(x).modifieddate, (row, value) => merge(row, extract(row).copy(modifieddate = value)))
+    override lazy val fields: PiViewFields = new PiViewFields {
+      override def id = Field[ProductId, PiViewRow](_path, "id", None, None, x => x.id, (row, value) => row.copy(id = value))
+      override def productid = Field[ProductId, PiViewRow](_path, "productid", None, None, x => x.productid, (row, value) => row.copy(productid = value))
+      override def locationid = Field[LocationId, PiViewRow](_path, "locationid", None, None, x => x.locationid, (row, value) => row.copy(locationid = value))
+      override def shelf = Field[/* max 10 chars */ String, PiViewRow](_path, "shelf", None, None, x => x.shelf, (row, value) => row.copy(shelf = value))
+      override def bin = Field[TypoShort, PiViewRow](_path, "bin", None, None, x => x.bin, (row, value) => row.copy(bin = value))
+      override def quantity = Field[TypoShort, PiViewRow](_path, "quantity", None, None, x => x.quantity, (row, value) => row.copy(quantity = value))
+      override def rowguid = Field[TypoUUID, PiViewRow](_path, "rowguid", None, None, x => x.rowguid, (row, value) => row.copy(rowguid = value))
+      override def modifieddate = Field[TypoLocalDateTime, PiViewRow](_path, "modifieddate", Some("text"), None, x => x.modifieddate, (row, value) => row.copy(modifieddate = value))
     }
   
-    override val columns: List[FieldLikeNoHkt[?, Row]] =
-      List[FieldLikeNoHkt[?, Row]](fields.id, fields.productid, fields.locationid, fields.shelf, fields.bin, fields.quantity, fields.rowguid, fields.modifieddate)
+    override lazy val columns: List[FieldLikeNoHkt[?, PiViewRow]] =
+      List[FieldLikeNoHkt[?, PiViewRow]](fields.id, fields.productid, fields.locationid, fields.shelf, fields.bin, fields.quantity, fields.rowguid, fields.modifieddate)
   
-    override def copy[NewRow](prefix: Option[String], extract: NewRow => PiViewRow, merge: (NewRow, PiViewRow) => NewRow): Impl[NewRow] =
-      new Impl(prefix, extract, merge)
+    override def copy(path: List[Path]): Impl =
+      new Impl(path)
   }
   
 }

--- a/typo-tester-zio-jdbc/generated-and-checked-in/adventureworks/pr/plph/PlphViewFields.scala
+++ b/typo-tester-zio-jdbc/generated-and-checked-in/adventureworks/pr/plph/PlphViewFields.scala
@@ -9,41 +9,42 @@ package plph
 
 import adventureworks.customtypes.TypoLocalDateTime
 import adventureworks.production.product.ProductId
+import typo.dsl.Path
 import typo.dsl.SqlExpr.Field
 import typo.dsl.SqlExpr.FieldLikeNoHkt
 import typo.dsl.SqlExpr.OptField
 import typo.dsl.Structure.Relation
 
-trait PlphViewFields[Row] {
-  val id: Field[ProductId, Row]
-  val productid: Field[ProductId, Row]
-  val startdate: Field[TypoLocalDateTime, Row]
-  val enddate: OptField[TypoLocalDateTime, Row]
-  val listprice: Field[BigDecimal, Row]
-  val modifieddate: Field[TypoLocalDateTime, Row]
+trait PlphViewFields {
+  def id: Field[ProductId, PlphViewRow]
+  def productid: Field[ProductId, PlphViewRow]
+  def startdate: Field[TypoLocalDateTime, PlphViewRow]
+  def enddate: OptField[TypoLocalDateTime, PlphViewRow]
+  def listprice: Field[BigDecimal, PlphViewRow]
+  def modifieddate: Field[TypoLocalDateTime, PlphViewRow]
 }
 
 object PlphViewFields {
-  val structure: Relation[PlphViewFields, PlphViewRow, PlphViewRow] = 
-    new Impl(None, identity, (_, x) => x)
+  lazy val structure: Relation[PlphViewFields, PlphViewRow] =
+    new Impl(Nil)
     
-  private final class Impl[Row](val prefix: Option[String], val extract: Row => PlphViewRow, val merge: (Row, PlphViewRow) => Row)
-    extends Relation[PlphViewFields, PlphViewRow, Row] { 
+  private final class Impl(val _path: List[Path])
+    extends Relation[PlphViewFields, PlphViewRow] {
   
-    override val fields: PlphViewFields[Row] = new PlphViewFields[Row] {
-      override val id = new Field[ProductId, Row](prefix, "id", None, None)(x => extract(x).id, (row, value) => merge(row, extract(row).copy(id = value)))
-      override val productid = new Field[ProductId, Row](prefix, "productid", None, None)(x => extract(x).productid, (row, value) => merge(row, extract(row).copy(productid = value)))
-      override val startdate = new Field[TypoLocalDateTime, Row](prefix, "startdate", Some("text"), None)(x => extract(x).startdate, (row, value) => merge(row, extract(row).copy(startdate = value)))
-      override val enddate = new OptField[TypoLocalDateTime, Row](prefix, "enddate", Some("text"), None)(x => extract(x).enddate, (row, value) => merge(row, extract(row).copy(enddate = value)))
-      override val listprice = new Field[BigDecimal, Row](prefix, "listprice", None, None)(x => extract(x).listprice, (row, value) => merge(row, extract(row).copy(listprice = value)))
-      override val modifieddate = new Field[TypoLocalDateTime, Row](prefix, "modifieddate", Some("text"), None)(x => extract(x).modifieddate, (row, value) => merge(row, extract(row).copy(modifieddate = value)))
+    override lazy val fields: PlphViewFields = new PlphViewFields {
+      override def id = Field[ProductId, PlphViewRow](_path, "id", None, None, x => x.id, (row, value) => row.copy(id = value))
+      override def productid = Field[ProductId, PlphViewRow](_path, "productid", None, None, x => x.productid, (row, value) => row.copy(productid = value))
+      override def startdate = Field[TypoLocalDateTime, PlphViewRow](_path, "startdate", Some("text"), None, x => x.startdate, (row, value) => row.copy(startdate = value))
+      override def enddate = OptField[TypoLocalDateTime, PlphViewRow](_path, "enddate", Some("text"), None, x => x.enddate, (row, value) => row.copy(enddate = value))
+      override def listprice = Field[BigDecimal, PlphViewRow](_path, "listprice", None, None, x => x.listprice, (row, value) => row.copy(listprice = value))
+      override def modifieddate = Field[TypoLocalDateTime, PlphViewRow](_path, "modifieddate", Some("text"), None, x => x.modifieddate, (row, value) => row.copy(modifieddate = value))
     }
   
-    override val columns: List[FieldLikeNoHkt[?, Row]] =
-      List[FieldLikeNoHkt[?, Row]](fields.id, fields.productid, fields.startdate, fields.enddate, fields.listprice, fields.modifieddate)
+    override lazy val columns: List[FieldLikeNoHkt[?, PlphViewRow]] =
+      List[FieldLikeNoHkt[?, PlphViewRow]](fields.id, fields.productid, fields.startdate, fields.enddate, fields.listprice, fields.modifieddate)
   
-    override def copy[NewRow](prefix: Option[String], extract: NewRow => PlphViewRow, merge: (NewRow, PlphViewRow) => NewRow): Impl[NewRow] =
-      new Impl(prefix, extract, merge)
+    override def copy(path: List[Path]): Impl =
+      new Impl(path)
   }
   
 }

--- a/typo-tester-zio-jdbc/generated-and-checked-in/adventureworks/pr/pm/PmViewFields.scala
+++ b/typo-tester-zio-jdbc/generated-and-checked-in/adventureworks/pr/pm/PmViewFields.scala
@@ -12,43 +12,44 @@ import adventureworks.customtypes.TypoUUID
 import adventureworks.customtypes.TypoXml
 import adventureworks.production.productmodel.ProductmodelId
 import adventureworks.public.Name
+import typo.dsl.Path
 import typo.dsl.SqlExpr.Field
 import typo.dsl.SqlExpr.FieldLikeNoHkt
 import typo.dsl.SqlExpr.OptField
 import typo.dsl.Structure.Relation
 
-trait PmViewFields[Row] {
-  val id: Field[ProductmodelId, Row]
-  val productmodelid: Field[ProductmodelId, Row]
-  val name: Field[Name, Row]
-  val catalogdescription: OptField[TypoXml, Row]
-  val instructions: OptField[TypoXml, Row]
-  val rowguid: Field[TypoUUID, Row]
-  val modifieddate: Field[TypoLocalDateTime, Row]
+trait PmViewFields {
+  def id: Field[ProductmodelId, PmViewRow]
+  def productmodelid: Field[ProductmodelId, PmViewRow]
+  def name: Field[Name, PmViewRow]
+  def catalogdescription: OptField[TypoXml, PmViewRow]
+  def instructions: OptField[TypoXml, PmViewRow]
+  def rowguid: Field[TypoUUID, PmViewRow]
+  def modifieddate: Field[TypoLocalDateTime, PmViewRow]
 }
 
 object PmViewFields {
-  val structure: Relation[PmViewFields, PmViewRow, PmViewRow] = 
-    new Impl(None, identity, (_, x) => x)
+  lazy val structure: Relation[PmViewFields, PmViewRow] =
+    new Impl(Nil)
     
-  private final class Impl[Row](val prefix: Option[String], val extract: Row => PmViewRow, val merge: (Row, PmViewRow) => Row)
-    extends Relation[PmViewFields, PmViewRow, Row] { 
+  private final class Impl(val _path: List[Path])
+    extends Relation[PmViewFields, PmViewRow] {
   
-    override val fields: PmViewFields[Row] = new PmViewFields[Row] {
-      override val id = new Field[ProductmodelId, Row](prefix, "id", None, None)(x => extract(x).id, (row, value) => merge(row, extract(row).copy(id = value)))
-      override val productmodelid = new Field[ProductmodelId, Row](prefix, "productmodelid", None, None)(x => extract(x).productmodelid, (row, value) => merge(row, extract(row).copy(productmodelid = value)))
-      override val name = new Field[Name, Row](prefix, "name", None, None)(x => extract(x).name, (row, value) => merge(row, extract(row).copy(name = value)))
-      override val catalogdescription = new OptField[TypoXml, Row](prefix, "catalogdescription", None, None)(x => extract(x).catalogdescription, (row, value) => merge(row, extract(row).copy(catalogdescription = value)))
-      override val instructions = new OptField[TypoXml, Row](prefix, "instructions", None, None)(x => extract(x).instructions, (row, value) => merge(row, extract(row).copy(instructions = value)))
-      override val rowguid = new Field[TypoUUID, Row](prefix, "rowguid", None, None)(x => extract(x).rowguid, (row, value) => merge(row, extract(row).copy(rowguid = value)))
-      override val modifieddate = new Field[TypoLocalDateTime, Row](prefix, "modifieddate", Some("text"), None)(x => extract(x).modifieddate, (row, value) => merge(row, extract(row).copy(modifieddate = value)))
+    override lazy val fields: PmViewFields = new PmViewFields {
+      override def id = Field[ProductmodelId, PmViewRow](_path, "id", None, None, x => x.id, (row, value) => row.copy(id = value))
+      override def productmodelid = Field[ProductmodelId, PmViewRow](_path, "productmodelid", None, None, x => x.productmodelid, (row, value) => row.copy(productmodelid = value))
+      override def name = Field[Name, PmViewRow](_path, "name", None, None, x => x.name, (row, value) => row.copy(name = value))
+      override def catalogdescription = OptField[TypoXml, PmViewRow](_path, "catalogdescription", None, None, x => x.catalogdescription, (row, value) => row.copy(catalogdescription = value))
+      override def instructions = OptField[TypoXml, PmViewRow](_path, "instructions", None, None, x => x.instructions, (row, value) => row.copy(instructions = value))
+      override def rowguid = Field[TypoUUID, PmViewRow](_path, "rowguid", None, None, x => x.rowguid, (row, value) => row.copy(rowguid = value))
+      override def modifieddate = Field[TypoLocalDateTime, PmViewRow](_path, "modifieddate", Some("text"), None, x => x.modifieddate, (row, value) => row.copy(modifieddate = value))
     }
   
-    override val columns: List[FieldLikeNoHkt[?, Row]] =
-      List[FieldLikeNoHkt[?, Row]](fields.id, fields.productmodelid, fields.name, fields.catalogdescription, fields.instructions, fields.rowguid, fields.modifieddate)
+    override lazy val columns: List[FieldLikeNoHkt[?, PmViewRow]] =
+      List[FieldLikeNoHkt[?, PmViewRow]](fields.id, fields.productmodelid, fields.name, fields.catalogdescription, fields.instructions, fields.rowguid, fields.modifieddate)
   
-    override def copy[NewRow](prefix: Option[String], extract: NewRow => PmViewRow, merge: (NewRow, PmViewRow) => NewRow): Impl[NewRow] =
-      new Impl(prefix, extract, merge)
+    override def copy(path: List[Path]): Impl =
+      new Impl(path)
   }
   
 }

--- a/typo-tester-zio-jdbc/generated-and-checked-in/adventureworks/pr/pmpdc/PmpdcViewFields.scala
+++ b/typo-tester-zio-jdbc/generated-and-checked-in/adventureworks/pr/pmpdc/PmpdcViewFields.scala
@@ -11,36 +11,37 @@ import adventureworks.customtypes.TypoLocalDateTime
 import adventureworks.production.culture.CultureId
 import adventureworks.production.productdescription.ProductdescriptionId
 import adventureworks.production.productmodel.ProductmodelId
+import typo.dsl.Path
 import typo.dsl.SqlExpr.Field
 import typo.dsl.SqlExpr.FieldLikeNoHkt
 import typo.dsl.Structure.Relation
 
-trait PmpdcViewFields[Row] {
-  val productmodelid: Field[ProductmodelId, Row]
-  val productdescriptionid: Field[ProductdescriptionId, Row]
-  val cultureid: Field[CultureId, Row]
-  val modifieddate: Field[TypoLocalDateTime, Row]
+trait PmpdcViewFields {
+  def productmodelid: Field[ProductmodelId, PmpdcViewRow]
+  def productdescriptionid: Field[ProductdescriptionId, PmpdcViewRow]
+  def cultureid: Field[CultureId, PmpdcViewRow]
+  def modifieddate: Field[TypoLocalDateTime, PmpdcViewRow]
 }
 
 object PmpdcViewFields {
-  val structure: Relation[PmpdcViewFields, PmpdcViewRow, PmpdcViewRow] = 
-    new Impl(None, identity, (_, x) => x)
+  lazy val structure: Relation[PmpdcViewFields, PmpdcViewRow] =
+    new Impl(Nil)
     
-  private final class Impl[Row](val prefix: Option[String], val extract: Row => PmpdcViewRow, val merge: (Row, PmpdcViewRow) => Row)
-    extends Relation[PmpdcViewFields, PmpdcViewRow, Row] { 
+  private final class Impl(val _path: List[Path])
+    extends Relation[PmpdcViewFields, PmpdcViewRow] {
   
-    override val fields: PmpdcViewFields[Row] = new PmpdcViewFields[Row] {
-      override val productmodelid = new Field[ProductmodelId, Row](prefix, "productmodelid", None, None)(x => extract(x).productmodelid, (row, value) => merge(row, extract(row).copy(productmodelid = value)))
-      override val productdescriptionid = new Field[ProductdescriptionId, Row](prefix, "productdescriptionid", None, None)(x => extract(x).productdescriptionid, (row, value) => merge(row, extract(row).copy(productdescriptionid = value)))
-      override val cultureid = new Field[CultureId, Row](prefix, "cultureid", None, None)(x => extract(x).cultureid, (row, value) => merge(row, extract(row).copy(cultureid = value)))
-      override val modifieddate = new Field[TypoLocalDateTime, Row](prefix, "modifieddate", Some("text"), None)(x => extract(x).modifieddate, (row, value) => merge(row, extract(row).copy(modifieddate = value)))
+    override lazy val fields: PmpdcViewFields = new PmpdcViewFields {
+      override def productmodelid = Field[ProductmodelId, PmpdcViewRow](_path, "productmodelid", None, None, x => x.productmodelid, (row, value) => row.copy(productmodelid = value))
+      override def productdescriptionid = Field[ProductdescriptionId, PmpdcViewRow](_path, "productdescriptionid", None, None, x => x.productdescriptionid, (row, value) => row.copy(productdescriptionid = value))
+      override def cultureid = Field[CultureId, PmpdcViewRow](_path, "cultureid", None, None, x => x.cultureid, (row, value) => row.copy(cultureid = value))
+      override def modifieddate = Field[TypoLocalDateTime, PmpdcViewRow](_path, "modifieddate", Some("text"), None, x => x.modifieddate, (row, value) => row.copy(modifieddate = value))
     }
   
-    override val columns: List[FieldLikeNoHkt[?, Row]] =
-      List[FieldLikeNoHkt[?, Row]](fields.productmodelid, fields.productdescriptionid, fields.cultureid, fields.modifieddate)
+    override lazy val columns: List[FieldLikeNoHkt[?, PmpdcViewRow]] =
+      List[FieldLikeNoHkt[?, PmpdcViewRow]](fields.productmodelid, fields.productdescriptionid, fields.cultureid, fields.modifieddate)
   
-    override def copy[NewRow](prefix: Option[String], extract: NewRow => PmpdcViewRow, merge: (NewRow, PmpdcViewRow) => NewRow): Impl[NewRow] =
-      new Impl(prefix, extract, merge)
+    override def copy(path: List[Path]): Impl =
+      new Impl(path)
   }
   
 }

--- a/typo-tester-zio-jdbc/generated-and-checked-in/adventureworks/pr/pp/PpViewFields.scala
+++ b/typo-tester-zio-jdbc/generated-and-checked-in/adventureworks/pr/pp/PpViewFields.scala
@@ -10,43 +10,44 @@ package pp
 import adventureworks.customtypes.TypoBytea
 import adventureworks.customtypes.TypoLocalDateTime
 import adventureworks.production.productphoto.ProductphotoId
+import typo.dsl.Path
 import typo.dsl.SqlExpr.Field
 import typo.dsl.SqlExpr.FieldLikeNoHkt
 import typo.dsl.SqlExpr.OptField
 import typo.dsl.Structure.Relation
 
-trait PpViewFields[Row] {
-  val id: Field[ProductphotoId, Row]
-  val productphotoid: Field[ProductphotoId, Row]
-  val thumbnailphoto: OptField[TypoBytea, Row]
-  val thumbnailphotofilename: OptField[/* max 50 chars */ String, Row]
-  val largephoto: OptField[TypoBytea, Row]
-  val largephotofilename: OptField[/* max 50 chars */ String, Row]
-  val modifieddate: Field[TypoLocalDateTime, Row]
+trait PpViewFields {
+  def id: Field[ProductphotoId, PpViewRow]
+  def productphotoid: Field[ProductphotoId, PpViewRow]
+  def thumbnailphoto: OptField[TypoBytea, PpViewRow]
+  def thumbnailphotofilename: OptField[/* max 50 chars */ String, PpViewRow]
+  def largephoto: OptField[TypoBytea, PpViewRow]
+  def largephotofilename: OptField[/* max 50 chars */ String, PpViewRow]
+  def modifieddate: Field[TypoLocalDateTime, PpViewRow]
 }
 
 object PpViewFields {
-  val structure: Relation[PpViewFields, PpViewRow, PpViewRow] = 
-    new Impl(None, identity, (_, x) => x)
+  lazy val structure: Relation[PpViewFields, PpViewRow] =
+    new Impl(Nil)
     
-  private final class Impl[Row](val prefix: Option[String], val extract: Row => PpViewRow, val merge: (Row, PpViewRow) => Row)
-    extends Relation[PpViewFields, PpViewRow, Row] { 
+  private final class Impl(val _path: List[Path])
+    extends Relation[PpViewFields, PpViewRow] {
   
-    override val fields: PpViewFields[Row] = new PpViewFields[Row] {
-      override val id = new Field[ProductphotoId, Row](prefix, "id", None, None)(x => extract(x).id, (row, value) => merge(row, extract(row).copy(id = value)))
-      override val productphotoid = new Field[ProductphotoId, Row](prefix, "productphotoid", None, None)(x => extract(x).productphotoid, (row, value) => merge(row, extract(row).copy(productphotoid = value)))
-      override val thumbnailphoto = new OptField[TypoBytea, Row](prefix, "thumbnailphoto", None, None)(x => extract(x).thumbnailphoto, (row, value) => merge(row, extract(row).copy(thumbnailphoto = value)))
-      override val thumbnailphotofilename = new OptField[/* max 50 chars */ String, Row](prefix, "thumbnailphotofilename", None, None)(x => extract(x).thumbnailphotofilename, (row, value) => merge(row, extract(row).copy(thumbnailphotofilename = value)))
-      override val largephoto = new OptField[TypoBytea, Row](prefix, "largephoto", None, None)(x => extract(x).largephoto, (row, value) => merge(row, extract(row).copy(largephoto = value)))
-      override val largephotofilename = new OptField[/* max 50 chars */ String, Row](prefix, "largephotofilename", None, None)(x => extract(x).largephotofilename, (row, value) => merge(row, extract(row).copy(largephotofilename = value)))
-      override val modifieddate = new Field[TypoLocalDateTime, Row](prefix, "modifieddate", Some("text"), None)(x => extract(x).modifieddate, (row, value) => merge(row, extract(row).copy(modifieddate = value)))
+    override lazy val fields: PpViewFields = new PpViewFields {
+      override def id = Field[ProductphotoId, PpViewRow](_path, "id", None, None, x => x.id, (row, value) => row.copy(id = value))
+      override def productphotoid = Field[ProductphotoId, PpViewRow](_path, "productphotoid", None, None, x => x.productphotoid, (row, value) => row.copy(productphotoid = value))
+      override def thumbnailphoto = OptField[TypoBytea, PpViewRow](_path, "thumbnailphoto", None, None, x => x.thumbnailphoto, (row, value) => row.copy(thumbnailphoto = value))
+      override def thumbnailphotofilename = OptField[/* max 50 chars */ String, PpViewRow](_path, "thumbnailphotofilename", None, None, x => x.thumbnailphotofilename, (row, value) => row.copy(thumbnailphotofilename = value))
+      override def largephoto = OptField[TypoBytea, PpViewRow](_path, "largephoto", None, None, x => x.largephoto, (row, value) => row.copy(largephoto = value))
+      override def largephotofilename = OptField[/* max 50 chars */ String, PpViewRow](_path, "largephotofilename", None, None, x => x.largephotofilename, (row, value) => row.copy(largephotofilename = value))
+      override def modifieddate = Field[TypoLocalDateTime, PpViewRow](_path, "modifieddate", Some("text"), None, x => x.modifieddate, (row, value) => row.copy(modifieddate = value))
     }
   
-    override val columns: List[FieldLikeNoHkt[?, Row]] =
-      List[FieldLikeNoHkt[?, Row]](fields.id, fields.productphotoid, fields.thumbnailphoto, fields.thumbnailphotofilename, fields.largephoto, fields.largephotofilename, fields.modifieddate)
+    override lazy val columns: List[FieldLikeNoHkt[?, PpViewRow]] =
+      List[FieldLikeNoHkt[?, PpViewRow]](fields.id, fields.productphotoid, fields.thumbnailphoto, fields.thumbnailphotofilename, fields.largephoto, fields.largephotofilename, fields.modifieddate)
   
-    override def copy[NewRow](prefix: Option[String], extract: NewRow => PpViewRow, merge: (NewRow, PpViewRow) => NewRow): Impl[NewRow] =
-      new Impl(prefix, extract, merge)
+    override def copy(path: List[Path]): Impl =
+      new Impl(path)
   }
   
 }

--- a/typo-tester-zio-jdbc/generated-and-checked-in/adventureworks/pr/ppp/PppViewFields.scala
+++ b/typo-tester-zio-jdbc/generated-and-checked-in/adventureworks/pr/ppp/PppViewFields.scala
@@ -11,36 +11,37 @@ import adventureworks.customtypes.TypoLocalDateTime
 import adventureworks.production.product.ProductId
 import adventureworks.production.productphoto.ProductphotoId
 import adventureworks.public.Flag
+import typo.dsl.Path
 import typo.dsl.SqlExpr.Field
 import typo.dsl.SqlExpr.FieldLikeNoHkt
 import typo.dsl.Structure.Relation
 
-trait PppViewFields[Row] {
-  val productid: Field[ProductId, Row]
-  val productphotoid: Field[ProductphotoId, Row]
-  val primary: Field[Flag, Row]
-  val modifieddate: Field[TypoLocalDateTime, Row]
+trait PppViewFields {
+  def productid: Field[ProductId, PppViewRow]
+  def productphotoid: Field[ProductphotoId, PppViewRow]
+  def primary: Field[Flag, PppViewRow]
+  def modifieddate: Field[TypoLocalDateTime, PppViewRow]
 }
 
 object PppViewFields {
-  val structure: Relation[PppViewFields, PppViewRow, PppViewRow] = 
-    new Impl(None, identity, (_, x) => x)
+  lazy val structure: Relation[PppViewFields, PppViewRow] =
+    new Impl(Nil)
     
-  private final class Impl[Row](val prefix: Option[String], val extract: Row => PppViewRow, val merge: (Row, PppViewRow) => Row)
-    extends Relation[PppViewFields, PppViewRow, Row] { 
+  private final class Impl(val _path: List[Path])
+    extends Relation[PppViewFields, PppViewRow] {
   
-    override val fields: PppViewFields[Row] = new PppViewFields[Row] {
-      override val productid = new Field[ProductId, Row](prefix, "productid", None, None)(x => extract(x).productid, (row, value) => merge(row, extract(row).copy(productid = value)))
-      override val productphotoid = new Field[ProductphotoId, Row](prefix, "productphotoid", None, None)(x => extract(x).productphotoid, (row, value) => merge(row, extract(row).copy(productphotoid = value)))
-      override val primary = new Field[Flag, Row](prefix, "primary", None, None)(x => extract(x).primary, (row, value) => merge(row, extract(row).copy(primary = value)))
-      override val modifieddate = new Field[TypoLocalDateTime, Row](prefix, "modifieddate", Some("text"), None)(x => extract(x).modifieddate, (row, value) => merge(row, extract(row).copy(modifieddate = value)))
+    override lazy val fields: PppViewFields = new PppViewFields {
+      override def productid = Field[ProductId, PppViewRow](_path, "productid", None, None, x => x.productid, (row, value) => row.copy(productid = value))
+      override def productphotoid = Field[ProductphotoId, PppViewRow](_path, "productphotoid", None, None, x => x.productphotoid, (row, value) => row.copy(productphotoid = value))
+      override def primary = Field[Flag, PppViewRow](_path, "primary", None, None, x => x.primary, (row, value) => row.copy(primary = value))
+      override def modifieddate = Field[TypoLocalDateTime, PppViewRow](_path, "modifieddate", Some("text"), None, x => x.modifieddate, (row, value) => row.copy(modifieddate = value))
     }
   
-    override val columns: List[FieldLikeNoHkt[?, Row]] =
-      List[FieldLikeNoHkt[?, Row]](fields.productid, fields.productphotoid, fields.primary, fields.modifieddate)
+    override lazy val columns: List[FieldLikeNoHkt[?, PppViewRow]] =
+      List[FieldLikeNoHkt[?, PppViewRow]](fields.productid, fields.productphotoid, fields.primary, fields.modifieddate)
   
-    override def copy[NewRow](prefix: Option[String], extract: NewRow => PppViewRow, merge: (NewRow, PppViewRow) => NewRow): Impl[NewRow] =
-      new Impl(prefix, extract, merge)
+    override def copy(path: List[Path]): Impl =
+      new Impl(path)
   }
   
 }

--- a/typo-tester-zio-jdbc/generated-and-checked-in/adventureworks/pr/pr/PrViewFields.scala
+++ b/typo-tester-zio-jdbc/generated-and-checked-in/adventureworks/pr/pr/PrViewFields.scala
@@ -11,47 +11,48 @@ import adventureworks.customtypes.TypoLocalDateTime
 import adventureworks.production.product.ProductId
 import adventureworks.production.productreview.ProductreviewId
 import adventureworks.public.Name
+import typo.dsl.Path
 import typo.dsl.SqlExpr.Field
 import typo.dsl.SqlExpr.FieldLikeNoHkt
 import typo.dsl.SqlExpr.OptField
 import typo.dsl.Structure.Relation
 
-trait PrViewFields[Row] {
-  val id: Field[ProductreviewId, Row]
-  val productreviewid: Field[ProductreviewId, Row]
-  val productid: Field[ProductId, Row]
-  val reviewername: Field[Name, Row]
-  val reviewdate: Field[TypoLocalDateTime, Row]
-  val emailaddress: Field[/* max 50 chars */ String, Row]
-  val rating: Field[Int, Row]
-  val comments: OptField[/* max 3850 chars */ String, Row]
-  val modifieddate: Field[TypoLocalDateTime, Row]
+trait PrViewFields {
+  def id: Field[ProductreviewId, PrViewRow]
+  def productreviewid: Field[ProductreviewId, PrViewRow]
+  def productid: Field[ProductId, PrViewRow]
+  def reviewername: Field[Name, PrViewRow]
+  def reviewdate: Field[TypoLocalDateTime, PrViewRow]
+  def emailaddress: Field[/* max 50 chars */ String, PrViewRow]
+  def rating: Field[Int, PrViewRow]
+  def comments: OptField[/* max 3850 chars */ String, PrViewRow]
+  def modifieddate: Field[TypoLocalDateTime, PrViewRow]
 }
 
 object PrViewFields {
-  val structure: Relation[PrViewFields, PrViewRow, PrViewRow] = 
-    new Impl(None, identity, (_, x) => x)
+  lazy val structure: Relation[PrViewFields, PrViewRow] =
+    new Impl(Nil)
     
-  private final class Impl[Row](val prefix: Option[String], val extract: Row => PrViewRow, val merge: (Row, PrViewRow) => Row)
-    extends Relation[PrViewFields, PrViewRow, Row] { 
+  private final class Impl(val _path: List[Path])
+    extends Relation[PrViewFields, PrViewRow] {
   
-    override val fields: PrViewFields[Row] = new PrViewFields[Row] {
-      override val id = new Field[ProductreviewId, Row](prefix, "id", None, None)(x => extract(x).id, (row, value) => merge(row, extract(row).copy(id = value)))
-      override val productreviewid = new Field[ProductreviewId, Row](prefix, "productreviewid", None, None)(x => extract(x).productreviewid, (row, value) => merge(row, extract(row).copy(productreviewid = value)))
-      override val productid = new Field[ProductId, Row](prefix, "productid", None, None)(x => extract(x).productid, (row, value) => merge(row, extract(row).copy(productid = value)))
-      override val reviewername = new Field[Name, Row](prefix, "reviewername", None, None)(x => extract(x).reviewername, (row, value) => merge(row, extract(row).copy(reviewername = value)))
-      override val reviewdate = new Field[TypoLocalDateTime, Row](prefix, "reviewdate", Some("text"), None)(x => extract(x).reviewdate, (row, value) => merge(row, extract(row).copy(reviewdate = value)))
-      override val emailaddress = new Field[/* max 50 chars */ String, Row](prefix, "emailaddress", None, None)(x => extract(x).emailaddress, (row, value) => merge(row, extract(row).copy(emailaddress = value)))
-      override val rating = new Field[Int, Row](prefix, "rating", None, None)(x => extract(x).rating, (row, value) => merge(row, extract(row).copy(rating = value)))
-      override val comments = new OptField[/* max 3850 chars */ String, Row](prefix, "comments", None, None)(x => extract(x).comments, (row, value) => merge(row, extract(row).copy(comments = value)))
-      override val modifieddate = new Field[TypoLocalDateTime, Row](prefix, "modifieddate", Some("text"), None)(x => extract(x).modifieddate, (row, value) => merge(row, extract(row).copy(modifieddate = value)))
+    override lazy val fields: PrViewFields = new PrViewFields {
+      override def id = Field[ProductreviewId, PrViewRow](_path, "id", None, None, x => x.id, (row, value) => row.copy(id = value))
+      override def productreviewid = Field[ProductreviewId, PrViewRow](_path, "productreviewid", None, None, x => x.productreviewid, (row, value) => row.copy(productreviewid = value))
+      override def productid = Field[ProductId, PrViewRow](_path, "productid", None, None, x => x.productid, (row, value) => row.copy(productid = value))
+      override def reviewername = Field[Name, PrViewRow](_path, "reviewername", None, None, x => x.reviewername, (row, value) => row.copy(reviewername = value))
+      override def reviewdate = Field[TypoLocalDateTime, PrViewRow](_path, "reviewdate", Some("text"), None, x => x.reviewdate, (row, value) => row.copy(reviewdate = value))
+      override def emailaddress = Field[/* max 50 chars */ String, PrViewRow](_path, "emailaddress", None, None, x => x.emailaddress, (row, value) => row.copy(emailaddress = value))
+      override def rating = Field[Int, PrViewRow](_path, "rating", None, None, x => x.rating, (row, value) => row.copy(rating = value))
+      override def comments = OptField[/* max 3850 chars */ String, PrViewRow](_path, "comments", None, None, x => x.comments, (row, value) => row.copy(comments = value))
+      override def modifieddate = Field[TypoLocalDateTime, PrViewRow](_path, "modifieddate", Some("text"), None, x => x.modifieddate, (row, value) => row.copy(modifieddate = value))
     }
   
-    override val columns: List[FieldLikeNoHkt[?, Row]] =
-      List[FieldLikeNoHkt[?, Row]](fields.id, fields.productreviewid, fields.productid, fields.reviewername, fields.reviewdate, fields.emailaddress, fields.rating, fields.comments, fields.modifieddate)
+    override lazy val columns: List[FieldLikeNoHkt[?, PrViewRow]] =
+      List[FieldLikeNoHkt[?, PrViewRow]](fields.id, fields.productreviewid, fields.productid, fields.reviewername, fields.reviewdate, fields.emailaddress, fields.rating, fields.comments, fields.modifieddate)
   
-    override def copy[NewRow](prefix: Option[String], extract: NewRow => PrViewRow, merge: (NewRow, PrViewRow) => NewRow): Impl[NewRow] =
-      new Impl(prefix, extract, merge)
+    override def copy(path: List[Path]): Impl =
+      new Impl(path)
   }
   
 }

--- a/typo-tester-zio-jdbc/generated-and-checked-in/adventureworks/pr/psc/PscViewFields.scala
+++ b/typo-tester-zio-jdbc/generated-and-checked-in/adventureworks/pr/psc/PscViewFields.scala
@@ -12,40 +12,41 @@ import adventureworks.customtypes.TypoUUID
 import adventureworks.production.productcategory.ProductcategoryId
 import adventureworks.production.productsubcategory.ProductsubcategoryId
 import adventureworks.public.Name
+import typo.dsl.Path
 import typo.dsl.SqlExpr.Field
 import typo.dsl.SqlExpr.FieldLikeNoHkt
 import typo.dsl.Structure.Relation
 
-trait PscViewFields[Row] {
-  val id: Field[ProductsubcategoryId, Row]
-  val productsubcategoryid: Field[ProductsubcategoryId, Row]
-  val productcategoryid: Field[ProductcategoryId, Row]
-  val name: Field[Name, Row]
-  val rowguid: Field[TypoUUID, Row]
-  val modifieddate: Field[TypoLocalDateTime, Row]
+trait PscViewFields {
+  def id: Field[ProductsubcategoryId, PscViewRow]
+  def productsubcategoryid: Field[ProductsubcategoryId, PscViewRow]
+  def productcategoryid: Field[ProductcategoryId, PscViewRow]
+  def name: Field[Name, PscViewRow]
+  def rowguid: Field[TypoUUID, PscViewRow]
+  def modifieddate: Field[TypoLocalDateTime, PscViewRow]
 }
 
 object PscViewFields {
-  val structure: Relation[PscViewFields, PscViewRow, PscViewRow] = 
-    new Impl(None, identity, (_, x) => x)
+  lazy val structure: Relation[PscViewFields, PscViewRow] =
+    new Impl(Nil)
     
-  private final class Impl[Row](val prefix: Option[String], val extract: Row => PscViewRow, val merge: (Row, PscViewRow) => Row)
-    extends Relation[PscViewFields, PscViewRow, Row] { 
+  private final class Impl(val _path: List[Path])
+    extends Relation[PscViewFields, PscViewRow] {
   
-    override val fields: PscViewFields[Row] = new PscViewFields[Row] {
-      override val id = new Field[ProductsubcategoryId, Row](prefix, "id", None, None)(x => extract(x).id, (row, value) => merge(row, extract(row).copy(id = value)))
-      override val productsubcategoryid = new Field[ProductsubcategoryId, Row](prefix, "productsubcategoryid", None, None)(x => extract(x).productsubcategoryid, (row, value) => merge(row, extract(row).copy(productsubcategoryid = value)))
-      override val productcategoryid = new Field[ProductcategoryId, Row](prefix, "productcategoryid", None, None)(x => extract(x).productcategoryid, (row, value) => merge(row, extract(row).copy(productcategoryid = value)))
-      override val name = new Field[Name, Row](prefix, "name", None, None)(x => extract(x).name, (row, value) => merge(row, extract(row).copy(name = value)))
-      override val rowguid = new Field[TypoUUID, Row](prefix, "rowguid", None, None)(x => extract(x).rowguid, (row, value) => merge(row, extract(row).copy(rowguid = value)))
-      override val modifieddate = new Field[TypoLocalDateTime, Row](prefix, "modifieddate", Some("text"), None)(x => extract(x).modifieddate, (row, value) => merge(row, extract(row).copy(modifieddate = value)))
+    override lazy val fields: PscViewFields = new PscViewFields {
+      override def id = Field[ProductsubcategoryId, PscViewRow](_path, "id", None, None, x => x.id, (row, value) => row.copy(id = value))
+      override def productsubcategoryid = Field[ProductsubcategoryId, PscViewRow](_path, "productsubcategoryid", None, None, x => x.productsubcategoryid, (row, value) => row.copy(productsubcategoryid = value))
+      override def productcategoryid = Field[ProductcategoryId, PscViewRow](_path, "productcategoryid", None, None, x => x.productcategoryid, (row, value) => row.copy(productcategoryid = value))
+      override def name = Field[Name, PscViewRow](_path, "name", None, None, x => x.name, (row, value) => row.copy(name = value))
+      override def rowguid = Field[TypoUUID, PscViewRow](_path, "rowguid", None, None, x => x.rowguid, (row, value) => row.copy(rowguid = value))
+      override def modifieddate = Field[TypoLocalDateTime, PscViewRow](_path, "modifieddate", Some("text"), None, x => x.modifieddate, (row, value) => row.copy(modifieddate = value))
     }
   
-    override val columns: List[FieldLikeNoHkt[?, Row]] =
-      List[FieldLikeNoHkt[?, Row]](fields.id, fields.productsubcategoryid, fields.productcategoryid, fields.name, fields.rowguid, fields.modifieddate)
+    override lazy val columns: List[FieldLikeNoHkt[?, PscViewRow]] =
+      List[FieldLikeNoHkt[?, PscViewRow]](fields.id, fields.productsubcategoryid, fields.productcategoryid, fields.name, fields.rowguid, fields.modifieddate)
   
-    override def copy[NewRow](prefix: Option[String], extract: NewRow => PscViewRow, merge: (NewRow, PscViewRow) => NewRow): Impl[NewRow] =
-      new Impl(prefix, extract, merge)
+    override def copy(path: List[Path]): Impl =
+      new Impl(path)
   }
   
 }

--- a/typo-tester-zio-jdbc/generated-and-checked-in/adventureworks/pr/sr/SrViewFields.scala
+++ b/typo-tester-zio-jdbc/generated-and-checked-in/adventureworks/pr/sr/SrViewFields.scala
@@ -10,36 +10,37 @@ package sr
 import adventureworks.customtypes.TypoLocalDateTime
 import adventureworks.production.scrapreason.ScrapreasonId
 import adventureworks.public.Name
+import typo.dsl.Path
 import typo.dsl.SqlExpr.Field
 import typo.dsl.SqlExpr.FieldLikeNoHkt
 import typo.dsl.Structure.Relation
 
-trait SrViewFields[Row] {
-  val id: Field[ScrapreasonId, Row]
-  val scrapreasonid: Field[ScrapreasonId, Row]
-  val name: Field[Name, Row]
-  val modifieddate: Field[TypoLocalDateTime, Row]
+trait SrViewFields {
+  def id: Field[ScrapreasonId, SrViewRow]
+  def scrapreasonid: Field[ScrapreasonId, SrViewRow]
+  def name: Field[Name, SrViewRow]
+  def modifieddate: Field[TypoLocalDateTime, SrViewRow]
 }
 
 object SrViewFields {
-  val structure: Relation[SrViewFields, SrViewRow, SrViewRow] = 
-    new Impl(None, identity, (_, x) => x)
+  lazy val structure: Relation[SrViewFields, SrViewRow] =
+    new Impl(Nil)
     
-  private final class Impl[Row](val prefix: Option[String], val extract: Row => SrViewRow, val merge: (Row, SrViewRow) => Row)
-    extends Relation[SrViewFields, SrViewRow, Row] { 
+  private final class Impl(val _path: List[Path])
+    extends Relation[SrViewFields, SrViewRow] {
   
-    override val fields: SrViewFields[Row] = new SrViewFields[Row] {
-      override val id = new Field[ScrapreasonId, Row](prefix, "id", None, None)(x => extract(x).id, (row, value) => merge(row, extract(row).copy(id = value)))
-      override val scrapreasonid = new Field[ScrapreasonId, Row](prefix, "scrapreasonid", None, None)(x => extract(x).scrapreasonid, (row, value) => merge(row, extract(row).copy(scrapreasonid = value)))
-      override val name = new Field[Name, Row](prefix, "name", None, None)(x => extract(x).name, (row, value) => merge(row, extract(row).copy(name = value)))
-      override val modifieddate = new Field[TypoLocalDateTime, Row](prefix, "modifieddate", Some("text"), None)(x => extract(x).modifieddate, (row, value) => merge(row, extract(row).copy(modifieddate = value)))
+    override lazy val fields: SrViewFields = new SrViewFields {
+      override def id = Field[ScrapreasonId, SrViewRow](_path, "id", None, None, x => x.id, (row, value) => row.copy(id = value))
+      override def scrapreasonid = Field[ScrapreasonId, SrViewRow](_path, "scrapreasonid", None, None, x => x.scrapreasonid, (row, value) => row.copy(scrapreasonid = value))
+      override def name = Field[Name, SrViewRow](_path, "name", None, None, x => x.name, (row, value) => row.copy(name = value))
+      override def modifieddate = Field[TypoLocalDateTime, SrViewRow](_path, "modifieddate", Some("text"), None, x => x.modifieddate, (row, value) => row.copy(modifieddate = value))
     }
   
-    override val columns: List[FieldLikeNoHkt[?, Row]] =
-      List[FieldLikeNoHkt[?, Row]](fields.id, fields.scrapreasonid, fields.name, fields.modifieddate)
+    override lazy val columns: List[FieldLikeNoHkt[?, SrViewRow]] =
+      List[FieldLikeNoHkt[?, SrViewRow]](fields.id, fields.scrapreasonid, fields.name, fields.modifieddate)
   
-    override def copy[NewRow](prefix: Option[String], extract: NewRow => SrViewRow, merge: (NewRow, SrViewRow) => NewRow): Impl[NewRow] =
-      new Impl(prefix, extract, merge)
+    override def copy(path: List[Path]): Impl =
+      new Impl(path)
   }
   
 }

--- a/typo-tester-zio-jdbc/generated-and-checked-in/adventureworks/pr/th/ThViewFields.scala
+++ b/typo-tester-zio-jdbc/generated-and-checked-in/adventureworks/pr/th/ThViewFields.scala
@@ -10,48 +10,49 @@ package th
 import adventureworks.customtypes.TypoLocalDateTime
 import adventureworks.production.product.ProductId
 import adventureworks.production.transactionhistory.TransactionhistoryId
+import typo.dsl.Path
 import typo.dsl.SqlExpr.Field
 import typo.dsl.SqlExpr.FieldLikeNoHkt
 import typo.dsl.Structure.Relation
 
-trait ThViewFields[Row] {
-  val id: Field[TransactionhistoryId, Row]
-  val transactionid: Field[TransactionhistoryId, Row]
-  val productid: Field[ProductId, Row]
-  val referenceorderid: Field[Int, Row]
-  val referenceorderlineid: Field[Int, Row]
-  val transactiondate: Field[TypoLocalDateTime, Row]
-  val transactiontype: Field[/* bpchar, max 1 chars */ String, Row]
-  val quantity: Field[Int, Row]
-  val actualcost: Field[BigDecimal, Row]
-  val modifieddate: Field[TypoLocalDateTime, Row]
+trait ThViewFields {
+  def id: Field[TransactionhistoryId, ThViewRow]
+  def transactionid: Field[TransactionhistoryId, ThViewRow]
+  def productid: Field[ProductId, ThViewRow]
+  def referenceorderid: Field[Int, ThViewRow]
+  def referenceorderlineid: Field[Int, ThViewRow]
+  def transactiondate: Field[TypoLocalDateTime, ThViewRow]
+  def transactiontype: Field[/* bpchar, max 1 chars */ String, ThViewRow]
+  def quantity: Field[Int, ThViewRow]
+  def actualcost: Field[BigDecimal, ThViewRow]
+  def modifieddate: Field[TypoLocalDateTime, ThViewRow]
 }
 
 object ThViewFields {
-  val structure: Relation[ThViewFields, ThViewRow, ThViewRow] = 
-    new Impl(None, identity, (_, x) => x)
+  lazy val structure: Relation[ThViewFields, ThViewRow] =
+    new Impl(Nil)
     
-  private final class Impl[Row](val prefix: Option[String], val extract: Row => ThViewRow, val merge: (Row, ThViewRow) => Row)
-    extends Relation[ThViewFields, ThViewRow, Row] { 
+  private final class Impl(val _path: List[Path])
+    extends Relation[ThViewFields, ThViewRow] {
   
-    override val fields: ThViewFields[Row] = new ThViewFields[Row] {
-      override val id = new Field[TransactionhistoryId, Row](prefix, "id", None, None)(x => extract(x).id, (row, value) => merge(row, extract(row).copy(id = value)))
-      override val transactionid = new Field[TransactionhistoryId, Row](prefix, "transactionid", None, None)(x => extract(x).transactionid, (row, value) => merge(row, extract(row).copy(transactionid = value)))
-      override val productid = new Field[ProductId, Row](prefix, "productid", None, None)(x => extract(x).productid, (row, value) => merge(row, extract(row).copy(productid = value)))
-      override val referenceorderid = new Field[Int, Row](prefix, "referenceorderid", None, None)(x => extract(x).referenceorderid, (row, value) => merge(row, extract(row).copy(referenceorderid = value)))
-      override val referenceorderlineid = new Field[Int, Row](prefix, "referenceorderlineid", None, None)(x => extract(x).referenceorderlineid, (row, value) => merge(row, extract(row).copy(referenceorderlineid = value)))
-      override val transactiondate = new Field[TypoLocalDateTime, Row](prefix, "transactiondate", Some("text"), None)(x => extract(x).transactiondate, (row, value) => merge(row, extract(row).copy(transactiondate = value)))
-      override val transactiontype = new Field[/* bpchar, max 1 chars */ String, Row](prefix, "transactiontype", None, None)(x => extract(x).transactiontype, (row, value) => merge(row, extract(row).copy(transactiontype = value)))
-      override val quantity = new Field[Int, Row](prefix, "quantity", None, None)(x => extract(x).quantity, (row, value) => merge(row, extract(row).copy(quantity = value)))
-      override val actualcost = new Field[BigDecimal, Row](prefix, "actualcost", None, None)(x => extract(x).actualcost, (row, value) => merge(row, extract(row).copy(actualcost = value)))
-      override val modifieddate = new Field[TypoLocalDateTime, Row](prefix, "modifieddate", Some("text"), None)(x => extract(x).modifieddate, (row, value) => merge(row, extract(row).copy(modifieddate = value)))
+    override lazy val fields: ThViewFields = new ThViewFields {
+      override def id = Field[TransactionhistoryId, ThViewRow](_path, "id", None, None, x => x.id, (row, value) => row.copy(id = value))
+      override def transactionid = Field[TransactionhistoryId, ThViewRow](_path, "transactionid", None, None, x => x.transactionid, (row, value) => row.copy(transactionid = value))
+      override def productid = Field[ProductId, ThViewRow](_path, "productid", None, None, x => x.productid, (row, value) => row.copy(productid = value))
+      override def referenceorderid = Field[Int, ThViewRow](_path, "referenceorderid", None, None, x => x.referenceorderid, (row, value) => row.copy(referenceorderid = value))
+      override def referenceorderlineid = Field[Int, ThViewRow](_path, "referenceorderlineid", None, None, x => x.referenceorderlineid, (row, value) => row.copy(referenceorderlineid = value))
+      override def transactiondate = Field[TypoLocalDateTime, ThViewRow](_path, "transactiondate", Some("text"), None, x => x.transactiondate, (row, value) => row.copy(transactiondate = value))
+      override def transactiontype = Field[/* bpchar, max 1 chars */ String, ThViewRow](_path, "transactiontype", None, None, x => x.transactiontype, (row, value) => row.copy(transactiontype = value))
+      override def quantity = Field[Int, ThViewRow](_path, "quantity", None, None, x => x.quantity, (row, value) => row.copy(quantity = value))
+      override def actualcost = Field[BigDecimal, ThViewRow](_path, "actualcost", None, None, x => x.actualcost, (row, value) => row.copy(actualcost = value))
+      override def modifieddate = Field[TypoLocalDateTime, ThViewRow](_path, "modifieddate", Some("text"), None, x => x.modifieddate, (row, value) => row.copy(modifieddate = value))
     }
   
-    override val columns: List[FieldLikeNoHkt[?, Row]] =
-      List[FieldLikeNoHkt[?, Row]](fields.id, fields.transactionid, fields.productid, fields.referenceorderid, fields.referenceorderlineid, fields.transactiondate, fields.transactiontype, fields.quantity, fields.actualcost, fields.modifieddate)
+    override lazy val columns: List[FieldLikeNoHkt[?, ThViewRow]] =
+      List[FieldLikeNoHkt[?, ThViewRow]](fields.id, fields.transactionid, fields.productid, fields.referenceorderid, fields.referenceorderlineid, fields.transactiondate, fields.transactiontype, fields.quantity, fields.actualcost, fields.modifieddate)
   
-    override def copy[NewRow](prefix: Option[String], extract: NewRow => ThViewRow, merge: (NewRow, ThViewRow) => NewRow): Impl[NewRow] =
-      new Impl(prefix, extract, merge)
+    override def copy(path: List[Path]): Impl =
+      new Impl(path)
   }
   
 }

--- a/typo-tester-zio-jdbc/generated-and-checked-in/adventureworks/pr/tha/ThaViewFields.scala
+++ b/typo-tester-zio-jdbc/generated-and-checked-in/adventureworks/pr/tha/ThaViewFields.scala
@@ -9,48 +9,49 @@ package tha
 
 import adventureworks.customtypes.TypoLocalDateTime
 import adventureworks.production.transactionhistoryarchive.TransactionhistoryarchiveId
+import typo.dsl.Path
 import typo.dsl.SqlExpr.Field
 import typo.dsl.SqlExpr.FieldLikeNoHkt
 import typo.dsl.Structure.Relation
 
-trait ThaViewFields[Row] {
-  val id: Field[TransactionhistoryarchiveId, Row]
-  val transactionid: Field[TransactionhistoryarchiveId, Row]
-  val productid: Field[Int, Row]
-  val referenceorderid: Field[Int, Row]
-  val referenceorderlineid: Field[Int, Row]
-  val transactiondate: Field[TypoLocalDateTime, Row]
-  val transactiontype: Field[/* bpchar, max 1 chars */ String, Row]
-  val quantity: Field[Int, Row]
-  val actualcost: Field[BigDecimal, Row]
-  val modifieddate: Field[TypoLocalDateTime, Row]
+trait ThaViewFields {
+  def id: Field[TransactionhistoryarchiveId, ThaViewRow]
+  def transactionid: Field[TransactionhistoryarchiveId, ThaViewRow]
+  def productid: Field[Int, ThaViewRow]
+  def referenceorderid: Field[Int, ThaViewRow]
+  def referenceorderlineid: Field[Int, ThaViewRow]
+  def transactiondate: Field[TypoLocalDateTime, ThaViewRow]
+  def transactiontype: Field[/* bpchar, max 1 chars */ String, ThaViewRow]
+  def quantity: Field[Int, ThaViewRow]
+  def actualcost: Field[BigDecimal, ThaViewRow]
+  def modifieddate: Field[TypoLocalDateTime, ThaViewRow]
 }
 
 object ThaViewFields {
-  val structure: Relation[ThaViewFields, ThaViewRow, ThaViewRow] = 
-    new Impl(None, identity, (_, x) => x)
+  lazy val structure: Relation[ThaViewFields, ThaViewRow] =
+    new Impl(Nil)
     
-  private final class Impl[Row](val prefix: Option[String], val extract: Row => ThaViewRow, val merge: (Row, ThaViewRow) => Row)
-    extends Relation[ThaViewFields, ThaViewRow, Row] { 
+  private final class Impl(val _path: List[Path])
+    extends Relation[ThaViewFields, ThaViewRow] {
   
-    override val fields: ThaViewFields[Row] = new ThaViewFields[Row] {
-      override val id = new Field[TransactionhistoryarchiveId, Row](prefix, "id", None, None)(x => extract(x).id, (row, value) => merge(row, extract(row).copy(id = value)))
-      override val transactionid = new Field[TransactionhistoryarchiveId, Row](prefix, "transactionid", None, None)(x => extract(x).transactionid, (row, value) => merge(row, extract(row).copy(transactionid = value)))
-      override val productid = new Field[Int, Row](prefix, "productid", None, None)(x => extract(x).productid, (row, value) => merge(row, extract(row).copy(productid = value)))
-      override val referenceorderid = new Field[Int, Row](prefix, "referenceorderid", None, None)(x => extract(x).referenceorderid, (row, value) => merge(row, extract(row).copy(referenceorderid = value)))
-      override val referenceorderlineid = new Field[Int, Row](prefix, "referenceorderlineid", None, None)(x => extract(x).referenceorderlineid, (row, value) => merge(row, extract(row).copy(referenceorderlineid = value)))
-      override val transactiondate = new Field[TypoLocalDateTime, Row](prefix, "transactiondate", Some("text"), None)(x => extract(x).transactiondate, (row, value) => merge(row, extract(row).copy(transactiondate = value)))
-      override val transactiontype = new Field[/* bpchar, max 1 chars */ String, Row](prefix, "transactiontype", None, None)(x => extract(x).transactiontype, (row, value) => merge(row, extract(row).copy(transactiontype = value)))
-      override val quantity = new Field[Int, Row](prefix, "quantity", None, None)(x => extract(x).quantity, (row, value) => merge(row, extract(row).copy(quantity = value)))
-      override val actualcost = new Field[BigDecimal, Row](prefix, "actualcost", None, None)(x => extract(x).actualcost, (row, value) => merge(row, extract(row).copy(actualcost = value)))
-      override val modifieddate = new Field[TypoLocalDateTime, Row](prefix, "modifieddate", Some("text"), None)(x => extract(x).modifieddate, (row, value) => merge(row, extract(row).copy(modifieddate = value)))
+    override lazy val fields: ThaViewFields = new ThaViewFields {
+      override def id = Field[TransactionhistoryarchiveId, ThaViewRow](_path, "id", None, None, x => x.id, (row, value) => row.copy(id = value))
+      override def transactionid = Field[TransactionhistoryarchiveId, ThaViewRow](_path, "transactionid", None, None, x => x.transactionid, (row, value) => row.copy(transactionid = value))
+      override def productid = Field[Int, ThaViewRow](_path, "productid", None, None, x => x.productid, (row, value) => row.copy(productid = value))
+      override def referenceorderid = Field[Int, ThaViewRow](_path, "referenceorderid", None, None, x => x.referenceorderid, (row, value) => row.copy(referenceorderid = value))
+      override def referenceorderlineid = Field[Int, ThaViewRow](_path, "referenceorderlineid", None, None, x => x.referenceorderlineid, (row, value) => row.copy(referenceorderlineid = value))
+      override def transactiondate = Field[TypoLocalDateTime, ThaViewRow](_path, "transactiondate", Some("text"), None, x => x.transactiondate, (row, value) => row.copy(transactiondate = value))
+      override def transactiontype = Field[/* bpchar, max 1 chars */ String, ThaViewRow](_path, "transactiontype", None, None, x => x.transactiontype, (row, value) => row.copy(transactiontype = value))
+      override def quantity = Field[Int, ThaViewRow](_path, "quantity", None, None, x => x.quantity, (row, value) => row.copy(quantity = value))
+      override def actualcost = Field[BigDecimal, ThaViewRow](_path, "actualcost", None, None, x => x.actualcost, (row, value) => row.copy(actualcost = value))
+      override def modifieddate = Field[TypoLocalDateTime, ThaViewRow](_path, "modifieddate", Some("text"), None, x => x.modifieddate, (row, value) => row.copy(modifieddate = value))
     }
   
-    override val columns: List[FieldLikeNoHkt[?, Row]] =
-      List[FieldLikeNoHkt[?, Row]](fields.id, fields.transactionid, fields.productid, fields.referenceorderid, fields.referenceorderlineid, fields.transactiondate, fields.transactiontype, fields.quantity, fields.actualcost, fields.modifieddate)
+    override lazy val columns: List[FieldLikeNoHkt[?, ThaViewRow]] =
+      List[FieldLikeNoHkt[?, ThaViewRow]](fields.id, fields.transactionid, fields.productid, fields.referenceorderid, fields.referenceorderlineid, fields.transactiondate, fields.transactiontype, fields.quantity, fields.actualcost, fields.modifieddate)
   
-    override def copy[NewRow](prefix: Option[String], extract: NewRow => ThaViewRow, merge: (NewRow, ThaViewRow) => NewRow): Impl[NewRow] =
-      new Impl(prefix, extract, merge)
+    override def copy(path: List[Path]): Impl =
+      new Impl(path)
   }
   
 }

--- a/typo-tester-zio-jdbc/generated-and-checked-in/adventureworks/pr/um/UmViewFields.scala
+++ b/typo-tester-zio-jdbc/generated-and-checked-in/adventureworks/pr/um/UmViewFields.scala
@@ -10,36 +10,37 @@ package um
 import adventureworks.customtypes.TypoLocalDateTime
 import adventureworks.production.unitmeasure.UnitmeasureId
 import adventureworks.public.Name
+import typo.dsl.Path
 import typo.dsl.SqlExpr.Field
 import typo.dsl.SqlExpr.FieldLikeNoHkt
 import typo.dsl.Structure.Relation
 
-trait UmViewFields[Row] {
-  val id: Field[UnitmeasureId, Row]
-  val unitmeasurecode: Field[UnitmeasureId, Row]
-  val name: Field[Name, Row]
-  val modifieddate: Field[TypoLocalDateTime, Row]
+trait UmViewFields {
+  def id: Field[UnitmeasureId, UmViewRow]
+  def unitmeasurecode: Field[UnitmeasureId, UmViewRow]
+  def name: Field[Name, UmViewRow]
+  def modifieddate: Field[TypoLocalDateTime, UmViewRow]
 }
 
 object UmViewFields {
-  val structure: Relation[UmViewFields, UmViewRow, UmViewRow] = 
-    new Impl(None, identity, (_, x) => x)
+  lazy val structure: Relation[UmViewFields, UmViewRow] =
+    new Impl(Nil)
     
-  private final class Impl[Row](val prefix: Option[String], val extract: Row => UmViewRow, val merge: (Row, UmViewRow) => Row)
-    extends Relation[UmViewFields, UmViewRow, Row] { 
+  private final class Impl(val _path: List[Path])
+    extends Relation[UmViewFields, UmViewRow] {
   
-    override val fields: UmViewFields[Row] = new UmViewFields[Row] {
-      override val id = new Field[UnitmeasureId, Row](prefix, "id", None, None)(x => extract(x).id, (row, value) => merge(row, extract(row).copy(id = value)))
-      override val unitmeasurecode = new Field[UnitmeasureId, Row](prefix, "unitmeasurecode", None, None)(x => extract(x).unitmeasurecode, (row, value) => merge(row, extract(row).copy(unitmeasurecode = value)))
-      override val name = new Field[Name, Row](prefix, "name", None, None)(x => extract(x).name, (row, value) => merge(row, extract(row).copy(name = value)))
-      override val modifieddate = new Field[TypoLocalDateTime, Row](prefix, "modifieddate", Some("text"), None)(x => extract(x).modifieddate, (row, value) => merge(row, extract(row).copy(modifieddate = value)))
+    override lazy val fields: UmViewFields = new UmViewFields {
+      override def id = Field[UnitmeasureId, UmViewRow](_path, "id", None, None, x => x.id, (row, value) => row.copy(id = value))
+      override def unitmeasurecode = Field[UnitmeasureId, UmViewRow](_path, "unitmeasurecode", None, None, x => x.unitmeasurecode, (row, value) => row.copy(unitmeasurecode = value))
+      override def name = Field[Name, UmViewRow](_path, "name", None, None, x => x.name, (row, value) => row.copy(name = value))
+      override def modifieddate = Field[TypoLocalDateTime, UmViewRow](_path, "modifieddate", Some("text"), None, x => x.modifieddate, (row, value) => row.copy(modifieddate = value))
     }
   
-    override val columns: List[FieldLikeNoHkt[?, Row]] =
-      List[FieldLikeNoHkt[?, Row]](fields.id, fields.unitmeasurecode, fields.name, fields.modifieddate)
+    override lazy val columns: List[FieldLikeNoHkt[?, UmViewRow]] =
+      List[FieldLikeNoHkt[?, UmViewRow]](fields.id, fields.unitmeasurecode, fields.name, fields.modifieddate)
   
-    override def copy[NewRow](prefix: Option[String], extract: NewRow => UmViewRow, merge: (NewRow, UmViewRow) => NewRow): Impl[NewRow] =
-      new Impl(prefix, extract, merge)
+    override def copy(path: List[Path]): Impl =
+      new Impl(path)
   }
   
 }

--- a/typo-tester-zio-jdbc/generated-and-checked-in/adventureworks/pr/w/WViewFields.scala
+++ b/typo-tester-zio-jdbc/generated-and-checked-in/adventureworks/pr/w/WViewFields.scala
@@ -12,49 +12,50 @@ import adventureworks.customtypes.TypoShort
 import adventureworks.production.product.ProductId
 import adventureworks.production.scrapreason.ScrapreasonId
 import adventureworks.production.workorder.WorkorderId
+import typo.dsl.Path
 import typo.dsl.SqlExpr.Field
 import typo.dsl.SqlExpr.FieldLikeNoHkt
 import typo.dsl.SqlExpr.OptField
 import typo.dsl.Structure.Relation
 
-trait WViewFields[Row] {
-  val id: Field[WorkorderId, Row]
-  val workorderid: Field[WorkorderId, Row]
-  val productid: Field[ProductId, Row]
-  val orderqty: Field[Int, Row]
-  val scrappedqty: Field[TypoShort, Row]
-  val startdate: Field[TypoLocalDateTime, Row]
-  val enddate: OptField[TypoLocalDateTime, Row]
-  val duedate: Field[TypoLocalDateTime, Row]
-  val scrapreasonid: OptField[ScrapreasonId, Row]
-  val modifieddate: Field[TypoLocalDateTime, Row]
+trait WViewFields {
+  def id: Field[WorkorderId, WViewRow]
+  def workorderid: Field[WorkorderId, WViewRow]
+  def productid: Field[ProductId, WViewRow]
+  def orderqty: Field[Int, WViewRow]
+  def scrappedqty: Field[TypoShort, WViewRow]
+  def startdate: Field[TypoLocalDateTime, WViewRow]
+  def enddate: OptField[TypoLocalDateTime, WViewRow]
+  def duedate: Field[TypoLocalDateTime, WViewRow]
+  def scrapreasonid: OptField[ScrapreasonId, WViewRow]
+  def modifieddate: Field[TypoLocalDateTime, WViewRow]
 }
 
 object WViewFields {
-  val structure: Relation[WViewFields, WViewRow, WViewRow] = 
-    new Impl(None, identity, (_, x) => x)
+  lazy val structure: Relation[WViewFields, WViewRow] =
+    new Impl(Nil)
     
-  private final class Impl[Row](val prefix: Option[String], val extract: Row => WViewRow, val merge: (Row, WViewRow) => Row)
-    extends Relation[WViewFields, WViewRow, Row] { 
+  private final class Impl(val _path: List[Path])
+    extends Relation[WViewFields, WViewRow] {
   
-    override val fields: WViewFields[Row] = new WViewFields[Row] {
-      override val id = new Field[WorkorderId, Row](prefix, "id", None, None)(x => extract(x).id, (row, value) => merge(row, extract(row).copy(id = value)))
-      override val workorderid = new Field[WorkorderId, Row](prefix, "workorderid", None, None)(x => extract(x).workorderid, (row, value) => merge(row, extract(row).copy(workorderid = value)))
-      override val productid = new Field[ProductId, Row](prefix, "productid", None, None)(x => extract(x).productid, (row, value) => merge(row, extract(row).copy(productid = value)))
-      override val orderqty = new Field[Int, Row](prefix, "orderqty", None, None)(x => extract(x).orderqty, (row, value) => merge(row, extract(row).copy(orderqty = value)))
-      override val scrappedqty = new Field[TypoShort, Row](prefix, "scrappedqty", None, None)(x => extract(x).scrappedqty, (row, value) => merge(row, extract(row).copy(scrappedqty = value)))
-      override val startdate = new Field[TypoLocalDateTime, Row](prefix, "startdate", Some("text"), None)(x => extract(x).startdate, (row, value) => merge(row, extract(row).copy(startdate = value)))
-      override val enddate = new OptField[TypoLocalDateTime, Row](prefix, "enddate", Some("text"), None)(x => extract(x).enddate, (row, value) => merge(row, extract(row).copy(enddate = value)))
-      override val duedate = new Field[TypoLocalDateTime, Row](prefix, "duedate", Some("text"), None)(x => extract(x).duedate, (row, value) => merge(row, extract(row).copy(duedate = value)))
-      override val scrapreasonid = new OptField[ScrapreasonId, Row](prefix, "scrapreasonid", None, None)(x => extract(x).scrapreasonid, (row, value) => merge(row, extract(row).copy(scrapreasonid = value)))
-      override val modifieddate = new Field[TypoLocalDateTime, Row](prefix, "modifieddate", Some("text"), None)(x => extract(x).modifieddate, (row, value) => merge(row, extract(row).copy(modifieddate = value)))
+    override lazy val fields: WViewFields = new WViewFields {
+      override def id = Field[WorkorderId, WViewRow](_path, "id", None, None, x => x.id, (row, value) => row.copy(id = value))
+      override def workorderid = Field[WorkorderId, WViewRow](_path, "workorderid", None, None, x => x.workorderid, (row, value) => row.copy(workorderid = value))
+      override def productid = Field[ProductId, WViewRow](_path, "productid", None, None, x => x.productid, (row, value) => row.copy(productid = value))
+      override def orderqty = Field[Int, WViewRow](_path, "orderqty", None, None, x => x.orderqty, (row, value) => row.copy(orderqty = value))
+      override def scrappedqty = Field[TypoShort, WViewRow](_path, "scrappedqty", None, None, x => x.scrappedqty, (row, value) => row.copy(scrappedqty = value))
+      override def startdate = Field[TypoLocalDateTime, WViewRow](_path, "startdate", Some("text"), None, x => x.startdate, (row, value) => row.copy(startdate = value))
+      override def enddate = OptField[TypoLocalDateTime, WViewRow](_path, "enddate", Some("text"), None, x => x.enddate, (row, value) => row.copy(enddate = value))
+      override def duedate = Field[TypoLocalDateTime, WViewRow](_path, "duedate", Some("text"), None, x => x.duedate, (row, value) => row.copy(duedate = value))
+      override def scrapreasonid = OptField[ScrapreasonId, WViewRow](_path, "scrapreasonid", None, None, x => x.scrapreasonid, (row, value) => row.copy(scrapreasonid = value))
+      override def modifieddate = Field[TypoLocalDateTime, WViewRow](_path, "modifieddate", Some("text"), None, x => x.modifieddate, (row, value) => row.copy(modifieddate = value))
     }
   
-    override val columns: List[FieldLikeNoHkt[?, Row]] =
-      List[FieldLikeNoHkt[?, Row]](fields.id, fields.workorderid, fields.productid, fields.orderqty, fields.scrappedqty, fields.startdate, fields.enddate, fields.duedate, fields.scrapreasonid, fields.modifieddate)
+    override lazy val columns: List[FieldLikeNoHkt[?, WViewRow]] =
+      List[FieldLikeNoHkt[?, WViewRow]](fields.id, fields.workorderid, fields.productid, fields.orderqty, fields.scrappedqty, fields.startdate, fields.enddate, fields.duedate, fields.scrapreasonid, fields.modifieddate)
   
-    override def copy[NewRow](prefix: Option[String], extract: NewRow => WViewRow, merge: (NewRow, WViewRow) => NewRow): Impl[NewRow] =
-      new Impl(prefix, extract, merge)
+    override def copy(path: List[Path]): Impl =
+      new Impl(path)
   }
   
 }

--- a/typo-tester-zio-jdbc/generated-and-checked-in/adventureworks/pr/wr/WrViewFields.scala
+++ b/typo-tester-zio-jdbc/generated-and-checked-in/adventureworks/pr/wr/WrViewFields.scala
@@ -11,55 +11,56 @@ import adventureworks.customtypes.TypoLocalDateTime
 import adventureworks.customtypes.TypoShort
 import adventureworks.production.location.LocationId
 import adventureworks.production.workorder.WorkorderId
+import typo.dsl.Path
 import typo.dsl.SqlExpr.Field
 import typo.dsl.SqlExpr.FieldLikeNoHkt
 import typo.dsl.SqlExpr.OptField
 import typo.dsl.Structure.Relation
 
-trait WrViewFields[Row] {
-  val id: Field[WorkorderId, Row]
-  val workorderid: Field[WorkorderId, Row]
-  val productid: Field[Int, Row]
-  val operationsequence: Field[TypoShort, Row]
-  val locationid: Field[LocationId, Row]
-  val scheduledstartdate: Field[TypoLocalDateTime, Row]
-  val scheduledenddate: Field[TypoLocalDateTime, Row]
-  val actualstartdate: OptField[TypoLocalDateTime, Row]
-  val actualenddate: OptField[TypoLocalDateTime, Row]
-  val actualresourcehrs: OptField[BigDecimal, Row]
-  val plannedcost: Field[BigDecimal, Row]
-  val actualcost: OptField[BigDecimal, Row]
-  val modifieddate: Field[TypoLocalDateTime, Row]
+trait WrViewFields {
+  def id: Field[WorkorderId, WrViewRow]
+  def workorderid: Field[WorkorderId, WrViewRow]
+  def productid: Field[Int, WrViewRow]
+  def operationsequence: Field[TypoShort, WrViewRow]
+  def locationid: Field[LocationId, WrViewRow]
+  def scheduledstartdate: Field[TypoLocalDateTime, WrViewRow]
+  def scheduledenddate: Field[TypoLocalDateTime, WrViewRow]
+  def actualstartdate: OptField[TypoLocalDateTime, WrViewRow]
+  def actualenddate: OptField[TypoLocalDateTime, WrViewRow]
+  def actualresourcehrs: OptField[BigDecimal, WrViewRow]
+  def plannedcost: Field[BigDecimal, WrViewRow]
+  def actualcost: OptField[BigDecimal, WrViewRow]
+  def modifieddate: Field[TypoLocalDateTime, WrViewRow]
 }
 
 object WrViewFields {
-  val structure: Relation[WrViewFields, WrViewRow, WrViewRow] = 
-    new Impl(None, identity, (_, x) => x)
+  lazy val structure: Relation[WrViewFields, WrViewRow] =
+    new Impl(Nil)
     
-  private final class Impl[Row](val prefix: Option[String], val extract: Row => WrViewRow, val merge: (Row, WrViewRow) => Row)
-    extends Relation[WrViewFields, WrViewRow, Row] { 
+  private final class Impl(val _path: List[Path])
+    extends Relation[WrViewFields, WrViewRow] {
   
-    override val fields: WrViewFields[Row] = new WrViewFields[Row] {
-      override val id = new Field[WorkorderId, Row](prefix, "id", None, None)(x => extract(x).id, (row, value) => merge(row, extract(row).copy(id = value)))
-      override val workorderid = new Field[WorkorderId, Row](prefix, "workorderid", None, None)(x => extract(x).workorderid, (row, value) => merge(row, extract(row).copy(workorderid = value)))
-      override val productid = new Field[Int, Row](prefix, "productid", None, None)(x => extract(x).productid, (row, value) => merge(row, extract(row).copy(productid = value)))
-      override val operationsequence = new Field[TypoShort, Row](prefix, "operationsequence", None, None)(x => extract(x).operationsequence, (row, value) => merge(row, extract(row).copy(operationsequence = value)))
-      override val locationid = new Field[LocationId, Row](prefix, "locationid", None, None)(x => extract(x).locationid, (row, value) => merge(row, extract(row).copy(locationid = value)))
-      override val scheduledstartdate = new Field[TypoLocalDateTime, Row](prefix, "scheduledstartdate", Some("text"), None)(x => extract(x).scheduledstartdate, (row, value) => merge(row, extract(row).copy(scheduledstartdate = value)))
-      override val scheduledenddate = new Field[TypoLocalDateTime, Row](prefix, "scheduledenddate", Some("text"), None)(x => extract(x).scheduledenddate, (row, value) => merge(row, extract(row).copy(scheduledenddate = value)))
-      override val actualstartdate = new OptField[TypoLocalDateTime, Row](prefix, "actualstartdate", Some("text"), None)(x => extract(x).actualstartdate, (row, value) => merge(row, extract(row).copy(actualstartdate = value)))
-      override val actualenddate = new OptField[TypoLocalDateTime, Row](prefix, "actualenddate", Some("text"), None)(x => extract(x).actualenddate, (row, value) => merge(row, extract(row).copy(actualenddate = value)))
-      override val actualresourcehrs = new OptField[BigDecimal, Row](prefix, "actualresourcehrs", None, None)(x => extract(x).actualresourcehrs, (row, value) => merge(row, extract(row).copy(actualresourcehrs = value)))
-      override val plannedcost = new Field[BigDecimal, Row](prefix, "plannedcost", None, None)(x => extract(x).plannedcost, (row, value) => merge(row, extract(row).copy(plannedcost = value)))
-      override val actualcost = new OptField[BigDecimal, Row](prefix, "actualcost", None, None)(x => extract(x).actualcost, (row, value) => merge(row, extract(row).copy(actualcost = value)))
-      override val modifieddate = new Field[TypoLocalDateTime, Row](prefix, "modifieddate", Some("text"), None)(x => extract(x).modifieddate, (row, value) => merge(row, extract(row).copy(modifieddate = value)))
+    override lazy val fields: WrViewFields = new WrViewFields {
+      override def id = Field[WorkorderId, WrViewRow](_path, "id", None, None, x => x.id, (row, value) => row.copy(id = value))
+      override def workorderid = Field[WorkorderId, WrViewRow](_path, "workorderid", None, None, x => x.workorderid, (row, value) => row.copy(workorderid = value))
+      override def productid = Field[Int, WrViewRow](_path, "productid", None, None, x => x.productid, (row, value) => row.copy(productid = value))
+      override def operationsequence = Field[TypoShort, WrViewRow](_path, "operationsequence", None, None, x => x.operationsequence, (row, value) => row.copy(operationsequence = value))
+      override def locationid = Field[LocationId, WrViewRow](_path, "locationid", None, None, x => x.locationid, (row, value) => row.copy(locationid = value))
+      override def scheduledstartdate = Field[TypoLocalDateTime, WrViewRow](_path, "scheduledstartdate", Some("text"), None, x => x.scheduledstartdate, (row, value) => row.copy(scheduledstartdate = value))
+      override def scheduledenddate = Field[TypoLocalDateTime, WrViewRow](_path, "scheduledenddate", Some("text"), None, x => x.scheduledenddate, (row, value) => row.copy(scheduledenddate = value))
+      override def actualstartdate = OptField[TypoLocalDateTime, WrViewRow](_path, "actualstartdate", Some("text"), None, x => x.actualstartdate, (row, value) => row.copy(actualstartdate = value))
+      override def actualenddate = OptField[TypoLocalDateTime, WrViewRow](_path, "actualenddate", Some("text"), None, x => x.actualenddate, (row, value) => row.copy(actualenddate = value))
+      override def actualresourcehrs = OptField[BigDecimal, WrViewRow](_path, "actualresourcehrs", None, None, x => x.actualresourcehrs, (row, value) => row.copy(actualresourcehrs = value))
+      override def plannedcost = Field[BigDecimal, WrViewRow](_path, "plannedcost", None, None, x => x.plannedcost, (row, value) => row.copy(plannedcost = value))
+      override def actualcost = OptField[BigDecimal, WrViewRow](_path, "actualcost", None, None, x => x.actualcost, (row, value) => row.copy(actualcost = value))
+      override def modifieddate = Field[TypoLocalDateTime, WrViewRow](_path, "modifieddate", Some("text"), None, x => x.modifieddate, (row, value) => row.copy(modifieddate = value))
     }
   
-    override val columns: List[FieldLikeNoHkt[?, Row]] =
-      List[FieldLikeNoHkt[?, Row]](fields.id, fields.workorderid, fields.productid, fields.operationsequence, fields.locationid, fields.scheduledstartdate, fields.scheduledenddate, fields.actualstartdate, fields.actualenddate, fields.actualresourcehrs, fields.plannedcost, fields.actualcost, fields.modifieddate)
+    override lazy val columns: List[FieldLikeNoHkt[?, WrViewRow]] =
+      List[FieldLikeNoHkt[?, WrViewRow]](fields.id, fields.workorderid, fields.productid, fields.operationsequence, fields.locationid, fields.scheduledstartdate, fields.scheduledenddate, fields.actualstartdate, fields.actualenddate, fields.actualresourcehrs, fields.plannedcost, fields.actualcost, fields.modifieddate)
   
-    override def copy[NewRow](prefix: Option[String], extract: NewRow => WrViewRow, merge: (NewRow, WrViewRow) => NewRow): Impl[NewRow] =
-      new Impl(prefix, extract, merge)
+    override def copy(path: List[Path]): Impl =
+      new Impl(path)
   }
   
 }

--- a/typo-tester-zio-jdbc/generated-and-checked-in/adventureworks/production/billofmaterials/BillofmaterialsFields.scala
+++ b/typo-tester-zio-jdbc/generated-and-checked-in/adventureworks/production/billofmaterials/BillofmaterialsFields.scala
@@ -11,48 +11,49 @@ import adventureworks.customtypes.TypoLocalDateTime
 import adventureworks.customtypes.TypoShort
 import adventureworks.production.product.ProductId
 import adventureworks.production.unitmeasure.UnitmeasureId
+import typo.dsl.Path
 import typo.dsl.SqlExpr.Field
 import typo.dsl.SqlExpr.FieldLikeNoHkt
 import typo.dsl.SqlExpr.IdField
 import typo.dsl.SqlExpr.OptField
 import typo.dsl.Structure.Relation
 
-trait BillofmaterialsFields[Row] {
-  val billofmaterialsid: IdField[Int, Row]
-  val productassemblyid: OptField[ProductId, Row]
-  val componentid: Field[ProductId, Row]
-  val startdate: Field[TypoLocalDateTime, Row]
-  val enddate: OptField[TypoLocalDateTime, Row]
-  val unitmeasurecode: Field[UnitmeasureId, Row]
-  val bomlevel: Field[TypoShort, Row]
-  val perassemblyqty: Field[BigDecimal, Row]
-  val modifieddate: Field[TypoLocalDateTime, Row]
+trait BillofmaterialsFields {
+  def billofmaterialsid: IdField[Int, BillofmaterialsRow]
+  def productassemblyid: OptField[ProductId, BillofmaterialsRow]
+  def componentid: Field[ProductId, BillofmaterialsRow]
+  def startdate: Field[TypoLocalDateTime, BillofmaterialsRow]
+  def enddate: OptField[TypoLocalDateTime, BillofmaterialsRow]
+  def unitmeasurecode: Field[UnitmeasureId, BillofmaterialsRow]
+  def bomlevel: Field[TypoShort, BillofmaterialsRow]
+  def perassemblyqty: Field[BigDecimal, BillofmaterialsRow]
+  def modifieddate: Field[TypoLocalDateTime, BillofmaterialsRow]
 }
 
 object BillofmaterialsFields {
-  val structure: Relation[BillofmaterialsFields, BillofmaterialsRow, BillofmaterialsRow] = 
-    new Impl(None, identity, (_, x) => x)
+  lazy val structure: Relation[BillofmaterialsFields, BillofmaterialsRow] =
+    new Impl(Nil)
     
-  private final class Impl[Row](val prefix: Option[String], val extract: Row => BillofmaterialsRow, val merge: (Row, BillofmaterialsRow) => Row)
-    extends Relation[BillofmaterialsFields, BillofmaterialsRow, Row] { 
+  private final class Impl(val _path: List[Path])
+    extends Relation[BillofmaterialsFields, BillofmaterialsRow] {
   
-    override val fields: BillofmaterialsFields[Row] = new BillofmaterialsFields[Row] {
-      override val billofmaterialsid = new IdField[Int, Row](prefix, "billofmaterialsid", None, Some("int4"))(x => extract(x).billofmaterialsid, (row, value) => merge(row, extract(row).copy(billofmaterialsid = value)))
-      override val productassemblyid = new OptField[ProductId, Row](prefix, "productassemblyid", None, Some("int4"))(x => extract(x).productassemblyid, (row, value) => merge(row, extract(row).copy(productassemblyid = value)))
-      override val componentid = new Field[ProductId, Row](prefix, "componentid", None, Some("int4"))(x => extract(x).componentid, (row, value) => merge(row, extract(row).copy(componentid = value)))
-      override val startdate = new Field[TypoLocalDateTime, Row](prefix, "startdate", Some("text"), Some("timestamp"))(x => extract(x).startdate, (row, value) => merge(row, extract(row).copy(startdate = value)))
-      override val enddate = new OptField[TypoLocalDateTime, Row](prefix, "enddate", Some("text"), Some("timestamp"))(x => extract(x).enddate, (row, value) => merge(row, extract(row).copy(enddate = value)))
-      override val unitmeasurecode = new Field[UnitmeasureId, Row](prefix, "unitmeasurecode", None, Some("bpchar"))(x => extract(x).unitmeasurecode, (row, value) => merge(row, extract(row).copy(unitmeasurecode = value)))
-      override val bomlevel = new Field[TypoShort, Row](prefix, "bomlevel", None, Some("int2"))(x => extract(x).bomlevel, (row, value) => merge(row, extract(row).copy(bomlevel = value)))
-      override val perassemblyqty = new Field[BigDecimal, Row](prefix, "perassemblyqty", None, Some("numeric"))(x => extract(x).perassemblyqty, (row, value) => merge(row, extract(row).copy(perassemblyqty = value)))
-      override val modifieddate = new Field[TypoLocalDateTime, Row](prefix, "modifieddate", Some("text"), Some("timestamp"))(x => extract(x).modifieddate, (row, value) => merge(row, extract(row).copy(modifieddate = value)))
+    override lazy val fields: BillofmaterialsFields = new BillofmaterialsFields {
+      override def billofmaterialsid = IdField[Int, BillofmaterialsRow](_path, "billofmaterialsid", None, Some("int4"), x => x.billofmaterialsid, (row, value) => row.copy(billofmaterialsid = value))
+      override def productassemblyid = OptField[ProductId, BillofmaterialsRow](_path, "productassemblyid", None, Some("int4"), x => x.productassemblyid, (row, value) => row.copy(productassemblyid = value))
+      override def componentid = Field[ProductId, BillofmaterialsRow](_path, "componentid", None, Some("int4"), x => x.componentid, (row, value) => row.copy(componentid = value))
+      override def startdate = Field[TypoLocalDateTime, BillofmaterialsRow](_path, "startdate", Some("text"), Some("timestamp"), x => x.startdate, (row, value) => row.copy(startdate = value))
+      override def enddate = OptField[TypoLocalDateTime, BillofmaterialsRow](_path, "enddate", Some("text"), Some("timestamp"), x => x.enddate, (row, value) => row.copy(enddate = value))
+      override def unitmeasurecode = Field[UnitmeasureId, BillofmaterialsRow](_path, "unitmeasurecode", None, Some("bpchar"), x => x.unitmeasurecode, (row, value) => row.copy(unitmeasurecode = value))
+      override def bomlevel = Field[TypoShort, BillofmaterialsRow](_path, "bomlevel", None, Some("int2"), x => x.bomlevel, (row, value) => row.copy(bomlevel = value))
+      override def perassemblyqty = Field[BigDecimal, BillofmaterialsRow](_path, "perassemblyqty", None, Some("numeric"), x => x.perassemblyqty, (row, value) => row.copy(perassemblyqty = value))
+      override def modifieddate = Field[TypoLocalDateTime, BillofmaterialsRow](_path, "modifieddate", Some("text"), Some("timestamp"), x => x.modifieddate, (row, value) => row.copy(modifieddate = value))
     }
   
-    override val columns: List[FieldLikeNoHkt[?, Row]] =
-      List[FieldLikeNoHkt[?, Row]](fields.billofmaterialsid, fields.productassemblyid, fields.componentid, fields.startdate, fields.enddate, fields.unitmeasurecode, fields.bomlevel, fields.perassemblyqty, fields.modifieddate)
+    override lazy val columns: List[FieldLikeNoHkt[?, BillofmaterialsRow]] =
+      List[FieldLikeNoHkt[?, BillofmaterialsRow]](fields.billofmaterialsid, fields.productassemblyid, fields.componentid, fields.startdate, fields.enddate, fields.unitmeasurecode, fields.bomlevel, fields.perassemblyqty, fields.modifieddate)
   
-    override def copy[NewRow](prefix: Option[String], extract: NewRow => BillofmaterialsRow, merge: (NewRow, BillofmaterialsRow) => NewRow): Impl[NewRow] =
-      new Impl(prefix, extract, merge)
+    override def copy(path: List[Path]): Impl =
+      new Impl(path)
   }
   
 }

--- a/typo-tester-zio-jdbc/generated-and-checked-in/adventureworks/production/billofmaterials/BillofmaterialsRepoMock.scala
+++ b/typo-tester-zio-jdbc/generated-and-checked-in/adventureworks/production/billofmaterials/BillofmaterialsRepoMock.scala
@@ -26,7 +26,7 @@ import zio.stream.ZStream
 class BillofmaterialsRepoMock(toRow: Function1[BillofmaterialsRowUnsaved, BillofmaterialsRow],
                               map: scala.collection.mutable.Map[Int, BillofmaterialsRow] = scala.collection.mutable.Map.empty) extends BillofmaterialsRepo {
   override def delete: DeleteBuilder[BillofmaterialsFields, BillofmaterialsRow] = {
-    DeleteBuilderMock(DeleteParams.empty, BillofmaterialsFields.structure.fields, map)
+    DeleteBuilderMock(DeleteParams.empty, BillofmaterialsFields.structure, map)
   }
   override def deleteById(billofmaterialsid: Int): ZIO[ZConnection, Throwable, Boolean] = {
     ZIO.succeed(map.remove(billofmaterialsid).isDefined)
@@ -85,7 +85,7 @@ class BillofmaterialsRepoMock(toRow: Function1[BillofmaterialsRowUnsaved, Billof
     }
   }
   override def update: UpdateBuilder[BillofmaterialsFields, BillofmaterialsRow] = {
-    UpdateBuilderMock(UpdateParams.empty, BillofmaterialsFields.structure.fields, map)
+    UpdateBuilderMock(UpdateParams.empty, BillofmaterialsFields.structure, map)
   }
   override def update(row: BillofmaterialsRow): ZIO[ZConnection, Throwable, Boolean] = {
     ZIO.succeed {

--- a/typo-tester-zio-jdbc/generated-and-checked-in/adventureworks/production/culture/CultureFields.scala
+++ b/typo-tester-zio-jdbc/generated-and-checked-in/adventureworks/production/culture/CultureFields.scala
@@ -9,35 +9,36 @@ package culture
 
 import adventureworks.customtypes.TypoLocalDateTime
 import adventureworks.public.Name
+import typo.dsl.Path
 import typo.dsl.SqlExpr.Field
 import typo.dsl.SqlExpr.FieldLikeNoHkt
 import typo.dsl.SqlExpr.IdField
 import typo.dsl.Structure.Relation
 
-trait CultureFields[Row] {
-  val cultureid: IdField[CultureId, Row]
-  val name: Field[Name, Row]
-  val modifieddate: Field[TypoLocalDateTime, Row]
+trait CultureFields {
+  def cultureid: IdField[CultureId, CultureRow]
+  def name: Field[Name, CultureRow]
+  def modifieddate: Field[TypoLocalDateTime, CultureRow]
 }
 
 object CultureFields {
-  val structure: Relation[CultureFields, CultureRow, CultureRow] = 
-    new Impl(None, identity, (_, x) => x)
+  lazy val structure: Relation[CultureFields, CultureRow] =
+    new Impl(Nil)
     
-  private final class Impl[Row](val prefix: Option[String], val extract: Row => CultureRow, val merge: (Row, CultureRow) => Row)
-    extends Relation[CultureFields, CultureRow, Row] { 
+  private final class Impl(val _path: List[Path])
+    extends Relation[CultureFields, CultureRow] {
   
-    override val fields: CultureFields[Row] = new CultureFields[Row] {
-      override val cultureid = new IdField[CultureId, Row](prefix, "cultureid", None, Some("bpchar"))(x => extract(x).cultureid, (row, value) => merge(row, extract(row).copy(cultureid = value)))
-      override val name = new Field[Name, Row](prefix, "name", None, Some("varchar"))(x => extract(x).name, (row, value) => merge(row, extract(row).copy(name = value)))
-      override val modifieddate = new Field[TypoLocalDateTime, Row](prefix, "modifieddate", Some("text"), Some("timestamp"))(x => extract(x).modifieddate, (row, value) => merge(row, extract(row).copy(modifieddate = value)))
+    override lazy val fields: CultureFields = new CultureFields {
+      override def cultureid = IdField[CultureId, CultureRow](_path, "cultureid", None, Some("bpchar"), x => x.cultureid, (row, value) => row.copy(cultureid = value))
+      override def name = Field[Name, CultureRow](_path, "name", None, Some("varchar"), x => x.name, (row, value) => row.copy(name = value))
+      override def modifieddate = Field[TypoLocalDateTime, CultureRow](_path, "modifieddate", Some("text"), Some("timestamp"), x => x.modifieddate, (row, value) => row.copy(modifieddate = value))
     }
   
-    override val columns: List[FieldLikeNoHkt[?, Row]] =
-      List[FieldLikeNoHkt[?, Row]](fields.cultureid, fields.name, fields.modifieddate)
+    override lazy val columns: List[FieldLikeNoHkt[?, CultureRow]] =
+      List[FieldLikeNoHkt[?, CultureRow]](fields.cultureid, fields.name, fields.modifieddate)
   
-    override def copy[NewRow](prefix: Option[String], extract: NewRow => CultureRow, merge: (NewRow, CultureRow) => NewRow): Impl[NewRow] =
-      new Impl(prefix, extract, merge)
+    override def copy(path: List[Path]): Impl =
+      new Impl(path)
   }
   
 }

--- a/typo-tester-zio-jdbc/generated-and-checked-in/adventureworks/production/culture/CultureRepoMock.scala
+++ b/typo-tester-zio-jdbc/generated-and-checked-in/adventureworks/production/culture/CultureRepoMock.scala
@@ -26,7 +26,7 @@ import zio.stream.ZStream
 class CultureRepoMock(toRow: Function1[CultureRowUnsaved, CultureRow],
                       map: scala.collection.mutable.Map[CultureId, CultureRow] = scala.collection.mutable.Map.empty) extends CultureRepo {
   override def delete: DeleteBuilder[CultureFields, CultureRow] = {
-    DeleteBuilderMock(DeleteParams.empty, CultureFields.structure.fields, map)
+    DeleteBuilderMock(DeleteParams.empty, CultureFields.structure, map)
   }
   override def deleteById(cultureid: CultureId): ZIO[ZConnection, Throwable, Boolean] = {
     ZIO.succeed(map.remove(cultureid).isDefined)
@@ -85,7 +85,7 @@ class CultureRepoMock(toRow: Function1[CultureRowUnsaved, CultureRow],
     }
   }
   override def update: UpdateBuilder[CultureFields, CultureRow] = {
-    UpdateBuilderMock(UpdateParams.empty, CultureFields.structure.fields, map)
+    UpdateBuilderMock(UpdateParams.empty, CultureFields.structure, map)
   }
   override def update(row: CultureRow): ZIO[ZConnection, Throwable, Boolean] = {
     ZIO.succeed {

--- a/typo-tester-zio-jdbc/generated-and-checked-in/adventureworks/production/document/DocumentFields.scala
+++ b/typo-tester-zio-jdbc/generated-and-checked-in/adventureworks/production/document/DocumentFields.scala
@@ -13,56 +13,57 @@ import adventureworks.customtypes.TypoShort
 import adventureworks.customtypes.TypoUUID
 import adventureworks.person.businessentity.BusinessentityId
 import adventureworks.public.Flag
+import typo.dsl.Path
 import typo.dsl.SqlExpr.Field
 import typo.dsl.SqlExpr.FieldLikeNoHkt
 import typo.dsl.SqlExpr.IdField
 import typo.dsl.SqlExpr.OptField
 import typo.dsl.Structure.Relation
 
-trait DocumentFields[Row] {
-  val title: Field[/* max 50 chars */ String, Row]
-  val owner: Field[BusinessentityId, Row]
-  val folderflag: Field[Flag, Row]
-  val filename: Field[/* max 400 chars */ String, Row]
-  val fileextension: OptField[/* max 8 chars */ String, Row]
-  val revision: Field[/* bpchar, max 5 chars */ String, Row]
-  val changenumber: Field[Int, Row]
-  val status: Field[TypoShort, Row]
-  val documentsummary: OptField[String, Row]
-  val document: OptField[TypoBytea, Row]
-  val rowguid: Field[TypoUUID, Row]
-  val modifieddate: Field[TypoLocalDateTime, Row]
-  val documentnode: IdField[DocumentId, Row]
+trait DocumentFields {
+  def title: Field[/* max 50 chars */ String, DocumentRow]
+  def owner: Field[BusinessentityId, DocumentRow]
+  def folderflag: Field[Flag, DocumentRow]
+  def filename: Field[/* max 400 chars */ String, DocumentRow]
+  def fileextension: OptField[/* max 8 chars */ String, DocumentRow]
+  def revision: Field[/* bpchar, max 5 chars */ String, DocumentRow]
+  def changenumber: Field[Int, DocumentRow]
+  def status: Field[TypoShort, DocumentRow]
+  def documentsummary: OptField[String, DocumentRow]
+  def document: OptField[TypoBytea, DocumentRow]
+  def rowguid: Field[TypoUUID, DocumentRow]
+  def modifieddate: Field[TypoLocalDateTime, DocumentRow]
+  def documentnode: IdField[DocumentId, DocumentRow]
 }
 
 object DocumentFields {
-  val structure: Relation[DocumentFields, DocumentRow, DocumentRow] = 
-    new Impl(None, identity, (_, x) => x)
+  lazy val structure: Relation[DocumentFields, DocumentRow] =
+    new Impl(Nil)
     
-  private final class Impl[Row](val prefix: Option[String], val extract: Row => DocumentRow, val merge: (Row, DocumentRow) => Row)
-    extends Relation[DocumentFields, DocumentRow, Row] { 
+  private final class Impl(val _path: List[Path])
+    extends Relation[DocumentFields, DocumentRow] {
   
-    override val fields: DocumentFields[Row] = new DocumentFields[Row] {
-      override val title = new Field[/* max 50 chars */ String, Row](prefix, "title", None, None)(x => extract(x).title, (row, value) => merge(row, extract(row).copy(title = value)))
-      override val owner = new Field[BusinessentityId, Row](prefix, "owner", None, Some("int4"))(x => extract(x).owner, (row, value) => merge(row, extract(row).copy(owner = value)))
-      override val folderflag = new Field[Flag, Row](prefix, "folderflag", None, Some("bool"))(x => extract(x).folderflag, (row, value) => merge(row, extract(row).copy(folderflag = value)))
-      override val filename = new Field[/* max 400 chars */ String, Row](prefix, "filename", None, None)(x => extract(x).filename, (row, value) => merge(row, extract(row).copy(filename = value)))
-      override val fileextension = new OptField[/* max 8 chars */ String, Row](prefix, "fileextension", None, None)(x => extract(x).fileextension, (row, value) => merge(row, extract(row).copy(fileextension = value)))
-      override val revision = new Field[/* bpchar, max 5 chars */ String, Row](prefix, "revision", None, Some("bpchar"))(x => extract(x).revision, (row, value) => merge(row, extract(row).copy(revision = value)))
-      override val changenumber = new Field[Int, Row](prefix, "changenumber", None, Some("int4"))(x => extract(x).changenumber, (row, value) => merge(row, extract(row).copy(changenumber = value)))
-      override val status = new Field[TypoShort, Row](prefix, "status", None, Some("int2"))(x => extract(x).status, (row, value) => merge(row, extract(row).copy(status = value)))
-      override val documentsummary = new OptField[String, Row](prefix, "documentsummary", None, None)(x => extract(x).documentsummary, (row, value) => merge(row, extract(row).copy(documentsummary = value)))
-      override val document = new OptField[TypoBytea, Row](prefix, "document", None, Some("bytea"))(x => extract(x).document, (row, value) => merge(row, extract(row).copy(document = value)))
-      override val rowguid = new Field[TypoUUID, Row](prefix, "rowguid", None, Some("uuid"))(x => extract(x).rowguid, (row, value) => merge(row, extract(row).copy(rowguid = value)))
-      override val modifieddate = new Field[TypoLocalDateTime, Row](prefix, "modifieddate", Some("text"), Some("timestamp"))(x => extract(x).modifieddate, (row, value) => merge(row, extract(row).copy(modifieddate = value)))
-      override val documentnode = new IdField[DocumentId, Row](prefix, "documentnode", None, None)(x => extract(x).documentnode, (row, value) => merge(row, extract(row).copy(documentnode = value)))
+    override lazy val fields: DocumentFields = new DocumentFields {
+      override def title = Field[/* max 50 chars */ String, DocumentRow](_path, "title", None, None, x => x.title, (row, value) => row.copy(title = value))
+      override def owner = Field[BusinessentityId, DocumentRow](_path, "owner", None, Some("int4"), x => x.owner, (row, value) => row.copy(owner = value))
+      override def folderflag = Field[Flag, DocumentRow](_path, "folderflag", None, Some("bool"), x => x.folderflag, (row, value) => row.copy(folderflag = value))
+      override def filename = Field[/* max 400 chars */ String, DocumentRow](_path, "filename", None, None, x => x.filename, (row, value) => row.copy(filename = value))
+      override def fileextension = OptField[/* max 8 chars */ String, DocumentRow](_path, "fileextension", None, None, x => x.fileextension, (row, value) => row.copy(fileextension = value))
+      override def revision = Field[/* bpchar, max 5 chars */ String, DocumentRow](_path, "revision", None, Some("bpchar"), x => x.revision, (row, value) => row.copy(revision = value))
+      override def changenumber = Field[Int, DocumentRow](_path, "changenumber", None, Some("int4"), x => x.changenumber, (row, value) => row.copy(changenumber = value))
+      override def status = Field[TypoShort, DocumentRow](_path, "status", None, Some("int2"), x => x.status, (row, value) => row.copy(status = value))
+      override def documentsummary = OptField[String, DocumentRow](_path, "documentsummary", None, None, x => x.documentsummary, (row, value) => row.copy(documentsummary = value))
+      override def document = OptField[TypoBytea, DocumentRow](_path, "document", None, Some("bytea"), x => x.document, (row, value) => row.copy(document = value))
+      override def rowguid = Field[TypoUUID, DocumentRow](_path, "rowguid", None, Some("uuid"), x => x.rowguid, (row, value) => row.copy(rowguid = value))
+      override def modifieddate = Field[TypoLocalDateTime, DocumentRow](_path, "modifieddate", Some("text"), Some("timestamp"), x => x.modifieddate, (row, value) => row.copy(modifieddate = value))
+      override def documentnode = IdField[DocumentId, DocumentRow](_path, "documentnode", None, None, x => x.documentnode, (row, value) => row.copy(documentnode = value))
     }
   
-    override val columns: List[FieldLikeNoHkt[?, Row]] =
-      List[FieldLikeNoHkt[?, Row]](fields.title, fields.owner, fields.folderflag, fields.filename, fields.fileextension, fields.revision, fields.changenumber, fields.status, fields.documentsummary, fields.document, fields.rowguid, fields.modifieddate, fields.documentnode)
+    override lazy val columns: List[FieldLikeNoHkt[?, DocumentRow]] =
+      List[FieldLikeNoHkt[?, DocumentRow]](fields.title, fields.owner, fields.folderflag, fields.filename, fields.fileextension, fields.revision, fields.changenumber, fields.status, fields.documentsummary, fields.document, fields.rowguid, fields.modifieddate, fields.documentnode)
   
-    override def copy[NewRow](prefix: Option[String], extract: NewRow => DocumentRow, merge: (NewRow, DocumentRow) => NewRow): Impl[NewRow] =
-      new Impl(prefix, extract, merge)
+    override def copy(path: List[Path]): Impl =
+      new Impl(path)
   }
   
 }

--- a/typo-tester-zio-jdbc/generated-and-checked-in/adventureworks/production/document/DocumentRepoMock.scala
+++ b/typo-tester-zio-jdbc/generated-and-checked-in/adventureworks/production/document/DocumentRepoMock.scala
@@ -27,7 +27,7 @@ import zio.stream.ZStream
 class DocumentRepoMock(toRow: Function1[DocumentRowUnsaved, DocumentRow],
                        map: scala.collection.mutable.Map[DocumentId, DocumentRow] = scala.collection.mutable.Map.empty) extends DocumentRepo {
   override def delete: DeleteBuilder[DocumentFields, DocumentRow] = {
-    DeleteBuilderMock(DeleteParams.empty, DocumentFields.structure.fields, map)
+    DeleteBuilderMock(DeleteParams.empty, DocumentFields.structure, map)
   }
   override def deleteById(documentnode: DocumentId): ZIO[ZConnection, Throwable, Boolean] = {
     ZIO.succeed(map.remove(documentnode).isDefined)
@@ -89,7 +89,7 @@ class DocumentRepoMock(toRow: Function1[DocumentRowUnsaved, DocumentRow],
     ZIO.succeed(map.values.find(v => rowguid == v.rowguid))
   }
   override def update: UpdateBuilder[DocumentFields, DocumentRow] = {
-    UpdateBuilderMock(UpdateParams.empty, DocumentFields.structure.fields, map)
+    UpdateBuilderMock(UpdateParams.empty, DocumentFields.structure, map)
   }
   override def update(row: DocumentRow): ZIO[ZConnection, Throwable, Boolean] = {
     ZIO.succeed {

--- a/typo-tester-zio-jdbc/generated-and-checked-in/adventureworks/production/illustration/IllustrationFields.scala
+++ b/typo-tester-zio-jdbc/generated-and-checked-in/adventureworks/production/illustration/IllustrationFields.scala
@@ -9,36 +9,37 @@ package illustration
 
 import adventureworks.customtypes.TypoLocalDateTime
 import adventureworks.customtypes.TypoXml
+import typo.dsl.Path
 import typo.dsl.SqlExpr.Field
 import typo.dsl.SqlExpr.FieldLikeNoHkt
 import typo.dsl.SqlExpr.IdField
 import typo.dsl.SqlExpr.OptField
 import typo.dsl.Structure.Relation
 
-trait IllustrationFields[Row] {
-  val illustrationid: IdField[IllustrationId, Row]
-  val diagram: OptField[TypoXml, Row]
-  val modifieddate: Field[TypoLocalDateTime, Row]
+trait IllustrationFields {
+  def illustrationid: IdField[IllustrationId, IllustrationRow]
+  def diagram: OptField[TypoXml, IllustrationRow]
+  def modifieddate: Field[TypoLocalDateTime, IllustrationRow]
 }
 
 object IllustrationFields {
-  val structure: Relation[IllustrationFields, IllustrationRow, IllustrationRow] = 
-    new Impl(None, identity, (_, x) => x)
+  lazy val structure: Relation[IllustrationFields, IllustrationRow] =
+    new Impl(Nil)
     
-  private final class Impl[Row](val prefix: Option[String], val extract: Row => IllustrationRow, val merge: (Row, IllustrationRow) => Row)
-    extends Relation[IllustrationFields, IllustrationRow, Row] { 
+  private final class Impl(val _path: List[Path])
+    extends Relation[IllustrationFields, IllustrationRow] {
   
-    override val fields: IllustrationFields[Row] = new IllustrationFields[Row] {
-      override val illustrationid = new IdField[IllustrationId, Row](prefix, "illustrationid", None, Some("int4"))(x => extract(x).illustrationid, (row, value) => merge(row, extract(row).copy(illustrationid = value)))
-      override val diagram = new OptField[TypoXml, Row](prefix, "diagram", None, Some("xml"))(x => extract(x).diagram, (row, value) => merge(row, extract(row).copy(diagram = value)))
-      override val modifieddate = new Field[TypoLocalDateTime, Row](prefix, "modifieddate", Some("text"), Some("timestamp"))(x => extract(x).modifieddate, (row, value) => merge(row, extract(row).copy(modifieddate = value)))
+    override lazy val fields: IllustrationFields = new IllustrationFields {
+      override def illustrationid = IdField[IllustrationId, IllustrationRow](_path, "illustrationid", None, Some("int4"), x => x.illustrationid, (row, value) => row.copy(illustrationid = value))
+      override def diagram = OptField[TypoXml, IllustrationRow](_path, "diagram", None, Some("xml"), x => x.diagram, (row, value) => row.copy(diagram = value))
+      override def modifieddate = Field[TypoLocalDateTime, IllustrationRow](_path, "modifieddate", Some("text"), Some("timestamp"), x => x.modifieddate, (row, value) => row.copy(modifieddate = value))
     }
   
-    override val columns: List[FieldLikeNoHkt[?, Row]] =
-      List[FieldLikeNoHkt[?, Row]](fields.illustrationid, fields.diagram, fields.modifieddate)
+    override lazy val columns: List[FieldLikeNoHkt[?, IllustrationRow]] =
+      List[FieldLikeNoHkt[?, IllustrationRow]](fields.illustrationid, fields.diagram, fields.modifieddate)
   
-    override def copy[NewRow](prefix: Option[String], extract: NewRow => IllustrationRow, merge: (NewRow, IllustrationRow) => NewRow): Impl[NewRow] =
-      new Impl(prefix, extract, merge)
+    override def copy(path: List[Path]): Impl =
+      new Impl(path)
   }
   
 }

--- a/typo-tester-zio-jdbc/generated-and-checked-in/adventureworks/production/illustration/IllustrationRepoMock.scala
+++ b/typo-tester-zio-jdbc/generated-and-checked-in/adventureworks/production/illustration/IllustrationRepoMock.scala
@@ -26,7 +26,7 @@ import zio.stream.ZStream
 class IllustrationRepoMock(toRow: Function1[IllustrationRowUnsaved, IllustrationRow],
                            map: scala.collection.mutable.Map[IllustrationId, IllustrationRow] = scala.collection.mutable.Map.empty) extends IllustrationRepo {
   override def delete: DeleteBuilder[IllustrationFields, IllustrationRow] = {
-    DeleteBuilderMock(DeleteParams.empty, IllustrationFields.structure.fields, map)
+    DeleteBuilderMock(DeleteParams.empty, IllustrationFields.structure, map)
   }
   override def deleteById(illustrationid: IllustrationId): ZIO[ZConnection, Throwable, Boolean] = {
     ZIO.succeed(map.remove(illustrationid).isDefined)
@@ -85,7 +85,7 @@ class IllustrationRepoMock(toRow: Function1[IllustrationRowUnsaved, Illustration
     }
   }
   override def update: UpdateBuilder[IllustrationFields, IllustrationRow] = {
-    UpdateBuilderMock(UpdateParams.empty, IllustrationFields.structure.fields, map)
+    UpdateBuilderMock(UpdateParams.empty, IllustrationFields.structure, map)
   }
   override def update(row: IllustrationRow): ZIO[ZConnection, Throwable, Boolean] = {
     ZIO.succeed {

--- a/typo-tester-zio-jdbc/generated-and-checked-in/adventureworks/production/location/LocationFields.scala
+++ b/typo-tester-zio-jdbc/generated-and-checked-in/adventureworks/production/location/LocationFields.scala
@@ -9,39 +9,40 @@ package location
 
 import adventureworks.customtypes.TypoLocalDateTime
 import adventureworks.public.Name
+import typo.dsl.Path
 import typo.dsl.SqlExpr.Field
 import typo.dsl.SqlExpr.FieldLikeNoHkt
 import typo.dsl.SqlExpr.IdField
 import typo.dsl.Structure.Relation
 
-trait LocationFields[Row] {
-  val locationid: IdField[LocationId, Row]
-  val name: Field[Name, Row]
-  val costrate: Field[BigDecimal, Row]
-  val availability: Field[BigDecimal, Row]
-  val modifieddate: Field[TypoLocalDateTime, Row]
+trait LocationFields {
+  def locationid: IdField[LocationId, LocationRow]
+  def name: Field[Name, LocationRow]
+  def costrate: Field[BigDecimal, LocationRow]
+  def availability: Field[BigDecimal, LocationRow]
+  def modifieddate: Field[TypoLocalDateTime, LocationRow]
 }
 
 object LocationFields {
-  val structure: Relation[LocationFields, LocationRow, LocationRow] = 
-    new Impl(None, identity, (_, x) => x)
+  lazy val structure: Relation[LocationFields, LocationRow] =
+    new Impl(Nil)
     
-  private final class Impl[Row](val prefix: Option[String], val extract: Row => LocationRow, val merge: (Row, LocationRow) => Row)
-    extends Relation[LocationFields, LocationRow, Row] { 
+  private final class Impl(val _path: List[Path])
+    extends Relation[LocationFields, LocationRow] {
   
-    override val fields: LocationFields[Row] = new LocationFields[Row] {
-      override val locationid = new IdField[LocationId, Row](prefix, "locationid", None, Some("int4"))(x => extract(x).locationid, (row, value) => merge(row, extract(row).copy(locationid = value)))
-      override val name = new Field[Name, Row](prefix, "name", None, Some("varchar"))(x => extract(x).name, (row, value) => merge(row, extract(row).copy(name = value)))
-      override val costrate = new Field[BigDecimal, Row](prefix, "costrate", None, Some("numeric"))(x => extract(x).costrate, (row, value) => merge(row, extract(row).copy(costrate = value)))
-      override val availability = new Field[BigDecimal, Row](prefix, "availability", None, Some("numeric"))(x => extract(x).availability, (row, value) => merge(row, extract(row).copy(availability = value)))
-      override val modifieddate = new Field[TypoLocalDateTime, Row](prefix, "modifieddate", Some("text"), Some("timestamp"))(x => extract(x).modifieddate, (row, value) => merge(row, extract(row).copy(modifieddate = value)))
+    override lazy val fields: LocationFields = new LocationFields {
+      override def locationid = IdField[LocationId, LocationRow](_path, "locationid", None, Some("int4"), x => x.locationid, (row, value) => row.copy(locationid = value))
+      override def name = Field[Name, LocationRow](_path, "name", None, Some("varchar"), x => x.name, (row, value) => row.copy(name = value))
+      override def costrate = Field[BigDecimal, LocationRow](_path, "costrate", None, Some("numeric"), x => x.costrate, (row, value) => row.copy(costrate = value))
+      override def availability = Field[BigDecimal, LocationRow](_path, "availability", None, Some("numeric"), x => x.availability, (row, value) => row.copy(availability = value))
+      override def modifieddate = Field[TypoLocalDateTime, LocationRow](_path, "modifieddate", Some("text"), Some("timestamp"), x => x.modifieddate, (row, value) => row.copy(modifieddate = value))
     }
   
-    override val columns: List[FieldLikeNoHkt[?, Row]] =
-      List[FieldLikeNoHkt[?, Row]](fields.locationid, fields.name, fields.costrate, fields.availability, fields.modifieddate)
+    override lazy val columns: List[FieldLikeNoHkt[?, LocationRow]] =
+      List[FieldLikeNoHkt[?, LocationRow]](fields.locationid, fields.name, fields.costrate, fields.availability, fields.modifieddate)
   
-    override def copy[NewRow](prefix: Option[String], extract: NewRow => LocationRow, merge: (NewRow, LocationRow) => NewRow): Impl[NewRow] =
-      new Impl(prefix, extract, merge)
+    override def copy(path: List[Path]): Impl =
+      new Impl(path)
   }
   
 }

--- a/typo-tester-zio-jdbc/generated-and-checked-in/adventureworks/production/location/LocationRepoMock.scala
+++ b/typo-tester-zio-jdbc/generated-and-checked-in/adventureworks/production/location/LocationRepoMock.scala
@@ -26,7 +26,7 @@ import zio.stream.ZStream
 class LocationRepoMock(toRow: Function1[LocationRowUnsaved, LocationRow],
                        map: scala.collection.mutable.Map[LocationId, LocationRow] = scala.collection.mutable.Map.empty) extends LocationRepo {
   override def delete: DeleteBuilder[LocationFields, LocationRow] = {
-    DeleteBuilderMock(DeleteParams.empty, LocationFields.structure.fields, map)
+    DeleteBuilderMock(DeleteParams.empty, LocationFields.structure, map)
   }
   override def deleteById(locationid: LocationId): ZIO[ZConnection, Throwable, Boolean] = {
     ZIO.succeed(map.remove(locationid).isDefined)
@@ -85,7 +85,7 @@ class LocationRepoMock(toRow: Function1[LocationRowUnsaved, LocationRow],
     }
   }
   override def update: UpdateBuilder[LocationFields, LocationRow] = {
-    UpdateBuilderMock(UpdateParams.empty, LocationFields.structure.fields, map)
+    UpdateBuilderMock(UpdateParams.empty, LocationFields.structure, map)
   }
   override def update(row: LocationRow): ZIO[ZConnection, Throwable, Boolean] = {
     ZIO.succeed {

--- a/typo-tester-zio-jdbc/generated-and-checked-in/adventureworks/production/product/ProductFields.scala
+++ b/typo-tester-zio-jdbc/generated-and-checked-in/adventureworks/production/product/ProductFields.scala
@@ -15,80 +15,81 @@ import adventureworks.production.productsubcategory.ProductsubcategoryId
 import adventureworks.production.unitmeasure.UnitmeasureId
 import adventureworks.public.Flag
 import adventureworks.public.Name
+import typo.dsl.Path
 import typo.dsl.SqlExpr.Field
 import typo.dsl.SqlExpr.FieldLikeNoHkt
 import typo.dsl.SqlExpr.IdField
 import typo.dsl.SqlExpr.OptField
 import typo.dsl.Structure.Relation
 
-trait ProductFields[Row] {
-  val productid: IdField[ProductId, Row]
-  val name: Field[Name, Row]
-  val productnumber: Field[/* max 25 chars */ String, Row]
-  val makeflag: Field[Flag, Row]
-  val finishedgoodsflag: Field[Flag, Row]
-  val color: OptField[/* max 15 chars */ String, Row]
-  val safetystocklevel: Field[TypoShort, Row]
-  val reorderpoint: Field[TypoShort, Row]
-  val standardcost: Field[BigDecimal, Row]
-  val listprice: Field[BigDecimal, Row]
-  val size: OptField[/* max 5 chars */ String, Row]
-  val sizeunitmeasurecode: OptField[UnitmeasureId, Row]
-  val weightunitmeasurecode: OptField[UnitmeasureId, Row]
-  val weight: OptField[BigDecimal, Row]
-  val daystomanufacture: Field[Int, Row]
-  val productline: OptField[/* bpchar, max 2 chars */ String, Row]
-  val `class`: OptField[/* bpchar, max 2 chars */ String, Row]
-  val style: OptField[/* bpchar, max 2 chars */ String, Row]
-  val productsubcategoryid: OptField[ProductsubcategoryId, Row]
-  val productmodelid: OptField[ProductmodelId, Row]
-  val sellstartdate: Field[TypoLocalDateTime, Row]
-  val sellenddate: OptField[TypoLocalDateTime, Row]
-  val discontinueddate: OptField[TypoLocalDateTime, Row]
-  val rowguid: Field[TypoUUID, Row]
-  val modifieddate: Field[TypoLocalDateTime, Row]
+trait ProductFields {
+  def productid: IdField[ProductId, ProductRow]
+  def name: Field[Name, ProductRow]
+  def productnumber: Field[/* max 25 chars */ String, ProductRow]
+  def makeflag: Field[Flag, ProductRow]
+  def finishedgoodsflag: Field[Flag, ProductRow]
+  def color: OptField[/* max 15 chars */ String, ProductRow]
+  def safetystocklevel: Field[TypoShort, ProductRow]
+  def reorderpoint: Field[TypoShort, ProductRow]
+  def standardcost: Field[BigDecimal, ProductRow]
+  def listprice: Field[BigDecimal, ProductRow]
+  def size: OptField[/* max 5 chars */ String, ProductRow]
+  def sizeunitmeasurecode: OptField[UnitmeasureId, ProductRow]
+  def weightunitmeasurecode: OptField[UnitmeasureId, ProductRow]
+  def weight: OptField[BigDecimal, ProductRow]
+  def daystomanufacture: Field[Int, ProductRow]
+  def productline: OptField[/* bpchar, max 2 chars */ String, ProductRow]
+  def `class`: OptField[/* bpchar, max 2 chars */ String, ProductRow]
+  def style: OptField[/* bpchar, max 2 chars */ String, ProductRow]
+  def productsubcategoryid: OptField[ProductsubcategoryId, ProductRow]
+  def productmodelid: OptField[ProductmodelId, ProductRow]
+  def sellstartdate: Field[TypoLocalDateTime, ProductRow]
+  def sellenddate: OptField[TypoLocalDateTime, ProductRow]
+  def discontinueddate: OptField[TypoLocalDateTime, ProductRow]
+  def rowguid: Field[TypoUUID, ProductRow]
+  def modifieddate: Field[TypoLocalDateTime, ProductRow]
 }
 
 object ProductFields {
-  val structure: Relation[ProductFields, ProductRow, ProductRow] = 
-    new Impl(None, identity, (_, x) => x)
+  lazy val structure: Relation[ProductFields, ProductRow] =
+    new Impl(Nil)
     
-  private final class Impl[Row](val prefix: Option[String], val extract: Row => ProductRow, val merge: (Row, ProductRow) => Row)
-    extends Relation[ProductFields, ProductRow, Row] { 
+  private final class Impl(val _path: List[Path])
+    extends Relation[ProductFields, ProductRow] {
   
-    override val fields: ProductFields[Row] = new ProductFields[Row] {
-      override val productid = new IdField[ProductId, Row](prefix, "productid", None, Some("int4"))(x => extract(x).productid, (row, value) => merge(row, extract(row).copy(productid = value)))
-      override val name = new Field[Name, Row](prefix, "name", None, Some("varchar"))(x => extract(x).name, (row, value) => merge(row, extract(row).copy(name = value)))
-      override val productnumber = new Field[/* max 25 chars */ String, Row](prefix, "productnumber", None, None)(x => extract(x).productnumber, (row, value) => merge(row, extract(row).copy(productnumber = value)))
-      override val makeflag = new Field[Flag, Row](prefix, "makeflag", None, Some("bool"))(x => extract(x).makeflag, (row, value) => merge(row, extract(row).copy(makeflag = value)))
-      override val finishedgoodsflag = new Field[Flag, Row](prefix, "finishedgoodsflag", None, Some("bool"))(x => extract(x).finishedgoodsflag, (row, value) => merge(row, extract(row).copy(finishedgoodsflag = value)))
-      override val color = new OptField[/* max 15 chars */ String, Row](prefix, "color", None, None)(x => extract(x).color, (row, value) => merge(row, extract(row).copy(color = value)))
-      override val safetystocklevel = new Field[TypoShort, Row](prefix, "safetystocklevel", None, Some("int2"))(x => extract(x).safetystocklevel, (row, value) => merge(row, extract(row).copy(safetystocklevel = value)))
-      override val reorderpoint = new Field[TypoShort, Row](prefix, "reorderpoint", None, Some("int2"))(x => extract(x).reorderpoint, (row, value) => merge(row, extract(row).copy(reorderpoint = value)))
-      override val standardcost = new Field[BigDecimal, Row](prefix, "standardcost", None, Some("numeric"))(x => extract(x).standardcost, (row, value) => merge(row, extract(row).copy(standardcost = value)))
-      override val listprice = new Field[BigDecimal, Row](prefix, "listprice", None, Some("numeric"))(x => extract(x).listprice, (row, value) => merge(row, extract(row).copy(listprice = value)))
-      override val size = new OptField[/* max 5 chars */ String, Row](prefix, "size", None, None)(x => extract(x).size, (row, value) => merge(row, extract(row).copy(size = value)))
-      override val sizeunitmeasurecode = new OptField[UnitmeasureId, Row](prefix, "sizeunitmeasurecode", None, Some("bpchar"))(x => extract(x).sizeunitmeasurecode, (row, value) => merge(row, extract(row).copy(sizeunitmeasurecode = value)))
-      override val weightunitmeasurecode = new OptField[UnitmeasureId, Row](prefix, "weightunitmeasurecode", None, Some("bpchar"))(x => extract(x).weightunitmeasurecode, (row, value) => merge(row, extract(row).copy(weightunitmeasurecode = value)))
-      override val weight = new OptField[BigDecimal, Row](prefix, "weight", None, Some("numeric"))(x => extract(x).weight, (row, value) => merge(row, extract(row).copy(weight = value)))
-      override val daystomanufacture = new Field[Int, Row](prefix, "daystomanufacture", None, Some("int4"))(x => extract(x).daystomanufacture, (row, value) => merge(row, extract(row).copy(daystomanufacture = value)))
-      override val productline = new OptField[/* bpchar, max 2 chars */ String, Row](prefix, "productline", None, Some("bpchar"))(x => extract(x).productline, (row, value) => merge(row, extract(row).copy(productline = value)))
-      override val `class` = new OptField[/* bpchar, max 2 chars */ String, Row](prefix, "class", None, Some("bpchar"))(x => extract(x).`class`, (row, value) => merge(row, extract(row).copy(`class` = value)))
-      override val style = new OptField[/* bpchar, max 2 chars */ String, Row](prefix, "style", None, Some("bpchar"))(x => extract(x).style, (row, value) => merge(row, extract(row).copy(style = value)))
-      override val productsubcategoryid = new OptField[ProductsubcategoryId, Row](prefix, "productsubcategoryid", None, Some("int4"))(x => extract(x).productsubcategoryid, (row, value) => merge(row, extract(row).copy(productsubcategoryid = value)))
-      override val productmodelid = new OptField[ProductmodelId, Row](prefix, "productmodelid", None, Some("int4"))(x => extract(x).productmodelid, (row, value) => merge(row, extract(row).copy(productmodelid = value)))
-      override val sellstartdate = new Field[TypoLocalDateTime, Row](prefix, "sellstartdate", Some("text"), Some("timestamp"))(x => extract(x).sellstartdate, (row, value) => merge(row, extract(row).copy(sellstartdate = value)))
-      override val sellenddate = new OptField[TypoLocalDateTime, Row](prefix, "sellenddate", Some("text"), Some("timestamp"))(x => extract(x).sellenddate, (row, value) => merge(row, extract(row).copy(sellenddate = value)))
-      override val discontinueddate = new OptField[TypoLocalDateTime, Row](prefix, "discontinueddate", Some("text"), Some("timestamp"))(x => extract(x).discontinueddate, (row, value) => merge(row, extract(row).copy(discontinueddate = value)))
-      override val rowguid = new Field[TypoUUID, Row](prefix, "rowguid", None, Some("uuid"))(x => extract(x).rowguid, (row, value) => merge(row, extract(row).copy(rowguid = value)))
-      override val modifieddate = new Field[TypoLocalDateTime, Row](prefix, "modifieddate", Some("text"), Some("timestamp"))(x => extract(x).modifieddate, (row, value) => merge(row, extract(row).copy(modifieddate = value)))
+    override lazy val fields: ProductFields = new ProductFields {
+      override def productid = IdField[ProductId, ProductRow](_path, "productid", None, Some("int4"), x => x.productid, (row, value) => row.copy(productid = value))
+      override def name = Field[Name, ProductRow](_path, "name", None, Some("varchar"), x => x.name, (row, value) => row.copy(name = value))
+      override def productnumber = Field[/* max 25 chars */ String, ProductRow](_path, "productnumber", None, None, x => x.productnumber, (row, value) => row.copy(productnumber = value))
+      override def makeflag = Field[Flag, ProductRow](_path, "makeflag", None, Some("bool"), x => x.makeflag, (row, value) => row.copy(makeflag = value))
+      override def finishedgoodsflag = Field[Flag, ProductRow](_path, "finishedgoodsflag", None, Some("bool"), x => x.finishedgoodsflag, (row, value) => row.copy(finishedgoodsflag = value))
+      override def color = OptField[/* max 15 chars */ String, ProductRow](_path, "color", None, None, x => x.color, (row, value) => row.copy(color = value))
+      override def safetystocklevel = Field[TypoShort, ProductRow](_path, "safetystocklevel", None, Some("int2"), x => x.safetystocklevel, (row, value) => row.copy(safetystocklevel = value))
+      override def reorderpoint = Field[TypoShort, ProductRow](_path, "reorderpoint", None, Some("int2"), x => x.reorderpoint, (row, value) => row.copy(reorderpoint = value))
+      override def standardcost = Field[BigDecimal, ProductRow](_path, "standardcost", None, Some("numeric"), x => x.standardcost, (row, value) => row.copy(standardcost = value))
+      override def listprice = Field[BigDecimal, ProductRow](_path, "listprice", None, Some("numeric"), x => x.listprice, (row, value) => row.copy(listprice = value))
+      override def size = OptField[/* max 5 chars */ String, ProductRow](_path, "size", None, None, x => x.size, (row, value) => row.copy(size = value))
+      override def sizeunitmeasurecode = OptField[UnitmeasureId, ProductRow](_path, "sizeunitmeasurecode", None, Some("bpchar"), x => x.sizeunitmeasurecode, (row, value) => row.copy(sizeunitmeasurecode = value))
+      override def weightunitmeasurecode = OptField[UnitmeasureId, ProductRow](_path, "weightunitmeasurecode", None, Some("bpchar"), x => x.weightunitmeasurecode, (row, value) => row.copy(weightunitmeasurecode = value))
+      override def weight = OptField[BigDecimal, ProductRow](_path, "weight", None, Some("numeric"), x => x.weight, (row, value) => row.copy(weight = value))
+      override def daystomanufacture = Field[Int, ProductRow](_path, "daystomanufacture", None, Some("int4"), x => x.daystomanufacture, (row, value) => row.copy(daystomanufacture = value))
+      override def productline = OptField[/* bpchar, max 2 chars */ String, ProductRow](_path, "productline", None, Some("bpchar"), x => x.productline, (row, value) => row.copy(productline = value))
+      override def `class` = OptField[/* bpchar, max 2 chars */ String, ProductRow](_path, "class", None, Some("bpchar"), x => x.`class`, (row, value) => row.copy(`class` = value))
+      override def style = OptField[/* bpchar, max 2 chars */ String, ProductRow](_path, "style", None, Some("bpchar"), x => x.style, (row, value) => row.copy(style = value))
+      override def productsubcategoryid = OptField[ProductsubcategoryId, ProductRow](_path, "productsubcategoryid", None, Some("int4"), x => x.productsubcategoryid, (row, value) => row.copy(productsubcategoryid = value))
+      override def productmodelid = OptField[ProductmodelId, ProductRow](_path, "productmodelid", None, Some("int4"), x => x.productmodelid, (row, value) => row.copy(productmodelid = value))
+      override def sellstartdate = Field[TypoLocalDateTime, ProductRow](_path, "sellstartdate", Some("text"), Some("timestamp"), x => x.sellstartdate, (row, value) => row.copy(sellstartdate = value))
+      override def sellenddate = OptField[TypoLocalDateTime, ProductRow](_path, "sellenddate", Some("text"), Some("timestamp"), x => x.sellenddate, (row, value) => row.copy(sellenddate = value))
+      override def discontinueddate = OptField[TypoLocalDateTime, ProductRow](_path, "discontinueddate", Some("text"), Some("timestamp"), x => x.discontinueddate, (row, value) => row.copy(discontinueddate = value))
+      override def rowguid = Field[TypoUUID, ProductRow](_path, "rowguid", None, Some("uuid"), x => x.rowguid, (row, value) => row.copy(rowguid = value))
+      override def modifieddate = Field[TypoLocalDateTime, ProductRow](_path, "modifieddate", Some("text"), Some("timestamp"), x => x.modifieddate, (row, value) => row.copy(modifieddate = value))
     }
   
-    override val columns: List[FieldLikeNoHkt[?, Row]] =
-      List[FieldLikeNoHkt[?, Row]](fields.productid, fields.name, fields.productnumber, fields.makeflag, fields.finishedgoodsflag, fields.color, fields.safetystocklevel, fields.reorderpoint, fields.standardcost, fields.listprice, fields.size, fields.sizeunitmeasurecode, fields.weightunitmeasurecode, fields.weight, fields.daystomanufacture, fields.productline, fields.`class`, fields.style, fields.productsubcategoryid, fields.productmodelid, fields.sellstartdate, fields.sellenddate, fields.discontinueddate, fields.rowguid, fields.modifieddate)
+    override lazy val columns: List[FieldLikeNoHkt[?, ProductRow]] =
+      List[FieldLikeNoHkt[?, ProductRow]](fields.productid, fields.name, fields.productnumber, fields.makeflag, fields.finishedgoodsflag, fields.color, fields.safetystocklevel, fields.reorderpoint, fields.standardcost, fields.listprice, fields.size, fields.sizeunitmeasurecode, fields.weightunitmeasurecode, fields.weight, fields.daystomanufacture, fields.productline, fields.`class`, fields.style, fields.productsubcategoryid, fields.productmodelid, fields.sellstartdate, fields.sellenddate, fields.discontinueddate, fields.rowguid, fields.modifieddate)
   
-    override def copy[NewRow](prefix: Option[String], extract: NewRow => ProductRow, merge: (NewRow, ProductRow) => NewRow): Impl[NewRow] =
-      new Impl(prefix, extract, merge)
+    override def copy(path: List[Path]): Impl =
+      new Impl(path)
   }
   
 }

--- a/typo-tester-zio-jdbc/generated-and-checked-in/adventureworks/production/product/ProductRepoMock.scala
+++ b/typo-tester-zio-jdbc/generated-and-checked-in/adventureworks/production/product/ProductRepoMock.scala
@@ -26,7 +26,7 @@ import zio.stream.ZStream
 class ProductRepoMock(toRow: Function1[ProductRowUnsaved, ProductRow],
                       map: scala.collection.mutable.Map[ProductId, ProductRow] = scala.collection.mutable.Map.empty) extends ProductRepo {
   override def delete: DeleteBuilder[ProductFields, ProductRow] = {
-    DeleteBuilderMock(DeleteParams.empty, ProductFields.structure.fields, map)
+    DeleteBuilderMock(DeleteParams.empty, ProductFields.structure, map)
   }
   override def deleteById(productid: ProductId): ZIO[ZConnection, Throwable, Boolean] = {
     ZIO.succeed(map.remove(productid).isDefined)
@@ -85,7 +85,7 @@ class ProductRepoMock(toRow: Function1[ProductRowUnsaved, ProductRow],
     }
   }
   override def update: UpdateBuilder[ProductFields, ProductRow] = {
-    UpdateBuilderMock(UpdateParams.empty, ProductFields.structure.fields, map)
+    UpdateBuilderMock(UpdateParams.empty, ProductFields.structure, map)
   }
   override def update(row: ProductRow): ZIO[ZConnection, Throwable, Boolean] = {
     ZIO.succeed {

--- a/typo-tester-zio-jdbc/generated-and-checked-in/adventureworks/production/productcategory/ProductcategoryFields.scala
+++ b/typo-tester-zio-jdbc/generated-and-checked-in/adventureworks/production/productcategory/ProductcategoryFields.scala
@@ -10,37 +10,38 @@ package productcategory
 import adventureworks.customtypes.TypoLocalDateTime
 import adventureworks.customtypes.TypoUUID
 import adventureworks.public.Name
+import typo.dsl.Path
 import typo.dsl.SqlExpr.Field
 import typo.dsl.SqlExpr.FieldLikeNoHkt
 import typo.dsl.SqlExpr.IdField
 import typo.dsl.Structure.Relation
 
-trait ProductcategoryFields[Row] {
-  val productcategoryid: IdField[ProductcategoryId, Row]
-  val name: Field[Name, Row]
-  val rowguid: Field[TypoUUID, Row]
-  val modifieddate: Field[TypoLocalDateTime, Row]
+trait ProductcategoryFields {
+  def productcategoryid: IdField[ProductcategoryId, ProductcategoryRow]
+  def name: Field[Name, ProductcategoryRow]
+  def rowguid: Field[TypoUUID, ProductcategoryRow]
+  def modifieddate: Field[TypoLocalDateTime, ProductcategoryRow]
 }
 
 object ProductcategoryFields {
-  val structure: Relation[ProductcategoryFields, ProductcategoryRow, ProductcategoryRow] = 
-    new Impl(None, identity, (_, x) => x)
+  lazy val structure: Relation[ProductcategoryFields, ProductcategoryRow] =
+    new Impl(Nil)
     
-  private final class Impl[Row](val prefix: Option[String], val extract: Row => ProductcategoryRow, val merge: (Row, ProductcategoryRow) => Row)
-    extends Relation[ProductcategoryFields, ProductcategoryRow, Row] { 
+  private final class Impl(val _path: List[Path])
+    extends Relation[ProductcategoryFields, ProductcategoryRow] {
   
-    override val fields: ProductcategoryFields[Row] = new ProductcategoryFields[Row] {
-      override val productcategoryid = new IdField[ProductcategoryId, Row](prefix, "productcategoryid", None, Some("int4"))(x => extract(x).productcategoryid, (row, value) => merge(row, extract(row).copy(productcategoryid = value)))
-      override val name = new Field[Name, Row](prefix, "name", None, Some("varchar"))(x => extract(x).name, (row, value) => merge(row, extract(row).copy(name = value)))
-      override val rowguid = new Field[TypoUUID, Row](prefix, "rowguid", None, Some("uuid"))(x => extract(x).rowguid, (row, value) => merge(row, extract(row).copy(rowguid = value)))
-      override val modifieddate = new Field[TypoLocalDateTime, Row](prefix, "modifieddate", Some("text"), Some("timestamp"))(x => extract(x).modifieddate, (row, value) => merge(row, extract(row).copy(modifieddate = value)))
+    override lazy val fields: ProductcategoryFields = new ProductcategoryFields {
+      override def productcategoryid = IdField[ProductcategoryId, ProductcategoryRow](_path, "productcategoryid", None, Some("int4"), x => x.productcategoryid, (row, value) => row.copy(productcategoryid = value))
+      override def name = Field[Name, ProductcategoryRow](_path, "name", None, Some("varchar"), x => x.name, (row, value) => row.copy(name = value))
+      override def rowguid = Field[TypoUUID, ProductcategoryRow](_path, "rowguid", None, Some("uuid"), x => x.rowguid, (row, value) => row.copy(rowguid = value))
+      override def modifieddate = Field[TypoLocalDateTime, ProductcategoryRow](_path, "modifieddate", Some("text"), Some("timestamp"), x => x.modifieddate, (row, value) => row.copy(modifieddate = value))
     }
   
-    override val columns: List[FieldLikeNoHkt[?, Row]] =
-      List[FieldLikeNoHkt[?, Row]](fields.productcategoryid, fields.name, fields.rowguid, fields.modifieddate)
+    override lazy val columns: List[FieldLikeNoHkt[?, ProductcategoryRow]] =
+      List[FieldLikeNoHkt[?, ProductcategoryRow]](fields.productcategoryid, fields.name, fields.rowguid, fields.modifieddate)
   
-    override def copy[NewRow](prefix: Option[String], extract: NewRow => ProductcategoryRow, merge: (NewRow, ProductcategoryRow) => NewRow): Impl[NewRow] =
-      new Impl(prefix, extract, merge)
+    override def copy(path: List[Path]): Impl =
+      new Impl(path)
   }
   
 }

--- a/typo-tester-zio-jdbc/generated-and-checked-in/adventureworks/production/productcategory/ProductcategoryRepoMock.scala
+++ b/typo-tester-zio-jdbc/generated-and-checked-in/adventureworks/production/productcategory/ProductcategoryRepoMock.scala
@@ -26,7 +26,7 @@ import zio.stream.ZStream
 class ProductcategoryRepoMock(toRow: Function1[ProductcategoryRowUnsaved, ProductcategoryRow],
                               map: scala.collection.mutable.Map[ProductcategoryId, ProductcategoryRow] = scala.collection.mutable.Map.empty) extends ProductcategoryRepo {
   override def delete: DeleteBuilder[ProductcategoryFields, ProductcategoryRow] = {
-    DeleteBuilderMock(DeleteParams.empty, ProductcategoryFields.structure.fields, map)
+    DeleteBuilderMock(DeleteParams.empty, ProductcategoryFields.structure, map)
   }
   override def deleteById(productcategoryid: ProductcategoryId): ZIO[ZConnection, Throwable, Boolean] = {
     ZIO.succeed(map.remove(productcategoryid).isDefined)
@@ -85,7 +85,7 @@ class ProductcategoryRepoMock(toRow: Function1[ProductcategoryRowUnsaved, Produc
     }
   }
   override def update: UpdateBuilder[ProductcategoryFields, ProductcategoryRow] = {
-    UpdateBuilderMock(UpdateParams.empty, ProductcategoryFields.structure.fields, map)
+    UpdateBuilderMock(UpdateParams.empty, ProductcategoryFields.structure, map)
   }
   override def update(row: ProductcategoryRow): ZIO[ZConnection, Throwable, Boolean] = {
     ZIO.succeed {

--- a/typo-tester-zio-jdbc/generated-and-checked-in/adventureworks/production/productcosthistory/ProductcosthistoryFields.scala
+++ b/typo-tester-zio-jdbc/generated-and-checked-in/adventureworks/production/productcosthistory/ProductcosthistoryFields.scala
@@ -9,40 +9,41 @@ package productcosthistory
 
 import adventureworks.customtypes.TypoLocalDateTime
 import adventureworks.production.product.ProductId
+import typo.dsl.Path
 import typo.dsl.SqlExpr.Field
 import typo.dsl.SqlExpr.FieldLikeNoHkt
 import typo.dsl.SqlExpr.IdField
 import typo.dsl.SqlExpr.OptField
 import typo.dsl.Structure.Relation
 
-trait ProductcosthistoryFields[Row] {
-  val productid: IdField[ProductId, Row]
-  val startdate: IdField[TypoLocalDateTime, Row]
-  val enddate: OptField[TypoLocalDateTime, Row]
-  val standardcost: Field[BigDecimal, Row]
-  val modifieddate: Field[TypoLocalDateTime, Row]
+trait ProductcosthistoryFields {
+  def productid: IdField[ProductId, ProductcosthistoryRow]
+  def startdate: IdField[TypoLocalDateTime, ProductcosthistoryRow]
+  def enddate: OptField[TypoLocalDateTime, ProductcosthistoryRow]
+  def standardcost: Field[BigDecimal, ProductcosthistoryRow]
+  def modifieddate: Field[TypoLocalDateTime, ProductcosthistoryRow]
 }
 
 object ProductcosthistoryFields {
-  val structure: Relation[ProductcosthistoryFields, ProductcosthistoryRow, ProductcosthistoryRow] = 
-    new Impl(None, identity, (_, x) => x)
+  lazy val structure: Relation[ProductcosthistoryFields, ProductcosthistoryRow] =
+    new Impl(Nil)
     
-  private final class Impl[Row](val prefix: Option[String], val extract: Row => ProductcosthistoryRow, val merge: (Row, ProductcosthistoryRow) => Row)
-    extends Relation[ProductcosthistoryFields, ProductcosthistoryRow, Row] { 
+  private final class Impl(val _path: List[Path])
+    extends Relation[ProductcosthistoryFields, ProductcosthistoryRow] {
   
-    override val fields: ProductcosthistoryFields[Row] = new ProductcosthistoryFields[Row] {
-      override val productid = new IdField[ProductId, Row](prefix, "productid", None, Some("int4"))(x => extract(x).productid, (row, value) => merge(row, extract(row).copy(productid = value)))
-      override val startdate = new IdField[TypoLocalDateTime, Row](prefix, "startdate", Some("text"), Some("timestamp"))(x => extract(x).startdate, (row, value) => merge(row, extract(row).copy(startdate = value)))
-      override val enddate = new OptField[TypoLocalDateTime, Row](prefix, "enddate", Some("text"), Some("timestamp"))(x => extract(x).enddate, (row, value) => merge(row, extract(row).copy(enddate = value)))
-      override val standardcost = new Field[BigDecimal, Row](prefix, "standardcost", None, Some("numeric"))(x => extract(x).standardcost, (row, value) => merge(row, extract(row).copy(standardcost = value)))
-      override val modifieddate = new Field[TypoLocalDateTime, Row](prefix, "modifieddate", Some("text"), Some("timestamp"))(x => extract(x).modifieddate, (row, value) => merge(row, extract(row).copy(modifieddate = value)))
+    override lazy val fields: ProductcosthistoryFields = new ProductcosthistoryFields {
+      override def productid = IdField[ProductId, ProductcosthistoryRow](_path, "productid", None, Some("int4"), x => x.productid, (row, value) => row.copy(productid = value))
+      override def startdate = IdField[TypoLocalDateTime, ProductcosthistoryRow](_path, "startdate", Some("text"), Some("timestamp"), x => x.startdate, (row, value) => row.copy(startdate = value))
+      override def enddate = OptField[TypoLocalDateTime, ProductcosthistoryRow](_path, "enddate", Some("text"), Some("timestamp"), x => x.enddate, (row, value) => row.copy(enddate = value))
+      override def standardcost = Field[BigDecimal, ProductcosthistoryRow](_path, "standardcost", None, Some("numeric"), x => x.standardcost, (row, value) => row.copy(standardcost = value))
+      override def modifieddate = Field[TypoLocalDateTime, ProductcosthistoryRow](_path, "modifieddate", Some("text"), Some("timestamp"), x => x.modifieddate, (row, value) => row.copy(modifieddate = value))
     }
   
-    override val columns: List[FieldLikeNoHkt[?, Row]] =
-      List[FieldLikeNoHkt[?, Row]](fields.productid, fields.startdate, fields.enddate, fields.standardcost, fields.modifieddate)
+    override lazy val columns: List[FieldLikeNoHkt[?, ProductcosthistoryRow]] =
+      List[FieldLikeNoHkt[?, ProductcosthistoryRow]](fields.productid, fields.startdate, fields.enddate, fields.standardcost, fields.modifieddate)
   
-    override def copy[NewRow](prefix: Option[String], extract: NewRow => ProductcosthistoryRow, merge: (NewRow, ProductcosthistoryRow) => NewRow): Impl[NewRow] =
-      new Impl(prefix, extract, merge)
+    override def copy(path: List[Path]): Impl =
+      new Impl(path)
   }
   
 }

--- a/typo-tester-zio-jdbc/generated-and-checked-in/adventureworks/production/productcosthistory/ProductcosthistoryRepoMock.scala
+++ b/typo-tester-zio-jdbc/generated-and-checked-in/adventureworks/production/productcosthistory/ProductcosthistoryRepoMock.scala
@@ -26,7 +26,7 @@ import zio.stream.ZStream
 class ProductcosthistoryRepoMock(toRow: Function1[ProductcosthistoryRowUnsaved, ProductcosthistoryRow],
                                  map: scala.collection.mutable.Map[ProductcosthistoryId, ProductcosthistoryRow] = scala.collection.mutable.Map.empty) extends ProductcosthistoryRepo {
   override def delete: DeleteBuilder[ProductcosthistoryFields, ProductcosthistoryRow] = {
-    DeleteBuilderMock(DeleteParams.empty, ProductcosthistoryFields.structure.fields, map)
+    DeleteBuilderMock(DeleteParams.empty, ProductcosthistoryFields.structure, map)
   }
   override def deleteById(compositeId: ProductcosthistoryId): ZIO[ZConnection, Throwable, Boolean] = {
     ZIO.succeed(map.remove(compositeId).isDefined)
@@ -85,7 +85,7 @@ class ProductcosthistoryRepoMock(toRow: Function1[ProductcosthistoryRowUnsaved, 
     }
   }
   override def update: UpdateBuilder[ProductcosthistoryFields, ProductcosthistoryRow] = {
-    UpdateBuilderMock(UpdateParams.empty, ProductcosthistoryFields.structure.fields, map)
+    UpdateBuilderMock(UpdateParams.empty, ProductcosthistoryFields.structure, map)
   }
   override def update(row: ProductcosthistoryRow): ZIO[ZConnection, Throwable, Boolean] = {
     ZIO.succeed {

--- a/typo-tester-zio-jdbc/generated-and-checked-in/adventureworks/production/productdescription/ProductdescriptionFields.scala
+++ b/typo-tester-zio-jdbc/generated-and-checked-in/adventureworks/production/productdescription/ProductdescriptionFields.scala
@@ -9,37 +9,38 @@ package productdescription
 
 import adventureworks.customtypes.TypoLocalDateTime
 import adventureworks.customtypes.TypoUUID
+import typo.dsl.Path
 import typo.dsl.SqlExpr.Field
 import typo.dsl.SqlExpr.FieldLikeNoHkt
 import typo.dsl.SqlExpr.IdField
 import typo.dsl.Structure.Relation
 
-trait ProductdescriptionFields[Row] {
-  val productdescriptionid: IdField[ProductdescriptionId, Row]
-  val description: Field[/* max 400 chars */ String, Row]
-  val rowguid: Field[TypoUUID, Row]
-  val modifieddate: Field[TypoLocalDateTime, Row]
+trait ProductdescriptionFields {
+  def productdescriptionid: IdField[ProductdescriptionId, ProductdescriptionRow]
+  def description: Field[/* max 400 chars */ String, ProductdescriptionRow]
+  def rowguid: Field[TypoUUID, ProductdescriptionRow]
+  def modifieddate: Field[TypoLocalDateTime, ProductdescriptionRow]
 }
 
 object ProductdescriptionFields {
-  val structure: Relation[ProductdescriptionFields, ProductdescriptionRow, ProductdescriptionRow] = 
-    new Impl(None, identity, (_, x) => x)
+  lazy val structure: Relation[ProductdescriptionFields, ProductdescriptionRow] =
+    new Impl(Nil)
     
-  private final class Impl[Row](val prefix: Option[String], val extract: Row => ProductdescriptionRow, val merge: (Row, ProductdescriptionRow) => Row)
-    extends Relation[ProductdescriptionFields, ProductdescriptionRow, Row] { 
+  private final class Impl(val _path: List[Path])
+    extends Relation[ProductdescriptionFields, ProductdescriptionRow] {
   
-    override val fields: ProductdescriptionFields[Row] = new ProductdescriptionFields[Row] {
-      override val productdescriptionid = new IdField[ProductdescriptionId, Row](prefix, "productdescriptionid", None, Some("int4"))(x => extract(x).productdescriptionid, (row, value) => merge(row, extract(row).copy(productdescriptionid = value)))
-      override val description = new Field[/* max 400 chars */ String, Row](prefix, "description", None, None)(x => extract(x).description, (row, value) => merge(row, extract(row).copy(description = value)))
-      override val rowguid = new Field[TypoUUID, Row](prefix, "rowguid", None, Some("uuid"))(x => extract(x).rowguid, (row, value) => merge(row, extract(row).copy(rowguid = value)))
-      override val modifieddate = new Field[TypoLocalDateTime, Row](prefix, "modifieddate", Some("text"), Some("timestamp"))(x => extract(x).modifieddate, (row, value) => merge(row, extract(row).copy(modifieddate = value)))
+    override lazy val fields: ProductdescriptionFields = new ProductdescriptionFields {
+      override def productdescriptionid = IdField[ProductdescriptionId, ProductdescriptionRow](_path, "productdescriptionid", None, Some("int4"), x => x.productdescriptionid, (row, value) => row.copy(productdescriptionid = value))
+      override def description = Field[/* max 400 chars */ String, ProductdescriptionRow](_path, "description", None, None, x => x.description, (row, value) => row.copy(description = value))
+      override def rowguid = Field[TypoUUID, ProductdescriptionRow](_path, "rowguid", None, Some("uuid"), x => x.rowguid, (row, value) => row.copy(rowguid = value))
+      override def modifieddate = Field[TypoLocalDateTime, ProductdescriptionRow](_path, "modifieddate", Some("text"), Some("timestamp"), x => x.modifieddate, (row, value) => row.copy(modifieddate = value))
     }
   
-    override val columns: List[FieldLikeNoHkt[?, Row]] =
-      List[FieldLikeNoHkt[?, Row]](fields.productdescriptionid, fields.description, fields.rowguid, fields.modifieddate)
+    override lazy val columns: List[FieldLikeNoHkt[?, ProductdescriptionRow]] =
+      List[FieldLikeNoHkt[?, ProductdescriptionRow]](fields.productdescriptionid, fields.description, fields.rowguid, fields.modifieddate)
   
-    override def copy[NewRow](prefix: Option[String], extract: NewRow => ProductdescriptionRow, merge: (NewRow, ProductdescriptionRow) => NewRow): Impl[NewRow] =
-      new Impl(prefix, extract, merge)
+    override def copy(path: List[Path]): Impl =
+      new Impl(path)
   }
   
 }

--- a/typo-tester-zio-jdbc/generated-and-checked-in/adventureworks/production/productdescription/ProductdescriptionRepoMock.scala
+++ b/typo-tester-zio-jdbc/generated-and-checked-in/adventureworks/production/productdescription/ProductdescriptionRepoMock.scala
@@ -26,7 +26,7 @@ import zio.stream.ZStream
 class ProductdescriptionRepoMock(toRow: Function1[ProductdescriptionRowUnsaved, ProductdescriptionRow],
                                  map: scala.collection.mutable.Map[ProductdescriptionId, ProductdescriptionRow] = scala.collection.mutable.Map.empty) extends ProductdescriptionRepo {
   override def delete: DeleteBuilder[ProductdescriptionFields, ProductdescriptionRow] = {
-    DeleteBuilderMock(DeleteParams.empty, ProductdescriptionFields.structure.fields, map)
+    DeleteBuilderMock(DeleteParams.empty, ProductdescriptionFields.structure, map)
   }
   override def deleteById(productdescriptionid: ProductdescriptionId): ZIO[ZConnection, Throwable, Boolean] = {
     ZIO.succeed(map.remove(productdescriptionid).isDefined)
@@ -85,7 +85,7 @@ class ProductdescriptionRepoMock(toRow: Function1[ProductdescriptionRowUnsaved, 
     }
   }
   override def update: UpdateBuilder[ProductdescriptionFields, ProductdescriptionRow] = {
-    UpdateBuilderMock(UpdateParams.empty, ProductdescriptionFields.structure.fields, map)
+    UpdateBuilderMock(UpdateParams.empty, ProductdescriptionFields.structure, map)
   }
   override def update(row: ProductdescriptionRow): ZIO[ZConnection, Throwable, Boolean] = {
     ZIO.succeed {

--- a/typo-tester-zio-jdbc/generated-and-checked-in/adventureworks/production/productdocument/ProductdocumentFields.scala
+++ b/typo-tester-zio-jdbc/generated-and-checked-in/adventureworks/production/productdocument/ProductdocumentFields.scala
@@ -10,35 +10,36 @@ package productdocument
 import adventureworks.customtypes.TypoLocalDateTime
 import adventureworks.production.document.DocumentId
 import adventureworks.production.product.ProductId
+import typo.dsl.Path
 import typo.dsl.SqlExpr.Field
 import typo.dsl.SqlExpr.FieldLikeNoHkt
 import typo.dsl.SqlExpr.IdField
 import typo.dsl.Structure.Relation
 
-trait ProductdocumentFields[Row] {
-  val productid: IdField[ProductId, Row]
-  val modifieddate: Field[TypoLocalDateTime, Row]
-  val documentnode: IdField[DocumentId, Row]
+trait ProductdocumentFields {
+  def productid: IdField[ProductId, ProductdocumentRow]
+  def modifieddate: Field[TypoLocalDateTime, ProductdocumentRow]
+  def documentnode: IdField[DocumentId, ProductdocumentRow]
 }
 
 object ProductdocumentFields {
-  val structure: Relation[ProductdocumentFields, ProductdocumentRow, ProductdocumentRow] = 
-    new Impl(None, identity, (_, x) => x)
+  lazy val structure: Relation[ProductdocumentFields, ProductdocumentRow] =
+    new Impl(Nil)
     
-  private final class Impl[Row](val prefix: Option[String], val extract: Row => ProductdocumentRow, val merge: (Row, ProductdocumentRow) => Row)
-    extends Relation[ProductdocumentFields, ProductdocumentRow, Row] { 
+  private final class Impl(val _path: List[Path])
+    extends Relation[ProductdocumentFields, ProductdocumentRow] {
   
-    override val fields: ProductdocumentFields[Row] = new ProductdocumentFields[Row] {
-      override val productid = new IdField[ProductId, Row](prefix, "productid", None, Some("int4"))(x => extract(x).productid, (row, value) => merge(row, extract(row).copy(productid = value)))
-      override val modifieddate = new Field[TypoLocalDateTime, Row](prefix, "modifieddate", Some("text"), Some("timestamp"))(x => extract(x).modifieddate, (row, value) => merge(row, extract(row).copy(modifieddate = value)))
-      override val documentnode = new IdField[DocumentId, Row](prefix, "documentnode", None, None)(x => extract(x).documentnode, (row, value) => merge(row, extract(row).copy(documentnode = value)))
+    override lazy val fields: ProductdocumentFields = new ProductdocumentFields {
+      override def productid = IdField[ProductId, ProductdocumentRow](_path, "productid", None, Some("int4"), x => x.productid, (row, value) => row.copy(productid = value))
+      override def modifieddate = Field[TypoLocalDateTime, ProductdocumentRow](_path, "modifieddate", Some("text"), Some("timestamp"), x => x.modifieddate, (row, value) => row.copy(modifieddate = value))
+      override def documentnode = IdField[DocumentId, ProductdocumentRow](_path, "documentnode", None, None, x => x.documentnode, (row, value) => row.copy(documentnode = value))
     }
   
-    override val columns: List[FieldLikeNoHkt[?, Row]] =
-      List[FieldLikeNoHkt[?, Row]](fields.productid, fields.modifieddate, fields.documentnode)
+    override lazy val columns: List[FieldLikeNoHkt[?, ProductdocumentRow]] =
+      List[FieldLikeNoHkt[?, ProductdocumentRow]](fields.productid, fields.modifieddate, fields.documentnode)
   
-    override def copy[NewRow](prefix: Option[String], extract: NewRow => ProductdocumentRow, merge: (NewRow, ProductdocumentRow) => NewRow): Impl[NewRow] =
-      new Impl(prefix, extract, merge)
+    override def copy(path: List[Path]): Impl =
+      new Impl(path)
   }
   
 }

--- a/typo-tester-zio-jdbc/generated-and-checked-in/adventureworks/production/productdocument/ProductdocumentRepoMock.scala
+++ b/typo-tester-zio-jdbc/generated-and-checked-in/adventureworks/production/productdocument/ProductdocumentRepoMock.scala
@@ -26,7 +26,7 @@ import zio.stream.ZStream
 class ProductdocumentRepoMock(toRow: Function1[ProductdocumentRowUnsaved, ProductdocumentRow],
                               map: scala.collection.mutable.Map[ProductdocumentId, ProductdocumentRow] = scala.collection.mutable.Map.empty) extends ProductdocumentRepo {
   override def delete: DeleteBuilder[ProductdocumentFields, ProductdocumentRow] = {
-    DeleteBuilderMock(DeleteParams.empty, ProductdocumentFields.structure.fields, map)
+    DeleteBuilderMock(DeleteParams.empty, ProductdocumentFields.structure, map)
   }
   override def deleteById(compositeId: ProductdocumentId): ZIO[ZConnection, Throwable, Boolean] = {
     ZIO.succeed(map.remove(compositeId).isDefined)
@@ -85,7 +85,7 @@ class ProductdocumentRepoMock(toRow: Function1[ProductdocumentRowUnsaved, Produc
     }
   }
   override def update: UpdateBuilder[ProductdocumentFields, ProductdocumentRow] = {
-    UpdateBuilderMock(UpdateParams.empty, ProductdocumentFields.structure.fields, map)
+    UpdateBuilderMock(UpdateParams.empty, ProductdocumentFields.structure, map)
   }
   override def update(row: ProductdocumentRow): ZIO[ZConnection, Throwable, Boolean] = {
     ZIO.succeed {

--- a/typo-tester-zio-jdbc/generated-and-checked-in/adventureworks/production/productinventory/ProductinventoryFields.scala
+++ b/typo-tester-zio-jdbc/generated-and-checked-in/adventureworks/production/productinventory/ProductinventoryFields.scala
@@ -12,43 +12,44 @@ import adventureworks.customtypes.TypoShort
 import adventureworks.customtypes.TypoUUID
 import adventureworks.production.location.LocationId
 import adventureworks.production.product.ProductId
+import typo.dsl.Path
 import typo.dsl.SqlExpr.Field
 import typo.dsl.SqlExpr.FieldLikeNoHkt
 import typo.dsl.SqlExpr.IdField
 import typo.dsl.Structure.Relation
 
-trait ProductinventoryFields[Row] {
-  val productid: IdField[ProductId, Row]
-  val locationid: IdField[LocationId, Row]
-  val shelf: Field[/* max 10 chars */ String, Row]
-  val bin: Field[TypoShort, Row]
-  val quantity: Field[TypoShort, Row]
-  val rowguid: Field[TypoUUID, Row]
-  val modifieddate: Field[TypoLocalDateTime, Row]
+trait ProductinventoryFields {
+  def productid: IdField[ProductId, ProductinventoryRow]
+  def locationid: IdField[LocationId, ProductinventoryRow]
+  def shelf: Field[/* max 10 chars */ String, ProductinventoryRow]
+  def bin: Field[TypoShort, ProductinventoryRow]
+  def quantity: Field[TypoShort, ProductinventoryRow]
+  def rowguid: Field[TypoUUID, ProductinventoryRow]
+  def modifieddate: Field[TypoLocalDateTime, ProductinventoryRow]
 }
 
 object ProductinventoryFields {
-  val structure: Relation[ProductinventoryFields, ProductinventoryRow, ProductinventoryRow] = 
-    new Impl(None, identity, (_, x) => x)
+  lazy val structure: Relation[ProductinventoryFields, ProductinventoryRow] =
+    new Impl(Nil)
     
-  private final class Impl[Row](val prefix: Option[String], val extract: Row => ProductinventoryRow, val merge: (Row, ProductinventoryRow) => Row)
-    extends Relation[ProductinventoryFields, ProductinventoryRow, Row] { 
+  private final class Impl(val _path: List[Path])
+    extends Relation[ProductinventoryFields, ProductinventoryRow] {
   
-    override val fields: ProductinventoryFields[Row] = new ProductinventoryFields[Row] {
-      override val productid = new IdField[ProductId, Row](prefix, "productid", None, Some("int4"))(x => extract(x).productid, (row, value) => merge(row, extract(row).copy(productid = value)))
-      override val locationid = new IdField[LocationId, Row](prefix, "locationid", None, Some("int2"))(x => extract(x).locationid, (row, value) => merge(row, extract(row).copy(locationid = value)))
-      override val shelf = new Field[/* max 10 chars */ String, Row](prefix, "shelf", None, None)(x => extract(x).shelf, (row, value) => merge(row, extract(row).copy(shelf = value)))
-      override val bin = new Field[TypoShort, Row](prefix, "bin", None, Some("int2"))(x => extract(x).bin, (row, value) => merge(row, extract(row).copy(bin = value)))
-      override val quantity = new Field[TypoShort, Row](prefix, "quantity", None, Some("int2"))(x => extract(x).quantity, (row, value) => merge(row, extract(row).copy(quantity = value)))
-      override val rowguid = new Field[TypoUUID, Row](prefix, "rowguid", None, Some("uuid"))(x => extract(x).rowguid, (row, value) => merge(row, extract(row).copy(rowguid = value)))
-      override val modifieddate = new Field[TypoLocalDateTime, Row](prefix, "modifieddate", Some("text"), Some("timestamp"))(x => extract(x).modifieddate, (row, value) => merge(row, extract(row).copy(modifieddate = value)))
+    override lazy val fields: ProductinventoryFields = new ProductinventoryFields {
+      override def productid = IdField[ProductId, ProductinventoryRow](_path, "productid", None, Some("int4"), x => x.productid, (row, value) => row.copy(productid = value))
+      override def locationid = IdField[LocationId, ProductinventoryRow](_path, "locationid", None, Some("int2"), x => x.locationid, (row, value) => row.copy(locationid = value))
+      override def shelf = Field[/* max 10 chars */ String, ProductinventoryRow](_path, "shelf", None, None, x => x.shelf, (row, value) => row.copy(shelf = value))
+      override def bin = Field[TypoShort, ProductinventoryRow](_path, "bin", None, Some("int2"), x => x.bin, (row, value) => row.copy(bin = value))
+      override def quantity = Field[TypoShort, ProductinventoryRow](_path, "quantity", None, Some("int2"), x => x.quantity, (row, value) => row.copy(quantity = value))
+      override def rowguid = Field[TypoUUID, ProductinventoryRow](_path, "rowguid", None, Some("uuid"), x => x.rowguid, (row, value) => row.copy(rowguid = value))
+      override def modifieddate = Field[TypoLocalDateTime, ProductinventoryRow](_path, "modifieddate", Some("text"), Some("timestamp"), x => x.modifieddate, (row, value) => row.copy(modifieddate = value))
     }
   
-    override val columns: List[FieldLikeNoHkt[?, Row]] =
-      List[FieldLikeNoHkt[?, Row]](fields.productid, fields.locationid, fields.shelf, fields.bin, fields.quantity, fields.rowguid, fields.modifieddate)
+    override lazy val columns: List[FieldLikeNoHkt[?, ProductinventoryRow]] =
+      List[FieldLikeNoHkt[?, ProductinventoryRow]](fields.productid, fields.locationid, fields.shelf, fields.bin, fields.quantity, fields.rowguid, fields.modifieddate)
   
-    override def copy[NewRow](prefix: Option[String], extract: NewRow => ProductinventoryRow, merge: (NewRow, ProductinventoryRow) => NewRow): Impl[NewRow] =
-      new Impl(prefix, extract, merge)
+    override def copy(path: List[Path]): Impl =
+      new Impl(path)
   }
   
 }

--- a/typo-tester-zio-jdbc/generated-and-checked-in/adventureworks/production/productinventory/ProductinventoryRepoMock.scala
+++ b/typo-tester-zio-jdbc/generated-and-checked-in/adventureworks/production/productinventory/ProductinventoryRepoMock.scala
@@ -26,7 +26,7 @@ import zio.stream.ZStream
 class ProductinventoryRepoMock(toRow: Function1[ProductinventoryRowUnsaved, ProductinventoryRow],
                                map: scala.collection.mutable.Map[ProductinventoryId, ProductinventoryRow] = scala.collection.mutable.Map.empty) extends ProductinventoryRepo {
   override def delete: DeleteBuilder[ProductinventoryFields, ProductinventoryRow] = {
-    DeleteBuilderMock(DeleteParams.empty, ProductinventoryFields.structure.fields, map)
+    DeleteBuilderMock(DeleteParams.empty, ProductinventoryFields.structure, map)
   }
   override def deleteById(compositeId: ProductinventoryId): ZIO[ZConnection, Throwable, Boolean] = {
     ZIO.succeed(map.remove(compositeId).isDefined)
@@ -85,7 +85,7 @@ class ProductinventoryRepoMock(toRow: Function1[ProductinventoryRowUnsaved, Prod
     }
   }
   override def update: UpdateBuilder[ProductinventoryFields, ProductinventoryRow] = {
-    UpdateBuilderMock(UpdateParams.empty, ProductinventoryFields.structure.fields, map)
+    UpdateBuilderMock(UpdateParams.empty, ProductinventoryFields.structure, map)
   }
   override def update(row: ProductinventoryRow): ZIO[ZConnection, Throwable, Boolean] = {
     ZIO.succeed {

--- a/typo-tester-zio-jdbc/generated-and-checked-in/adventureworks/production/productlistpricehistory/ProductlistpricehistoryFields.scala
+++ b/typo-tester-zio-jdbc/generated-and-checked-in/adventureworks/production/productlistpricehistory/ProductlistpricehistoryFields.scala
@@ -9,40 +9,41 @@ package productlistpricehistory
 
 import adventureworks.customtypes.TypoLocalDateTime
 import adventureworks.production.product.ProductId
+import typo.dsl.Path
 import typo.dsl.SqlExpr.Field
 import typo.dsl.SqlExpr.FieldLikeNoHkt
 import typo.dsl.SqlExpr.IdField
 import typo.dsl.SqlExpr.OptField
 import typo.dsl.Structure.Relation
 
-trait ProductlistpricehistoryFields[Row] {
-  val productid: IdField[ProductId, Row]
-  val startdate: IdField[TypoLocalDateTime, Row]
-  val enddate: OptField[TypoLocalDateTime, Row]
-  val listprice: Field[BigDecimal, Row]
-  val modifieddate: Field[TypoLocalDateTime, Row]
+trait ProductlistpricehistoryFields {
+  def productid: IdField[ProductId, ProductlistpricehistoryRow]
+  def startdate: IdField[TypoLocalDateTime, ProductlistpricehistoryRow]
+  def enddate: OptField[TypoLocalDateTime, ProductlistpricehistoryRow]
+  def listprice: Field[BigDecimal, ProductlistpricehistoryRow]
+  def modifieddate: Field[TypoLocalDateTime, ProductlistpricehistoryRow]
 }
 
 object ProductlistpricehistoryFields {
-  val structure: Relation[ProductlistpricehistoryFields, ProductlistpricehistoryRow, ProductlistpricehistoryRow] = 
-    new Impl(None, identity, (_, x) => x)
+  lazy val structure: Relation[ProductlistpricehistoryFields, ProductlistpricehistoryRow] =
+    new Impl(Nil)
     
-  private final class Impl[Row](val prefix: Option[String], val extract: Row => ProductlistpricehistoryRow, val merge: (Row, ProductlistpricehistoryRow) => Row)
-    extends Relation[ProductlistpricehistoryFields, ProductlistpricehistoryRow, Row] { 
+  private final class Impl(val _path: List[Path])
+    extends Relation[ProductlistpricehistoryFields, ProductlistpricehistoryRow] {
   
-    override val fields: ProductlistpricehistoryFields[Row] = new ProductlistpricehistoryFields[Row] {
-      override val productid = new IdField[ProductId, Row](prefix, "productid", None, Some("int4"))(x => extract(x).productid, (row, value) => merge(row, extract(row).copy(productid = value)))
-      override val startdate = new IdField[TypoLocalDateTime, Row](prefix, "startdate", Some("text"), Some("timestamp"))(x => extract(x).startdate, (row, value) => merge(row, extract(row).copy(startdate = value)))
-      override val enddate = new OptField[TypoLocalDateTime, Row](prefix, "enddate", Some("text"), Some("timestamp"))(x => extract(x).enddate, (row, value) => merge(row, extract(row).copy(enddate = value)))
-      override val listprice = new Field[BigDecimal, Row](prefix, "listprice", None, Some("numeric"))(x => extract(x).listprice, (row, value) => merge(row, extract(row).copy(listprice = value)))
-      override val modifieddate = new Field[TypoLocalDateTime, Row](prefix, "modifieddate", Some("text"), Some("timestamp"))(x => extract(x).modifieddate, (row, value) => merge(row, extract(row).copy(modifieddate = value)))
+    override lazy val fields: ProductlistpricehistoryFields = new ProductlistpricehistoryFields {
+      override def productid = IdField[ProductId, ProductlistpricehistoryRow](_path, "productid", None, Some("int4"), x => x.productid, (row, value) => row.copy(productid = value))
+      override def startdate = IdField[TypoLocalDateTime, ProductlistpricehistoryRow](_path, "startdate", Some("text"), Some("timestamp"), x => x.startdate, (row, value) => row.copy(startdate = value))
+      override def enddate = OptField[TypoLocalDateTime, ProductlistpricehistoryRow](_path, "enddate", Some("text"), Some("timestamp"), x => x.enddate, (row, value) => row.copy(enddate = value))
+      override def listprice = Field[BigDecimal, ProductlistpricehistoryRow](_path, "listprice", None, Some("numeric"), x => x.listprice, (row, value) => row.copy(listprice = value))
+      override def modifieddate = Field[TypoLocalDateTime, ProductlistpricehistoryRow](_path, "modifieddate", Some("text"), Some("timestamp"), x => x.modifieddate, (row, value) => row.copy(modifieddate = value))
     }
   
-    override val columns: List[FieldLikeNoHkt[?, Row]] =
-      List[FieldLikeNoHkt[?, Row]](fields.productid, fields.startdate, fields.enddate, fields.listprice, fields.modifieddate)
+    override lazy val columns: List[FieldLikeNoHkt[?, ProductlistpricehistoryRow]] =
+      List[FieldLikeNoHkt[?, ProductlistpricehistoryRow]](fields.productid, fields.startdate, fields.enddate, fields.listprice, fields.modifieddate)
   
-    override def copy[NewRow](prefix: Option[String], extract: NewRow => ProductlistpricehistoryRow, merge: (NewRow, ProductlistpricehistoryRow) => NewRow): Impl[NewRow] =
-      new Impl(prefix, extract, merge)
+    override def copy(path: List[Path]): Impl =
+      new Impl(path)
   }
   
 }

--- a/typo-tester-zio-jdbc/generated-and-checked-in/adventureworks/production/productlistpricehistory/ProductlistpricehistoryRepoMock.scala
+++ b/typo-tester-zio-jdbc/generated-and-checked-in/adventureworks/production/productlistpricehistory/ProductlistpricehistoryRepoMock.scala
@@ -26,7 +26,7 @@ import zio.stream.ZStream
 class ProductlistpricehistoryRepoMock(toRow: Function1[ProductlistpricehistoryRowUnsaved, ProductlistpricehistoryRow],
                                       map: scala.collection.mutable.Map[ProductlistpricehistoryId, ProductlistpricehistoryRow] = scala.collection.mutable.Map.empty) extends ProductlistpricehistoryRepo {
   override def delete: DeleteBuilder[ProductlistpricehistoryFields, ProductlistpricehistoryRow] = {
-    DeleteBuilderMock(DeleteParams.empty, ProductlistpricehistoryFields.structure.fields, map)
+    DeleteBuilderMock(DeleteParams.empty, ProductlistpricehistoryFields.structure, map)
   }
   override def deleteById(compositeId: ProductlistpricehistoryId): ZIO[ZConnection, Throwable, Boolean] = {
     ZIO.succeed(map.remove(compositeId).isDefined)
@@ -85,7 +85,7 @@ class ProductlistpricehistoryRepoMock(toRow: Function1[ProductlistpricehistoryRo
     }
   }
   override def update: UpdateBuilder[ProductlistpricehistoryFields, ProductlistpricehistoryRow] = {
-    UpdateBuilderMock(UpdateParams.empty, ProductlistpricehistoryFields.structure.fields, map)
+    UpdateBuilderMock(UpdateParams.empty, ProductlistpricehistoryFields.structure, map)
   }
   override def update(row: ProductlistpricehistoryRow): ZIO[ZConnection, Throwable, Boolean] = {
     ZIO.succeed {

--- a/typo-tester-zio-jdbc/generated-and-checked-in/adventureworks/production/productmodel/ProductmodelFields.scala
+++ b/typo-tester-zio-jdbc/generated-and-checked-in/adventureworks/production/productmodel/ProductmodelFields.scala
@@ -11,42 +11,43 @@ import adventureworks.customtypes.TypoLocalDateTime
 import adventureworks.customtypes.TypoUUID
 import adventureworks.customtypes.TypoXml
 import adventureworks.public.Name
+import typo.dsl.Path
 import typo.dsl.SqlExpr.Field
 import typo.dsl.SqlExpr.FieldLikeNoHkt
 import typo.dsl.SqlExpr.IdField
 import typo.dsl.SqlExpr.OptField
 import typo.dsl.Structure.Relation
 
-trait ProductmodelFields[Row] {
-  val productmodelid: IdField[ProductmodelId, Row]
-  val name: Field[Name, Row]
-  val catalogdescription: OptField[TypoXml, Row]
-  val instructions: OptField[TypoXml, Row]
-  val rowguid: Field[TypoUUID, Row]
-  val modifieddate: Field[TypoLocalDateTime, Row]
+trait ProductmodelFields {
+  def productmodelid: IdField[ProductmodelId, ProductmodelRow]
+  def name: Field[Name, ProductmodelRow]
+  def catalogdescription: OptField[TypoXml, ProductmodelRow]
+  def instructions: OptField[TypoXml, ProductmodelRow]
+  def rowguid: Field[TypoUUID, ProductmodelRow]
+  def modifieddate: Field[TypoLocalDateTime, ProductmodelRow]
 }
 
 object ProductmodelFields {
-  val structure: Relation[ProductmodelFields, ProductmodelRow, ProductmodelRow] = 
-    new Impl(None, identity, (_, x) => x)
+  lazy val structure: Relation[ProductmodelFields, ProductmodelRow] =
+    new Impl(Nil)
     
-  private final class Impl[Row](val prefix: Option[String], val extract: Row => ProductmodelRow, val merge: (Row, ProductmodelRow) => Row)
-    extends Relation[ProductmodelFields, ProductmodelRow, Row] { 
+  private final class Impl(val _path: List[Path])
+    extends Relation[ProductmodelFields, ProductmodelRow] {
   
-    override val fields: ProductmodelFields[Row] = new ProductmodelFields[Row] {
-      override val productmodelid = new IdField[ProductmodelId, Row](prefix, "productmodelid", None, Some("int4"))(x => extract(x).productmodelid, (row, value) => merge(row, extract(row).copy(productmodelid = value)))
-      override val name = new Field[Name, Row](prefix, "name", None, Some("varchar"))(x => extract(x).name, (row, value) => merge(row, extract(row).copy(name = value)))
-      override val catalogdescription = new OptField[TypoXml, Row](prefix, "catalogdescription", None, Some("xml"))(x => extract(x).catalogdescription, (row, value) => merge(row, extract(row).copy(catalogdescription = value)))
-      override val instructions = new OptField[TypoXml, Row](prefix, "instructions", None, Some("xml"))(x => extract(x).instructions, (row, value) => merge(row, extract(row).copy(instructions = value)))
-      override val rowguid = new Field[TypoUUID, Row](prefix, "rowguid", None, Some("uuid"))(x => extract(x).rowguid, (row, value) => merge(row, extract(row).copy(rowguid = value)))
-      override val modifieddate = new Field[TypoLocalDateTime, Row](prefix, "modifieddate", Some("text"), Some("timestamp"))(x => extract(x).modifieddate, (row, value) => merge(row, extract(row).copy(modifieddate = value)))
+    override lazy val fields: ProductmodelFields = new ProductmodelFields {
+      override def productmodelid = IdField[ProductmodelId, ProductmodelRow](_path, "productmodelid", None, Some("int4"), x => x.productmodelid, (row, value) => row.copy(productmodelid = value))
+      override def name = Field[Name, ProductmodelRow](_path, "name", None, Some("varchar"), x => x.name, (row, value) => row.copy(name = value))
+      override def catalogdescription = OptField[TypoXml, ProductmodelRow](_path, "catalogdescription", None, Some("xml"), x => x.catalogdescription, (row, value) => row.copy(catalogdescription = value))
+      override def instructions = OptField[TypoXml, ProductmodelRow](_path, "instructions", None, Some("xml"), x => x.instructions, (row, value) => row.copy(instructions = value))
+      override def rowguid = Field[TypoUUID, ProductmodelRow](_path, "rowguid", None, Some("uuid"), x => x.rowguid, (row, value) => row.copy(rowguid = value))
+      override def modifieddate = Field[TypoLocalDateTime, ProductmodelRow](_path, "modifieddate", Some("text"), Some("timestamp"), x => x.modifieddate, (row, value) => row.copy(modifieddate = value))
     }
   
-    override val columns: List[FieldLikeNoHkt[?, Row]] =
-      List[FieldLikeNoHkt[?, Row]](fields.productmodelid, fields.name, fields.catalogdescription, fields.instructions, fields.rowguid, fields.modifieddate)
+    override lazy val columns: List[FieldLikeNoHkt[?, ProductmodelRow]] =
+      List[FieldLikeNoHkt[?, ProductmodelRow]](fields.productmodelid, fields.name, fields.catalogdescription, fields.instructions, fields.rowguid, fields.modifieddate)
   
-    override def copy[NewRow](prefix: Option[String], extract: NewRow => ProductmodelRow, merge: (NewRow, ProductmodelRow) => NewRow): Impl[NewRow] =
-      new Impl(prefix, extract, merge)
+    override def copy(path: List[Path]): Impl =
+      new Impl(path)
   }
   
 }

--- a/typo-tester-zio-jdbc/generated-and-checked-in/adventureworks/production/productmodel/ProductmodelRepoMock.scala
+++ b/typo-tester-zio-jdbc/generated-and-checked-in/adventureworks/production/productmodel/ProductmodelRepoMock.scala
@@ -26,7 +26,7 @@ import zio.stream.ZStream
 class ProductmodelRepoMock(toRow: Function1[ProductmodelRowUnsaved, ProductmodelRow],
                            map: scala.collection.mutable.Map[ProductmodelId, ProductmodelRow] = scala.collection.mutable.Map.empty) extends ProductmodelRepo {
   override def delete: DeleteBuilder[ProductmodelFields, ProductmodelRow] = {
-    DeleteBuilderMock(DeleteParams.empty, ProductmodelFields.structure.fields, map)
+    DeleteBuilderMock(DeleteParams.empty, ProductmodelFields.structure, map)
   }
   override def deleteById(productmodelid: ProductmodelId): ZIO[ZConnection, Throwable, Boolean] = {
     ZIO.succeed(map.remove(productmodelid).isDefined)
@@ -85,7 +85,7 @@ class ProductmodelRepoMock(toRow: Function1[ProductmodelRowUnsaved, Productmodel
     }
   }
   override def update: UpdateBuilder[ProductmodelFields, ProductmodelRow] = {
-    UpdateBuilderMock(UpdateParams.empty, ProductmodelFields.structure.fields, map)
+    UpdateBuilderMock(UpdateParams.empty, ProductmodelFields.structure, map)
   }
   override def update(row: ProductmodelRow): ZIO[ZConnection, Throwable, Boolean] = {
     ZIO.succeed {

--- a/typo-tester-zio-jdbc/generated-and-checked-in/adventureworks/production/productmodelillustration/ProductmodelillustrationFields.scala
+++ b/typo-tester-zio-jdbc/generated-and-checked-in/adventureworks/production/productmodelillustration/ProductmodelillustrationFields.scala
@@ -10,35 +10,36 @@ package productmodelillustration
 import adventureworks.customtypes.TypoLocalDateTime
 import adventureworks.production.illustration.IllustrationId
 import adventureworks.production.productmodel.ProductmodelId
+import typo.dsl.Path
 import typo.dsl.SqlExpr.Field
 import typo.dsl.SqlExpr.FieldLikeNoHkt
 import typo.dsl.SqlExpr.IdField
 import typo.dsl.Structure.Relation
 
-trait ProductmodelillustrationFields[Row] {
-  val productmodelid: IdField[ProductmodelId, Row]
-  val illustrationid: IdField[IllustrationId, Row]
-  val modifieddate: Field[TypoLocalDateTime, Row]
+trait ProductmodelillustrationFields {
+  def productmodelid: IdField[ProductmodelId, ProductmodelillustrationRow]
+  def illustrationid: IdField[IllustrationId, ProductmodelillustrationRow]
+  def modifieddate: Field[TypoLocalDateTime, ProductmodelillustrationRow]
 }
 
 object ProductmodelillustrationFields {
-  val structure: Relation[ProductmodelillustrationFields, ProductmodelillustrationRow, ProductmodelillustrationRow] = 
-    new Impl(None, identity, (_, x) => x)
+  lazy val structure: Relation[ProductmodelillustrationFields, ProductmodelillustrationRow] =
+    new Impl(Nil)
     
-  private final class Impl[Row](val prefix: Option[String], val extract: Row => ProductmodelillustrationRow, val merge: (Row, ProductmodelillustrationRow) => Row)
-    extends Relation[ProductmodelillustrationFields, ProductmodelillustrationRow, Row] { 
+  private final class Impl(val _path: List[Path])
+    extends Relation[ProductmodelillustrationFields, ProductmodelillustrationRow] {
   
-    override val fields: ProductmodelillustrationFields[Row] = new ProductmodelillustrationFields[Row] {
-      override val productmodelid = new IdField[ProductmodelId, Row](prefix, "productmodelid", None, Some("int4"))(x => extract(x).productmodelid, (row, value) => merge(row, extract(row).copy(productmodelid = value)))
-      override val illustrationid = new IdField[IllustrationId, Row](prefix, "illustrationid", None, Some("int4"))(x => extract(x).illustrationid, (row, value) => merge(row, extract(row).copy(illustrationid = value)))
-      override val modifieddate = new Field[TypoLocalDateTime, Row](prefix, "modifieddate", Some("text"), Some("timestamp"))(x => extract(x).modifieddate, (row, value) => merge(row, extract(row).copy(modifieddate = value)))
+    override lazy val fields: ProductmodelillustrationFields = new ProductmodelillustrationFields {
+      override def productmodelid = IdField[ProductmodelId, ProductmodelillustrationRow](_path, "productmodelid", None, Some("int4"), x => x.productmodelid, (row, value) => row.copy(productmodelid = value))
+      override def illustrationid = IdField[IllustrationId, ProductmodelillustrationRow](_path, "illustrationid", None, Some("int4"), x => x.illustrationid, (row, value) => row.copy(illustrationid = value))
+      override def modifieddate = Field[TypoLocalDateTime, ProductmodelillustrationRow](_path, "modifieddate", Some("text"), Some("timestamp"), x => x.modifieddate, (row, value) => row.copy(modifieddate = value))
     }
   
-    override val columns: List[FieldLikeNoHkt[?, Row]] =
-      List[FieldLikeNoHkt[?, Row]](fields.productmodelid, fields.illustrationid, fields.modifieddate)
+    override lazy val columns: List[FieldLikeNoHkt[?, ProductmodelillustrationRow]] =
+      List[FieldLikeNoHkt[?, ProductmodelillustrationRow]](fields.productmodelid, fields.illustrationid, fields.modifieddate)
   
-    override def copy[NewRow](prefix: Option[String], extract: NewRow => ProductmodelillustrationRow, merge: (NewRow, ProductmodelillustrationRow) => NewRow): Impl[NewRow] =
-      new Impl(prefix, extract, merge)
+    override def copy(path: List[Path]): Impl =
+      new Impl(path)
   }
   
 }

--- a/typo-tester-zio-jdbc/generated-and-checked-in/adventureworks/production/productmodelillustration/ProductmodelillustrationRepoMock.scala
+++ b/typo-tester-zio-jdbc/generated-and-checked-in/adventureworks/production/productmodelillustration/ProductmodelillustrationRepoMock.scala
@@ -26,7 +26,7 @@ import zio.stream.ZStream
 class ProductmodelillustrationRepoMock(toRow: Function1[ProductmodelillustrationRowUnsaved, ProductmodelillustrationRow],
                                        map: scala.collection.mutable.Map[ProductmodelillustrationId, ProductmodelillustrationRow] = scala.collection.mutable.Map.empty) extends ProductmodelillustrationRepo {
   override def delete: DeleteBuilder[ProductmodelillustrationFields, ProductmodelillustrationRow] = {
-    DeleteBuilderMock(DeleteParams.empty, ProductmodelillustrationFields.structure.fields, map)
+    DeleteBuilderMock(DeleteParams.empty, ProductmodelillustrationFields.structure, map)
   }
   override def deleteById(compositeId: ProductmodelillustrationId): ZIO[ZConnection, Throwable, Boolean] = {
     ZIO.succeed(map.remove(compositeId).isDefined)
@@ -85,7 +85,7 @@ class ProductmodelillustrationRepoMock(toRow: Function1[Productmodelillustration
     }
   }
   override def update: UpdateBuilder[ProductmodelillustrationFields, ProductmodelillustrationRow] = {
-    UpdateBuilderMock(UpdateParams.empty, ProductmodelillustrationFields.structure.fields, map)
+    UpdateBuilderMock(UpdateParams.empty, ProductmodelillustrationFields.structure, map)
   }
   override def update(row: ProductmodelillustrationRow): ZIO[ZConnection, Throwable, Boolean] = {
     ZIO.succeed {

--- a/typo-tester-zio-jdbc/generated-and-checked-in/adventureworks/production/productmodelproductdescriptionculture/ProductmodelproductdescriptioncultureFields.scala
+++ b/typo-tester-zio-jdbc/generated-and-checked-in/adventureworks/production/productmodelproductdescriptionculture/ProductmodelproductdescriptioncultureFields.scala
@@ -11,37 +11,38 @@ import adventureworks.customtypes.TypoLocalDateTime
 import adventureworks.production.culture.CultureId
 import adventureworks.production.productdescription.ProductdescriptionId
 import adventureworks.production.productmodel.ProductmodelId
+import typo.dsl.Path
 import typo.dsl.SqlExpr.Field
 import typo.dsl.SqlExpr.FieldLikeNoHkt
 import typo.dsl.SqlExpr.IdField
 import typo.dsl.Structure.Relation
 
-trait ProductmodelproductdescriptioncultureFields[Row] {
-  val productmodelid: IdField[ProductmodelId, Row]
-  val productdescriptionid: IdField[ProductdescriptionId, Row]
-  val cultureid: IdField[CultureId, Row]
-  val modifieddate: Field[TypoLocalDateTime, Row]
+trait ProductmodelproductdescriptioncultureFields {
+  def productmodelid: IdField[ProductmodelId, ProductmodelproductdescriptioncultureRow]
+  def productdescriptionid: IdField[ProductdescriptionId, ProductmodelproductdescriptioncultureRow]
+  def cultureid: IdField[CultureId, ProductmodelproductdescriptioncultureRow]
+  def modifieddate: Field[TypoLocalDateTime, ProductmodelproductdescriptioncultureRow]
 }
 
 object ProductmodelproductdescriptioncultureFields {
-  val structure: Relation[ProductmodelproductdescriptioncultureFields, ProductmodelproductdescriptioncultureRow, ProductmodelproductdescriptioncultureRow] = 
-    new Impl(None, identity, (_, x) => x)
+  lazy val structure: Relation[ProductmodelproductdescriptioncultureFields, ProductmodelproductdescriptioncultureRow] =
+    new Impl(Nil)
     
-  private final class Impl[Row](val prefix: Option[String], val extract: Row => ProductmodelproductdescriptioncultureRow, val merge: (Row, ProductmodelproductdescriptioncultureRow) => Row)
-    extends Relation[ProductmodelproductdescriptioncultureFields, ProductmodelproductdescriptioncultureRow, Row] { 
+  private final class Impl(val _path: List[Path])
+    extends Relation[ProductmodelproductdescriptioncultureFields, ProductmodelproductdescriptioncultureRow] {
   
-    override val fields: ProductmodelproductdescriptioncultureFields[Row] = new ProductmodelproductdescriptioncultureFields[Row] {
-      override val productmodelid = new IdField[ProductmodelId, Row](prefix, "productmodelid", None, Some("int4"))(x => extract(x).productmodelid, (row, value) => merge(row, extract(row).copy(productmodelid = value)))
-      override val productdescriptionid = new IdField[ProductdescriptionId, Row](prefix, "productdescriptionid", None, Some("int4"))(x => extract(x).productdescriptionid, (row, value) => merge(row, extract(row).copy(productdescriptionid = value)))
-      override val cultureid = new IdField[CultureId, Row](prefix, "cultureid", None, Some("bpchar"))(x => extract(x).cultureid, (row, value) => merge(row, extract(row).copy(cultureid = value)))
-      override val modifieddate = new Field[TypoLocalDateTime, Row](prefix, "modifieddate", Some("text"), Some("timestamp"))(x => extract(x).modifieddate, (row, value) => merge(row, extract(row).copy(modifieddate = value)))
+    override lazy val fields: ProductmodelproductdescriptioncultureFields = new ProductmodelproductdescriptioncultureFields {
+      override def productmodelid = IdField[ProductmodelId, ProductmodelproductdescriptioncultureRow](_path, "productmodelid", None, Some("int4"), x => x.productmodelid, (row, value) => row.copy(productmodelid = value))
+      override def productdescriptionid = IdField[ProductdescriptionId, ProductmodelproductdescriptioncultureRow](_path, "productdescriptionid", None, Some("int4"), x => x.productdescriptionid, (row, value) => row.copy(productdescriptionid = value))
+      override def cultureid = IdField[CultureId, ProductmodelproductdescriptioncultureRow](_path, "cultureid", None, Some("bpchar"), x => x.cultureid, (row, value) => row.copy(cultureid = value))
+      override def modifieddate = Field[TypoLocalDateTime, ProductmodelproductdescriptioncultureRow](_path, "modifieddate", Some("text"), Some("timestamp"), x => x.modifieddate, (row, value) => row.copy(modifieddate = value))
     }
   
-    override val columns: List[FieldLikeNoHkt[?, Row]] =
-      List[FieldLikeNoHkt[?, Row]](fields.productmodelid, fields.productdescriptionid, fields.cultureid, fields.modifieddate)
+    override lazy val columns: List[FieldLikeNoHkt[?, ProductmodelproductdescriptioncultureRow]] =
+      List[FieldLikeNoHkt[?, ProductmodelproductdescriptioncultureRow]](fields.productmodelid, fields.productdescriptionid, fields.cultureid, fields.modifieddate)
   
-    override def copy[NewRow](prefix: Option[String], extract: NewRow => ProductmodelproductdescriptioncultureRow, merge: (NewRow, ProductmodelproductdescriptioncultureRow) => NewRow): Impl[NewRow] =
-      new Impl(prefix, extract, merge)
+    override def copy(path: List[Path]): Impl =
+      new Impl(path)
   }
   
 }

--- a/typo-tester-zio-jdbc/generated-and-checked-in/adventureworks/production/productmodelproductdescriptionculture/ProductmodelproductdescriptioncultureRepoMock.scala
+++ b/typo-tester-zio-jdbc/generated-and-checked-in/adventureworks/production/productmodelproductdescriptionculture/ProductmodelproductdescriptioncultureRepoMock.scala
@@ -26,7 +26,7 @@ import zio.stream.ZStream
 class ProductmodelproductdescriptioncultureRepoMock(toRow: Function1[ProductmodelproductdescriptioncultureRowUnsaved, ProductmodelproductdescriptioncultureRow],
                                                     map: scala.collection.mutable.Map[ProductmodelproductdescriptioncultureId, ProductmodelproductdescriptioncultureRow] = scala.collection.mutable.Map.empty) extends ProductmodelproductdescriptioncultureRepo {
   override def delete: DeleteBuilder[ProductmodelproductdescriptioncultureFields, ProductmodelproductdescriptioncultureRow] = {
-    DeleteBuilderMock(DeleteParams.empty, ProductmodelproductdescriptioncultureFields.structure.fields, map)
+    DeleteBuilderMock(DeleteParams.empty, ProductmodelproductdescriptioncultureFields.structure, map)
   }
   override def deleteById(compositeId: ProductmodelproductdescriptioncultureId): ZIO[ZConnection, Throwable, Boolean] = {
     ZIO.succeed(map.remove(compositeId).isDefined)
@@ -85,7 +85,7 @@ class ProductmodelproductdescriptioncultureRepoMock(toRow: Function1[Productmode
     }
   }
   override def update: UpdateBuilder[ProductmodelproductdescriptioncultureFields, ProductmodelproductdescriptioncultureRow] = {
-    UpdateBuilderMock(UpdateParams.empty, ProductmodelproductdescriptioncultureFields.structure.fields, map)
+    UpdateBuilderMock(UpdateParams.empty, ProductmodelproductdescriptioncultureFields.structure, map)
   }
   override def update(row: ProductmodelproductdescriptioncultureRow): ZIO[ZConnection, Throwable, Boolean] = {
     ZIO.succeed {

--- a/typo-tester-zio-jdbc/generated-and-checked-in/adventureworks/production/productphoto/ProductphotoFields.scala
+++ b/typo-tester-zio-jdbc/generated-and-checked-in/adventureworks/production/productphoto/ProductphotoFields.scala
@@ -9,42 +9,43 @@ package productphoto
 
 import adventureworks.customtypes.TypoBytea
 import adventureworks.customtypes.TypoLocalDateTime
+import typo.dsl.Path
 import typo.dsl.SqlExpr.Field
 import typo.dsl.SqlExpr.FieldLikeNoHkt
 import typo.dsl.SqlExpr.IdField
 import typo.dsl.SqlExpr.OptField
 import typo.dsl.Structure.Relation
 
-trait ProductphotoFields[Row] {
-  val productphotoid: IdField[ProductphotoId, Row]
-  val thumbnailphoto: OptField[TypoBytea, Row]
-  val thumbnailphotofilename: OptField[/* max 50 chars */ String, Row]
-  val largephoto: OptField[TypoBytea, Row]
-  val largephotofilename: OptField[/* max 50 chars */ String, Row]
-  val modifieddate: Field[TypoLocalDateTime, Row]
+trait ProductphotoFields {
+  def productphotoid: IdField[ProductphotoId, ProductphotoRow]
+  def thumbnailphoto: OptField[TypoBytea, ProductphotoRow]
+  def thumbnailphotofilename: OptField[/* max 50 chars */ String, ProductphotoRow]
+  def largephoto: OptField[TypoBytea, ProductphotoRow]
+  def largephotofilename: OptField[/* max 50 chars */ String, ProductphotoRow]
+  def modifieddate: Field[TypoLocalDateTime, ProductphotoRow]
 }
 
 object ProductphotoFields {
-  val structure: Relation[ProductphotoFields, ProductphotoRow, ProductphotoRow] = 
-    new Impl(None, identity, (_, x) => x)
+  lazy val structure: Relation[ProductphotoFields, ProductphotoRow] =
+    new Impl(Nil)
     
-  private final class Impl[Row](val prefix: Option[String], val extract: Row => ProductphotoRow, val merge: (Row, ProductphotoRow) => Row)
-    extends Relation[ProductphotoFields, ProductphotoRow, Row] { 
+  private final class Impl(val _path: List[Path])
+    extends Relation[ProductphotoFields, ProductphotoRow] {
   
-    override val fields: ProductphotoFields[Row] = new ProductphotoFields[Row] {
-      override val productphotoid = new IdField[ProductphotoId, Row](prefix, "productphotoid", None, Some("int4"))(x => extract(x).productphotoid, (row, value) => merge(row, extract(row).copy(productphotoid = value)))
-      override val thumbnailphoto = new OptField[TypoBytea, Row](prefix, "thumbnailphoto", None, Some("bytea"))(x => extract(x).thumbnailphoto, (row, value) => merge(row, extract(row).copy(thumbnailphoto = value)))
-      override val thumbnailphotofilename = new OptField[/* max 50 chars */ String, Row](prefix, "thumbnailphotofilename", None, None)(x => extract(x).thumbnailphotofilename, (row, value) => merge(row, extract(row).copy(thumbnailphotofilename = value)))
-      override val largephoto = new OptField[TypoBytea, Row](prefix, "largephoto", None, Some("bytea"))(x => extract(x).largephoto, (row, value) => merge(row, extract(row).copy(largephoto = value)))
-      override val largephotofilename = new OptField[/* max 50 chars */ String, Row](prefix, "largephotofilename", None, None)(x => extract(x).largephotofilename, (row, value) => merge(row, extract(row).copy(largephotofilename = value)))
-      override val modifieddate = new Field[TypoLocalDateTime, Row](prefix, "modifieddate", Some("text"), Some("timestamp"))(x => extract(x).modifieddate, (row, value) => merge(row, extract(row).copy(modifieddate = value)))
+    override lazy val fields: ProductphotoFields = new ProductphotoFields {
+      override def productphotoid = IdField[ProductphotoId, ProductphotoRow](_path, "productphotoid", None, Some("int4"), x => x.productphotoid, (row, value) => row.copy(productphotoid = value))
+      override def thumbnailphoto = OptField[TypoBytea, ProductphotoRow](_path, "thumbnailphoto", None, Some("bytea"), x => x.thumbnailphoto, (row, value) => row.copy(thumbnailphoto = value))
+      override def thumbnailphotofilename = OptField[/* max 50 chars */ String, ProductphotoRow](_path, "thumbnailphotofilename", None, None, x => x.thumbnailphotofilename, (row, value) => row.copy(thumbnailphotofilename = value))
+      override def largephoto = OptField[TypoBytea, ProductphotoRow](_path, "largephoto", None, Some("bytea"), x => x.largephoto, (row, value) => row.copy(largephoto = value))
+      override def largephotofilename = OptField[/* max 50 chars */ String, ProductphotoRow](_path, "largephotofilename", None, None, x => x.largephotofilename, (row, value) => row.copy(largephotofilename = value))
+      override def modifieddate = Field[TypoLocalDateTime, ProductphotoRow](_path, "modifieddate", Some("text"), Some("timestamp"), x => x.modifieddate, (row, value) => row.copy(modifieddate = value))
     }
   
-    override val columns: List[FieldLikeNoHkt[?, Row]] =
-      List[FieldLikeNoHkt[?, Row]](fields.productphotoid, fields.thumbnailphoto, fields.thumbnailphotofilename, fields.largephoto, fields.largephotofilename, fields.modifieddate)
+    override lazy val columns: List[FieldLikeNoHkt[?, ProductphotoRow]] =
+      List[FieldLikeNoHkt[?, ProductphotoRow]](fields.productphotoid, fields.thumbnailphoto, fields.thumbnailphotofilename, fields.largephoto, fields.largephotofilename, fields.modifieddate)
   
-    override def copy[NewRow](prefix: Option[String], extract: NewRow => ProductphotoRow, merge: (NewRow, ProductphotoRow) => NewRow): Impl[NewRow] =
-      new Impl(prefix, extract, merge)
+    override def copy(path: List[Path]): Impl =
+      new Impl(path)
   }
   
 }

--- a/typo-tester-zio-jdbc/generated-and-checked-in/adventureworks/production/productphoto/ProductphotoRepoMock.scala
+++ b/typo-tester-zio-jdbc/generated-and-checked-in/adventureworks/production/productphoto/ProductphotoRepoMock.scala
@@ -26,7 +26,7 @@ import zio.stream.ZStream
 class ProductphotoRepoMock(toRow: Function1[ProductphotoRowUnsaved, ProductphotoRow],
                            map: scala.collection.mutable.Map[ProductphotoId, ProductphotoRow] = scala.collection.mutable.Map.empty) extends ProductphotoRepo {
   override def delete: DeleteBuilder[ProductphotoFields, ProductphotoRow] = {
-    DeleteBuilderMock(DeleteParams.empty, ProductphotoFields.structure.fields, map)
+    DeleteBuilderMock(DeleteParams.empty, ProductphotoFields.structure, map)
   }
   override def deleteById(productphotoid: ProductphotoId): ZIO[ZConnection, Throwable, Boolean] = {
     ZIO.succeed(map.remove(productphotoid).isDefined)
@@ -85,7 +85,7 @@ class ProductphotoRepoMock(toRow: Function1[ProductphotoRowUnsaved, Productphoto
     }
   }
   override def update: UpdateBuilder[ProductphotoFields, ProductphotoRow] = {
-    UpdateBuilderMock(UpdateParams.empty, ProductphotoFields.structure.fields, map)
+    UpdateBuilderMock(UpdateParams.empty, ProductphotoFields.structure, map)
   }
   override def update(row: ProductphotoRow): ZIO[ZConnection, Throwable, Boolean] = {
     ZIO.succeed {

--- a/typo-tester-zio-jdbc/generated-and-checked-in/adventureworks/production/productproductphoto/ProductproductphotoFields.scala
+++ b/typo-tester-zio-jdbc/generated-and-checked-in/adventureworks/production/productproductphoto/ProductproductphotoFields.scala
@@ -11,37 +11,38 @@ import adventureworks.customtypes.TypoLocalDateTime
 import adventureworks.production.product.ProductId
 import adventureworks.production.productphoto.ProductphotoId
 import adventureworks.public.Flag
+import typo.dsl.Path
 import typo.dsl.SqlExpr.Field
 import typo.dsl.SqlExpr.FieldLikeNoHkt
 import typo.dsl.SqlExpr.IdField
 import typo.dsl.Structure.Relation
 
-trait ProductproductphotoFields[Row] {
-  val productid: IdField[ProductId, Row]
-  val productphotoid: IdField[ProductphotoId, Row]
-  val primary: Field[Flag, Row]
-  val modifieddate: Field[TypoLocalDateTime, Row]
+trait ProductproductphotoFields {
+  def productid: IdField[ProductId, ProductproductphotoRow]
+  def productphotoid: IdField[ProductphotoId, ProductproductphotoRow]
+  def primary: Field[Flag, ProductproductphotoRow]
+  def modifieddate: Field[TypoLocalDateTime, ProductproductphotoRow]
 }
 
 object ProductproductphotoFields {
-  val structure: Relation[ProductproductphotoFields, ProductproductphotoRow, ProductproductphotoRow] = 
-    new Impl(None, identity, (_, x) => x)
+  lazy val structure: Relation[ProductproductphotoFields, ProductproductphotoRow] =
+    new Impl(Nil)
     
-  private final class Impl[Row](val prefix: Option[String], val extract: Row => ProductproductphotoRow, val merge: (Row, ProductproductphotoRow) => Row)
-    extends Relation[ProductproductphotoFields, ProductproductphotoRow, Row] { 
+  private final class Impl(val _path: List[Path])
+    extends Relation[ProductproductphotoFields, ProductproductphotoRow] {
   
-    override val fields: ProductproductphotoFields[Row] = new ProductproductphotoFields[Row] {
-      override val productid = new IdField[ProductId, Row](prefix, "productid", None, Some("int4"))(x => extract(x).productid, (row, value) => merge(row, extract(row).copy(productid = value)))
-      override val productphotoid = new IdField[ProductphotoId, Row](prefix, "productphotoid", None, Some("int4"))(x => extract(x).productphotoid, (row, value) => merge(row, extract(row).copy(productphotoid = value)))
-      override val primary = new Field[Flag, Row](prefix, "primary", None, Some("bool"))(x => extract(x).primary, (row, value) => merge(row, extract(row).copy(primary = value)))
-      override val modifieddate = new Field[TypoLocalDateTime, Row](prefix, "modifieddate", Some("text"), Some("timestamp"))(x => extract(x).modifieddate, (row, value) => merge(row, extract(row).copy(modifieddate = value)))
+    override lazy val fields: ProductproductphotoFields = new ProductproductphotoFields {
+      override def productid = IdField[ProductId, ProductproductphotoRow](_path, "productid", None, Some("int4"), x => x.productid, (row, value) => row.copy(productid = value))
+      override def productphotoid = IdField[ProductphotoId, ProductproductphotoRow](_path, "productphotoid", None, Some("int4"), x => x.productphotoid, (row, value) => row.copy(productphotoid = value))
+      override def primary = Field[Flag, ProductproductphotoRow](_path, "primary", None, Some("bool"), x => x.primary, (row, value) => row.copy(primary = value))
+      override def modifieddate = Field[TypoLocalDateTime, ProductproductphotoRow](_path, "modifieddate", Some("text"), Some("timestamp"), x => x.modifieddate, (row, value) => row.copy(modifieddate = value))
     }
   
-    override val columns: List[FieldLikeNoHkt[?, Row]] =
-      List[FieldLikeNoHkt[?, Row]](fields.productid, fields.productphotoid, fields.primary, fields.modifieddate)
+    override lazy val columns: List[FieldLikeNoHkt[?, ProductproductphotoRow]] =
+      List[FieldLikeNoHkt[?, ProductproductphotoRow]](fields.productid, fields.productphotoid, fields.primary, fields.modifieddate)
   
-    override def copy[NewRow](prefix: Option[String], extract: NewRow => ProductproductphotoRow, merge: (NewRow, ProductproductphotoRow) => NewRow): Impl[NewRow] =
-      new Impl(prefix, extract, merge)
+    override def copy(path: List[Path]): Impl =
+      new Impl(path)
   }
   
 }

--- a/typo-tester-zio-jdbc/generated-and-checked-in/adventureworks/production/productproductphoto/ProductproductphotoRepoMock.scala
+++ b/typo-tester-zio-jdbc/generated-and-checked-in/adventureworks/production/productproductphoto/ProductproductphotoRepoMock.scala
@@ -26,7 +26,7 @@ import zio.stream.ZStream
 class ProductproductphotoRepoMock(toRow: Function1[ProductproductphotoRowUnsaved, ProductproductphotoRow],
                                   map: scala.collection.mutable.Map[ProductproductphotoId, ProductproductphotoRow] = scala.collection.mutable.Map.empty) extends ProductproductphotoRepo {
   override def delete: DeleteBuilder[ProductproductphotoFields, ProductproductphotoRow] = {
-    DeleteBuilderMock(DeleteParams.empty, ProductproductphotoFields.structure.fields, map)
+    DeleteBuilderMock(DeleteParams.empty, ProductproductphotoFields.structure, map)
   }
   override def deleteById(compositeId: ProductproductphotoId): ZIO[ZConnection, Throwable, Boolean] = {
     ZIO.succeed(map.remove(compositeId).isDefined)
@@ -85,7 +85,7 @@ class ProductproductphotoRepoMock(toRow: Function1[ProductproductphotoRowUnsaved
     }
   }
   override def update: UpdateBuilder[ProductproductphotoFields, ProductproductphotoRow] = {
-    UpdateBuilderMock(UpdateParams.empty, ProductproductphotoFields.structure.fields, map)
+    UpdateBuilderMock(UpdateParams.empty, ProductproductphotoFields.structure, map)
   }
   override def update(row: ProductproductphotoRow): ZIO[ZConnection, Throwable, Boolean] = {
     ZIO.succeed {

--- a/typo-tester-zio-jdbc/generated-and-checked-in/adventureworks/production/productreview/ProductreviewFields.scala
+++ b/typo-tester-zio-jdbc/generated-and-checked-in/adventureworks/production/productreview/ProductreviewFields.scala
@@ -10,46 +10,47 @@ package productreview
 import adventureworks.customtypes.TypoLocalDateTime
 import adventureworks.production.product.ProductId
 import adventureworks.public.Name
+import typo.dsl.Path
 import typo.dsl.SqlExpr.Field
 import typo.dsl.SqlExpr.FieldLikeNoHkt
 import typo.dsl.SqlExpr.IdField
 import typo.dsl.SqlExpr.OptField
 import typo.dsl.Structure.Relation
 
-trait ProductreviewFields[Row] {
-  val productreviewid: IdField[ProductreviewId, Row]
-  val productid: Field[ProductId, Row]
-  val reviewername: Field[Name, Row]
-  val reviewdate: Field[TypoLocalDateTime, Row]
-  val emailaddress: Field[/* max 50 chars */ String, Row]
-  val rating: Field[Int, Row]
-  val comments: OptField[/* max 3850 chars */ String, Row]
-  val modifieddate: Field[TypoLocalDateTime, Row]
+trait ProductreviewFields {
+  def productreviewid: IdField[ProductreviewId, ProductreviewRow]
+  def productid: Field[ProductId, ProductreviewRow]
+  def reviewername: Field[Name, ProductreviewRow]
+  def reviewdate: Field[TypoLocalDateTime, ProductreviewRow]
+  def emailaddress: Field[/* max 50 chars */ String, ProductreviewRow]
+  def rating: Field[Int, ProductreviewRow]
+  def comments: OptField[/* max 3850 chars */ String, ProductreviewRow]
+  def modifieddate: Field[TypoLocalDateTime, ProductreviewRow]
 }
 
 object ProductreviewFields {
-  val structure: Relation[ProductreviewFields, ProductreviewRow, ProductreviewRow] = 
-    new Impl(None, identity, (_, x) => x)
+  lazy val structure: Relation[ProductreviewFields, ProductreviewRow] =
+    new Impl(Nil)
     
-  private final class Impl[Row](val prefix: Option[String], val extract: Row => ProductreviewRow, val merge: (Row, ProductreviewRow) => Row)
-    extends Relation[ProductreviewFields, ProductreviewRow, Row] { 
+  private final class Impl(val _path: List[Path])
+    extends Relation[ProductreviewFields, ProductreviewRow] {
   
-    override val fields: ProductreviewFields[Row] = new ProductreviewFields[Row] {
-      override val productreviewid = new IdField[ProductreviewId, Row](prefix, "productreviewid", None, Some("int4"))(x => extract(x).productreviewid, (row, value) => merge(row, extract(row).copy(productreviewid = value)))
-      override val productid = new Field[ProductId, Row](prefix, "productid", None, Some("int4"))(x => extract(x).productid, (row, value) => merge(row, extract(row).copy(productid = value)))
-      override val reviewername = new Field[Name, Row](prefix, "reviewername", None, Some("varchar"))(x => extract(x).reviewername, (row, value) => merge(row, extract(row).copy(reviewername = value)))
-      override val reviewdate = new Field[TypoLocalDateTime, Row](prefix, "reviewdate", Some("text"), Some("timestamp"))(x => extract(x).reviewdate, (row, value) => merge(row, extract(row).copy(reviewdate = value)))
-      override val emailaddress = new Field[/* max 50 chars */ String, Row](prefix, "emailaddress", None, None)(x => extract(x).emailaddress, (row, value) => merge(row, extract(row).copy(emailaddress = value)))
-      override val rating = new Field[Int, Row](prefix, "rating", None, Some("int4"))(x => extract(x).rating, (row, value) => merge(row, extract(row).copy(rating = value)))
-      override val comments = new OptField[/* max 3850 chars */ String, Row](prefix, "comments", None, None)(x => extract(x).comments, (row, value) => merge(row, extract(row).copy(comments = value)))
-      override val modifieddate = new Field[TypoLocalDateTime, Row](prefix, "modifieddate", Some("text"), Some("timestamp"))(x => extract(x).modifieddate, (row, value) => merge(row, extract(row).copy(modifieddate = value)))
+    override lazy val fields: ProductreviewFields = new ProductreviewFields {
+      override def productreviewid = IdField[ProductreviewId, ProductreviewRow](_path, "productreviewid", None, Some("int4"), x => x.productreviewid, (row, value) => row.copy(productreviewid = value))
+      override def productid = Field[ProductId, ProductreviewRow](_path, "productid", None, Some("int4"), x => x.productid, (row, value) => row.copy(productid = value))
+      override def reviewername = Field[Name, ProductreviewRow](_path, "reviewername", None, Some("varchar"), x => x.reviewername, (row, value) => row.copy(reviewername = value))
+      override def reviewdate = Field[TypoLocalDateTime, ProductreviewRow](_path, "reviewdate", Some("text"), Some("timestamp"), x => x.reviewdate, (row, value) => row.copy(reviewdate = value))
+      override def emailaddress = Field[/* max 50 chars */ String, ProductreviewRow](_path, "emailaddress", None, None, x => x.emailaddress, (row, value) => row.copy(emailaddress = value))
+      override def rating = Field[Int, ProductreviewRow](_path, "rating", None, Some("int4"), x => x.rating, (row, value) => row.copy(rating = value))
+      override def comments = OptField[/* max 3850 chars */ String, ProductreviewRow](_path, "comments", None, None, x => x.comments, (row, value) => row.copy(comments = value))
+      override def modifieddate = Field[TypoLocalDateTime, ProductreviewRow](_path, "modifieddate", Some("text"), Some("timestamp"), x => x.modifieddate, (row, value) => row.copy(modifieddate = value))
     }
   
-    override val columns: List[FieldLikeNoHkt[?, Row]] =
-      List[FieldLikeNoHkt[?, Row]](fields.productreviewid, fields.productid, fields.reviewername, fields.reviewdate, fields.emailaddress, fields.rating, fields.comments, fields.modifieddate)
+    override lazy val columns: List[FieldLikeNoHkt[?, ProductreviewRow]] =
+      List[FieldLikeNoHkt[?, ProductreviewRow]](fields.productreviewid, fields.productid, fields.reviewername, fields.reviewdate, fields.emailaddress, fields.rating, fields.comments, fields.modifieddate)
   
-    override def copy[NewRow](prefix: Option[String], extract: NewRow => ProductreviewRow, merge: (NewRow, ProductreviewRow) => NewRow): Impl[NewRow] =
-      new Impl(prefix, extract, merge)
+    override def copy(path: List[Path]): Impl =
+      new Impl(path)
   }
   
 }

--- a/typo-tester-zio-jdbc/generated-and-checked-in/adventureworks/production/productreview/ProductreviewRepoMock.scala
+++ b/typo-tester-zio-jdbc/generated-and-checked-in/adventureworks/production/productreview/ProductreviewRepoMock.scala
@@ -26,7 +26,7 @@ import zio.stream.ZStream
 class ProductreviewRepoMock(toRow: Function1[ProductreviewRowUnsaved, ProductreviewRow],
                             map: scala.collection.mutable.Map[ProductreviewId, ProductreviewRow] = scala.collection.mutable.Map.empty) extends ProductreviewRepo {
   override def delete: DeleteBuilder[ProductreviewFields, ProductreviewRow] = {
-    DeleteBuilderMock(DeleteParams.empty, ProductreviewFields.structure.fields, map)
+    DeleteBuilderMock(DeleteParams.empty, ProductreviewFields.structure, map)
   }
   override def deleteById(productreviewid: ProductreviewId): ZIO[ZConnection, Throwable, Boolean] = {
     ZIO.succeed(map.remove(productreviewid).isDefined)
@@ -85,7 +85,7 @@ class ProductreviewRepoMock(toRow: Function1[ProductreviewRowUnsaved, Productrev
     }
   }
   override def update: UpdateBuilder[ProductreviewFields, ProductreviewRow] = {
-    UpdateBuilderMock(UpdateParams.empty, ProductreviewFields.structure.fields, map)
+    UpdateBuilderMock(UpdateParams.empty, ProductreviewFields.structure, map)
   }
   override def update(row: ProductreviewRow): ZIO[ZConnection, Throwable, Boolean] = {
     ZIO.succeed {

--- a/typo-tester-zio-jdbc/generated-and-checked-in/adventureworks/production/productsubcategory/ProductsubcategoryFields.scala
+++ b/typo-tester-zio-jdbc/generated-and-checked-in/adventureworks/production/productsubcategory/ProductsubcategoryFields.scala
@@ -11,39 +11,40 @@ import adventureworks.customtypes.TypoLocalDateTime
 import adventureworks.customtypes.TypoUUID
 import adventureworks.production.productcategory.ProductcategoryId
 import adventureworks.public.Name
+import typo.dsl.Path
 import typo.dsl.SqlExpr.Field
 import typo.dsl.SqlExpr.FieldLikeNoHkt
 import typo.dsl.SqlExpr.IdField
 import typo.dsl.Structure.Relation
 
-trait ProductsubcategoryFields[Row] {
-  val productsubcategoryid: IdField[ProductsubcategoryId, Row]
-  val productcategoryid: Field[ProductcategoryId, Row]
-  val name: Field[Name, Row]
-  val rowguid: Field[TypoUUID, Row]
-  val modifieddate: Field[TypoLocalDateTime, Row]
+trait ProductsubcategoryFields {
+  def productsubcategoryid: IdField[ProductsubcategoryId, ProductsubcategoryRow]
+  def productcategoryid: Field[ProductcategoryId, ProductsubcategoryRow]
+  def name: Field[Name, ProductsubcategoryRow]
+  def rowguid: Field[TypoUUID, ProductsubcategoryRow]
+  def modifieddate: Field[TypoLocalDateTime, ProductsubcategoryRow]
 }
 
 object ProductsubcategoryFields {
-  val structure: Relation[ProductsubcategoryFields, ProductsubcategoryRow, ProductsubcategoryRow] = 
-    new Impl(None, identity, (_, x) => x)
+  lazy val structure: Relation[ProductsubcategoryFields, ProductsubcategoryRow] =
+    new Impl(Nil)
     
-  private final class Impl[Row](val prefix: Option[String], val extract: Row => ProductsubcategoryRow, val merge: (Row, ProductsubcategoryRow) => Row)
-    extends Relation[ProductsubcategoryFields, ProductsubcategoryRow, Row] { 
+  private final class Impl(val _path: List[Path])
+    extends Relation[ProductsubcategoryFields, ProductsubcategoryRow] {
   
-    override val fields: ProductsubcategoryFields[Row] = new ProductsubcategoryFields[Row] {
-      override val productsubcategoryid = new IdField[ProductsubcategoryId, Row](prefix, "productsubcategoryid", None, Some("int4"))(x => extract(x).productsubcategoryid, (row, value) => merge(row, extract(row).copy(productsubcategoryid = value)))
-      override val productcategoryid = new Field[ProductcategoryId, Row](prefix, "productcategoryid", None, Some("int4"))(x => extract(x).productcategoryid, (row, value) => merge(row, extract(row).copy(productcategoryid = value)))
-      override val name = new Field[Name, Row](prefix, "name", None, Some("varchar"))(x => extract(x).name, (row, value) => merge(row, extract(row).copy(name = value)))
-      override val rowguid = new Field[TypoUUID, Row](prefix, "rowguid", None, Some("uuid"))(x => extract(x).rowguid, (row, value) => merge(row, extract(row).copy(rowguid = value)))
-      override val modifieddate = new Field[TypoLocalDateTime, Row](prefix, "modifieddate", Some("text"), Some("timestamp"))(x => extract(x).modifieddate, (row, value) => merge(row, extract(row).copy(modifieddate = value)))
+    override lazy val fields: ProductsubcategoryFields = new ProductsubcategoryFields {
+      override def productsubcategoryid = IdField[ProductsubcategoryId, ProductsubcategoryRow](_path, "productsubcategoryid", None, Some("int4"), x => x.productsubcategoryid, (row, value) => row.copy(productsubcategoryid = value))
+      override def productcategoryid = Field[ProductcategoryId, ProductsubcategoryRow](_path, "productcategoryid", None, Some("int4"), x => x.productcategoryid, (row, value) => row.copy(productcategoryid = value))
+      override def name = Field[Name, ProductsubcategoryRow](_path, "name", None, Some("varchar"), x => x.name, (row, value) => row.copy(name = value))
+      override def rowguid = Field[TypoUUID, ProductsubcategoryRow](_path, "rowguid", None, Some("uuid"), x => x.rowguid, (row, value) => row.copy(rowguid = value))
+      override def modifieddate = Field[TypoLocalDateTime, ProductsubcategoryRow](_path, "modifieddate", Some("text"), Some("timestamp"), x => x.modifieddate, (row, value) => row.copy(modifieddate = value))
     }
   
-    override val columns: List[FieldLikeNoHkt[?, Row]] =
-      List[FieldLikeNoHkt[?, Row]](fields.productsubcategoryid, fields.productcategoryid, fields.name, fields.rowguid, fields.modifieddate)
+    override lazy val columns: List[FieldLikeNoHkt[?, ProductsubcategoryRow]] =
+      List[FieldLikeNoHkt[?, ProductsubcategoryRow]](fields.productsubcategoryid, fields.productcategoryid, fields.name, fields.rowguid, fields.modifieddate)
   
-    override def copy[NewRow](prefix: Option[String], extract: NewRow => ProductsubcategoryRow, merge: (NewRow, ProductsubcategoryRow) => NewRow): Impl[NewRow] =
-      new Impl(prefix, extract, merge)
+    override def copy(path: List[Path]): Impl =
+      new Impl(path)
   }
   
 }

--- a/typo-tester-zio-jdbc/generated-and-checked-in/adventureworks/production/productsubcategory/ProductsubcategoryRepoMock.scala
+++ b/typo-tester-zio-jdbc/generated-and-checked-in/adventureworks/production/productsubcategory/ProductsubcategoryRepoMock.scala
@@ -26,7 +26,7 @@ import zio.stream.ZStream
 class ProductsubcategoryRepoMock(toRow: Function1[ProductsubcategoryRowUnsaved, ProductsubcategoryRow],
                                  map: scala.collection.mutable.Map[ProductsubcategoryId, ProductsubcategoryRow] = scala.collection.mutable.Map.empty) extends ProductsubcategoryRepo {
   override def delete: DeleteBuilder[ProductsubcategoryFields, ProductsubcategoryRow] = {
-    DeleteBuilderMock(DeleteParams.empty, ProductsubcategoryFields.structure.fields, map)
+    DeleteBuilderMock(DeleteParams.empty, ProductsubcategoryFields.structure, map)
   }
   override def deleteById(productsubcategoryid: ProductsubcategoryId): ZIO[ZConnection, Throwable, Boolean] = {
     ZIO.succeed(map.remove(productsubcategoryid).isDefined)
@@ -85,7 +85,7 @@ class ProductsubcategoryRepoMock(toRow: Function1[ProductsubcategoryRowUnsaved, 
     }
   }
   override def update: UpdateBuilder[ProductsubcategoryFields, ProductsubcategoryRow] = {
-    UpdateBuilderMock(UpdateParams.empty, ProductsubcategoryFields.structure.fields, map)
+    UpdateBuilderMock(UpdateParams.empty, ProductsubcategoryFields.structure, map)
   }
   override def update(row: ProductsubcategoryRow): ZIO[ZConnection, Throwable, Boolean] = {
     ZIO.succeed {

--- a/typo-tester-zio-jdbc/generated-and-checked-in/adventureworks/production/scrapreason/ScrapreasonFields.scala
+++ b/typo-tester-zio-jdbc/generated-and-checked-in/adventureworks/production/scrapreason/ScrapreasonFields.scala
@@ -9,35 +9,36 @@ package scrapreason
 
 import adventureworks.customtypes.TypoLocalDateTime
 import adventureworks.public.Name
+import typo.dsl.Path
 import typo.dsl.SqlExpr.Field
 import typo.dsl.SqlExpr.FieldLikeNoHkt
 import typo.dsl.SqlExpr.IdField
 import typo.dsl.Structure.Relation
 
-trait ScrapreasonFields[Row] {
-  val scrapreasonid: IdField[ScrapreasonId, Row]
-  val name: Field[Name, Row]
-  val modifieddate: Field[TypoLocalDateTime, Row]
+trait ScrapreasonFields {
+  def scrapreasonid: IdField[ScrapreasonId, ScrapreasonRow]
+  def name: Field[Name, ScrapreasonRow]
+  def modifieddate: Field[TypoLocalDateTime, ScrapreasonRow]
 }
 
 object ScrapreasonFields {
-  val structure: Relation[ScrapreasonFields, ScrapreasonRow, ScrapreasonRow] = 
-    new Impl(None, identity, (_, x) => x)
+  lazy val structure: Relation[ScrapreasonFields, ScrapreasonRow] =
+    new Impl(Nil)
     
-  private final class Impl[Row](val prefix: Option[String], val extract: Row => ScrapreasonRow, val merge: (Row, ScrapreasonRow) => Row)
-    extends Relation[ScrapreasonFields, ScrapreasonRow, Row] { 
+  private final class Impl(val _path: List[Path])
+    extends Relation[ScrapreasonFields, ScrapreasonRow] {
   
-    override val fields: ScrapreasonFields[Row] = new ScrapreasonFields[Row] {
-      override val scrapreasonid = new IdField[ScrapreasonId, Row](prefix, "scrapreasonid", None, Some("int4"))(x => extract(x).scrapreasonid, (row, value) => merge(row, extract(row).copy(scrapreasonid = value)))
-      override val name = new Field[Name, Row](prefix, "name", None, Some("varchar"))(x => extract(x).name, (row, value) => merge(row, extract(row).copy(name = value)))
-      override val modifieddate = new Field[TypoLocalDateTime, Row](prefix, "modifieddate", Some("text"), Some("timestamp"))(x => extract(x).modifieddate, (row, value) => merge(row, extract(row).copy(modifieddate = value)))
+    override lazy val fields: ScrapreasonFields = new ScrapreasonFields {
+      override def scrapreasonid = IdField[ScrapreasonId, ScrapreasonRow](_path, "scrapreasonid", None, Some("int4"), x => x.scrapreasonid, (row, value) => row.copy(scrapreasonid = value))
+      override def name = Field[Name, ScrapreasonRow](_path, "name", None, Some("varchar"), x => x.name, (row, value) => row.copy(name = value))
+      override def modifieddate = Field[TypoLocalDateTime, ScrapreasonRow](_path, "modifieddate", Some("text"), Some("timestamp"), x => x.modifieddate, (row, value) => row.copy(modifieddate = value))
     }
   
-    override val columns: List[FieldLikeNoHkt[?, Row]] =
-      List[FieldLikeNoHkt[?, Row]](fields.scrapreasonid, fields.name, fields.modifieddate)
+    override lazy val columns: List[FieldLikeNoHkt[?, ScrapreasonRow]] =
+      List[FieldLikeNoHkt[?, ScrapreasonRow]](fields.scrapreasonid, fields.name, fields.modifieddate)
   
-    override def copy[NewRow](prefix: Option[String], extract: NewRow => ScrapreasonRow, merge: (NewRow, ScrapreasonRow) => NewRow): Impl[NewRow] =
-      new Impl(prefix, extract, merge)
+    override def copy(path: List[Path]): Impl =
+      new Impl(path)
   }
   
 }

--- a/typo-tester-zio-jdbc/generated-and-checked-in/adventureworks/production/scrapreason/ScrapreasonRepoMock.scala
+++ b/typo-tester-zio-jdbc/generated-and-checked-in/adventureworks/production/scrapreason/ScrapreasonRepoMock.scala
@@ -26,7 +26,7 @@ import zio.stream.ZStream
 class ScrapreasonRepoMock(toRow: Function1[ScrapreasonRowUnsaved, ScrapreasonRow],
                           map: scala.collection.mutable.Map[ScrapreasonId, ScrapreasonRow] = scala.collection.mutable.Map.empty) extends ScrapreasonRepo {
   override def delete: DeleteBuilder[ScrapreasonFields, ScrapreasonRow] = {
-    DeleteBuilderMock(DeleteParams.empty, ScrapreasonFields.structure.fields, map)
+    DeleteBuilderMock(DeleteParams.empty, ScrapreasonFields.structure, map)
   }
   override def deleteById(scrapreasonid: ScrapreasonId): ZIO[ZConnection, Throwable, Boolean] = {
     ZIO.succeed(map.remove(scrapreasonid).isDefined)
@@ -85,7 +85,7 @@ class ScrapreasonRepoMock(toRow: Function1[ScrapreasonRowUnsaved, ScrapreasonRow
     }
   }
   override def update: UpdateBuilder[ScrapreasonFields, ScrapreasonRow] = {
-    UpdateBuilderMock(UpdateParams.empty, ScrapreasonFields.structure.fields, map)
+    UpdateBuilderMock(UpdateParams.empty, ScrapreasonFields.structure, map)
   }
   override def update(row: ScrapreasonRow): ZIO[ZConnection, Throwable, Boolean] = {
     ZIO.succeed {

--- a/typo-tester-zio-jdbc/generated-and-checked-in/adventureworks/production/transactionhistory/TransactionhistoryFields.scala
+++ b/typo-tester-zio-jdbc/generated-and-checked-in/adventureworks/production/transactionhistory/TransactionhistoryFields.scala
@@ -9,47 +9,48 @@ package transactionhistory
 
 import adventureworks.customtypes.TypoLocalDateTime
 import adventureworks.production.product.ProductId
+import typo.dsl.Path
 import typo.dsl.SqlExpr.Field
 import typo.dsl.SqlExpr.FieldLikeNoHkt
 import typo.dsl.SqlExpr.IdField
 import typo.dsl.Structure.Relation
 
-trait TransactionhistoryFields[Row] {
-  val transactionid: IdField[TransactionhistoryId, Row]
-  val productid: Field[ProductId, Row]
-  val referenceorderid: Field[Int, Row]
-  val referenceorderlineid: Field[Int, Row]
-  val transactiondate: Field[TypoLocalDateTime, Row]
-  val transactiontype: Field[/* bpchar, max 1 chars */ String, Row]
-  val quantity: Field[Int, Row]
-  val actualcost: Field[BigDecimal, Row]
-  val modifieddate: Field[TypoLocalDateTime, Row]
+trait TransactionhistoryFields {
+  def transactionid: IdField[TransactionhistoryId, TransactionhistoryRow]
+  def productid: Field[ProductId, TransactionhistoryRow]
+  def referenceorderid: Field[Int, TransactionhistoryRow]
+  def referenceorderlineid: Field[Int, TransactionhistoryRow]
+  def transactiondate: Field[TypoLocalDateTime, TransactionhistoryRow]
+  def transactiontype: Field[/* bpchar, max 1 chars */ String, TransactionhistoryRow]
+  def quantity: Field[Int, TransactionhistoryRow]
+  def actualcost: Field[BigDecimal, TransactionhistoryRow]
+  def modifieddate: Field[TypoLocalDateTime, TransactionhistoryRow]
 }
 
 object TransactionhistoryFields {
-  val structure: Relation[TransactionhistoryFields, TransactionhistoryRow, TransactionhistoryRow] = 
-    new Impl(None, identity, (_, x) => x)
+  lazy val structure: Relation[TransactionhistoryFields, TransactionhistoryRow] =
+    new Impl(Nil)
     
-  private final class Impl[Row](val prefix: Option[String], val extract: Row => TransactionhistoryRow, val merge: (Row, TransactionhistoryRow) => Row)
-    extends Relation[TransactionhistoryFields, TransactionhistoryRow, Row] { 
+  private final class Impl(val _path: List[Path])
+    extends Relation[TransactionhistoryFields, TransactionhistoryRow] {
   
-    override val fields: TransactionhistoryFields[Row] = new TransactionhistoryFields[Row] {
-      override val transactionid = new IdField[TransactionhistoryId, Row](prefix, "transactionid", None, Some("int4"))(x => extract(x).transactionid, (row, value) => merge(row, extract(row).copy(transactionid = value)))
-      override val productid = new Field[ProductId, Row](prefix, "productid", None, Some("int4"))(x => extract(x).productid, (row, value) => merge(row, extract(row).copy(productid = value)))
-      override val referenceorderid = new Field[Int, Row](prefix, "referenceorderid", None, Some("int4"))(x => extract(x).referenceorderid, (row, value) => merge(row, extract(row).copy(referenceorderid = value)))
-      override val referenceorderlineid = new Field[Int, Row](prefix, "referenceorderlineid", None, Some("int4"))(x => extract(x).referenceorderlineid, (row, value) => merge(row, extract(row).copy(referenceorderlineid = value)))
-      override val transactiondate = new Field[TypoLocalDateTime, Row](prefix, "transactiondate", Some("text"), Some("timestamp"))(x => extract(x).transactiondate, (row, value) => merge(row, extract(row).copy(transactiondate = value)))
-      override val transactiontype = new Field[/* bpchar, max 1 chars */ String, Row](prefix, "transactiontype", None, Some("bpchar"))(x => extract(x).transactiontype, (row, value) => merge(row, extract(row).copy(transactiontype = value)))
-      override val quantity = new Field[Int, Row](prefix, "quantity", None, Some("int4"))(x => extract(x).quantity, (row, value) => merge(row, extract(row).copy(quantity = value)))
-      override val actualcost = new Field[BigDecimal, Row](prefix, "actualcost", None, Some("numeric"))(x => extract(x).actualcost, (row, value) => merge(row, extract(row).copy(actualcost = value)))
-      override val modifieddate = new Field[TypoLocalDateTime, Row](prefix, "modifieddate", Some("text"), Some("timestamp"))(x => extract(x).modifieddate, (row, value) => merge(row, extract(row).copy(modifieddate = value)))
+    override lazy val fields: TransactionhistoryFields = new TransactionhistoryFields {
+      override def transactionid = IdField[TransactionhistoryId, TransactionhistoryRow](_path, "transactionid", None, Some("int4"), x => x.transactionid, (row, value) => row.copy(transactionid = value))
+      override def productid = Field[ProductId, TransactionhistoryRow](_path, "productid", None, Some("int4"), x => x.productid, (row, value) => row.copy(productid = value))
+      override def referenceorderid = Field[Int, TransactionhistoryRow](_path, "referenceorderid", None, Some("int4"), x => x.referenceorderid, (row, value) => row.copy(referenceorderid = value))
+      override def referenceorderlineid = Field[Int, TransactionhistoryRow](_path, "referenceorderlineid", None, Some("int4"), x => x.referenceorderlineid, (row, value) => row.copy(referenceorderlineid = value))
+      override def transactiondate = Field[TypoLocalDateTime, TransactionhistoryRow](_path, "transactiondate", Some("text"), Some("timestamp"), x => x.transactiondate, (row, value) => row.copy(transactiondate = value))
+      override def transactiontype = Field[/* bpchar, max 1 chars */ String, TransactionhistoryRow](_path, "transactiontype", None, Some("bpchar"), x => x.transactiontype, (row, value) => row.copy(transactiontype = value))
+      override def quantity = Field[Int, TransactionhistoryRow](_path, "quantity", None, Some("int4"), x => x.quantity, (row, value) => row.copy(quantity = value))
+      override def actualcost = Field[BigDecimal, TransactionhistoryRow](_path, "actualcost", None, Some("numeric"), x => x.actualcost, (row, value) => row.copy(actualcost = value))
+      override def modifieddate = Field[TypoLocalDateTime, TransactionhistoryRow](_path, "modifieddate", Some("text"), Some("timestamp"), x => x.modifieddate, (row, value) => row.copy(modifieddate = value))
     }
   
-    override val columns: List[FieldLikeNoHkt[?, Row]] =
-      List[FieldLikeNoHkt[?, Row]](fields.transactionid, fields.productid, fields.referenceorderid, fields.referenceorderlineid, fields.transactiondate, fields.transactiontype, fields.quantity, fields.actualcost, fields.modifieddate)
+    override lazy val columns: List[FieldLikeNoHkt[?, TransactionhistoryRow]] =
+      List[FieldLikeNoHkt[?, TransactionhistoryRow]](fields.transactionid, fields.productid, fields.referenceorderid, fields.referenceorderlineid, fields.transactiondate, fields.transactiontype, fields.quantity, fields.actualcost, fields.modifieddate)
   
-    override def copy[NewRow](prefix: Option[String], extract: NewRow => TransactionhistoryRow, merge: (NewRow, TransactionhistoryRow) => NewRow): Impl[NewRow] =
-      new Impl(prefix, extract, merge)
+    override def copy(path: List[Path]): Impl =
+      new Impl(path)
   }
   
 }

--- a/typo-tester-zio-jdbc/generated-and-checked-in/adventureworks/production/transactionhistory/TransactionhistoryRepoMock.scala
+++ b/typo-tester-zio-jdbc/generated-and-checked-in/adventureworks/production/transactionhistory/TransactionhistoryRepoMock.scala
@@ -26,7 +26,7 @@ import zio.stream.ZStream
 class TransactionhistoryRepoMock(toRow: Function1[TransactionhistoryRowUnsaved, TransactionhistoryRow],
                                  map: scala.collection.mutable.Map[TransactionhistoryId, TransactionhistoryRow] = scala.collection.mutable.Map.empty) extends TransactionhistoryRepo {
   override def delete: DeleteBuilder[TransactionhistoryFields, TransactionhistoryRow] = {
-    DeleteBuilderMock(DeleteParams.empty, TransactionhistoryFields.structure.fields, map)
+    DeleteBuilderMock(DeleteParams.empty, TransactionhistoryFields.structure, map)
   }
   override def deleteById(transactionid: TransactionhistoryId): ZIO[ZConnection, Throwable, Boolean] = {
     ZIO.succeed(map.remove(transactionid).isDefined)
@@ -85,7 +85,7 @@ class TransactionhistoryRepoMock(toRow: Function1[TransactionhistoryRowUnsaved, 
     }
   }
   override def update: UpdateBuilder[TransactionhistoryFields, TransactionhistoryRow] = {
-    UpdateBuilderMock(UpdateParams.empty, TransactionhistoryFields.structure.fields, map)
+    UpdateBuilderMock(UpdateParams.empty, TransactionhistoryFields.structure, map)
   }
   override def update(row: TransactionhistoryRow): ZIO[ZConnection, Throwable, Boolean] = {
     ZIO.succeed {

--- a/typo-tester-zio-jdbc/generated-and-checked-in/adventureworks/production/transactionhistoryarchive/TransactionhistoryarchiveFields.scala
+++ b/typo-tester-zio-jdbc/generated-and-checked-in/adventureworks/production/transactionhistoryarchive/TransactionhistoryarchiveFields.scala
@@ -8,47 +8,48 @@ package production
 package transactionhistoryarchive
 
 import adventureworks.customtypes.TypoLocalDateTime
+import typo.dsl.Path
 import typo.dsl.SqlExpr.Field
 import typo.dsl.SqlExpr.FieldLikeNoHkt
 import typo.dsl.SqlExpr.IdField
 import typo.dsl.Structure.Relation
 
-trait TransactionhistoryarchiveFields[Row] {
-  val transactionid: IdField[TransactionhistoryarchiveId, Row]
-  val productid: Field[Int, Row]
-  val referenceorderid: Field[Int, Row]
-  val referenceorderlineid: Field[Int, Row]
-  val transactiondate: Field[TypoLocalDateTime, Row]
-  val transactiontype: Field[/* bpchar, max 1 chars */ String, Row]
-  val quantity: Field[Int, Row]
-  val actualcost: Field[BigDecimal, Row]
-  val modifieddate: Field[TypoLocalDateTime, Row]
+trait TransactionhistoryarchiveFields {
+  def transactionid: IdField[TransactionhistoryarchiveId, TransactionhistoryarchiveRow]
+  def productid: Field[Int, TransactionhistoryarchiveRow]
+  def referenceorderid: Field[Int, TransactionhistoryarchiveRow]
+  def referenceorderlineid: Field[Int, TransactionhistoryarchiveRow]
+  def transactiondate: Field[TypoLocalDateTime, TransactionhistoryarchiveRow]
+  def transactiontype: Field[/* bpchar, max 1 chars */ String, TransactionhistoryarchiveRow]
+  def quantity: Field[Int, TransactionhistoryarchiveRow]
+  def actualcost: Field[BigDecimal, TransactionhistoryarchiveRow]
+  def modifieddate: Field[TypoLocalDateTime, TransactionhistoryarchiveRow]
 }
 
 object TransactionhistoryarchiveFields {
-  val structure: Relation[TransactionhistoryarchiveFields, TransactionhistoryarchiveRow, TransactionhistoryarchiveRow] = 
-    new Impl(None, identity, (_, x) => x)
+  lazy val structure: Relation[TransactionhistoryarchiveFields, TransactionhistoryarchiveRow] =
+    new Impl(Nil)
     
-  private final class Impl[Row](val prefix: Option[String], val extract: Row => TransactionhistoryarchiveRow, val merge: (Row, TransactionhistoryarchiveRow) => Row)
-    extends Relation[TransactionhistoryarchiveFields, TransactionhistoryarchiveRow, Row] { 
+  private final class Impl(val _path: List[Path])
+    extends Relation[TransactionhistoryarchiveFields, TransactionhistoryarchiveRow] {
   
-    override val fields: TransactionhistoryarchiveFields[Row] = new TransactionhistoryarchiveFields[Row] {
-      override val transactionid = new IdField[TransactionhistoryarchiveId, Row](prefix, "transactionid", None, Some("int4"))(x => extract(x).transactionid, (row, value) => merge(row, extract(row).copy(transactionid = value)))
-      override val productid = new Field[Int, Row](prefix, "productid", None, Some("int4"))(x => extract(x).productid, (row, value) => merge(row, extract(row).copy(productid = value)))
-      override val referenceorderid = new Field[Int, Row](prefix, "referenceorderid", None, Some("int4"))(x => extract(x).referenceorderid, (row, value) => merge(row, extract(row).copy(referenceorderid = value)))
-      override val referenceorderlineid = new Field[Int, Row](prefix, "referenceorderlineid", None, Some("int4"))(x => extract(x).referenceorderlineid, (row, value) => merge(row, extract(row).copy(referenceorderlineid = value)))
-      override val transactiondate = new Field[TypoLocalDateTime, Row](prefix, "transactiondate", Some("text"), Some("timestamp"))(x => extract(x).transactiondate, (row, value) => merge(row, extract(row).copy(transactiondate = value)))
-      override val transactiontype = new Field[/* bpchar, max 1 chars */ String, Row](prefix, "transactiontype", None, Some("bpchar"))(x => extract(x).transactiontype, (row, value) => merge(row, extract(row).copy(transactiontype = value)))
-      override val quantity = new Field[Int, Row](prefix, "quantity", None, Some("int4"))(x => extract(x).quantity, (row, value) => merge(row, extract(row).copy(quantity = value)))
-      override val actualcost = new Field[BigDecimal, Row](prefix, "actualcost", None, Some("numeric"))(x => extract(x).actualcost, (row, value) => merge(row, extract(row).copy(actualcost = value)))
-      override val modifieddate = new Field[TypoLocalDateTime, Row](prefix, "modifieddate", Some("text"), Some("timestamp"))(x => extract(x).modifieddate, (row, value) => merge(row, extract(row).copy(modifieddate = value)))
+    override lazy val fields: TransactionhistoryarchiveFields = new TransactionhistoryarchiveFields {
+      override def transactionid = IdField[TransactionhistoryarchiveId, TransactionhistoryarchiveRow](_path, "transactionid", None, Some("int4"), x => x.transactionid, (row, value) => row.copy(transactionid = value))
+      override def productid = Field[Int, TransactionhistoryarchiveRow](_path, "productid", None, Some("int4"), x => x.productid, (row, value) => row.copy(productid = value))
+      override def referenceorderid = Field[Int, TransactionhistoryarchiveRow](_path, "referenceorderid", None, Some("int4"), x => x.referenceorderid, (row, value) => row.copy(referenceorderid = value))
+      override def referenceorderlineid = Field[Int, TransactionhistoryarchiveRow](_path, "referenceorderlineid", None, Some("int4"), x => x.referenceorderlineid, (row, value) => row.copy(referenceorderlineid = value))
+      override def transactiondate = Field[TypoLocalDateTime, TransactionhistoryarchiveRow](_path, "transactiondate", Some("text"), Some("timestamp"), x => x.transactiondate, (row, value) => row.copy(transactiondate = value))
+      override def transactiontype = Field[/* bpchar, max 1 chars */ String, TransactionhistoryarchiveRow](_path, "transactiontype", None, Some("bpchar"), x => x.transactiontype, (row, value) => row.copy(transactiontype = value))
+      override def quantity = Field[Int, TransactionhistoryarchiveRow](_path, "quantity", None, Some("int4"), x => x.quantity, (row, value) => row.copy(quantity = value))
+      override def actualcost = Field[BigDecimal, TransactionhistoryarchiveRow](_path, "actualcost", None, Some("numeric"), x => x.actualcost, (row, value) => row.copy(actualcost = value))
+      override def modifieddate = Field[TypoLocalDateTime, TransactionhistoryarchiveRow](_path, "modifieddate", Some("text"), Some("timestamp"), x => x.modifieddate, (row, value) => row.copy(modifieddate = value))
     }
   
-    override val columns: List[FieldLikeNoHkt[?, Row]] =
-      List[FieldLikeNoHkt[?, Row]](fields.transactionid, fields.productid, fields.referenceorderid, fields.referenceorderlineid, fields.transactiondate, fields.transactiontype, fields.quantity, fields.actualcost, fields.modifieddate)
+    override lazy val columns: List[FieldLikeNoHkt[?, TransactionhistoryarchiveRow]] =
+      List[FieldLikeNoHkt[?, TransactionhistoryarchiveRow]](fields.transactionid, fields.productid, fields.referenceorderid, fields.referenceorderlineid, fields.transactiondate, fields.transactiontype, fields.quantity, fields.actualcost, fields.modifieddate)
   
-    override def copy[NewRow](prefix: Option[String], extract: NewRow => TransactionhistoryarchiveRow, merge: (NewRow, TransactionhistoryarchiveRow) => NewRow): Impl[NewRow] =
-      new Impl(prefix, extract, merge)
+    override def copy(path: List[Path]): Impl =
+      new Impl(path)
   }
   
 }

--- a/typo-tester-zio-jdbc/generated-and-checked-in/adventureworks/production/transactionhistoryarchive/TransactionhistoryarchiveRepoMock.scala
+++ b/typo-tester-zio-jdbc/generated-and-checked-in/adventureworks/production/transactionhistoryarchive/TransactionhistoryarchiveRepoMock.scala
@@ -26,7 +26,7 @@ import zio.stream.ZStream
 class TransactionhistoryarchiveRepoMock(toRow: Function1[TransactionhistoryarchiveRowUnsaved, TransactionhistoryarchiveRow],
                                         map: scala.collection.mutable.Map[TransactionhistoryarchiveId, TransactionhistoryarchiveRow] = scala.collection.mutable.Map.empty) extends TransactionhistoryarchiveRepo {
   override def delete: DeleteBuilder[TransactionhistoryarchiveFields, TransactionhistoryarchiveRow] = {
-    DeleteBuilderMock(DeleteParams.empty, TransactionhistoryarchiveFields.structure.fields, map)
+    DeleteBuilderMock(DeleteParams.empty, TransactionhistoryarchiveFields.structure, map)
   }
   override def deleteById(transactionid: TransactionhistoryarchiveId): ZIO[ZConnection, Throwable, Boolean] = {
     ZIO.succeed(map.remove(transactionid).isDefined)
@@ -85,7 +85,7 @@ class TransactionhistoryarchiveRepoMock(toRow: Function1[Transactionhistoryarchi
     }
   }
   override def update: UpdateBuilder[TransactionhistoryarchiveFields, TransactionhistoryarchiveRow] = {
-    UpdateBuilderMock(UpdateParams.empty, TransactionhistoryarchiveFields.structure.fields, map)
+    UpdateBuilderMock(UpdateParams.empty, TransactionhistoryarchiveFields.structure, map)
   }
   override def update(row: TransactionhistoryarchiveRow): ZIO[ZConnection, Throwable, Boolean] = {
     ZIO.succeed {

--- a/typo-tester-zio-jdbc/generated-and-checked-in/adventureworks/production/unitmeasure/UnitmeasureFields.scala
+++ b/typo-tester-zio-jdbc/generated-and-checked-in/adventureworks/production/unitmeasure/UnitmeasureFields.scala
@@ -9,35 +9,36 @@ package unitmeasure
 
 import adventureworks.customtypes.TypoLocalDateTime
 import adventureworks.public.Name
+import typo.dsl.Path
 import typo.dsl.SqlExpr.Field
 import typo.dsl.SqlExpr.FieldLikeNoHkt
 import typo.dsl.SqlExpr.IdField
 import typo.dsl.Structure.Relation
 
-trait UnitmeasureFields[Row] {
-  val unitmeasurecode: IdField[UnitmeasureId, Row]
-  val name: Field[Name, Row]
-  val modifieddate: Field[TypoLocalDateTime, Row]
+trait UnitmeasureFields {
+  def unitmeasurecode: IdField[UnitmeasureId, UnitmeasureRow]
+  def name: Field[Name, UnitmeasureRow]
+  def modifieddate: Field[TypoLocalDateTime, UnitmeasureRow]
 }
 
 object UnitmeasureFields {
-  val structure: Relation[UnitmeasureFields, UnitmeasureRow, UnitmeasureRow] = 
-    new Impl(None, identity, (_, x) => x)
+  lazy val structure: Relation[UnitmeasureFields, UnitmeasureRow] =
+    new Impl(Nil)
     
-  private final class Impl[Row](val prefix: Option[String], val extract: Row => UnitmeasureRow, val merge: (Row, UnitmeasureRow) => Row)
-    extends Relation[UnitmeasureFields, UnitmeasureRow, Row] { 
+  private final class Impl(val _path: List[Path])
+    extends Relation[UnitmeasureFields, UnitmeasureRow] {
   
-    override val fields: UnitmeasureFields[Row] = new UnitmeasureFields[Row] {
-      override val unitmeasurecode = new IdField[UnitmeasureId, Row](prefix, "unitmeasurecode", None, Some("bpchar"))(x => extract(x).unitmeasurecode, (row, value) => merge(row, extract(row).copy(unitmeasurecode = value)))
-      override val name = new Field[Name, Row](prefix, "name", None, Some("varchar"))(x => extract(x).name, (row, value) => merge(row, extract(row).copy(name = value)))
-      override val modifieddate = new Field[TypoLocalDateTime, Row](prefix, "modifieddate", Some("text"), Some("timestamp"))(x => extract(x).modifieddate, (row, value) => merge(row, extract(row).copy(modifieddate = value)))
+    override lazy val fields: UnitmeasureFields = new UnitmeasureFields {
+      override def unitmeasurecode = IdField[UnitmeasureId, UnitmeasureRow](_path, "unitmeasurecode", None, Some("bpchar"), x => x.unitmeasurecode, (row, value) => row.copy(unitmeasurecode = value))
+      override def name = Field[Name, UnitmeasureRow](_path, "name", None, Some("varchar"), x => x.name, (row, value) => row.copy(name = value))
+      override def modifieddate = Field[TypoLocalDateTime, UnitmeasureRow](_path, "modifieddate", Some("text"), Some("timestamp"), x => x.modifieddate, (row, value) => row.copy(modifieddate = value))
     }
   
-    override val columns: List[FieldLikeNoHkt[?, Row]] =
-      List[FieldLikeNoHkt[?, Row]](fields.unitmeasurecode, fields.name, fields.modifieddate)
+    override lazy val columns: List[FieldLikeNoHkt[?, UnitmeasureRow]] =
+      List[FieldLikeNoHkt[?, UnitmeasureRow]](fields.unitmeasurecode, fields.name, fields.modifieddate)
   
-    override def copy[NewRow](prefix: Option[String], extract: NewRow => UnitmeasureRow, merge: (NewRow, UnitmeasureRow) => NewRow): Impl[NewRow] =
-      new Impl(prefix, extract, merge)
+    override def copy(path: List[Path]): Impl =
+      new Impl(path)
   }
   
 }

--- a/typo-tester-zio-jdbc/generated-and-checked-in/adventureworks/production/unitmeasure/UnitmeasureRepoMock.scala
+++ b/typo-tester-zio-jdbc/generated-and-checked-in/adventureworks/production/unitmeasure/UnitmeasureRepoMock.scala
@@ -26,7 +26,7 @@ import zio.stream.ZStream
 class UnitmeasureRepoMock(toRow: Function1[UnitmeasureRowUnsaved, UnitmeasureRow],
                           map: scala.collection.mutable.Map[UnitmeasureId, UnitmeasureRow] = scala.collection.mutable.Map.empty) extends UnitmeasureRepo {
   override def delete: DeleteBuilder[UnitmeasureFields, UnitmeasureRow] = {
-    DeleteBuilderMock(DeleteParams.empty, UnitmeasureFields.structure.fields, map)
+    DeleteBuilderMock(DeleteParams.empty, UnitmeasureFields.structure, map)
   }
   override def deleteById(unitmeasurecode: UnitmeasureId): ZIO[ZConnection, Throwable, Boolean] = {
     ZIO.succeed(map.remove(unitmeasurecode).isDefined)
@@ -85,7 +85,7 @@ class UnitmeasureRepoMock(toRow: Function1[UnitmeasureRowUnsaved, UnitmeasureRow
     }
   }
   override def update: UpdateBuilder[UnitmeasureFields, UnitmeasureRow] = {
-    UpdateBuilderMock(UpdateParams.empty, UnitmeasureFields.structure.fields, map)
+    UpdateBuilderMock(UpdateParams.empty, UnitmeasureFields.structure, map)
   }
   override def update(row: UnitmeasureRow): ZIO[ZConnection, Throwable, Boolean] = {
     ZIO.succeed {

--- a/typo-tester-zio-jdbc/generated-and-checked-in/adventureworks/production/vproductanddescription/VproductanddescriptionMVFields.scala
+++ b/typo-tester-zio-jdbc/generated-and-checked-in/adventureworks/production/vproductanddescription/VproductanddescriptionMVFields.scala
@@ -10,38 +10,39 @@ package vproductanddescription
 import adventureworks.production.culture.CultureId
 import adventureworks.production.product.ProductId
 import adventureworks.public.Name
+import typo.dsl.Path
 import typo.dsl.SqlExpr.Field
 import typo.dsl.SqlExpr.FieldLikeNoHkt
 import typo.dsl.Structure.Relation
 
-trait VproductanddescriptionMVFields[Row] {
-  val productid: Field[ProductId, Row]
-  val name: Field[Name, Row]
-  val productmodel: Field[Name, Row]
-  val cultureid: Field[CultureId, Row]
-  val description: Field[/* max 400 chars */ String, Row]
+trait VproductanddescriptionMVFields {
+  def productid: Field[ProductId, VproductanddescriptionMVRow]
+  def name: Field[Name, VproductanddescriptionMVRow]
+  def productmodel: Field[Name, VproductanddescriptionMVRow]
+  def cultureid: Field[CultureId, VproductanddescriptionMVRow]
+  def description: Field[/* max 400 chars */ String, VproductanddescriptionMVRow]
 }
 
 object VproductanddescriptionMVFields {
-  val structure: Relation[VproductanddescriptionMVFields, VproductanddescriptionMVRow, VproductanddescriptionMVRow] = 
-    new Impl(None, identity, (_, x) => x)
+  lazy val structure: Relation[VproductanddescriptionMVFields, VproductanddescriptionMVRow] =
+    new Impl(Nil)
     
-  private final class Impl[Row](val prefix: Option[String], val extract: Row => VproductanddescriptionMVRow, val merge: (Row, VproductanddescriptionMVRow) => Row)
-    extends Relation[VproductanddescriptionMVFields, VproductanddescriptionMVRow, Row] { 
+  private final class Impl(val _path: List[Path])
+    extends Relation[VproductanddescriptionMVFields, VproductanddescriptionMVRow] {
   
-    override val fields: VproductanddescriptionMVFields[Row] = new VproductanddescriptionMVFields[Row] {
-      override val productid = new Field[ProductId, Row](prefix, "productid", None, None)(x => extract(x).productid, (row, value) => merge(row, extract(row).copy(productid = value)))
-      override val name = new Field[Name, Row](prefix, "name", None, None)(x => extract(x).name, (row, value) => merge(row, extract(row).copy(name = value)))
-      override val productmodel = new Field[Name, Row](prefix, "productmodel", None, None)(x => extract(x).productmodel, (row, value) => merge(row, extract(row).copy(productmodel = value)))
-      override val cultureid = new Field[CultureId, Row](prefix, "cultureid", None, None)(x => extract(x).cultureid, (row, value) => merge(row, extract(row).copy(cultureid = value)))
-      override val description = new Field[/* max 400 chars */ String, Row](prefix, "description", None, None)(x => extract(x).description, (row, value) => merge(row, extract(row).copy(description = value)))
+    override lazy val fields: VproductanddescriptionMVFields = new VproductanddescriptionMVFields {
+      override def productid = Field[ProductId, VproductanddescriptionMVRow](_path, "productid", None, None, x => x.productid, (row, value) => row.copy(productid = value))
+      override def name = Field[Name, VproductanddescriptionMVRow](_path, "name", None, None, x => x.name, (row, value) => row.copy(name = value))
+      override def productmodel = Field[Name, VproductanddescriptionMVRow](_path, "productmodel", None, None, x => x.productmodel, (row, value) => row.copy(productmodel = value))
+      override def cultureid = Field[CultureId, VproductanddescriptionMVRow](_path, "cultureid", None, None, x => x.cultureid, (row, value) => row.copy(cultureid = value))
+      override def description = Field[/* max 400 chars */ String, VproductanddescriptionMVRow](_path, "description", None, None, x => x.description, (row, value) => row.copy(description = value))
     }
   
-    override val columns: List[FieldLikeNoHkt[?, Row]] =
-      List[FieldLikeNoHkt[?, Row]](fields.productid, fields.name, fields.productmodel, fields.cultureid, fields.description)
+    override lazy val columns: List[FieldLikeNoHkt[?, VproductanddescriptionMVRow]] =
+      List[FieldLikeNoHkt[?, VproductanddescriptionMVRow]](fields.productid, fields.name, fields.productmodel, fields.cultureid, fields.description)
   
-    override def copy[NewRow](prefix: Option[String], extract: NewRow => VproductanddescriptionMVRow, merge: (NewRow, VproductanddescriptionMVRow) => NewRow): Impl[NewRow] =
-      new Impl(prefix, extract, merge)
+    override def copy(path: List[Path]): Impl =
+      new Impl(path)
   }
   
 }

--- a/typo-tester-zio-jdbc/generated-and-checked-in/adventureworks/production/vproductmodelcatalogdescription/VproductmodelcatalogdescriptionViewFields.scala
+++ b/typo-tester-zio-jdbc/generated-and-checked-in/adventureworks/production/vproductmodelcatalogdescription/VproductmodelcatalogdescriptionViewFields.scala
@@ -11,79 +11,80 @@ import adventureworks.customtypes.TypoLocalDateTime
 import adventureworks.customtypes.TypoUUID
 import adventureworks.production.productmodel.ProductmodelId
 import adventureworks.public.Name
+import typo.dsl.Path
 import typo.dsl.SqlExpr.Field
 import typo.dsl.SqlExpr.FieldLikeNoHkt
 import typo.dsl.SqlExpr.OptField
 import typo.dsl.Structure.Relation
 
-trait VproductmodelcatalogdescriptionViewFields[Row] {
-  val productmodelid: Field[ProductmodelId, Row]
-  val name: Field[Name, Row]
-  val Summary: OptField[String, Row]
-  val manufacturer: OptField[String, Row]
-  val copyright: OptField[/* max 30 chars */ String, Row]
-  val producturl: OptField[/* max 256 chars */ String, Row]
-  val warrantyperiod: OptField[/* max 256 chars */ String, Row]
-  val warrantydescription: OptField[/* max 256 chars */ String, Row]
-  val noofyears: OptField[/* max 256 chars */ String, Row]
-  val maintenancedescription: OptField[/* max 256 chars */ String, Row]
-  val wheel: OptField[/* max 256 chars */ String, Row]
-  val saddle: OptField[/* max 256 chars */ String, Row]
-  val pedal: OptField[/* max 256 chars */ String, Row]
-  val bikeframe: OptField[String, Row]
-  val crankset: OptField[/* max 256 chars */ String, Row]
-  val pictureangle: OptField[/* max 256 chars */ String, Row]
-  val picturesize: OptField[/* max 256 chars */ String, Row]
-  val productphotoid: OptField[/* max 256 chars */ String, Row]
-  val material: OptField[/* max 256 chars */ String, Row]
-  val color: OptField[/* max 256 chars */ String, Row]
-  val productline: OptField[/* max 256 chars */ String, Row]
-  val style: OptField[/* max 256 chars */ String, Row]
-  val riderexperience: OptField[/* max 1024 chars */ String, Row]
-  val rowguid: Field[TypoUUID, Row]
-  val modifieddate: Field[TypoLocalDateTime, Row]
+trait VproductmodelcatalogdescriptionViewFields {
+  def productmodelid: Field[ProductmodelId, VproductmodelcatalogdescriptionViewRow]
+  def name: Field[Name, VproductmodelcatalogdescriptionViewRow]
+  def Summary: OptField[String, VproductmodelcatalogdescriptionViewRow]
+  def manufacturer: OptField[String, VproductmodelcatalogdescriptionViewRow]
+  def copyright: OptField[/* max 30 chars */ String, VproductmodelcatalogdescriptionViewRow]
+  def producturl: OptField[/* max 256 chars */ String, VproductmodelcatalogdescriptionViewRow]
+  def warrantyperiod: OptField[/* max 256 chars */ String, VproductmodelcatalogdescriptionViewRow]
+  def warrantydescription: OptField[/* max 256 chars */ String, VproductmodelcatalogdescriptionViewRow]
+  def noofyears: OptField[/* max 256 chars */ String, VproductmodelcatalogdescriptionViewRow]
+  def maintenancedescription: OptField[/* max 256 chars */ String, VproductmodelcatalogdescriptionViewRow]
+  def wheel: OptField[/* max 256 chars */ String, VproductmodelcatalogdescriptionViewRow]
+  def saddle: OptField[/* max 256 chars */ String, VproductmodelcatalogdescriptionViewRow]
+  def pedal: OptField[/* max 256 chars */ String, VproductmodelcatalogdescriptionViewRow]
+  def bikeframe: OptField[String, VproductmodelcatalogdescriptionViewRow]
+  def crankset: OptField[/* max 256 chars */ String, VproductmodelcatalogdescriptionViewRow]
+  def pictureangle: OptField[/* max 256 chars */ String, VproductmodelcatalogdescriptionViewRow]
+  def picturesize: OptField[/* max 256 chars */ String, VproductmodelcatalogdescriptionViewRow]
+  def productphotoid: OptField[/* max 256 chars */ String, VproductmodelcatalogdescriptionViewRow]
+  def material: OptField[/* max 256 chars */ String, VproductmodelcatalogdescriptionViewRow]
+  def color: OptField[/* max 256 chars */ String, VproductmodelcatalogdescriptionViewRow]
+  def productline: OptField[/* max 256 chars */ String, VproductmodelcatalogdescriptionViewRow]
+  def style: OptField[/* max 256 chars */ String, VproductmodelcatalogdescriptionViewRow]
+  def riderexperience: OptField[/* max 1024 chars */ String, VproductmodelcatalogdescriptionViewRow]
+  def rowguid: Field[TypoUUID, VproductmodelcatalogdescriptionViewRow]
+  def modifieddate: Field[TypoLocalDateTime, VproductmodelcatalogdescriptionViewRow]
 }
 
 object VproductmodelcatalogdescriptionViewFields {
-  val structure: Relation[VproductmodelcatalogdescriptionViewFields, VproductmodelcatalogdescriptionViewRow, VproductmodelcatalogdescriptionViewRow] = 
-    new Impl(None, identity, (_, x) => x)
+  lazy val structure: Relation[VproductmodelcatalogdescriptionViewFields, VproductmodelcatalogdescriptionViewRow] =
+    new Impl(Nil)
     
-  private final class Impl[Row](val prefix: Option[String], val extract: Row => VproductmodelcatalogdescriptionViewRow, val merge: (Row, VproductmodelcatalogdescriptionViewRow) => Row)
-    extends Relation[VproductmodelcatalogdescriptionViewFields, VproductmodelcatalogdescriptionViewRow, Row] { 
+  private final class Impl(val _path: List[Path])
+    extends Relation[VproductmodelcatalogdescriptionViewFields, VproductmodelcatalogdescriptionViewRow] {
   
-    override val fields: VproductmodelcatalogdescriptionViewFields[Row] = new VproductmodelcatalogdescriptionViewFields[Row] {
-      override val productmodelid = new Field[ProductmodelId, Row](prefix, "productmodelid", None, None)(x => extract(x).productmodelid, (row, value) => merge(row, extract(row).copy(productmodelid = value)))
-      override val name = new Field[Name, Row](prefix, "name", None, None)(x => extract(x).name, (row, value) => merge(row, extract(row).copy(name = value)))
-      override val Summary = new OptField[String, Row](prefix, "Summary", None, None)(x => extract(x).Summary, (row, value) => merge(row, extract(row).copy(Summary = value)))
-      override val manufacturer = new OptField[String, Row](prefix, "manufacturer", None, None)(x => extract(x).manufacturer, (row, value) => merge(row, extract(row).copy(manufacturer = value)))
-      override val copyright = new OptField[/* max 30 chars */ String, Row](prefix, "copyright", None, None)(x => extract(x).copyright, (row, value) => merge(row, extract(row).copy(copyright = value)))
-      override val producturl = new OptField[/* max 256 chars */ String, Row](prefix, "producturl", None, None)(x => extract(x).producturl, (row, value) => merge(row, extract(row).copy(producturl = value)))
-      override val warrantyperiod = new OptField[/* max 256 chars */ String, Row](prefix, "warrantyperiod", None, None)(x => extract(x).warrantyperiod, (row, value) => merge(row, extract(row).copy(warrantyperiod = value)))
-      override val warrantydescription = new OptField[/* max 256 chars */ String, Row](prefix, "warrantydescription", None, None)(x => extract(x).warrantydescription, (row, value) => merge(row, extract(row).copy(warrantydescription = value)))
-      override val noofyears = new OptField[/* max 256 chars */ String, Row](prefix, "noofyears", None, None)(x => extract(x).noofyears, (row, value) => merge(row, extract(row).copy(noofyears = value)))
-      override val maintenancedescription = new OptField[/* max 256 chars */ String, Row](prefix, "maintenancedescription", None, None)(x => extract(x).maintenancedescription, (row, value) => merge(row, extract(row).copy(maintenancedescription = value)))
-      override val wheel = new OptField[/* max 256 chars */ String, Row](prefix, "wheel", None, None)(x => extract(x).wheel, (row, value) => merge(row, extract(row).copy(wheel = value)))
-      override val saddle = new OptField[/* max 256 chars */ String, Row](prefix, "saddle", None, None)(x => extract(x).saddle, (row, value) => merge(row, extract(row).copy(saddle = value)))
-      override val pedal = new OptField[/* max 256 chars */ String, Row](prefix, "pedal", None, None)(x => extract(x).pedal, (row, value) => merge(row, extract(row).copy(pedal = value)))
-      override val bikeframe = new OptField[String, Row](prefix, "bikeframe", None, None)(x => extract(x).bikeframe, (row, value) => merge(row, extract(row).copy(bikeframe = value)))
-      override val crankset = new OptField[/* max 256 chars */ String, Row](prefix, "crankset", None, None)(x => extract(x).crankset, (row, value) => merge(row, extract(row).copy(crankset = value)))
-      override val pictureangle = new OptField[/* max 256 chars */ String, Row](prefix, "pictureangle", None, None)(x => extract(x).pictureangle, (row, value) => merge(row, extract(row).copy(pictureangle = value)))
-      override val picturesize = new OptField[/* max 256 chars */ String, Row](prefix, "picturesize", None, None)(x => extract(x).picturesize, (row, value) => merge(row, extract(row).copy(picturesize = value)))
-      override val productphotoid = new OptField[/* max 256 chars */ String, Row](prefix, "productphotoid", None, None)(x => extract(x).productphotoid, (row, value) => merge(row, extract(row).copy(productphotoid = value)))
-      override val material = new OptField[/* max 256 chars */ String, Row](prefix, "material", None, None)(x => extract(x).material, (row, value) => merge(row, extract(row).copy(material = value)))
-      override val color = new OptField[/* max 256 chars */ String, Row](prefix, "color", None, None)(x => extract(x).color, (row, value) => merge(row, extract(row).copy(color = value)))
-      override val productline = new OptField[/* max 256 chars */ String, Row](prefix, "productline", None, None)(x => extract(x).productline, (row, value) => merge(row, extract(row).copy(productline = value)))
-      override val style = new OptField[/* max 256 chars */ String, Row](prefix, "style", None, None)(x => extract(x).style, (row, value) => merge(row, extract(row).copy(style = value)))
-      override val riderexperience = new OptField[/* max 1024 chars */ String, Row](prefix, "riderexperience", None, None)(x => extract(x).riderexperience, (row, value) => merge(row, extract(row).copy(riderexperience = value)))
-      override val rowguid = new Field[TypoUUID, Row](prefix, "rowguid", None, None)(x => extract(x).rowguid, (row, value) => merge(row, extract(row).copy(rowguid = value)))
-      override val modifieddate = new Field[TypoLocalDateTime, Row](prefix, "modifieddate", Some("text"), None)(x => extract(x).modifieddate, (row, value) => merge(row, extract(row).copy(modifieddate = value)))
+    override lazy val fields: VproductmodelcatalogdescriptionViewFields = new VproductmodelcatalogdescriptionViewFields {
+      override def productmodelid = Field[ProductmodelId, VproductmodelcatalogdescriptionViewRow](_path, "productmodelid", None, None, x => x.productmodelid, (row, value) => row.copy(productmodelid = value))
+      override def name = Field[Name, VproductmodelcatalogdescriptionViewRow](_path, "name", None, None, x => x.name, (row, value) => row.copy(name = value))
+      override def Summary = OptField[String, VproductmodelcatalogdescriptionViewRow](_path, "Summary", None, None, x => x.Summary, (row, value) => row.copy(Summary = value))
+      override def manufacturer = OptField[String, VproductmodelcatalogdescriptionViewRow](_path, "manufacturer", None, None, x => x.manufacturer, (row, value) => row.copy(manufacturer = value))
+      override def copyright = OptField[/* max 30 chars */ String, VproductmodelcatalogdescriptionViewRow](_path, "copyright", None, None, x => x.copyright, (row, value) => row.copy(copyright = value))
+      override def producturl = OptField[/* max 256 chars */ String, VproductmodelcatalogdescriptionViewRow](_path, "producturl", None, None, x => x.producturl, (row, value) => row.copy(producturl = value))
+      override def warrantyperiod = OptField[/* max 256 chars */ String, VproductmodelcatalogdescriptionViewRow](_path, "warrantyperiod", None, None, x => x.warrantyperiod, (row, value) => row.copy(warrantyperiod = value))
+      override def warrantydescription = OptField[/* max 256 chars */ String, VproductmodelcatalogdescriptionViewRow](_path, "warrantydescription", None, None, x => x.warrantydescription, (row, value) => row.copy(warrantydescription = value))
+      override def noofyears = OptField[/* max 256 chars */ String, VproductmodelcatalogdescriptionViewRow](_path, "noofyears", None, None, x => x.noofyears, (row, value) => row.copy(noofyears = value))
+      override def maintenancedescription = OptField[/* max 256 chars */ String, VproductmodelcatalogdescriptionViewRow](_path, "maintenancedescription", None, None, x => x.maintenancedescription, (row, value) => row.copy(maintenancedescription = value))
+      override def wheel = OptField[/* max 256 chars */ String, VproductmodelcatalogdescriptionViewRow](_path, "wheel", None, None, x => x.wheel, (row, value) => row.copy(wheel = value))
+      override def saddle = OptField[/* max 256 chars */ String, VproductmodelcatalogdescriptionViewRow](_path, "saddle", None, None, x => x.saddle, (row, value) => row.copy(saddle = value))
+      override def pedal = OptField[/* max 256 chars */ String, VproductmodelcatalogdescriptionViewRow](_path, "pedal", None, None, x => x.pedal, (row, value) => row.copy(pedal = value))
+      override def bikeframe = OptField[String, VproductmodelcatalogdescriptionViewRow](_path, "bikeframe", None, None, x => x.bikeframe, (row, value) => row.copy(bikeframe = value))
+      override def crankset = OptField[/* max 256 chars */ String, VproductmodelcatalogdescriptionViewRow](_path, "crankset", None, None, x => x.crankset, (row, value) => row.copy(crankset = value))
+      override def pictureangle = OptField[/* max 256 chars */ String, VproductmodelcatalogdescriptionViewRow](_path, "pictureangle", None, None, x => x.pictureangle, (row, value) => row.copy(pictureangle = value))
+      override def picturesize = OptField[/* max 256 chars */ String, VproductmodelcatalogdescriptionViewRow](_path, "picturesize", None, None, x => x.picturesize, (row, value) => row.copy(picturesize = value))
+      override def productphotoid = OptField[/* max 256 chars */ String, VproductmodelcatalogdescriptionViewRow](_path, "productphotoid", None, None, x => x.productphotoid, (row, value) => row.copy(productphotoid = value))
+      override def material = OptField[/* max 256 chars */ String, VproductmodelcatalogdescriptionViewRow](_path, "material", None, None, x => x.material, (row, value) => row.copy(material = value))
+      override def color = OptField[/* max 256 chars */ String, VproductmodelcatalogdescriptionViewRow](_path, "color", None, None, x => x.color, (row, value) => row.copy(color = value))
+      override def productline = OptField[/* max 256 chars */ String, VproductmodelcatalogdescriptionViewRow](_path, "productline", None, None, x => x.productline, (row, value) => row.copy(productline = value))
+      override def style = OptField[/* max 256 chars */ String, VproductmodelcatalogdescriptionViewRow](_path, "style", None, None, x => x.style, (row, value) => row.copy(style = value))
+      override def riderexperience = OptField[/* max 1024 chars */ String, VproductmodelcatalogdescriptionViewRow](_path, "riderexperience", None, None, x => x.riderexperience, (row, value) => row.copy(riderexperience = value))
+      override def rowguid = Field[TypoUUID, VproductmodelcatalogdescriptionViewRow](_path, "rowguid", None, None, x => x.rowguid, (row, value) => row.copy(rowguid = value))
+      override def modifieddate = Field[TypoLocalDateTime, VproductmodelcatalogdescriptionViewRow](_path, "modifieddate", Some("text"), None, x => x.modifieddate, (row, value) => row.copy(modifieddate = value))
     }
   
-    override val columns: List[FieldLikeNoHkt[?, Row]] =
-      List[FieldLikeNoHkt[?, Row]](fields.productmodelid, fields.name, fields.Summary, fields.manufacturer, fields.copyright, fields.producturl, fields.warrantyperiod, fields.warrantydescription, fields.noofyears, fields.maintenancedescription, fields.wheel, fields.saddle, fields.pedal, fields.bikeframe, fields.crankset, fields.pictureangle, fields.picturesize, fields.productphotoid, fields.material, fields.color, fields.productline, fields.style, fields.riderexperience, fields.rowguid, fields.modifieddate)
+    override lazy val columns: List[FieldLikeNoHkt[?, VproductmodelcatalogdescriptionViewRow]] =
+      List[FieldLikeNoHkt[?, VproductmodelcatalogdescriptionViewRow]](fields.productmodelid, fields.name, fields.Summary, fields.manufacturer, fields.copyright, fields.producturl, fields.warrantyperiod, fields.warrantydescription, fields.noofyears, fields.maintenancedescription, fields.wheel, fields.saddle, fields.pedal, fields.bikeframe, fields.crankset, fields.pictureangle, fields.picturesize, fields.productphotoid, fields.material, fields.color, fields.productline, fields.style, fields.riderexperience, fields.rowguid, fields.modifieddate)
   
-    override def copy[NewRow](prefix: Option[String], extract: NewRow => VproductmodelcatalogdescriptionViewRow, merge: (NewRow, VproductmodelcatalogdescriptionViewRow) => NewRow): Impl[NewRow] =
-      new Impl(prefix, extract, merge)
+    override def copy(path: List[Path]): Impl =
+      new Impl(path)
   }
   
 }

--- a/typo-tester-zio-jdbc/generated-and-checked-in/adventureworks/production/vproductmodelinstructions/VproductmodelinstructionsViewFields.scala
+++ b/typo-tester-zio-jdbc/generated-and-checked-in/adventureworks/production/vproductmodelinstructions/VproductmodelinstructionsViewFields.scala
@@ -11,51 +11,52 @@ import adventureworks.customtypes.TypoLocalDateTime
 import adventureworks.customtypes.TypoUUID
 import adventureworks.production.productmodel.ProductmodelId
 import adventureworks.public.Name
+import typo.dsl.Path
 import typo.dsl.SqlExpr.Field
 import typo.dsl.SqlExpr.FieldLikeNoHkt
 import typo.dsl.SqlExpr.OptField
 import typo.dsl.Structure.Relation
 
-trait VproductmodelinstructionsViewFields[Row] {
-  val productmodelid: Field[ProductmodelId, Row]
-  val name: Field[Name, Row]
-  val instructions: OptField[String, Row]
-  val LocationID: OptField[Int, Row]
-  val SetupHours: OptField[BigDecimal, Row]
-  val MachineHours: OptField[BigDecimal, Row]
-  val LaborHours: OptField[BigDecimal, Row]
-  val LotSize: OptField[Int, Row]
-  val Step: OptField[/* max 1024 chars */ String, Row]
-  val rowguid: Field[TypoUUID, Row]
-  val modifieddate: Field[TypoLocalDateTime, Row]
+trait VproductmodelinstructionsViewFields {
+  def productmodelid: Field[ProductmodelId, VproductmodelinstructionsViewRow]
+  def name: Field[Name, VproductmodelinstructionsViewRow]
+  def instructions: OptField[String, VproductmodelinstructionsViewRow]
+  def LocationID: OptField[Int, VproductmodelinstructionsViewRow]
+  def SetupHours: OptField[BigDecimal, VproductmodelinstructionsViewRow]
+  def MachineHours: OptField[BigDecimal, VproductmodelinstructionsViewRow]
+  def LaborHours: OptField[BigDecimal, VproductmodelinstructionsViewRow]
+  def LotSize: OptField[Int, VproductmodelinstructionsViewRow]
+  def Step: OptField[/* max 1024 chars */ String, VproductmodelinstructionsViewRow]
+  def rowguid: Field[TypoUUID, VproductmodelinstructionsViewRow]
+  def modifieddate: Field[TypoLocalDateTime, VproductmodelinstructionsViewRow]
 }
 
 object VproductmodelinstructionsViewFields {
-  val structure: Relation[VproductmodelinstructionsViewFields, VproductmodelinstructionsViewRow, VproductmodelinstructionsViewRow] = 
-    new Impl(None, identity, (_, x) => x)
+  lazy val structure: Relation[VproductmodelinstructionsViewFields, VproductmodelinstructionsViewRow] =
+    new Impl(Nil)
     
-  private final class Impl[Row](val prefix: Option[String], val extract: Row => VproductmodelinstructionsViewRow, val merge: (Row, VproductmodelinstructionsViewRow) => Row)
-    extends Relation[VproductmodelinstructionsViewFields, VproductmodelinstructionsViewRow, Row] { 
+  private final class Impl(val _path: List[Path])
+    extends Relation[VproductmodelinstructionsViewFields, VproductmodelinstructionsViewRow] {
   
-    override val fields: VproductmodelinstructionsViewFields[Row] = new VproductmodelinstructionsViewFields[Row] {
-      override val productmodelid = new Field[ProductmodelId, Row](prefix, "productmodelid", None, None)(x => extract(x).productmodelid, (row, value) => merge(row, extract(row).copy(productmodelid = value)))
-      override val name = new Field[Name, Row](prefix, "name", None, None)(x => extract(x).name, (row, value) => merge(row, extract(row).copy(name = value)))
-      override val instructions = new OptField[String, Row](prefix, "instructions", None, None)(x => extract(x).instructions, (row, value) => merge(row, extract(row).copy(instructions = value)))
-      override val LocationID = new OptField[Int, Row](prefix, "LocationID", None, None)(x => extract(x).LocationID, (row, value) => merge(row, extract(row).copy(LocationID = value)))
-      override val SetupHours = new OptField[BigDecimal, Row](prefix, "SetupHours", None, None)(x => extract(x).SetupHours, (row, value) => merge(row, extract(row).copy(SetupHours = value)))
-      override val MachineHours = new OptField[BigDecimal, Row](prefix, "MachineHours", None, None)(x => extract(x).MachineHours, (row, value) => merge(row, extract(row).copy(MachineHours = value)))
-      override val LaborHours = new OptField[BigDecimal, Row](prefix, "LaborHours", None, None)(x => extract(x).LaborHours, (row, value) => merge(row, extract(row).copy(LaborHours = value)))
-      override val LotSize = new OptField[Int, Row](prefix, "LotSize", None, None)(x => extract(x).LotSize, (row, value) => merge(row, extract(row).copy(LotSize = value)))
-      override val Step = new OptField[/* max 1024 chars */ String, Row](prefix, "Step", None, None)(x => extract(x).Step, (row, value) => merge(row, extract(row).copy(Step = value)))
-      override val rowguid = new Field[TypoUUID, Row](prefix, "rowguid", None, None)(x => extract(x).rowguid, (row, value) => merge(row, extract(row).copy(rowguid = value)))
-      override val modifieddate = new Field[TypoLocalDateTime, Row](prefix, "modifieddate", Some("text"), None)(x => extract(x).modifieddate, (row, value) => merge(row, extract(row).copy(modifieddate = value)))
+    override lazy val fields: VproductmodelinstructionsViewFields = new VproductmodelinstructionsViewFields {
+      override def productmodelid = Field[ProductmodelId, VproductmodelinstructionsViewRow](_path, "productmodelid", None, None, x => x.productmodelid, (row, value) => row.copy(productmodelid = value))
+      override def name = Field[Name, VproductmodelinstructionsViewRow](_path, "name", None, None, x => x.name, (row, value) => row.copy(name = value))
+      override def instructions = OptField[String, VproductmodelinstructionsViewRow](_path, "instructions", None, None, x => x.instructions, (row, value) => row.copy(instructions = value))
+      override def LocationID = OptField[Int, VproductmodelinstructionsViewRow](_path, "LocationID", None, None, x => x.LocationID, (row, value) => row.copy(LocationID = value))
+      override def SetupHours = OptField[BigDecimal, VproductmodelinstructionsViewRow](_path, "SetupHours", None, None, x => x.SetupHours, (row, value) => row.copy(SetupHours = value))
+      override def MachineHours = OptField[BigDecimal, VproductmodelinstructionsViewRow](_path, "MachineHours", None, None, x => x.MachineHours, (row, value) => row.copy(MachineHours = value))
+      override def LaborHours = OptField[BigDecimal, VproductmodelinstructionsViewRow](_path, "LaborHours", None, None, x => x.LaborHours, (row, value) => row.copy(LaborHours = value))
+      override def LotSize = OptField[Int, VproductmodelinstructionsViewRow](_path, "LotSize", None, None, x => x.LotSize, (row, value) => row.copy(LotSize = value))
+      override def Step = OptField[/* max 1024 chars */ String, VproductmodelinstructionsViewRow](_path, "Step", None, None, x => x.Step, (row, value) => row.copy(Step = value))
+      override def rowguid = Field[TypoUUID, VproductmodelinstructionsViewRow](_path, "rowguid", None, None, x => x.rowguid, (row, value) => row.copy(rowguid = value))
+      override def modifieddate = Field[TypoLocalDateTime, VproductmodelinstructionsViewRow](_path, "modifieddate", Some("text"), None, x => x.modifieddate, (row, value) => row.copy(modifieddate = value))
     }
   
-    override val columns: List[FieldLikeNoHkt[?, Row]] =
-      List[FieldLikeNoHkt[?, Row]](fields.productmodelid, fields.name, fields.instructions, fields.LocationID, fields.SetupHours, fields.MachineHours, fields.LaborHours, fields.LotSize, fields.Step, fields.rowguid, fields.modifieddate)
+    override lazy val columns: List[FieldLikeNoHkt[?, VproductmodelinstructionsViewRow]] =
+      List[FieldLikeNoHkt[?, VproductmodelinstructionsViewRow]](fields.productmodelid, fields.name, fields.instructions, fields.LocationID, fields.SetupHours, fields.MachineHours, fields.LaborHours, fields.LotSize, fields.Step, fields.rowguid, fields.modifieddate)
   
-    override def copy[NewRow](prefix: Option[String], extract: NewRow => VproductmodelinstructionsViewRow, merge: (NewRow, VproductmodelinstructionsViewRow) => NewRow): Impl[NewRow] =
-      new Impl(prefix, extract, merge)
+    override def copy(path: List[Path]): Impl =
+      new Impl(path)
   }
   
 }

--- a/typo-tester-zio-jdbc/generated-and-checked-in/adventureworks/production/workorder/WorkorderFields.scala
+++ b/typo-tester-zio-jdbc/generated-and-checked-in/adventureworks/production/workorder/WorkorderFields.scala
@@ -11,48 +11,49 @@ import adventureworks.customtypes.TypoLocalDateTime
 import adventureworks.customtypes.TypoShort
 import adventureworks.production.product.ProductId
 import adventureworks.production.scrapreason.ScrapreasonId
+import typo.dsl.Path
 import typo.dsl.SqlExpr.Field
 import typo.dsl.SqlExpr.FieldLikeNoHkt
 import typo.dsl.SqlExpr.IdField
 import typo.dsl.SqlExpr.OptField
 import typo.dsl.Structure.Relation
 
-trait WorkorderFields[Row] {
-  val workorderid: IdField[WorkorderId, Row]
-  val productid: Field[ProductId, Row]
-  val orderqty: Field[Int, Row]
-  val scrappedqty: Field[TypoShort, Row]
-  val startdate: Field[TypoLocalDateTime, Row]
-  val enddate: OptField[TypoLocalDateTime, Row]
-  val duedate: Field[TypoLocalDateTime, Row]
-  val scrapreasonid: OptField[ScrapreasonId, Row]
-  val modifieddate: Field[TypoLocalDateTime, Row]
+trait WorkorderFields {
+  def workorderid: IdField[WorkorderId, WorkorderRow]
+  def productid: Field[ProductId, WorkorderRow]
+  def orderqty: Field[Int, WorkorderRow]
+  def scrappedqty: Field[TypoShort, WorkorderRow]
+  def startdate: Field[TypoLocalDateTime, WorkorderRow]
+  def enddate: OptField[TypoLocalDateTime, WorkorderRow]
+  def duedate: Field[TypoLocalDateTime, WorkorderRow]
+  def scrapreasonid: OptField[ScrapreasonId, WorkorderRow]
+  def modifieddate: Field[TypoLocalDateTime, WorkorderRow]
 }
 
 object WorkorderFields {
-  val structure: Relation[WorkorderFields, WorkorderRow, WorkorderRow] = 
-    new Impl(None, identity, (_, x) => x)
+  lazy val structure: Relation[WorkorderFields, WorkorderRow] =
+    new Impl(Nil)
     
-  private final class Impl[Row](val prefix: Option[String], val extract: Row => WorkorderRow, val merge: (Row, WorkorderRow) => Row)
-    extends Relation[WorkorderFields, WorkorderRow, Row] { 
+  private final class Impl(val _path: List[Path])
+    extends Relation[WorkorderFields, WorkorderRow] {
   
-    override val fields: WorkorderFields[Row] = new WorkorderFields[Row] {
-      override val workorderid = new IdField[WorkorderId, Row](prefix, "workorderid", None, Some("int4"))(x => extract(x).workorderid, (row, value) => merge(row, extract(row).copy(workorderid = value)))
-      override val productid = new Field[ProductId, Row](prefix, "productid", None, Some("int4"))(x => extract(x).productid, (row, value) => merge(row, extract(row).copy(productid = value)))
-      override val orderqty = new Field[Int, Row](prefix, "orderqty", None, Some("int4"))(x => extract(x).orderqty, (row, value) => merge(row, extract(row).copy(orderqty = value)))
-      override val scrappedqty = new Field[TypoShort, Row](prefix, "scrappedqty", None, Some("int2"))(x => extract(x).scrappedqty, (row, value) => merge(row, extract(row).copy(scrappedqty = value)))
-      override val startdate = new Field[TypoLocalDateTime, Row](prefix, "startdate", Some("text"), Some("timestamp"))(x => extract(x).startdate, (row, value) => merge(row, extract(row).copy(startdate = value)))
-      override val enddate = new OptField[TypoLocalDateTime, Row](prefix, "enddate", Some("text"), Some("timestamp"))(x => extract(x).enddate, (row, value) => merge(row, extract(row).copy(enddate = value)))
-      override val duedate = new Field[TypoLocalDateTime, Row](prefix, "duedate", Some("text"), Some("timestamp"))(x => extract(x).duedate, (row, value) => merge(row, extract(row).copy(duedate = value)))
-      override val scrapreasonid = new OptField[ScrapreasonId, Row](prefix, "scrapreasonid", None, Some("int2"))(x => extract(x).scrapreasonid, (row, value) => merge(row, extract(row).copy(scrapreasonid = value)))
-      override val modifieddate = new Field[TypoLocalDateTime, Row](prefix, "modifieddate", Some("text"), Some("timestamp"))(x => extract(x).modifieddate, (row, value) => merge(row, extract(row).copy(modifieddate = value)))
+    override lazy val fields: WorkorderFields = new WorkorderFields {
+      override def workorderid = IdField[WorkorderId, WorkorderRow](_path, "workorderid", None, Some("int4"), x => x.workorderid, (row, value) => row.copy(workorderid = value))
+      override def productid = Field[ProductId, WorkorderRow](_path, "productid", None, Some("int4"), x => x.productid, (row, value) => row.copy(productid = value))
+      override def orderqty = Field[Int, WorkorderRow](_path, "orderqty", None, Some("int4"), x => x.orderqty, (row, value) => row.copy(orderqty = value))
+      override def scrappedqty = Field[TypoShort, WorkorderRow](_path, "scrappedqty", None, Some("int2"), x => x.scrappedqty, (row, value) => row.copy(scrappedqty = value))
+      override def startdate = Field[TypoLocalDateTime, WorkorderRow](_path, "startdate", Some("text"), Some("timestamp"), x => x.startdate, (row, value) => row.copy(startdate = value))
+      override def enddate = OptField[TypoLocalDateTime, WorkorderRow](_path, "enddate", Some("text"), Some("timestamp"), x => x.enddate, (row, value) => row.copy(enddate = value))
+      override def duedate = Field[TypoLocalDateTime, WorkorderRow](_path, "duedate", Some("text"), Some("timestamp"), x => x.duedate, (row, value) => row.copy(duedate = value))
+      override def scrapreasonid = OptField[ScrapreasonId, WorkorderRow](_path, "scrapreasonid", None, Some("int2"), x => x.scrapreasonid, (row, value) => row.copy(scrapreasonid = value))
+      override def modifieddate = Field[TypoLocalDateTime, WorkorderRow](_path, "modifieddate", Some("text"), Some("timestamp"), x => x.modifieddate, (row, value) => row.copy(modifieddate = value))
     }
   
-    override val columns: List[FieldLikeNoHkt[?, Row]] =
-      List[FieldLikeNoHkt[?, Row]](fields.workorderid, fields.productid, fields.orderqty, fields.scrappedqty, fields.startdate, fields.enddate, fields.duedate, fields.scrapreasonid, fields.modifieddate)
+    override lazy val columns: List[FieldLikeNoHkt[?, WorkorderRow]] =
+      List[FieldLikeNoHkt[?, WorkorderRow]](fields.workorderid, fields.productid, fields.orderqty, fields.scrappedqty, fields.startdate, fields.enddate, fields.duedate, fields.scrapreasonid, fields.modifieddate)
   
-    override def copy[NewRow](prefix: Option[String], extract: NewRow => WorkorderRow, merge: (NewRow, WorkorderRow) => NewRow): Impl[NewRow] =
-      new Impl(prefix, extract, merge)
+    override def copy(path: List[Path]): Impl =
+      new Impl(path)
   }
   
 }

--- a/typo-tester-zio-jdbc/generated-and-checked-in/adventureworks/production/workorder/WorkorderRepoMock.scala
+++ b/typo-tester-zio-jdbc/generated-and-checked-in/adventureworks/production/workorder/WorkorderRepoMock.scala
@@ -26,7 +26,7 @@ import zio.stream.ZStream
 class WorkorderRepoMock(toRow: Function1[WorkorderRowUnsaved, WorkorderRow],
                         map: scala.collection.mutable.Map[WorkorderId, WorkorderRow] = scala.collection.mutable.Map.empty) extends WorkorderRepo {
   override def delete: DeleteBuilder[WorkorderFields, WorkorderRow] = {
-    DeleteBuilderMock(DeleteParams.empty, WorkorderFields.structure.fields, map)
+    DeleteBuilderMock(DeleteParams.empty, WorkorderFields.structure, map)
   }
   override def deleteById(workorderid: WorkorderId): ZIO[ZConnection, Throwable, Boolean] = {
     ZIO.succeed(map.remove(workorderid).isDefined)
@@ -85,7 +85,7 @@ class WorkorderRepoMock(toRow: Function1[WorkorderRowUnsaved, WorkorderRow],
     }
   }
   override def update: UpdateBuilder[WorkorderFields, WorkorderRow] = {
-    UpdateBuilderMock(UpdateParams.empty, WorkorderFields.structure.fields, map)
+    UpdateBuilderMock(UpdateParams.empty, WorkorderFields.structure, map)
   }
   override def update(row: WorkorderRow): ZIO[ZConnection, Throwable, Boolean] = {
     ZIO.succeed {

--- a/typo-tester-zio-jdbc/generated-and-checked-in/adventureworks/production/workorderrouting/WorkorderroutingFields.scala
+++ b/typo-tester-zio-jdbc/generated-and-checked-in/adventureworks/production/workorderrouting/WorkorderroutingFields.scala
@@ -11,54 +11,55 @@ import adventureworks.customtypes.TypoLocalDateTime
 import adventureworks.customtypes.TypoShort
 import adventureworks.production.location.LocationId
 import adventureworks.production.workorder.WorkorderId
+import typo.dsl.Path
 import typo.dsl.SqlExpr.Field
 import typo.dsl.SqlExpr.FieldLikeNoHkt
 import typo.dsl.SqlExpr.IdField
 import typo.dsl.SqlExpr.OptField
 import typo.dsl.Structure.Relation
 
-trait WorkorderroutingFields[Row] {
-  val workorderid: IdField[WorkorderId, Row]
-  val productid: IdField[Int, Row]
-  val operationsequence: IdField[TypoShort, Row]
-  val locationid: Field[LocationId, Row]
-  val scheduledstartdate: Field[TypoLocalDateTime, Row]
-  val scheduledenddate: Field[TypoLocalDateTime, Row]
-  val actualstartdate: OptField[TypoLocalDateTime, Row]
-  val actualenddate: OptField[TypoLocalDateTime, Row]
-  val actualresourcehrs: OptField[BigDecimal, Row]
-  val plannedcost: Field[BigDecimal, Row]
-  val actualcost: OptField[BigDecimal, Row]
-  val modifieddate: Field[TypoLocalDateTime, Row]
+trait WorkorderroutingFields {
+  def workorderid: IdField[WorkorderId, WorkorderroutingRow]
+  def productid: IdField[Int, WorkorderroutingRow]
+  def operationsequence: IdField[TypoShort, WorkorderroutingRow]
+  def locationid: Field[LocationId, WorkorderroutingRow]
+  def scheduledstartdate: Field[TypoLocalDateTime, WorkorderroutingRow]
+  def scheduledenddate: Field[TypoLocalDateTime, WorkorderroutingRow]
+  def actualstartdate: OptField[TypoLocalDateTime, WorkorderroutingRow]
+  def actualenddate: OptField[TypoLocalDateTime, WorkorderroutingRow]
+  def actualresourcehrs: OptField[BigDecimal, WorkorderroutingRow]
+  def plannedcost: Field[BigDecimal, WorkorderroutingRow]
+  def actualcost: OptField[BigDecimal, WorkorderroutingRow]
+  def modifieddate: Field[TypoLocalDateTime, WorkorderroutingRow]
 }
 
 object WorkorderroutingFields {
-  val structure: Relation[WorkorderroutingFields, WorkorderroutingRow, WorkorderroutingRow] = 
-    new Impl(None, identity, (_, x) => x)
+  lazy val structure: Relation[WorkorderroutingFields, WorkorderroutingRow] =
+    new Impl(Nil)
     
-  private final class Impl[Row](val prefix: Option[String], val extract: Row => WorkorderroutingRow, val merge: (Row, WorkorderroutingRow) => Row)
-    extends Relation[WorkorderroutingFields, WorkorderroutingRow, Row] { 
+  private final class Impl(val _path: List[Path])
+    extends Relation[WorkorderroutingFields, WorkorderroutingRow] {
   
-    override val fields: WorkorderroutingFields[Row] = new WorkorderroutingFields[Row] {
-      override val workorderid = new IdField[WorkorderId, Row](prefix, "workorderid", None, Some("int4"))(x => extract(x).workorderid, (row, value) => merge(row, extract(row).copy(workorderid = value)))
-      override val productid = new IdField[Int, Row](prefix, "productid", None, Some("int4"))(x => extract(x).productid, (row, value) => merge(row, extract(row).copy(productid = value)))
-      override val operationsequence = new IdField[TypoShort, Row](prefix, "operationsequence", None, Some("int2"))(x => extract(x).operationsequence, (row, value) => merge(row, extract(row).copy(operationsequence = value)))
-      override val locationid = new Field[LocationId, Row](prefix, "locationid", None, Some("int2"))(x => extract(x).locationid, (row, value) => merge(row, extract(row).copy(locationid = value)))
-      override val scheduledstartdate = new Field[TypoLocalDateTime, Row](prefix, "scheduledstartdate", Some("text"), Some("timestamp"))(x => extract(x).scheduledstartdate, (row, value) => merge(row, extract(row).copy(scheduledstartdate = value)))
-      override val scheduledenddate = new Field[TypoLocalDateTime, Row](prefix, "scheduledenddate", Some("text"), Some("timestamp"))(x => extract(x).scheduledenddate, (row, value) => merge(row, extract(row).copy(scheduledenddate = value)))
-      override val actualstartdate = new OptField[TypoLocalDateTime, Row](prefix, "actualstartdate", Some("text"), Some("timestamp"))(x => extract(x).actualstartdate, (row, value) => merge(row, extract(row).copy(actualstartdate = value)))
-      override val actualenddate = new OptField[TypoLocalDateTime, Row](prefix, "actualenddate", Some("text"), Some("timestamp"))(x => extract(x).actualenddate, (row, value) => merge(row, extract(row).copy(actualenddate = value)))
-      override val actualresourcehrs = new OptField[BigDecimal, Row](prefix, "actualresourcehrs", None, Some("numeric"))(x => extract(x).actualresourcehrs, (row, value) => merge(row, extract(row).copy(actualresourcehrs = value)))
-      override val plannedcost = new Field[BigDecimal, Row](prefix, "plannedcost", None, Some("numeric"))(x => extract(x).plannedcost, (row, value) => merge(row, extract(row).copy(plannedcost = value)))
-      override val actualcost = new OptField[BigDecimal, Row](prefix, "actualcost", None, Some("numeric"))(x => extract(x).actualcost, (row, value) => merge(row, extract(row).copy(actualcost = value)))
-      override val modifieddate = new Field[TypoLocalDateTime, Row](prefix, "modifieddate", Some("text"), Some("timestamp"))(x => extract(x).modifieddate, (row, value) => merge(row, extract(row).copy(modifieddate = value)))
+    override lazy val fields: WorkorderroutingFields = new WorkorderroutingFields {
+      override def workorderid = IdField[WorkorderId, WorkorderroutingRow](_path, "workorderid", None, Some("int4"), x => x.workorderid, (row, value) => row.copy(workorderid = value))
+      override def productid = IdField[Int, WorkorderroutingRow](_path, "productid", None, Some("int4"), x => x.productid, (row, value) => row.copy(productid = value))
+      override def operationsequence = IdField[TypoShort, WorkorderroutingRow](_path, "operationsequence", None, Some("int2"), x => x.operationsequence, (row, value) => row.copy(operationsequence = value))
+      override def locationid = Field[LocationId, WorkorderroutingRow](_path, "locationid", None, Some("int2"), x => x.locationid, (row, value) => row.copy(locationid = value))
+      override def scheduledstartdate = Field[TypoLocalDateTime, WorkorderroutingRow](_path, "scheduledstartdate", Some("text"), Some("timestamp"), x => x.scheduledstartdate, (row, value) => row.copy(scheduledstartdate = value))
+      override def scheduledenddate = Field[TypoLocalDateTime, WorkorderroutingRow](_path, "scheduledenddate", Some("text"), Some("timestamp"), x => x.scheduledenddate, (row, value) => row.copy(scheduledenddate = value))
+      override def actualstartdate = OptField[TypoLocalDateTime, WorkorderroutingRow](_path, "actualstartdate", Some("text"), Some("timestamp"), x => x.actualstartdate, (row, value) => row.copy(actualstartdate = value))
+      override def actualenddate = OptField[TypoLocalDateTime, WorkorderroutingRow](_path, "actualenddate", Some("text"), Some("timestamp"), x => x.actualenddate, (row, value) => row.copy(actualenddate = value))
+      override def actualresourcehrs = OptField[BigDecimal, WorkorderroutingRow](_path, "actualresourcehrs", None, Some("numeric"), x => x.actualresourcehrs, (row, value) => row.copy(actualresourcehrs = value))
+      override def plannedcost = Field[BigDecimal, WorkorderroutingRow](_path, "plannedcost", None, Some("numeric"), x => x.plannedcost, (row, value) => row.copy(plannedcost = value))
+      override def actualcost = OptField[BigDecimal, WorkorderroutingRow](_path, "actualcost", None, Some("numeric"), x => x.actualcost, (row, value) => row.copy(actualcost = value))
+      override def modifieddate = Field[TypoLocalDateTime, WorkorderroutingRow](_path, "modifieddate", Some("text"), Some("timestamp"), x => x.modifieddate, (row, value) => row.copy(modifieddate = value))
     }
   
-    override val columns: List[FieldLikeNoHkt[?, Row]] =
-      List[FieldLikeNoHkt[?, Row]](fields.workorderid, fields.productid, fields.operationsequence, fields.locationid, fields.scheduledstartdate, fields.scheduledenddate, fields.actualstartdate, fields.actualenddate, fields.actualresourcehrs, fields.plannedcost, fields.actualcost, fields.modifieddate)
+    override lazy val columns: List[FieldLikeNoHkt[?, WorkorderroutingRow]] =
+      List[FieldLikeNoHkt[?, WorkorderroutingRow]](fields.workorderid, fields.productid, fields.operationsequence, fields.locationid, fields.scheduledstartdate, fields.scheduledenddate, fields.actualstartdate, fields.actualenddate, fields.actualresourcehrs, fields.plannedcost, fields.actualcost, fields.modifieddate)
   
-    override def copy[NewRow](prefix: Option[String], extract: NewRow => WorkorderroutingRow, merge: (NewRow, WorkorderroutingRow) => NewRow): Impl[NewRow] =
-      new Impl(prefix, extract, merge)
+    override def copy(path: List[Path]): Impl =
+      new Impl(path)
   }
   
 }

--- a/typo-tester-zio-jdbc/generated-and-checked-in/adventureworks/production/workorderrouting/WorkorderroutingRepoMock.scala
+++ b/typo-tester-zio-jdbc/generated-and-checked-in/adventureworks/production/workorderrouting/WorkorderroutingRepoMock.scala
@@ -26,7 +26,7 @@ import zio.stream.ZStream
 class WorkorderroutingRepoMock(toRow: Function1[WorkorderroutingRowUnsaved, WorkorderroutingRow],
                                map: scala.collection.mutable.Map[WorkorderroutingId, WorkorderroutingRow] = scala.collection.mutable.Map.empty) extends WorkorderroutingRepo {
   override def delete: DeleteBuilder[WorkorderroutingFields, WorkorderroutingRow] = {
-    DeleteBuilderMock(DeleteParams.empty, WorkorderroutingFields.structure.fields, map)
+    DeleteBuilderMock(DeleteParams.empty, WorkorderroutingFields.structure, map)
   }
   override def deleteById(compositeId: WorkorderroutingId): ZIO[ZConnection, Throwable, Boolean] = {
     ZIO.succeed(map.remove(compositeId).isDefined)
@@ -85,7 +85,7 @@ class WorkorderroutingRepoMock(toRow: Function1[WorkorderroutingRowUnsaved, Work
     }
   }
   override def update: UpdateBuilder[WorkorderroutingFields, WorkorderroutingRow] = {
-    UpdateBuilderMock(UpdateParams.empty, WorkorderroutingFields.structure.fields, map)
+    UpdateBuilderMock(UpdateParams.empty, WorkorderroutingFields.structure, map)
   }
   override def update(row: WorkorderroutingRow): ZIO[ZConnection, Throwable, Boolean] = {
     ZIO.succeed {

--- a/typo-tester-zio-jdbc/generated-and-checked-in/adventureworks/pu/pod/PodViewFields.scala
+++ b/typo-tester-zio-jdbc/generated-and-checked-in/adventureworks/pu/pod/PodViewFields.scala
@@ -11,48 +11,49 @@ import adventureworks.customtypes.TypoLocalDateTime
 import adventureworks.customtypes.TypoShort
 import adventureworks.production.product.ProductId
 import adventureworks.purchasing.purchaseorderheader.PurchaseorderheaderId
+import typo.dsl.Path
 import typo.dsl.SqlExpr.Field
 import typo.dsl.SqlExpr.FieldLikeNoHkt
 import typo.dsl.Structure.Relation
 
-trait PodViewFields[Row] {
-  val id: Field[Int, Row]
-  val purchaseorderid: Field[PurchaseorderheaderId, Row]
-  val purchaseorderdetailid: Field[Int, Row]
-  val duedate: Field[TypoLocalDateTime, Row]
-  val orderqty: Field[TypoShort, Row]
-  val productid: Field[ProductId, Row]
-  val unitprice: Field[BigDecimal, Row]
-  val receivedqty: Field[BigDecimal, Row]
-  val rejectedqty: Field[BigDecimal, Row]
-  val modifieddate: Field[TypoLocalDateTime, Row]
+trait PodViewFields {
+  def id: Field[Int, PodViewRow]
+  def purchaseorderid: Field[PurchaseorderheaderId, PodViewRow]
+  def purchaseorderdetailid: Field[Int, PodViewRow]
+  def duedate: Field[TypoLocalDateTime, PodViewRow]
+  def orderqty: Field[TypoShort, PodViewRow]
+  def productid: Field[ProductId, PodViewRow]
+  def unitprice: Field[BigDecimal, PodViewRow]
+  def receivedqty: Field[BigDecimal, PodViewRow]
+  def rejectedqty: Field[BigDecimal, PodViewRow]
+  def modifieddate: Field[TypoLocalDateTime, PodViewRow]
 }
 
 object PodViewFields {
-  val structure: Relation[PodViewFields, PodViewRow, PodViewRow] = 
-    new Impl(None, identity, (_, x) => x)
+  lazy val structure: Relation[PodViewFields, PodViewRow] =
+    new Impl(Nil)
     
-  private final class Impl[Row](val prefix: Option[String], val extract: Row => PodViewRow, val merge: (Row, PodViewRow) => Row)
-    extends Relation[PodViewFields, PodViewRow, Row] { 
+  private final class Impl(val _path: List[Path])
+    extends Relation[PodViewFields, PodViewRow] {
   
-    override val fields: PodViewFields[Row] = new PodViewFields[Row] {
-      override val id = new Field[Int, Row](prefix, "id", None, None)(x => extract(x).id, (row, value) => merge(row, extract(row).copy(id = value)))
-      override val purchaseorderid = new Field[PurchaseorderheaderId, Row](prefix, "purchaseorderid", None, None)(x => extract(x).purchaseorderid, (row, value) => merge(row, extract(row).copy(purchaseorderid = value)))
-      override val purchaseorderdetailid = new Field[Int, Row](prefix, "purchaseorderdetailid", None, None)(x => extract(x).purchaseorderdetailid, (row, value) => merge(row, extract(row).copy(purchaseorderdetailid = value)))
-      override val duedate = new Field[TypoLocalDateTime, Row](prefix, "duedate", Some("text"), None)(x => extract(x).duedate, (row, value) => merge(row, extract(row).copy(duedate = value)))
-      override val orderqty = new Field[TypoShort, Row](prefix, "orderqty", None, None)(x => extract(x).orderqty, (row, value) => merge(row, extract(row).copy(orderqty = value)))
-      override val productid = new Field[ProductId, Row](prefix, "productid", None, None)(x => extract(x).productid, (row, value) => merge(row, extract(row).copy(productid = value)))
-      override val unitprice = new Field[BigDecimal, Row](prefix, "unitprice", None, None)(x => extract(x).unitprice, (row, value) => merge(row, extract(row).copy(unitprice = value)))
-      override val receivedqty = new Field[BigDecimal, Row](prefix, "receivedqty", None, None)(x => extract(x).receivedqty, (row, value) => merge(row, extract(row).copy(receivedqty = value)))
-      override val rejectedqty = new Field[BigDecimal, Row](prefix, "rejectedqty", None, None)(x => extract(x).rejectedqty, (row, value) => merge(row, extract(row).copy(rejectedqty = value)))
-      override val modifieddate = new Field[TypoLocalDateTime, Row](prefix, "modifieddate", Some("text"), None)(x => extract(x).modifieddate, (row, value) => merge(row, extract(row).copy(modifieddate = value)))
+    override lazy val fields: PodViewFields = new PodViewFields {
+      override def id = Field[Int, PodViewRow](_path, "id", None, None, x => x.id, (row, value) => row.copy(id = value))
+      override def purchaseorderid = Field[PurchaseorderheaderId, PodViewRow](_path, "purchaseorderid", None, None, x => x.purchaseorderid, (row, value) => row.copy(purchaseorderid = value))
+      override def purchaseorderdetailid = Field[Int, PodViewRow](_path, "purchaseorderdetailid", None, None, x => x.purchaseorderdetailid, (row, value) => row.copy(purchaseorderdetailid = value))
+      override def duedate = Field[TypoLocalDateTime, PodViewRow](_path, "duedate", Some("text"), None, x => x.duedate, (row, value) => row.copy(duedate = value))
+      override def orderqty = Field[TypoShort, PodViewRow](_path, "orderqty", None, None, x => x.orderqty, (row, value) => row.copy(orderqty = value))
+      override def productid = Field[ProductId, PodViewRow](_path, "productid", None, None, x => x.productid, (row, value) => row.copy(productid = value))
+      override def unitprice = Field[BigDecimal, PodViewRow](_path, "unitprice", None, None, x => x.unitprice, (row, value) => row.copy(unitprice = value))
+      override def receivedqty = Field[BigDecimal, PodViewRow](_path, "receivedqty", None, None, x => x.receivedqty, (row, value) => row.copy(receivedqty = value))
+      override def rejectedqty = Field[BigDecimal, PodViewRow](_path, "rejectedqty", None, None, x => x.rejectedqty, (row, value) => row.copy(rejectedqty = value))
+      override def modifieddate = Field[TypoLocalDateTime, PodViewRow](_path, "modifieddate", Some("text"), None, x => x.modifieddate, (row, value) => row.copy(modifieddate = value))
     }
   
-    override val columns: List[FieldLikeNoHkt[?, Row]] =
-      List[FieldLikeNoHkt[?, Row]](fields.id, fields.purchaseorderid, fields.purchaseorderdetailid, fields.duedate, fields.orderqty, fields.productid, fields.unitprice, fields.receivedqty, fields.rejectedqty, fields.modifieddate)
+    override lazy val columns: List[FieldLikeNoHkt[?, PodViewRow]] =
+      List[FieldLikeNoHkt[?, PodViewRow]](fields.id, fields.purchaseorderid, fields.purchaseorderdetailid, fields.duedate, fields.orderqty, fields.productid, fields.unitprice, fields.receivedqty, fields.rejectedqty, fields.modifieddate)
   
-    override def copy[NewRow](prefix: Option[String], extract: NewRow => PodViewRow, merge: (NewRow, PodViewRow) => NewRow): Impl[NewRow] =
-      new Impl(prefix, extract, merge)
+    override def copy(path: List[Path]): Impl =
+      new Impl(path)
   }
   
 }

--- a/typo-tester-zio-jdbc/generated-and-checked-in/adventureworks/pu/poh/PohViewFields.scala
+++ b/typo-tester-zio-jdbc/generated-and-checked-in/adventureworks/pu/poh/PohViewFields.scala
@@ -12,55 +12,56 @@ import adventureworks.customtypes.TypoShort
 import adventureworks.person.businessentity.BusinessentityId
 import adventureworks.purchasing.purchaseorderheader.PurchaseorderheaderId
 import adventureworks.purchasing.shipmethod.ShipmethodId
+import typo.dsl.Path
 import typo.dsl.SqlExpr.Field
 import typo.dsl.SqlExpr.FieldLikeNoHkt
 import typo.dsl.SqlExpr.OptField
 import typo.dsl.Structure.Relation
 
-trait PohViewFields[Row] {
-  val id: Field[PurchaseorderheaderId, Row]
-  val purchaseorderid: Field[PurchaseorderheaderId, Row]
-  val revisionnumber: Field[TypoShort, Row]
-  val status: Field[TypoShort, Row]
-  val employeeid: Field[BusinessentityId, Row]
-  val vendorid: Field[BusinessentityId, Row]
-  val shipmethodid: Field[ShipmethodId, Row]
-  val orderdate: Field[TypoLocalDateTime, Row]
-  val shipdate: OptField[TypoLocalDateTime, Row]
-  val subtotal: Field[BigDecimal, Row]
-  val taxamt: Field[BigDecimal, Row]
-  val freight: Field[BigDecimal, Row]
-  val modifieddate: Field[TypoLocalDateTime, Row]
+trait PohViewFields {
+  def id: Field[PurchaseorderheaderId, PohViewRow]
+  def purchaseorderid: Field[PurchaseorderheaderId, PohViewRow]
+  def revisionnumber: Field[TypoShort, PohViewRow]
+  def status: Field[TypoShort, PohViewRow]
+  def employeeid: Field[BusinessentityId, PohViewRow]
+  def vendorid: Field[BusinessentityId, PohViewRow]
+  def shipmethodid: Field[ShipmethodId, PohViewRow]
+  def orderdate: Field[TypoLocalDateTime, PohViewRow]
+  def shipdate: OptField[TypoLocalDateTime, PohViewRow]
+  def subtotal: Field[BigDecimal, PohViewRow]
+  def taxamt: Field[BigDecimal, PohViewRow]
+  def freight: Field[BigDecimal, PohViewRow]
+  def modifieddate: Field[TypoLocalDateTime, PohViewRow]
 }
 
 object PohViewFields {
-  val structure: Relation[PohViewFields, PohViewRow, PohViewRow] = 
-    new Impl(None, identity, (_, x) => x)
+  lazy val structure: Relation[PohViewFields, PohViewRow] =
+    new Impl(Nil)
     
-  private final class Impl[Row](val prefix: Option[String], val extract: Row => PohViewRow, val merge: (Row, PohViewRow) => Row)
-    extends Relation[PohViewFields, PohViewRow, Row] { 
+  private final class Impl(val _path: List[Path])
+    extends Relation[PohViewFields, PohViewRow] {
   
-    override val fields: PohViewFields[Row] = new PohViewFields[Row] {
-      override val id = new Field[PurchaseorderheaderId, Row](prefix, "id", None, None)(x => extract(x).id, (row, value) => merge(row, extract(row).copy(id = value)))
-      override val purchaseorderid = new Field[PurchaseorderheaderId, Row](prefix, "purchaseorderid", None, None)(x => extract(x).purchaseorderid, (row, value) => merge(row, extract(row).copy(purchaseorderid = value)))
-      override val revisionnumber = new Field[TypoShort, Row](prefix, "revisionnumber", None, None)(x => extract(x).revisionnumber, (row, value) => merge(row, extract(row).copy(revisionnumber = value)))
-      override val status = new Field[TypoShort, Row](prefix, "status", None, None)(x => extract(x).status, (row, value) => merge(row, extract(row).copy(status = value)))
-      override val employeeid = new Field[BusinessentityId, Row](prefix, "employeeid", None, None)(x => extract(x).employeeid, (row, value) => merge(row, extract(row).copy(employeeid = value)))
-      override val vendorid = new Field[BusinessentityId, Row](prefix, "vendorid", None, None)(x => extract(x).vendorid, (row, value) => merge(row, extract(row).copy(vendorid = value)))
-      override val shipmethodid = new Field[ShipmethodId, Row](prefix, "shipmethodid", None, None)(x => extract(x).shipmethodid, (row, value) => merge(row, extract(row).copy(shipmethodid = value)))
-      override val orderdate = new Field[TypoLocalDateTime, Row](prefix, "orderdate", Some("text"), None)(x => extract(x).orderdate, (row, value) => merge(row, extract(row).copy(orderdate = value)))
-      override val shipdate = new OptField[TypoLocalDateTime, Row](prefix, "shipdate", Some("text"), None)(x => extract(x).shipdate, (row, value) => merge(row, extract(row).copy(shipdate = value)))
-      override val subtotal = new Field[BigDecimal, Row](prefix, "subtotal", None, None)(x => extract(x).subtotal, (row, value) => merge(row, extract(row).copy(subtotal = value)))
-      override val taxamt = new Field[BigDecimal, Row](prefix, "taxamt", None, None)(x => extract(x).taxamt, (row, value) => merge(row, extract(row).copy(taxamt = value)))
-      override val freight = new Field[BigDecimal, Row](prefix, "freight", None, None)(x => extract(x).freight, (row, value) => merge(row, extract(row).copy(freight = value)))
-      override val modifieddate = new Field[TypoLocalDateTime, Row](prefix, "modifieddate", Some("text"), None)(x => extract(x).modifieddate, (row, value) => merge(row, extract(row).copy(modifieddate = value)))
+    override lazy val fields: PohViewFields = new PohViewFields {
+      override def id = Field[PurchaseorderheaderId, PohViewRow](_path, "id", None, None, x => x.id, (row, value) => row.copy(id = value))
+      override def purchaseorderid = Field[PurchaseorderheaderId, PohViewRow](_path, "purchaseorderid", None, None, x => x.purchaseorderid, (row, value) => row.copy(purchaseorderid = value))
+      override def revisionnumber = Field[TypoShort, PohViewRow](_path, "revisionnumber", None, None, x => x.revisionnumber, (row, value) => row.copy(revisionnumber = value))
+      override def status = Field[TypoShort, PohViewRow](_path, "status", None, None, x => x.status, (row, value) => row.copy(status = value))
+      override def employeeid = Field[BusinessentityId, PohViewRow](_path, "employeeid", None, None, x => x.employeeid, (row, value) => row.copy(employeeid = value))
+      override def vendorid = Field[BusinessentityId, PohViewRow](_path, "vendorid", None, None, x => x.vendorid, (row, value) => row.copy(vendorid = value))
+      override def shipmethodid = Field[ShipmethodId, PohViewRow](_path, "shipmethodid", None, None, x => x.shipmethodid, (row, value) => row.copy(shipmethodid = value))
+      override def orderdate = Field[TypoLocalDateTime, PohViewRow](_path, "orderdate", Some("text"), None, x => x.orderdate, (row, value) => row.copy(orderdate = value))
+      override def shipdate = OptField[TypoLocalDateTime, PohViewRow](_path, "shipdate", Some("text"), None, x => x.shipdate, (row, value) => row.copy(shipdate = value))
+      override def subtotal = Field[BigDecimal, PohViewRow](_path, "subtotal", None, None, x => x.subtotal, (row, value) => row.copy(subtotal = value))
+      override def taxamt = Field[BigDecimal, PohViewRow](_path, "taxamt", None, None, x => x.taxamt, (row, value) => row.copy(taxamt = value))
+      override def freight = Field[BigDecimal, PohViewRow](_path, "freight", None, None, x => x.freight, (row, value) => row.copy(freight = value))
+      override def modifieddate = Field[TypoLocalDateTime, PohViewRow](_path, "modifieddate", Some("text"), None, x => x.modifieddate, (row, value) => row.copy(modifieddate = value))
     }
   
-    override val columns: List[FieldLikeNoHkt[?, Row]] =
-      List[FieldLikeNoHkt[?, Row]](fields.id, fields.purchaseorderid, fields.revisionnumber, fields.status, fields.employeeid, fields.vendorid, fields.shipmethodid, fields.orderdate, fields.shipdate, fields.subtotal, fields.taxamt, fields.freight, fields.modifieddate)
+    override lazy val columns: List[FieldLikeNoHkt[?, PohViewRow]] =
+      List[FieldLikeNoHkt[?, PohViewRow]](fields.id, fields.purchaseorderid, fields.revisionnumber, fields.status, fields.employeeid, fields.vendorid, fields.shipmethodid, fields.orderdate, fields.shipdate, fields.subtotal, fields.taxamt, fields.freight, fields.modifieddate)
   
-    override def copy[NewRow](prefix: Option[String], extract: NewRow => PohViewRow, merge: (NewRow, PohViewRow) => NewRow): Impl[NewRow] =
-      new Impl(prefix, extract, merge)
+    override def copy(path: List[Path]): Impl =
+      new Impl(path)
   }
   
 }

--- a/typo-tester-zio-jdbc/generated-and-checked-in/adventureworks/pu/pv/PvViewFields.scala
+++ b/typo-tester-zio-jdbc/generated-and-checked-in/adventureworks/pu/pv/PvViewFields.scala
@@ -11,53 +11,54 @@ import adventureworks.customtypes.TypoLocalDateTime
 import adventureworks.person.businessentity.BusinessentityId
 import adventureworks.production.product.ProductId
 import adventureworks.production.unitmeasure.UnitmeasureId
+import typo.dsl.Path
 import typo.dsl.SqlExpr.Field
 import typo.dsl.SqlExpr.FieldLikeNoHkt
 import typo.dsl.SqlExpr.OptField
 import typo.dsl.Structure.Relation
 
-trait PvViewFields[Row] {
-  val id: Field[ProductId, Row]
-  val productid: Field[ProductId, Row]
-  val businessentityid: Field[BusinessentityId, Row]
-  val averageleadtime: Field[Int, Row]
-  val standardprice: Field[BigDecimal, Row]
-  val lastreceiptcost: OptField[BigDecimal, Row]
-  val lastreceiptdate: OptField[TypoLocalDateTime, Row]
-  val minorderqty: Field[Int, Row]
-  val maxorderqty: Field[Int, Row]
-  val onorderqty: OptField[Int, Row]
-  val unitmeasurecode: Field[UnitmeasureId, Row]
-  val modifieddate: Field[TypoLocalDateTime, Row]
+trait PvViewFields {
+  def id: Field[ProductId, PvViewRow]
+  def productid: Field[ProductId, PvViewRow]
+  def businessentityid: Field[BusinessentityId, PvViewRow]
+  def averageleadtime: Field[Int, PvViewRow]
+  def standardprice: Field[BigDecimal, PvViewRow]
+  def lastreceiptcost: OptField[BigDecimal, PvViewRow]
+  def lastreceiptdate: OptField[TypoLocalDateTime, PvViewRow]
+  def minorderqty: Field[Int, PvViewRow]
+  def maxorderqty: Field[Int, PvViewRow]
+  def onorderqty: OptField[Int, PvViewRow]
+  def unitmeasurecode: Field[UnitmeasureId, PvViewRow]
+  def modifieddate: Field[TypoLocalDateTime, PvViewRow]
 }
 
 object PvViewFields {
-  val structure: Relation[PvViewFields, PvViewRow, PvViewRow] = 
-    new Impl(None, identity, (_, x) => x)
+  lazy val structure: Relation[PvViewFields, PvViewRow] =
+    new Impl(Nil)
     
-  private final class Impl[Row](val prefix: Option[String], val extract: Row => PvViewRow, val merge: (Row, PvViewRow) => Row)
-    extends Relation[PvViewFields, PvViewRow, Row] { 
+  private final class Impl(val _path: List[Path])
+    extends Relation[PvViewFields, PvViewRow] {
   
-    override val fields: PvViewFields[Row] = new PvViewFields[Row] {
-      override val id = new Field[ProductId, Row](prefix, "id", None, None)(x => extract(x).id, (row, value) => merge(row, extract(row).copy(id = value)))
-      override val productid = new Field[ProductId, Row](prefix, "productid", None, None)(x => extract(x).productid, (row, value) => merge(row, extract(row).copy(productid = value)))
-      override val businessentityid = new Field[BusinessentityId, Row](prefix, "businessentityid", None, None)(x => extract(x).businessentityid, (row, value) => merge(row, extract(row).copy(businessentityid = value)))
-      override val averageleadtime = new Field[Int, Row](prefix, "averageleadtime", None, None)(x => extract(x).averageleadtime, (row, value) => merge(row, extract(row).copy(averageleadtime = value)))
-      override val standardprice = new Field[BigDecimal, Row](prefix, "standardprice", None, None)(x => extract(x).standardprice, (row, value) => merge(row, extract(row).copy(standardprice = value)))
-      override val lastreceiptcost = new OptField[BigDecimal, Row](prefix, "lastreceiptcost", None, None)(x => extract(x).lastreceiptcost, (row, value) => merge(row, extract(row).copy(lastreceiptcost = value)))
-      override val lastreceiptdate = new OptField[TypoLocalDateTime, Row](prefix, "lastreceiptdate", Some("text"), None)(x => extract(x).lastreceiptdate, (row, value) => merge(row, extract(row).copy(lastreceiptdate = value)))
-      override val minorderqty = new Field[Int, Row](prefix, "minorderqty", None, None)(x => extract(x).minorderqty, (row, value) => merge(row, extract(row).copy(minorderqty = value)))
-      override val maxorderqty = new Field[Int, Row](prefix, "maxorderqty", None, None)(x => extract(x).maxorderqty, (row, value) => merge(row, extract(row).copy(maxorderqty = value)))
-      override val onorderqty = new OptField[Int, Row](prefix, "onorderqty", None, None)(x => extract(x).onorderqty, (row, value) => merge(row, extract(row).copy(onorderqty = value)))
-      override val unitmeasurecode = new Field[UnitmeasureId, Row](prefix, "unitmeasurecode", None, None)(x => extract(x).unitmeasurecode, (row, value) => merge(row, extract(row).copy(unitmeasurecode = value)))
-      override val modifieddate = new Field[TypoLocalDateTime, Row](prefix, "modifieddate", Some("text"), None)(x => extract(x).modifieddate, (row, value) => merge(row, extract(row).copy(modifieddate = value)))
+    override lazy val fields: PvViewFields = new PvViewFields {
+      override def id = Field[ProductId, PvViewRow](_path, "id", None, None, x => x.id, (row, value) => row.copy(id = value))
+      override def productid = Field[ProductId, PvViewRow](_path, "productid", None, None, x => x.productid, (row, value) => row.copy(productid = value))
+      override def businessentityid = Field[BusinessentityId, PvViewRow](_path, "businessentityid", None, None, x => x.businessentityid, (row, value) => row.copy(businessentityid = value))
+      override def averageleadtime = Field[Int, PvViewRow](_path, "averageleadtime", None, None, x => x.averageleadtime, (row, value) => row.copy(averageleadtime = value))
+      override def standardprice = Field[BigDecimal, PvViewRow](_path, "standardprice", None, None, x => x.standardprice, (row, value) => row.copy(standardprice = value))
+      override def lastreceiptcost = OptField[BigDecimal, PvViewRow](_path, "lastreceiptcost", None, None, x => x.lastreceiptcost, (row, value) => row.copy(lastreceiptcost = value))
+      override def lastreceiptdate = OptField[TypoLocalDateTime, PvViewRow](_path, "lastreceiptdate", Some("text"), None, x => x.lastreceiptdate, (row, value) => row.copy(lastreceiptdate = value))
+      override def minorderqty = Field[Int, PvViewRow](_path, "minorderqty", None, None, x => x.minorderqty, (row, value) => row.copy(minorderqty = value))
+      override def maxorderqty = Field[Int, PvViewRow](_path, "maxorderqty", None, None, x => x.maxorderqty, (row, value) => row.copy(maxorderqty = value))
+      override def onorderqty = OptField[Int, PvViewRow](_path, "onorderqty", None, None, x => x.onorderqty, (row, value) => row.copy(onorderqty = value))
+      override def unitmeasurecode = Field[UnitmeasureId, PvViewRow](_path, "unitmeasurecode", None, None, x => x.unitmeasurecode, (row, value) => row.copy(unitmeasurecode = value))
+      override def modifieddate = Field[TypoLocalDateTime, PvViewRow](_path, "modifieddate", Some("text"), None, x => x.modifieddate, (row, value) => row.copy(modifieddate = value))
     }
   
-    override val columns: List[FieldLikeNoHkt[?, Row]] =
-      List[FieldLikeNoHkt[?, Row]](fields.id, fields.productid, fields.businessentityid, fields.averageleadtime, fields.standardprice, fields.lastreceiptcost, fields.lastreceiptdate, fields.minorderqty, fields.maxorderqty, fields.onorderqty, fields.unitmeasurecode, fields.modifieddate)
+    override lazy val columns: List[FieldLikeNoHkt[?, PvViewRow]] =
+      List[FieldLikeNoHkt[?, PvViewRow]](fields.id, fields.productid, fields.businessentityid, fields.averageleadtime, fields.standardprice, fields.lastreceiptcost, fields.lastreceiptdate, fields.minorderqty, fields.maxorderqty, fields.onorderqty, fields.unitmeasurecode, fields.modifieddate)
   
-    override def copy[NewRow](prefix: Option[String], extract: NewRow => PvViewRow, merge: (NewRow, PvViewRow) => NewRow): Impl[NewRow] =
-      new Impl(prefix, extract, merge)
+    override def copy(path: List[Path]): Impl =
+      new Impl(path)
   }
   
 }

--- a/typo-tester-zio-jdbc/generated-and-checked-in/adventureworks/pu/sm/SmViewFields.scala
+++ b/typo-tester-zio-jdbc/generated-and-checked-in/adventureworks/pu/sm/SmViewFields.scala
@@ -11,42 +11,43 @@ import adventureworks.customtypes.TypoLocalDateTime
 import adventureworks.customtypes.TypoUUID
 import adventureworks.public.Name
 import adventureworks.purchasing.shipmethod.ShipmethodId
+import typo.dsl.Path
 import typo.dsl.SqlExpr.Field
 import typo.dsl.SqlExpr.FieldLikeNoHkt
 import typo.dsl.Structure.Relation
 
-trait SmViewFields[Row] {
-  val id: Field[ShipmethodId, Row]
-  val shipmethodid: Field[ShipmethodId, Row]
-  val name: Field[Name, Row]
-  val shipbase: Field[BigDecimal, Row]
-  val shiprate: Field[BigDecimal, Row]
-  val rowguid: Field[TypoUUID, Row]
-  val modifieddate: Field[TypoLocalDateTime, Row]
+trait SmViewFields {
+  def id: Field[ShipmethodId, SmViewRow]
+  def shipmethodid: Field[ShipmethodId, SmViewRow]
+  def name: Field[Name, SmViewRow]
+  def shipbase: Field[BigDecimal, SmViewRow]
+  def shiprate: Field[BigDecimal, SmViewRow]
+  def rowguid: Field[TypoUUID, SmViewRow]
+  def modifieddate: Field[TypoLocalDateTime, SmViewRow]
 }
 
 object SmViewFields {
-  val structure: Relation[SmViewFields, SmViewRow, SmViewRow] = 
-    new Impl(None, identity, (_, x) => x)
+  lazy val structure: Relation[SmViewFields, SmViewRow] =
+    new Impl(Nil)
     
-  private final class Impl[Row](val prefix: Option[String], val extract: Row => SmViewRow, val merge: (Row, SmViewRow) => Row)
-    extends Relation[SmViewFields, SmViewRow, Row] { 
+  private final class Impl(val _path: List[Path])
+    extends Relation[SmViewFields, SmViewRow] {
   
-    override val fields: SmViewFields[Row] = new SmViewFields[Row] {
-      override val id = new Field[ShipmethodId, Row](prefix, "id", None, None)(x => extract(x).id, (row, value) => merge(row, extract(row).copy(id = value)))
-      override val shipmethodid = new Field[ShipmethodId, Row](prefix, "shipmethodid", None, None)(x => extract(x).shipmethodid, (row, value) => merge(row, extract(row).copy(shipmethodid = value)))
-      override val name = new Field[Name, Row](prefix, "name", None, None)(x => extract(x).name, (row, value) => merge(row, extract(row).copy(name = value)))
-      override val shipbase = new Field[BigDecimal, Row](prefix, "shipbase", None, None)(x => extract(x).shipbase, (row, value) => merge(row, extract(row).copy(shipbase = value)))
-      override val shiprate = new Field[BigDecimal, Row](prefix, "shiprate", None, None)(x => extract(x).shiprate, (row, value) => merge(row, extract(row).copy(shiprate = value)))
-      override val rowguid = new Field[TypoUUID, Row](prefix, "rowguid", None, None)(x => extract(x).rowguid, (row, value) => merge(row, extract(row).copy(rowguid = value)))
-      override val modifieddate = new Field[TypoLocalDateTime, Row](prefix, "modifieddate", Some("text"), None)(x => extract(x).modifieddate, (row, value) => merge(row, extract(row).copy(modifieddate = value)))
+    override lazy val fields: SmViewFields = new SmViewFields {
+      override def id = Field[ShipmethodId, SmViewRow](_path, "id", None, None, x => x.id, (row, value) => row.copy(id = value))
+      override def shipmethodid = Field[ShipmethodId, SmViewRow](_path, "shipmethodid", None, None, x => x.shipmethodid, (row, value) => row.copy(shipmethodid = value))
+      override def name = Field[Name, SmViewRow](_path, "name", None, None, x => x.name, (row, value) => row.copy(name = value))
+      override def shipbase = Field[BigDecimal, SmViewRow](_path, "shipbase", None, None, x => x.shipbase, (row, value) => row.copy(shipbase = value))
+      override def shiprate = Field[BigDecimal, SmViewRow](_path, "shiprate", None, None, x => x.shiprate, (row, value) => row.copy(shiprate = value))
+      override def rowguid = Field[TypoUUID, SmViewRow](_path, "rowguid", None, None, x => x.rowguid, (row, value) => row.copy(rowguid = value))
+      override def modifieddate = Field[TypoLocalDateTime, SmViewRow](_path, "modifieddate", Some("text"), None, x => x.modifieddate, (row, value) => row.copy(modifieddate = value))
     }
   
-    override val columns: List[FieldLikeNoHkt[?, Row]] =
-      List[FieldLikeNoHkt[?, Row]](fields.id, fields.shipmethodid, fields.name, fields.shipbase, fields.shiprate, fields.rowguid, fields.modifieddate)
+    override lazy val columns: List[FieldLikeNoHkt[?, SmViewRow]] =
+      List[FieldLikeNoHkt[?, SmViewRow]](fields.id, fields.shipmethodid, fields.name, fields.shipbase, fields.shiprate, fields.rowguid, fields.modifieddate)
   
-    override def copy[NewRow](prefix: Option[String], extract: NewRow => SmViewRow, merge: (NewRow, SmViewRow) => NewRow): Impl[NewRow] =
-      new Impl(prefix, extract, merge)
+    override def copy(path: List[Path]): Impl =
+      new Impl(path)
   }
   
 }

--- a/typo-tester-zio-jdbc/generated-and-checked-in/adventureworks/pu/v/VViewFields.scala
+++ b/typo-tester-zio-jdbc/generated-and-checked-in/adventureworks/pu/v/VViewFields.scala
@@ -13,47 +13,48 @@ import adventureworks.person.businessentity.BusinessentityId
 import adventureworks.public.AccountNumber
 import adventureworks.public.Flag
 import adventureworks.public.Name
+import typo.dsl.Path
 import typo.dsl.SqlExpr.Field
 import typo.dsl.SqlExpr.FieldLikeNoHkt
 import typo.dsl.SqlExpr.OptField
 import typo.dsl.Structure.Relation
 
-trait VViewFields[Row] {
-  val id: Field[BusinessentityId, Row]
-  val businessentityid: Field[BusinessentityId, Row]
-  val accountnumber: Field[AccountNumber, Row]
-  val name: Field[Name, Row]
-  val creditrating: Field[TypoShort, Row]
-  val preferredvendorstatus: Field[Flag, Row]
-  val activeflag: Field[Flag, Row]
-  val purchasingwebserviceurl: OptField[/* max 1024 chars */ String, Row]
-  val modifieddate: Field[TypoLocalDateTime, Row]
+trait VViewFields {
+  def id: Field[BusinessentityId, VViewRow]
+  def businessentityid: Field[BusinessentityId, VViewRow]
+  def accountnumber: Field[AccountNumber, VViewRow]
+  def name: Field[Name, VViewRow]
+  def creditrating: Field[TypoShort, VViewRow]
+  def preferredvendorstatus: Field[Flag, VViewRow]
+  def activeflag: Field[Flag, VViewRow]
+  def purchasingwebserviceurl: OptField[/* max 1024 chars */ String, VViewRow]
+  def modifieddate: Field[TypoLocalDateTime, VViewRow]
 }
 
 object VViewFields {
-  val structure: Relation[VViewFields, VViewRow, VViewRow] = 
-    new Impl(None, identity, (_, x) => x)
+  lazy val structure: Relation[VViewFields, VViewRow] =
+    new Impl(Nil)
     
-  private final class Impl[Row](val prefix: Option[String], val extract: Row => VViewRow, val merge: (Row, VViewRow) => Row)
-    extends Relation[VViewFields, VViewRow, Row] { 
+  private final class Impl(val _path: List[Path])
+    extends Relation[VViewFields, VViewRow] {
   
-    override val fields: VViewFields[Row] = new VViewFields[Row] {
-      override val id = new Field[BusinessentityId, Row](prefix, "id", None, None)(x => extract(x).id, (row, value) => merge(row, extract(row).copy(id = value)))
-      override val businessentityid = new Field[BusinessentityId, Row](prefix, "businessentityid", None, None)(x => extract(x).businessentityid, (row, value) => merge(row, extract(row).copy(businessentityid = value)))
-      override val accountnumber = new Field[AccountNumber, Row](prefix, "accountnumber", None, None)(x => extract(x).accountnumber, (row, value) => merge(row, extract(row).copy(accountnumber = value)))
-      override val name = new Field[Name, Row](prefix, "name", None, None)(x => extract(x).name, (row, value) => merge(row, extract(row).copy(name = value)))
-      override val creditrating = new Field[TypoShort, Row](prefix, "creditrating", None, None)(x => extract(x).creditrating, (row, value) => merge(row, extract(row).copy(creditrating = value)))
-      override val preferredvendorstatus = new Field[Flag, Row](prefix, "preferredvendorstatus", None, None)(x => extract(x).preferredvendorstatus, (row, value) => merge(row, extract(row).copy(preferredvendorstatus = value)))
-      override val activeflag = new Field[Flag, Row](prefix, "activeflag", None, None)(x => extract(x).activeflag, (row, value) => merge(row, extract(row).copy(activeflag = value)))
-      override val purchasingwebserviceurl = new OptField[/* max 1024 chars */ String, Row](prefix, "purchasingwebserviceurl", None, None)(x => extract(x).purchasingwebserviceurl, (row, value) => merge(row, extract(row).copy(purchasingwebserviceurl = value)))
-      override val modifieddate = new Field[TypoLocalDateTime, Row](prefix, "modifieddate", Some("text"), None)(x => extract(x).modifieddate, (row, value) => merge(row, extract(row).copy(modifieddate = value)))
+    override lazy val fields: VViewFields = new VViewFields {
+      override def id = Field[BusinessentityId, VViewRow](_path, "id", None, None, x => x.id, (row, value) => row.copy(id = value))
+      override def businessentityid = Field[BusinessentityId, VViewRow](_path, "businessentityid", None, None, x => x.businessentityid, (row, value) => row.copy(businessentityid = value))
+      override def accountnumber = Field[AccountNumber, VViewRow](_path, "accountnumber", None, None, x => x.accountnumber, (row, value) => row.copy(accountnumber = value))
+      override def name = Field[Name, VViewRow](_path, "name", None, None, x => x.name, (row, value) => row.copy(name = value))
+      override def creditrating = Field[TypoShort, VViewRow](_path, "creditrating", None, None, x => x.creditrating, (row, value) => row.copy(creditrating = value))
+      override def preferredvendorstatus = Field[Flag, VViewRow](_path, "preferredvendorstatus", None, None, x => x.preferredvendorstatus, (row, value) => row.copy(preferredvendorstatus = value))
+      override def activeflag = Field[Flag, VViewRow](_path, "activeflag", None, None, x => x.activeflag, (row, value) => row.copy(activeflag = value))
+      override def purchasingwebserviceurl = OptField[/* max 1024 chars */ String, VViewRow](_path, "purchasingwebserviceurl", None, None, x => x.purchasingwebserviceurl, (row, value) => row.copy(purchasingwebserviceurl = value))
+      override def modifieddate = Field[TypoLocalDateTime, VViewRow](_path, "modifieddate", Some("text"), None, x => x.modifieddate, (row, value) => row.copy(modifieddate = value))
     }
   
-    override val columns: List[FieldLikeNoHkt[?, Row]] =
-      List[FieldLikeNoHkt[?, Row]](fields.id, fields.businessentityid, fields.accountnumber, fields.name, fields.creditrating, fields.preferredvendorstatus, fields.activeflag, fields.purchasingwebserviceurl, fields.modifieddate)
+    override lazy val columns: List[FieldLikeNoHkt[?, VViewRow]] =
+      List[FieldLikeNoHkt[?, VViewRow]](fields.id, fields.businessentityid, fields.accountnumber, fields.name, fields.creditrating, fields.preferredvendorstatus, fields.activeflag, fields.purchasingwebserviceurl, fields.modifieddate)
   
-    override def copy[NewRow](prefix: Option[String], extract: NewRow => VViewRow, merge: (NewRow, VViewRow) => NewRow): Impl[NewRow] =
-      new Impl(prefix, extract, merge)
+    override def copy(path: List[Path]): Impl =
+      new Impl(path)
   }
   
 }

--- a/typo-tester-zio-jdbc/generated-and-checked-in/adventureworks/public/flaff/FlaffFields.scala
+++ b/typo-tester-zio-jdbc/generated-and-checked-in/adventureworks/public/flaff/FlaffFields.scala
@@ -8,39 +8,40 @@ package public
 package flaff
 
 import adventureworks.public.ShortText
+import typo.dsl.Path
 import typo.dsl.SqlExpr.FieldLikeNoHkt
 import typo.dsl.SqlExpr.IdField
 import typo.dsl.SqlExpr.OptField
 import typo.dsl.Structure.Relation
 
-trait FlaffFields[Row] {
-  val code: IdField[ShortText, Row]
-  val anotherCode: IdField[/* max 20 chars */ String, Row]
-  val someNumber: IdField[Int, Row]
-  val specifier: IdField[ShortText, Row]
-  val parentspecifier: OptField[ShortText, Row]
+trait FlaffFields {
+  def code: IdField[ShortText, FlaffRow]
+  def anotherCode: IdField[/* max 20 chars */ String, FlaffRow]
+  def someNumber: IdField[Int, FlaffRow]
+  def specifier: IdField[ShortText, FlaffRow]
+  def parentspecifier: OptField[ShortText, FlaffRow]
 }
 
 object FlaffFields {
-  val structure: Relation[FlaffFields, FlaffRow, FlaffRow] = 
-    new Impl(None, identity, (_, x) => x)
+  lazy val structure: Relation[FlaffFields, FlaffRow] =
+    new Impl(Nil)
     
-  private final class Impl[Row](val prefix: Option[String], val extract: Row => FlaffRow, val merge: (Row, FlaffRow) => Row)
-    extends Relation[FlaffFields, FlaffRow, Row] { 
+  private final class Impl(val _path: List[Path])
+    extends Relation[FlaffFields, FlaffRow] {
   
-    override val fields: FlaffFields[Row] = new FlaffFields[Row] {
-      override val code = new IdField[ShortText, Row](prefix, "code", None, Some("text"))(x => extract(x).code, (row, value) => merge(row, extract(row).copy(code = value)))
-      override val anotherCode = new IdField[/* max 20 chars */ String, Row](prefix, "another_code", None, None)(x => extract(x).anotherCode, (row, value) => merge(row, extract(row).copy(anotherCode = value)))
-      override val someNumber = new IdField[Int, Row](prefix, "some_number", None, Some("int4"))(x => extract(x).someNumber, (row, value) => merge(row, extract(row).copy(someNumber = value)))
-      override val specifier = new IdField[ShortText, Row](prefix, "specifier", None, Some("text"))(x => extract(x).specifier, (row, value) => merge(row, extract(row).copy(specifier = value)))
-      override val parentspecifier = new OptField[ShortText, Row](prefix, "parentspecifier", None, Some("text"))(x => extract(x).parentspecifier, (row, value) => merge(row, extract(row).copy(parentspecifier = value)))
+    override lazy val fields: FlaffFields = new FlaffFields {
+      override def code = IdField[ShortText, FlaffRow](_path, "code", None, Some("text"), x => x.code, (row, value) => row.copy(code = value))
+      override def anotherCode = IdField[/* max 20 chars */ String, FlaffRow](_path, "another_code", None, None, x => x.anotherCode, (row, value) => row.copy(anotherCode = value))
+      override def someNumber = IdField[Int, FlaffRow](_path, "some_number", None, Some("int4"), x => x.someNumber, (row, value) => row.copy(someNumber = value))
+      override def specifier = IdField[ShortText, FlaffRow](_path, "specifier", None, Some("text"), x => x.specifier, (row, value) => row.copy(specifier = value))
+      override def parentspecifier = OptField[ShortText, FlaffRow](_path, "parentspecifier", None, Some("text"), x => x.parentspecifier, (row, value) => row.copy(parentspecifier = value))
     }
   
-    override val columns: List[FieldLikeNoHkt[?, Row]] =
-      List[FieldLikeNoHkt[?, Row]](fields.code, fields.anotherCode, fields.someNumber, fields.specifier, fields.parentspecifier)
+    override lazy val columns: List[FieldLikeNoHkt[?, FlaffRow]] =
+      List[FieldLikeNoHkt[?, FlaffRow]](fields.code, fields.anotherCode, fields.someNumber, fields.specifier, fields.parentspecifier)
   
-    override def copy[NewRow](prefix: Option[String], extract: NewRow => FlaffRow, merge: (NewRow, FlaffRow) => NewRow): Impl[NewRow] =
-      new Impl(prefix, extract, merge)
+    override def copy(path: List[Path]): Impl =
+      new Impl(path)
   }
   
 }

--- a/typo-tester-zio-jdbc/generated-and-checked-in/adventureworks/public/flaff/FlaffRepoMock.scala
+++ b/typo-tester-zio-jdbc/generated-and-checked-in/adventureworks/public/flaff/FlaffRepoMock.scala
@@ -25,7 +25,7 @@ import zio.stream.ZStream
 
 class FlaffRepoMock(map: scala.collection.mutable.Map[FlaffId, FlaffRow] = scala.collection.mutable.Map.empty) extends FlaffRepo {
   override def delete: DeleteBuilder[FlaffFields, FlaffRow] = {
-    DeleteBuilderMock(DeleteParams.empty, FlaffFields.structure.fields, map)
+    DeleteBuilderMock(DeleteParams.empty, FlaffFields.structure, map)
   }
   override def deleteById(compositeId: FlaffId): ZIO[ZConnection, Throwable, Boolean] = {
     ZIO.succeed(map.remove(compositeId).isDefined)
@@ -71,7 +71,7 @@ class FlaffRepoMock(map: scala.collection.mutable.Map[FlaffId, FlaffRow] = scala
     }
   }
   override def update: UpdateBuilder[FlaffFields, FlaffRow] = {
-    UpdateBuilderMock(UpdateParams.empty, FlaffFields.structure.fields, map)
+    UpdateBuilderMock(UpdateParams.empty, FlaffFields.structure, map)
   }
   override def update(row: FlaffRow): ZIO[ZConnection, Throwable, Boolean] = {
     ZIO.succeed {

--- a/typo-tester-zio-jdbc/generated-and-checked-in/adventureworks/public/identity_test/IdentityTestRepoMock.scala
+++ b/typo-tester-zio-jdbc/generated-and-checked-in/adventureworks/public/identity_test/IdentityTestRepoMock.scala
@@ -26,7 +26,7 @@ import zio.stream.ZStream
 class IdentityTestRepoMock(toRow: Function1[IdentityTestRowUnsaved, IdentityTestRow],
                            map: scala.collection.mutable.Map[IdentityTestId, IdentityTestRow] = scala.collection.mutable.Map.empty) extends IdentityTestRepo {
   override def delete: DeleteBuilder[IdentityTestFields, IdentityTestRow] = {
-    DeleteBuilderMock(DeleteParams.empty, IdentityTestFields.structure.fields, map)
+    DeleteBuilderMock(DeleteParams.empty, IdentityTestFields.structure, map)
   }
   override def deleteById(name: IdentityTestId): ZIO[ZConnection, Throwable, Boolean] = {
     ZIO.succeed(map.remove(name).isDefined)
@@ -85,7 +85,7 @@ class IdentityTestRepoMock(toRow: Function1[IdentityTestRowUnsaved, IdentityTest
     }
   }
   override def update: UpdateBuilder[IdentityTestFields, IdentityTestRow] = {
-    UpdateBuilderMock(UpdateParams.empty, IdentityTestFields.structure.fields, map)
+    UpdateBuilderMock(UpdateParams.empty, IdentityTestFields.structure, map)
   }
   override def update(row: IdentityTestRow): ZIO[ZConnection, Throwable, Boolean] = {
     ZIO.succeed {

--- a/typo-tester-zio-jdbc/generated-and-checked-in/adventureworks/public/pgtest/PgtestFields.scala
+++ b/typo-tester-zio-jdbc/generated-and-checked-in/adventureworks/public/pgtest/PgtestFields.scala
@@ -33,166 +33,167 @@ import adventureworks.customtypes.TypoVector
 import adventureworks.customtypes.TypoXml
 import adventureworks.public.Mydomain
 import adventureworks.public.Myenum
+import typo.dsl.Path
 import typo.dsl.SqlExpr.Field
 import typo.dsl.SqlExpr.FieldLikeNoHkt
 import typo.dsl.Structure.Relation
 
-trait PgtestFields[Row] {
-  val bool: Field[Boolean, Row]
-  val box: Field[TypoBox, Row]
-  val bpchar: Field[/* bpchar, max 3 chars */ String, Row]
-  val bytea: Field[TypoBytea, Row]
-  val char: Field[/* bpchar, max 1 chars */ String, Row]
-  val circle: Field[TypoCircle, Row]
-  val date: Field[TypoLocalDate, Row]
-  val float4: Field[Float, Row]
-  val float8: Field[Double, Row]
-  val hstore: Field[TypoHStore, Row]
-  val inet: Field[TypoInet, Row]
-  val int2: Field[TypoShort, Row]
-  val int2vector: Field[TypoInt2Vector, Row]
-  val int4: Field[Int, Row]
-  val int8: Field[Long, Row]
-  val interval: Field[TypoInterval, Row]
-  val json: Field[TypoJson, Row]
-  val jsonb: Field[TypoJsonb, Row]
-  val line: Field[TypoLine, Row]
-  val lseg: Field[TypoLineSegment, Row]
-  val money: Field[TypoMoney, Row]
-  val mydomain: Field[Mydomain, Row]
-  val myenum: Field[Myenum, Row]
-  val name: Field[String, Row]
-  val numeric: Field[BigDecimal, Row]
-  val path: Field[TypoPath, Row]
-  val point: Field[TypoPoint, Row]
-  val polygon: Field[TypoPolygon, Row]
-  val text: Field[String, Row]
-  val time: Field[TypoLocalTime, Row]
-  val timestamp: Field[TypoLocalDateTime, Row]
-  val timestampz: Field[TypoInstant, Row]
-  val timez: Field[TypoOffsetTime, Row]
-  val uuid: Field[TypoUUID, Row]
-  val varchar: Field[String, Row]
-  val vector: Field[TypoVector, Row]
-  val xml: Field[TypoXml, Row]
-  val boxes: Field[Array[TypoBox], Row]
-  val bpchares: Field[Array[/* bpchar */ String], Row]
-  val chares: Field[Array[/* bpchar */ String], Row]
-  val circlees: Field[Array[TypoCircle], Row]
-  val datees: Field[Array[TypoLocalDate], Row]
-  val float4es: Field[Array[Float], Row]
-  val float8es: Field[Array[Double], Row]
-  val inetes: Field[Array[TypoInet], Row]
-  val int2es: Field[Array[TypoShort], Row]
-  val int2vectores: Field[Array[TypoInt2Vector], Row]
-  val int4es: Field[Array[Int], Row]
-  val int8es: Field[Array[Long], Row]
-  val intervales: Field[Array[TypoInterval], Row]
-  val jsones: Field[Array[TypoJson], Row]
-  val jsonbes: Field[Array[TypoJsonb], Row]
-  val linees: Field[Array[TypoLine], Row]
-  val lseges: Field[Array[TypoLineSegment], Row]
-  val moneyes: Field[Array[TypoMoney], Row]
-  val myenumes: Field[Array[Myenum], Row]
-  val namees: Field[Array[String], Row]
-  val numerices: Field[Array[BigDecimal], Row]
-  val pathes: Field[Array[TypoPath], Row]
-  val pointes: Field[Array[TypoPoint], Row]
-  val polygones: Field[Array[TypoPolygon], Row]
-  val textes: Field[Array[String], Row]
-  val timees: Field[Array[TypoLocalTime], Row]
-  val timestampes: Field[Array[TypoLocalDateTime], Row]
-  val timestampzes: Field[Array[TypoInstant], Row]
-  val timezes: Field[Array[TypoOffsetTime], Row]
-  val uuides: Field[Array[TypoUUID], Row]
-  val varchares: Field[Array[String], Row]
-  val xmles: Field[Array[TypoXml], Row]
+trait PgtestFields {
+  def bool: Field[Boolean, PgtestRow]
+  def box: Field[TypoBox, PgtestRow]
+  def bpchar: Field[/* bpchar, max 3 chars */ String, PgtestRow]
+  def bytea: Field[TypoBytea, PgtestRow]
+  def char: Field[/* bpchar, max 1 chars */ String, PgtestRow]
+  def circle: Field[TypoCircle, PgtestRow]
+  def date: Field[TypoLocalDate, PgtestRow]
+  def float4: Field[Float, PgtestRow]
+  def float8: Field[Double, PgtestRow]
+  def hstore: Field[TypoHStore, PgtestRow]
+  def inet: Field[TypoInet, PgtestRow]
+  def int2: Field[TypoShort, PgtestRow]
+  def int2vector: Field[TypoInt2Vector, PgtestRow]
+  def int4: Field[Int, PgtestRow]
+  def int8: Field[Long, PgtestRow]
+  def interval: Field[TypoInterval, PgtestRow]
+  def json: Field[TypoJson, PgtestRow]
+  def jsonb: Field[TypoJsonb, PgtestRow]
+  def line: Field[TypoLine, PgtestRow]
+  def lseg: Field[TypoLineSegment, PgtestRow]
+  def money: Field[TypoMoney, PgtestRow]
+  def mydomain: Field[Mydomain, PgtestRow]
+  def myenum: Field[Myenum, PgtestRow]
+  def name: Field[String, PgtestRow]
+  def numeric: Field[BigDecimal, PgtestRow]
+  def path: Field[TypoPath, PgtestRow]
+  def point: Field[TypoPoint, PgtestRow]
+  def polygon: Field[TypoPolygon, PgtestRow]
+  def text: Field[String, PgtestRow]
+  def time: Field[TypoLocalTime, PgtestRow]
+  def timestamp: Field[TypoLocalDateTime, PgtestRow]
+  def timestampz: Field[TypoInstant, PgtestRow]
+  def timez: Field[TypoOffsetTime, PgtestRow]
+  def uuid: Field[TypoUUID, PgtestRow]
+  def varchar: Field[String, PgtestRow]
+  def vector: Field[TypoVector, PgtestRow]
+  def xml: Field[TypoXml, PgtestRow]
+  def boxes: Field[Array[TypoBox], PgtestRow]
+  def bpchares: Field[Array[/* bpchar */ String], PgtestRow]
+  def chares: Field[Array[/* bpchar */ String], PgtestRow]
+  def circlees: Field[Array[TypoCircle], PgtestRow]
+  def datees: Field[Array[TypoLocalDate], PgtestRow]
+  def float4es: Field[Array[Float], PgtestRow]
+  def float8es: Field[Array[Double], PgtestRow]
+  def inetes: Field[Array[TypoInet], PgtestRow]
+  def int2es: Field[Array[TypoShort], PgtestRow]
+  def int2vectores: Field[Array[TypoInt2Vector], PgtestRow]
+  def int4es: Field[Array[Int], PgtestRow]
+  def int8es: Field[Array[Long], PgtestRow]
+  def intervales: Field[Array[TypoInterval], PgtestRow]
+  def jsones: Field[Array[TypoJson], PgtestRow]
+  def jsonbes: Field[Array[TypoJsonb], PgtestRow]
+  def linees: Field[Array[TypoLine], PgtestRow]
+  def lseges: Field[Array[TypoLineSegment], PgtestRow]
+  def moneyes: Field[Array[TypoMoney], PgtestRow]
+  def myenumes: Field[Array[Myenum], PgtestRow]
+  def namees: Field[Array[String], PgtestRow]
+  def numerices: Field[Array[BigDecimal], PgtestRow]
+  def pathes: Field[Array[TypoPath], PgtestRow]
+  def pointes: Field[Array[TypoPoint], PgtestRow]
+  def polygones: Field[Array[TypoPolygon], PgtestRow]
+  def textes: Field[Array[String], PgtestRow]
+  def timees: Field[Array[TypoLocalTime], PgtestRow]
+  def timestampes: Field[Array[TypoLocalDateTime], PgtestRow]
+  def timestampzes: Field[Array[TypoInstant], PgtestRow]
+  def timezes: Field[Array[TypoOffsetTime], PgtestRow]
+  def uuides: Field[Array[TypoUUID], PgtestRow]
+  def varchares: Field[Array[String], PgtestRow]
+  def xmles: Field[Array[TypoXml], PgtestRow]
 }
 
 object PgtestFields {
-  val structure: Relation[PgtestFields, PgtestRow, PgtestRow] = 
-    new Impl(None, identity, (_, x) => x)
+  lazy val structure: Relation[PgtestFields, PgtestRow] =
+    new Impl(Nil)
     
-  private final class Impl[Row](val prefix: Option[String], val extract: Row => PgtestRow, val merge: (Row, PgtestRow) => Row)
-    extends Relation[PgtestFields, PgtestRow, Row] { 
+  private final class Impl(val _path: List[Path])
+    extends Relation[PgtestFields, PgtestRow] {
   
-    override val fields: PgtestFields[Row] = new PgtestFields[Row] {
-      override val bool = new Field[Boolean, Row](prefix, "bool", None, None)(x => extract(x).bool, (row, value) => merge(row, extract(row).copy(bool = value)))
-      override val box = new Field[TypoBox, Row](prefix, "box", None, Some("box"))(x => extract(x).box, (row, value) => merge(row, extract(row).copy(box = value)))
-      override val bpchar = new Field[/* bpchar, max 3 chars */ String, Row](prefix, "bpchar", None, Some("bpchar"))(x => extract(x).bpchar, (row, value) => merge(row, extract(row).copy(bpchar = value)))
-      override val bytea = new Field[TypoBytea, Row](prefix, "bytea", None, Some("bytea"))(x => extract(x).bytea, (row, value) => merge(row, extract(row).copy(bytea = value)))
-      override val char = new Field[/* bpchar, max 1 chars */ String, Row](prefix, "char", None, Some("bpchar"))(x => extract(x).char, (row, value) => merge(row, extract(row).copy(char = value)))
-      override val circle = new Field[TypoCircle, Row](prefix, "circle", None, Some("circle"))(x => extract(x).circle, (row, value) => merge(row, extract(row).copy(circle = value)))
-      override val date = new Field[TypoLocalDate, Row](prefix, "date", Some("text"), Some("date"))(x => extract(x).date, (row, value) => merge(row, extract(row).copy(date = value)))
-      override val float4 = new Field[Float, Row](prefix, "float4", None, Some("float4"))(x => extract(x).float4, (row, value) => merge(row, extract(row).copy(float4 = value)))
-      override val float8 = new Field[Double, Row](prefix, "float8", None, Some("float8"))(x => extract(x).float8, (row, value) => merge(row, extract(row).copy(float8 = value)))
-      override val hstore = new Field[TypoHStore, Row](prefix, "hstore", None, Some("hstore"))(x => extract(x).hstore, (row, value) => merge(row, extract(row).copy(hstore = value)))
-      override val inet = new Field[TypoInet, Row](prefix, "inet", None, Some("inet"))(x => extract(x).inet, (row, value) => merge(row, extract(row).copy(inet = value)))
-      override val int2 = new Field[TypoShort, Row](prefix, "int2", None, Some("int2"))(x => extract(x).int2, (row, value) => merge(row, extract(row).copy(int2 = value)))
-      override val int2vector = new Field[TypoInt2Vector, Row](prefix, "int2vector", None, Some("int2vector"))(x => extract(x).int2vector, (row, value) => merge(row, extract(row).copy(int2vector = value)))
-      override val int4 = new Field[Int, Row](prefix, "int4", None, Some("int4"))(x => extract(x).int4, (row, value) => merge(row, extract(row).copy(int4 = value)))
-      override val int8 = new Field[Long, Row](prefix, "int8", None, Some("int8"))(x => extract(x).int8, (row, value) => merge(row, extract(row).copy(int8 = value)))
-      override val interval = new Field[TypoInterval, Row](prefix, "interval", None, Some("interval"))(x => extract(x).interval, (row, value) => merge(row, extract(row).copy(interval = value)))
-      override val json = new Field[TypoJson, Row](prefix, "json", None, Some("json"))(x => extract(x).json, (row, value) => merge(row, extract(row).copy(json = value)))
-      override val jsonb = new Field[TypoJsonb, Row](prefix, "jsonb", None, Some("jsonb"))(x => extract(x).jsonb, (row, value) => merge(row, extract(row).copy(jsonb = value)))
-      override val line = new Field[TypoLine, Row](prefix, "line", None, Some("line"))(x => extract(x).line, (row, value) => merge(row, extract(row).copy(line = value)))
-      override val lseg = new Field[TypoLineSegment, Row](prefix, "lseg", None, Some("lseg"))(x => extract(x).lseg, (row, value) => merge(row, extract(row).copy(lseg = value)))
-      override val money = new Field[TypoMoney, Row](prefix, "money", Some("numeric"), Some("money"))(x => extract(x).money, (row, value) => merge(row, extract(row).copy(money = value)))
-      override val mydomain = new Field[Mydomain, Row](prefix, "mydomain", None, Some("text"))(x => extract(x).mydomain, (row, value) => merge(row, extract(row).copy(mydomain = value)))
-      override val myenum = new Field[Myenum, Row](prefix, "myenum", None, Some("public.myenum"))(x => extract(x).myenum, (row, value) => merge(row, extract(row).copy(myenum = value)))
-      override val name = new Field[String, Row](prefix, "name", None, Some("name"))(x => extract(x).name, (row, value) => merge(row, extract(row).copy(name = value)))
-      override val numeric = new Field[BigDecimal, Row](prefix, "numeric", None, Some("numeric"))(x => extract(x).numeric, (row, value) => merge(row, extract(row).copy(numeric = value)))
-      override val path = new Field[TypoPath, Row](prefix, "path", None, Some("path"))(x => extract(x).path, (row, value) => merge(row, extract(row).copy(path = value)))
-      override val point = new Field[TypoPoint, Row](prefix, "point", None, Some("point"))(x => extract(x).point, (row, value) => merge(row, extract(row).copy(point = value)))
-      override val polygon = new Field[TypoPolygon, Row](prefix, "polygon", None, Some("polygon"))(x => extract(x).polygon, (row, value) => merge(row, extract(row).copy(polygon = value)))
-      override val text = new Field[String, Row](prefix, "text", None, None)(x => extract(x).text, (row, value) => merge(row, extract(row).copy(text = value)))
-      override val time = new Field[TypoLocalTime, Row](prefix, "time", Some("text"), Some("time"))(x => extract(x).time, (row, value) => merge(row, extract(row).copy(time = value)))
-      override val timestamp = new Field[TypoLocalDateTime, Row](prefix, "timestamp", Some("text"), Some("timestamp"))(x => extract(x).timestamp, (row, value) => merge(row, extract(row).copy(timestamp = value)))
-      override val timestampz = new Field[TypoInstant, Row](prefix, "timestampz", Some("text"), Some("timestamptz"))(x => extract(x).timestampz, (row, value) => merge(row, extract(row).copy(timestampz = value)))
-      override val timez = new Field[TypoOffsetTime, Row](prefix, "timez", Some("text"), Some("timetz"))(x => extract(x).timez, (row, value) => merge(row, extract(row).copy(timez = value)))
-      override val uuid = new Field[TypoUUID, Row](prefix, "uuid", None, Some("uuid"))(x => extract(x).uuid, (row, value) => merge(row, extract(row).copy(uuid = value)))
-      override val varchar = new Field[String, Row](prefix, "varchar", None, None)(x => extract(x).varchar, (row, value) => merge(row, extract(row).copy(varchar = value)))
-      override val vector = new Field[TypoVector, Row](prefix, "vector", Some("float4[]"), Some("vector"))(x => extract(x).vector, (row, value) => merge(row, extract(row).copy(vector = value)))
-      override val xml = new Field[TypoXml, Row](prefix, "xml", None, Some("xml"))(x => extract(x).xml, (row, value) => merge(row, extract(row).copy(xml = value)))
-      override val boxes = new Field[Array[TypoBox], Row](prefix, "boxes", None, Some("_box"))(x => extract(x).boxes, (row, value) => merge(row, extract(row).copy(boxes = value)))
-      override val bpchares = new Field[Array[/* bpchar */ String], Row](prefix, "bpchares", None, Some("_bpchar"))(x => extract(x).bpchares, (row, value) => merge(row, extract(row).copy(bpchares = value)))
-      override val chares = new Field[Array[/* bpchar */ String], Row](prefix, "chares", None, Some("_bpchar"))(x => extract(x).chares, (row, value) => merge(row, extract(row).copy(chares = value)))
-      override val circlees = new Field[Array[TypoCircle], Row](prefix, "circlees", None, Some("_circle"))(x => extract(x).circlees, (row, value) => merge(row, extract(row).copy(circlees = value)))
-      override val datees = new Field[Array[TypoLocalDate], Row](prefix, "datees", Some("text[]"), Some("_date"))(x => extract(x).datees, (row, value) => merge(row, extract(row).copy(datees = value)))
-      override val float4es = new Field[Array[Float], Row](prefix, "float4es", None, Some("_float4"))(x => extract(x).float4es, (row, value) => merge(row, extract(row).copy(float4es = value)))
-      override val float8es = new Field[Array[Double], Row](prefix, "float8es", None, Some("_float8"))(x => extract(x).float8es, (row, value) => merge(row, extract(row).copy(float8es = value)))
-      override val inetes = new Field[Array[TypoInet], Row](prefix, "inetes", None, Some("_inet"))(x => extract(x).inetes, (row, value) => merge(row, extract(row).copy(inetes = value)))
-      override val int2es = new Field[Array[TypoShort], Row](prefix, "int2es", None, Some("_int2"))(x => extract(x).int2es, (row, value) => merge(row, extract(row).copy(int2es = value)))
-      override val int2vectores = new Field[Array[TypoInt2Vector], Row](prefix, "int2vectores", None, Some("_int2vector"))(x => extract(x).int2vectores, (row, value) => merge(row, extract(row).copy(int2vectores = value)))
-      override val int4es = new Field[Array[Int], Row](prefix, "int4es", None, Some("_int4"))(x => extract(x).int4es, (row, value) => merge(row, extract(row).copy(int4es = value)))
-      override val int8es = new Field[Array[Long], Row](prefix, "int8es", None, Some("_int8"))(x => extract(x).int8es, (row, value) => merge(row, extract(row).copy(int8es = value)))
-      override val intervales = new Field[Array[TypoInterval], Row](prefix, "intervales", None, Some("_interval"))(x => extract(x).intervales, (row, value) => merge(row, extract(row).copy(intervales = value)))
-      override val jsones = new Field[Array[TypoJson], Row](prefix, "jsones", None, Some("_json"))(x => extract(x).jsones, (row, value) => merge(row, extract(row).copy(jsones = value)))
-      override val jsonbes = new Field[Array[TypoJsonb], Row](prefix, "jsonbes", None, Some("_jsonb"))(x => extract(x).jsonbes, (row, value) => merge(row, extract(row).copy(jsonbes = value)))
-      override val linees = new Field[Array[TypoLine], Row](prefix, "linees", None, Some("_line"))(x => extract(x).linees, (row, value) => merge(row, extract(row).copy(linees = value)))
-      override val lseges = new Field[Array[TypoLineSegment], Row](prefix, "lseges", None, Some("_lseg"))(x => extract(x).lseges, (row, value) => merge(row, extract(row).copy(lseges = value)))
-      override val moneyes = new Field[Array[TypoMoney], Row](prefix, "moneyes", Some("numeric[]"), Some("_money"))(x => extract(x).moneyes, (row, value) => merge(row, extract(row).copy(moneyes = value)))
-      override val myenumes = new Field[Array[Myenum], Row](prefix, "myenumes", None, Some("_myenum"))(x => extract(x).myenumes, (row, value) => merge(row, extract(row).copy(myenumes = value)))
-      override val namees = new Field[Array[String], Row](prefix, "namees", None, Some("_name"))(x => extract(x).namees, (row, value) => merge(row, extract(row).copy(namees = value)))
-      override val numerices = new Field[Array[BigDecimal], Row](prefix, "numerices", None, Some("_numeric"))(x => extract(x).numerices, (row, value) => merge(row, extract(row).copy(numerices = value)))
-      override val pathes = new Field[Array[TypoPath], Row](prefix, "pathes", None, Some("_path"))(x => extract(x).pathes, (row, value) => merge(row, extract(row).copy(pathes = value)))
-      override val pointes = new Field[Array[TypoPoint], Row](prefix, "pointes", None, Some("_point"))(x => extract(x).pointes, (row, value) => merge(row, extract(row).copy(pointes = value)))
-      override val polygones = new Field[Array[TypoPolygon], Row](prefix, "polygones", None, Some("_polygon"))(x => extract(x).polygones, (row, value) => merge(row, extract(row).copy(polygones = value)))
-      override val textes = new Field[Array[String], Row](prefix, "textes", None, Some("_text"))(x => extract(x).textes, (row, value) => merge(row, extract(row).copy(textes = value)))
-      override val timees = new Field[Array[TypoLocalTime], Row](prefix, "timees", Some("text[]"), Some("_time"))(x => extract(x).timees, (row, value) => merge(row, extract(row).copy(timees = value)))
-      override val timestampes = new Field[Array[TypoLocalDateTime], Row](prefix, "timestampes", Some("text[]"), Some("_timestamp"))(x => extract(x).timestampes, (row, value) => merge(row, extract(row).copy(timestampes = value)))
-      override val timestampzes = new Field[Array[TypoInstant], Row](prefix, "timestampzes", Some("text[]"), Some("_timestamptz"))(x => extract(x).timestampzes, (row, value) => merge(row, extract(row).copy(timestampzes = value)))
-      override val timezes = new Field[Array[TypoOffsetTime], Row](prefix, "timezes", Some("text[]"), Some("_timetz"))(x => extract(x).timezes, (row, value) => merge(row, extract(row).copy(timezes = value)))
-      override val uuides = new Field[Array[TypoUUID], Row](prefix, "uuides", None, Some("_uuid"))(x => extract(x).uuides, (row, value) => merge(row, extract(row).copy(uuides = value)))
-      override val varchares = new Field[Array[String], Row](prefix, "varchares", None, Some("_varchar"))(x => extract(x).varchares, (row, value) => merge(row, extract(row).copy(varchares = value)))
-      override val xmles = new Field[Array[TypoXml], Row](prefix, "xmles", None, Some("_xml"))(x => extract(x).xmles, (row, value) => merge(row, extract(row).copy(xmles = value)))
+    override lazy val fields: PgtestFields = new PgtestFields {
+      override def bool = Field[Boolean, PgtestRow](_path, "bool", None, None, x => x.bool, (row, value) => row.copy(bool = value))
+      override def box = Field[TypoBox, PgtestRow](_path, "box", None, Some("box"), x => x.box, (row, value) => row.copy(box = value))
+      override def bpchar = Field[/* bpchar, max 3 chars */ String, PgtestRow](_path, "bpchar", None, Some("bpchar"), x => x.bpchar, (row, value) => row.copy(bpchar = value))
+      override def bytea = Field[TypoBytea, PgtestRow](_path, "bytea", None, Some("bytea"), x => x.bytea, (row, value) => row.copy(bytea = value))
+      override def char = Field[/* bpchar, max 1 chars */ String, PgtestRow](_path, "char", None, Some("bpchar"), x => x.char, (row, value) => row.copy(char = value))
+      override def circle = Field[TypoCircle, PgtestRow](_path, "circle", None, Some("circle"), x => x.circle, (row, value) => row.copy(circle = value))
+      override def date = Field[TypoLocalDate, PgtestRow](_path, "date", Some("text"), Some("date"), x => x.date, (row, value) => row.copy(date = value))
+      override def float4 = Field[Float, PgtestRow](_path, "float4", None, Some("float4"), x => x.float4, (row, value) => row.copy(float4 = value))
+      override def float8 = Field[Double, PgtestRow](_path, "float8", None, Some("float8"), x => x.float8, (row, value) => row.copy(float8 = value))
+      override def hstore = Field[TypoHStore, PgtestRow](_path, "hstore", None, Some("hstore"), x => x.hstore, (row, value) => row.copy(hstore = value))
+      override def inet = Field[TypoInet, PgtestRow](_path, "inet", None, Some("inet"), x => x.inet, (row, value) => row.copy(inet = value))
+      override def int2 = Field[TypoShort, PgtestRow](_path, "int2", None, Some("int2"), x => x.int2, (row, value) => row.copy(int2 = value))
+      override def int2vector = Field[TypoInt2Vector, PgtestRow](_path, "int2vector", None, Some("int2vector"), x => x.int2vector, (row, value) => row.copy(int2vector = value))
+      override def int4 = Field[Int, PgtestRow](_path, "int4", None, Some("int4"), x => x.int4, (row, value) => row.copy(int4 = value))
+      override def int8 = Field[Long, PgtestRow](_path, "int8", None, Some("int8"), x => x.int8, (row, value) => row.copy(int8 = value))
+      override def interval = Field[TypoInterval, PgtestRow](_path, "interval", None, Some("interval"), x => x.interval, (row, value) => row.copy(interval = value))
+      override def json = Field[TypoJson, PgtestRow](_path, "json", None, Some("json"), x => x.json, (row, value) => row.copy(json = value))
+      override def jsonb = Field[TypoJsonb, PgtestRow](_path, "jsonb", None, Some("jsonb"), x => x.jsonb, (row, value) => row.copy(jsonb = value))
+      override def line = Field[TypoLine, PgtestRow](_path, "line", None, Some("line"), x => x.line, (row, value) => row.copy(line = value))
+      override def lseg = Field[TypoLineSegment, PgtestRow](_path, "lseg", None, Some("lseg"), x => x.lseg, (row, value) => row.copy(lseg = value))
+      override def money = Field[TypoMoney, PgtestRow](_path, "money", Some("numeric"), Some("money"), x => x.money, (row, value) => row.copy(money = value))
+      override def mydomain = Field[Mydomain, PgtestRow](_path, "mydomain", None, Some("text"), x => x.mydomain, (row, value) => row.copy(mydomain = value))
+      override def myenum = Field[Myenum, PgtestRow](_path, "myenum", None, Some("public.myenum"), x => x.myenum, (row, value) => row.copy(myenum = value))
+      override def name = Field[String, PgtestRow](_path, "name", None, Some("name"), x => x.name, (row, value) => row.copy(name = value))
+      override def numeric = Field[BigDecimal, PgtestRow](_path, "numeric", None, Some("numeric"), x => x.numeric, (row, value) => row.copy(numeric = value))
+      override def path = Field[TypoPath, PgtestRow](_path, "path", None, Some("path"), x => x.path, (row, value) => row.copy(path = value))
+      override def point = Field[TypoPoint, PgtestRow](_path, "point", None, Some("point"), x => x.point, (row, value) => row.copy(point = value))
+      override def polygon = Field[TypoPolygon, PgtestRow](_path, "polygon", None, Some("polygon"), x => x.polygon, (row, value) => row.copy(polygon = value))
+      override def text = Field[String, PgtestRow](_path, "text", None, None, x => x.text, (row, value) => row.copy(text = value))
+      override def time = Field[TypoLocalTime, PgtestRow](_path, "time", Some("text"), Some("time"), x => x.time, (row, value) => row.copy(time = value))
+      override def timestamp = Field[TypoLocalDateTime, PgtestRow](_path, "timestamp", Some("text"), Some("timestamp"), x => x.timestamp, (row, value) => row.copy(timestamp = value))
+      override def timestampz = Field[TypoInstant, PgtestRow](_path, "timestampz", Some("text"), Some("timestamptz"), x => x.timestampz, (row, value) => row.copy(timestampz = value))
+      override def timez = Field[TypoOffsetTime, PgtestRow](_path, "timez", Some("text"), Some("timetz"), x => x.timez, (row, value) => row.copy(timez = value))
+      override def uuid = Field[TypoUUID, PgtestRow](_path, "uuid", None, Some("uuid"), x => x.uuid, (row, value) => row.copy(uuid = value))
+      override def varchar = Field[String, PgtestRow](_path, "varchar", None, None, x => x.varchar, (row, value) => row.copy(varchar = value))
+      override def vector = Field[TypoVector, PgtestRow](_path, "vector", Some("float4[]"), Some("vector"), x => x.vector, (row, value) => row.copy(vector = value))
+      override def xml = Field[TypoXml, PgtestRow](_path, "xml", None, Some("xml"), x => x.xml, (row, value) => row.copy(xml = value))
+      override def boxes = Field[Array[TypoBox], PgtestRow](_path, "boxes", None, Some("_box"), x => x.boxes, (row, value) => row.copy(boxes = value))
+      override def bpchares = Field[Array[/* bpchar */ String], PgtestRow](_path, "bpchares", None, Some("_bpchar"), x => x.bpchares, (row, value) => row.copy(bpchares = value))
+      override def chares = Field[Array[/* bpchar */ String], PgtestRow](_path, "chares", None, Some("_bpchar"), x => x.chares, (row, value) => row.copy(chares = value))
+      override def circlees = Field[Array[TypoCircle], PgtestRow](_path, "circlees", None, Some("_circle"), x => x.circlees, (row, value) => row.copy(circlees = value))
+      override def datees = Field[Array[TypoLocalDate], PgtestRow](_path, "datees", Some("text[]"), Some("_date"), x => x.datees, (row, value) => row.copy(datees = value))
+      override def float4es = Field[Array[Float], PgtestRow](_path, "float4es", None, Some("_float4"), x => x.float4es, (row, value) => row.copy(float4es = value))
+      override def float8es = Field[Array[Double], PgtestRow](_path, "float8es", None, Some("_float8"), x => x.float8es, (row, value) => row.copy(float8es = value))
+      override def inetes = Field[Array[TypoInet], PgtestRow](_path, "inetes", None, Some("_inet"), x => x.inetes, (row, value) => row.copy(inetes = value))
+      override def int2es = Field[Array[TypoShort], PgtestRow](_path, "int2es", None, Some("_int2"), x => x.int2es, (row, value) => row.copy(int2es = value))
+      override def int2vectores = Field[Array[TypoInt2Vector], PgtestRow](_path, "int2vectores", None, Some("_int2vector"), x => x.int2vectores, (row, value) => row.copy(int2vectores = value))
+      override def int4es = Field[Array[Int], PgtestRow](_path, "int4es", None, Some("_int4"), x => x.int4es, (row, value) => row.copy(int4es = value))
+      override def int8es = Field[Array[Long], PgtestRow](_path, "int8es", None, Some("_int8"), x => x.int8es, (row, value) => row.copy(int8es = value))
+      override def intervales = Field[Array[TypoInterval], PgtestRow](_path, "intervales", None, Some("_interval"), x => x.intervales, (row, value) => row.copy(intervales = value))
+      override def jsones = Field[Array[TypoJson], PgtestRow](_path, "jsones", None, Some("_json"), x => x.jsones, (row, value) => row.copy(jsones = value))
+      override def jsonbes = Field[Array[TypoJsonb], PgtestRow](_path, "jsonbes", None, Some("_jsonb"), x => x.jsonbes, (row, value) => row.copy(jsonbes = value))
+      override def linees = Field[Array[TypoLine], PgtestRow](_path, "linees", None, Some("_line"), x => x.linees, (row, value) => row.copy(linees = value))
+      override def lseges = Field[Array[TypoLineSegment], PgtestRow](_path, "lseges", None, Some("_lseg"), x => x.lseges, (row, value) => row.copy(lseges = value))
+      override def moneyes = Field[Array[TypoMoney], PgtestRow](_path, "moneyes", Some("numeric[]"), Some("_money"), x => x.moneyes, (row, value) => row.copy(moneyes = value))
+      override def myenumes = Field[Array[Myenum], PgtestRow](_path, "myenumes", None, Some("_myenum"), x => x.myenumes, (row, value) => row.copy(myenumes = value))
+      override def namees = Field[Array[String], PgtestRow](_path, "namees", None, Some("_name"), x => x.namees, (row, value) => row.copy(namees = value))
+      override def numerices = Field[Array[BigDecimal], PgtestRow](_path, "numerices", None, Some("_numeric"), x => x.numerices, (row, value) => row.copy(numerices = value))
+      override def pathes = Field[Array[TypoPath], PgtestRow](_path, "pathes", None, Some("_path"), x => x.pathes, (row, value) => row.copy(pathes = value))
+      override def pointes = Field[Array[TypoPoint], PgtestRow](_path, "pointes", None, Some("_point"), x => x.pointes, (row, value) => row.copy(pointes = value))
+      override def polygones = Field[Array[TypoPolygon], PgtestRow](_path, "polygones", None, Some("_polygon"), x => x.polygones, (row, value) => row.copy(polygones = value))
+      override def textes = Field[Array[String], PgtestRow](_path, "textes", None, Some("_text"), x => x.textes, (row, value) => row.copy(textes = value))
+      override def timees = Field[Array[TypoLocalTime], PgtestRow](_path, "timees", Some("text[]"), Some("_time"), x => x.timees, (row, value) => row.copy(timees = value))
+      override def timestampes = Field[Array[TypoLocalDateTime], PgtestRow](_path, "timestampes", Some("text[]"), Some("_timestamp"), x => x.timestampes, (row, value) => row.copy(timestampes = value))
+      override def timestampzes = Field[Array[TypoInstant], PgtestRow](_path, "timestampzes", Some("text[]"), Some("_timestamptz"), x => x.timestampzes, (row, value) => row.copy(timestampzes = value))
+      override def timezes = Field[Array[TypoOffsetTime], PgtestRow](_path, "timezes", Some("text[]"), Some("_timetz"), x => x.timezes, (row, value) => row.copy(timezes = value))
+      override def uuides = Field[Array[TypoUUID], PgtestRow](_path, "uuides", None, Some("_uuid"), x => x.uuides, (row, value) => row.copy(uuides = value))
+      override def varchares = Field[Array[String], PgtestRow](_path, "varchares", None, Some("_varchar"), x => x.varchares, (row, value) => row.copy(varchares = value))
+      override def xmles = Field[Array[TypoXml], PgtestRow](_path, "xmles", None, Some("_xml"), x => x.xmles, (row, value) => row.copy(xmles = value))
     }
   
-    override val columns: List[FieldLikeNoHkt[?, Row]] =
-      List[FieldLikeNoHkt[?, Row]](fields.bool, fields.box, fields.bpchar, fields.bytea, fields.char, fields.circle, fields.date, fields.float4, fields.float8, fields.hstore, fields.inet, fields.int2, fields.int2vector, fields.int4, fields.int8, fields.interval, fields.json, fields.jsonb, fields.line, fields.lseg, fields.money, fields.mydomain, fields.myenum, fields.name, fields.numeric, fields.path, fields.point, fields.polygon, fields.text, fields.time, fields.timestamp, fields.timestampz, fields.timez, fields.uuid, fields.varchar, fields.vector, fields.xml, fields.boxes, fields.bpchares, fields.chares, fields.circlees, fields.datees, fields.float4es, fields.float8es, fields.inetes, fields.int2es, fields.int2vectores, fields.int4es, fields.int8es, fields.intervales, fields.jsones, fields.jsonbes, fields.linees, fields.lseges, fields.moneyes, fields.myenumes, fields.namees, fields.numerices, fields.pathes, fields.pointes, fields.polygones, fields.textes, fields.timees, fields.timestampes, fields.timestampzes, fields.timezes, fields.uuides, fields.varchares, fields.xmles)
+    override lazy val columns: List[FieldLikeNoHkt[?, PgtestRow]] =
+      List[FieldLikeNoHkt[?, PgtestRow]](fields.bool, fields.box, fields.bpchar, fields.bytea, fields.char, fields.circle, fields.date, fields.float4, fields.float8, fields.hstore, fields.inet, fields.int2, fields.int2vector, fields.int4, fields.int8, fields.interval, fields.json, fields.jsonb, fields.line, fields.lseg, fields.money, fields.mydomain, fields.myenum, fields.name, fields.numeric, fields.path, fields.point, fields.polygon, fields.text, fields.time, fields.timestamp, fields.timestampz, fields.timez, fields.uuid, fields.varchar, fields.vector, fields.xml, fields.boxes, fields.bpchares, fields.chares, fields.circlees, fields.datees, fields.float4es, fields.float8es, fields.inetes, fields.int2es, fields.int2vectores, fields.int4es, fields.int8es, fields.intervales, fields.jsones, fields.jsonbes, fields.linees, fields.lseges, fields.moneyes, fields.myenumes, fields.namees, fields.numerices, fields.pathes, fields.pointes, fields.polygones, fields.textes, fields.timees, fields.timestampes, fields.timestampzes, fields.timezes, fields.uuides, fields.varchares, fields.xmles)
   
-    override def copy[NewRow](prefix: Option[String], extract: NewRow => PgtestRow, merge: (NewRow, PgtestRow) => NewRow): Impl[NewRow] =
-      new Impl(prefix, extract, merge)
+    override def copy(path: List[Path]): Impl =
+      new Impl(path)
   }
   
 }

--- a/typo-tester-zio-jdbc/generated-and-checked-in/adventureworks/public/pgtestnull/PgtestnullFields.scala
+++ b/typo-tester-zio-jdbc/generated-and-checked-in/adventureworks/public/pgtestnull/PgtestnullFields.scala
@@ -33,166 +33,167 @@ import adventureworks.customtypes.TypoVector
 import adventureworks.customtypes.TypoXml
 import adventureworks.public.Mydomain
 import adventureworks.public.Myenum
+import typo.dsl.Path
 import typo.dsl.SqlExpr.FieldLikeNoHkt
 import typo.dsl.SqlExpr.OptField
 import typo.dsl.Structure.Relation
 
-trait PgtestnullFields[Row] {
-  val bool: OptField[Boolean, Row]
-  val box: OptField[TypoBox, Row]
-  val bpchar: OptField[/* bpchar, max 3 chars */ String, Row]
-  val bytea: OptField[TypoBytea, Row]
-  val char: OptField[/* bpchar, max 1 chars */ String, Row]
-  val circle: OptField[TypoCircle, Row]
-  val date: OptField[TypoLocalDate, Row]
-  val float4: OptField[Float, Row]
-  val float8: OptField[Double, Row]
-  val hstore: OptField[TypoHStore, Row]
-  val inet: OptField[TypoInet, Row]
-  val int2: OptField[TypoShort, Row]
-  val int2vector: OptField[TypoInt2Vector, Row]
-  val int4: OptField[Int, Row]
-  val int8: OptField[Long, Row]
-  val interval: OptField[TypoInterval, Row]
-  val json: OptField[TypoJson, Row]
-  val jsonb: OptField[TypoJsonb, Row]
-  val line: OptField[TypoLine, Row]
-  val lseg: OptField[TypoLineSegment, Row]
-  val money: OptField[TypoMoney, Row]
-  val mydomain: OptField[Mydomain, Row]
-  val myenum: OptField[Myenum, Row]
-  val name: OptField[String, Row]
-  val numeric: OptField[BigDecimal, Row]
-  val path: OptField[TypoPath, Row]
-  val point: OptField[TypoPoint, Row]
-  val polygon: OptField[TypoPolygon, Row]
-  val text: OptField[String, Row]
-  val time: OptField[TypoLocalTime, Row]
-  val timestamp: OptField[TypoLocalDateTime, Row]
-  val timestampz: OptField[TypoInstant, Row]
-  val timez: OptField[TypoOffsetTime, Row]
-  val uuid: OptField[TypoUUID, Row]
-  val varchar: OptField[String, Row]
-  val vector: OptField[TypoVector, Row]
-  val xml: OptField[TypoXml, Row]
-  val boxes: OptField[Array[TypoBox], Row]
-  val bpchares: OptField[Array[/* bpchar */ String], Row]
-  val chares: OptField[Array[/* bpchar */ String], Row]
-  val circlees: OptField[Array[TypoCircle], Row]
-  val datees: OptField[Array[TypoLocalDate], Row]
-  val float4es: OptField[Array[Float], Row]
-  val float8es: OptField[Array[Double], Row]
-  val inetes: OptField[Array[TypoInet], Row]
-  val int2es: OptField[Array[TypoShort], Row]
-  val int2vectores: OptField[Array[TypoInt2Vector], Row]
-  val int4es: OptField[Array[Int], Row]
-  val int8es: OptField[Array[Long], Row]
-  val intervales: OptField[Array[TypoInterval], Row]
-  val jsones: OptField[Array[TypoJson], Row]
-  val jsonbes: OptField[Array[TypoJsonb], Row]
-  val linees: OptField[Array[TypoLine], Row]
-  val lseges: OptField[Array[TypoLineSegment], Row]
-  val moneyes: OptField[Array[TypoMoney], Row]
-  val myenumes: OptField[Array[Myenum], Row]
-  val namees: OptField[Array[String], Row]
-  val numerices: OptField[Array[BigDecimal], Row]
-  val pathes: OptField[Array[TypoPath], Row]
-  val pointes: OptField[Array[TypoPoint], Row]
-  val polygones: OptField[Array[TypoPolygon], Row]
-  val textes: OptField[Array[String], Row]
-  val timees: OptField[Array[TypoLocalTime], Row]
-  val timestampes: OptField[Array[TypoLocalDateTime], Row]
-  val timestampzes: OptField[Array[TypoInstant], Row]
-  val timezes: OptField[Array[TypoOffsetTime], Row]
-  val uuides: OptField[Array[TypoUUID], Row]
-  val varchares: OptField[Array[String], Row]
-  val xmles: OptField[Array[TypoXml], Row]
+trait PgtestnullFields {
+  def bool: OptField[Boolean, PgtestnullRow]
+  def box: OptField[TypoBox, PgtestnullRow]
+  def bpchar: OptField[/* bpchar, max 3 chars */ String, PgtestnullRow]
+  def bytea: OptField[TypoBytea, PgtestnullRow]
+  def char: OptField[/* bpchar, max 1 chars */ String, PgtestnullRow]
+  def circle: OptField[TypoCircle, PgtestnullRow]
+  def date: OptField[TypoLocalDate, PgtestnullRow]
+  def float4: OptField[Float, PgtestnullRow]
+  def float8: OptField[Double, PgtestnullRow]
+  def hstore: OptField[TypoHStore, PgtestnullRow]
+  def inet: OptField[TypoInet, PgtestnullRow]
+  def int2: OptField[TypoShort, PgtestnullRow]
+  def int2vector: OptField[TypoInt2Vector, PgtestnullRow]
+  def int4: OptField[Int, PgtestnullRow]
+  def int8: OptField[Long, PgtestnullRow]
+  def interval: OptField[TypoInterval, PgtestnullRow]
+  def json: OptField[TypoJson, PgtestnullRow]
+  def jsonb: OptField[TypoJsonb, PgtestnullRow]
+  def line: OptField[TypoLine, PgtestnullRow]
+  def lseg: OptField[TypoLineSegment, PgtestnullRow]
+  def money: OptField[TypoMoney, PgtestnullRow]
+  def mydomain: OptField[Mydomain, PgtestnullRow]
+  def myenum: OptField[Myenum, PgtestnullRow]
+  def name: OptField[String, PgtestnullRow]
+  def numeric: OptField[BigDecimal, PgtestnullRow]
+  def path: OptField[TypoPath, PgtestnullRow]
+  def point: OptField[TypoPoint, PgtestnullRow]
+  def polygon: OptField[TypoPolygon, PgtestnullRow]
+  def text: OptField[String, PgtestnullRow]
+  def time: OptField[TypoLocalTime, PgtestnullRow]
+  def timestamp: OptField[TypoLocalDateTime, PgtestnullRow]
+  def timestampz: OptField[TypoInstant, PgtestnullRow]
+  def timez: OptField[TypoOffsetTime, PgtestnullRow]
+  def uuid: OptField[TypoUUID, PgtestnullRow]
+  def varchar: OptField[String, PgtestnullRow]
+  def vector: OptField[TypoVector, PgtestnullRow]
+  def xml: OptField[TypoXml, PgtestnullRow]
+  def boxes: OptField[Array[TypoBox], PgtestnullRow]
+  def bpchares: OptField[Array[/* bpchar */ String], PgtestnullRow]
+  def chares: OptField[Array[/* bpchar */ String], PgtestnullRow]
+  def circlees: OptField[Array[TypoCircle], PgtestnullRow]
+  def datees: OptField[Array[TypoLocalDate], PgtestnullRow]
+  def float4es: OptField[Array[Float], PgtestnullRow]
+  def float8es: OptField[Array[Double], PgtestnullRow]
+  def inetes: OptField[Array[TypoInet], PgtestnullRow]
+  def int2es: OptField[Array[TypoShort], PgtestnullRow]
+  def int2vectores: OptField[Array[TypoInt2Vector], PgtestnullRow]
+  def int4es: OptField[Array[Int], PgtestnullRow]
+  def int8es: OptField[Array[Long], PgtestnullRow]
+  def intervales: OptField[Array[TypoInterval], PgtestnullRow]
+  def jsones: OptField[Array[TypoJson], PgtestnullRow]
+  def jsonbes: OptField[Array[TypoJsonb], PgtestnullRow]
+  def linees: OptField[Array[TypoLine], PgtestnullRow]
+  def lseges: OptField[Array[TypoLineSegment], PgtestnullRow]
+  def moneyes: OptField[Array[TypoMoney], PgtestnullRow]
+  def myenumes: OptField[Array[Myenum], PgtestnullRow]
+  def namees: OptField[Array[String], PgtestnullRow]
+  def numerices: OptField[Array[BigDecimal], PgtestnullRow]
+  def pathes: OptField[Array[TypoPath], PgtestnullRow]
+  def pointes: OptField[Array[TypoPoint], PgtestnullRow]
+  def polygones: OptField[Array[TypoPolygon], PgtestnullRow]
+  def textes: OptField[Array[String], PgtestnullRow]
+  def timees: OptField[Array[TypoLocalTime], PgtestnullRow]
+  def timestampes: OptField[Array[TypoLocalDateTime], PgtestnullRow]
+  def timestampzes: OptField[Array[TypoInstant], PgtestnullRow]
+  def timezes: OptField[Array[TypoOffsetTime], PgtestnullRow]
+  def uuides: OptField[Array[TypoUUID], PgtestnullRow]
+  def varchares: OptField[Array[String], PgtestnullRow]
+  def xmles: OptField[Array[TypoXml], PgtestnullRow]
 }
 
 object PgtestnullFields {
-  val structure: Relation[PgtestnullFields, PgtestnullRow, PgtestnullRow] = 
-    new Impl(None, identity, (_, x) => x)
+  lazy val structure: Relation[PgtestnullFields, PgtestnullRow] =
+    new Impl(Nil)
     
-  private final class Impl[Row](val prefix: Option[String], val extract: Row => PgtestnullRow, val merge: (Row, PgtestnullRow) => Row)
-    extends Relation[PgtestnullFields, PgtestnullRow, Row] { 
+  private final class Impl(val _path: List[Path])
+    extends Relation[PgtestnullFields, PgtestnullRow] {
   
-    override val fields: PgtestnullFields[Row] = new PgtestnullFields[Row] {
-      override val bool = new OptField[Boolean, Row](prefix, "bool", None, None)(x => extract(x).bool, (row, value) => merge(row, extract(row).copy(bool = value)))
-      override val box = new OptField[TypoBox, Row](prefix, "box", None, Some("box"))(x => extract(x).box, (row, value) => merge(row, extract(row).copy(box = value)))
-      override val bpchar = new OptField[/* bpchar, max 3 chars */ String, Row](prefix, "bpchar", None, Some("bpchar"))(x => extract(x).bpchar, (row, value) => merge(row, extract(row).copy(bpchar = value)))
-      override val bytea = new OptField[TypoBytea, Row](prefix, "bytea", None, Some("bytea"))(x => extract(x).bytea, (row, value) => merge(row, extract(row).copy(bytea = value)))
-      override val char = new OptField[/* bpchar, max 1 chars */ String, Row](prefix, "char", None, Some("bpchar"))(x => extract(x).char, (row, value) => merge(row, extract(row).copy(char = value)))
-      override val circle = new OptField[TypoCircle, Row](prefix, "circle", None, Some("circle"))(x => extract(x).circle, (row, value) => merge(row, extract(row).copy(circle = value)))
-      override val date = new OptField[TypoLocalDate, Row](prefix, "date", Some("text"), Some("date"))(x => extract(x).date, (row, value) => merge(row, extract(row).copy(date = value)))
-      override val float4 = new OptField[Float, Row](prefix, "float4", None, Some("float4"))(x => extract(x).float4, (row, value) => merge(row, extract(row).copy(float4 = value)))
-      override val float8 = new OptField[Double, Row](prefix, "float8", None, Some("float8"))(x => extract(x).float8, (row, value) => merge(row, extract(row).copy(float8 = value)))
-      override val hstore = new OptField[TypoHStore, Row](prefix, "hstore", None, Some("hstore"))(x => extract(x).hstore, (row, value) => merge(row, extract(row).copy(hstore = value)))
-      override val inet = new OptField[TypoInet, Row](prefix, "inet", None, Some("inet"))(x => extract(x).inet, (row, value) => merge(row, extract(row).copy(inet = value)))
-      override val int2 = new OptField[TypoShort, Row](prefix, "int2", None, Some("int2"))(x => extract(x).int2, (row, value) => merge(row, extract(row).copy(int2 = value)))
-      override val int2vector = new OptField[TypoInt2Vector, Row](prefix, "int2vector", None, Some("int2vector"))(x => extract(x).int2vector, (row, value) => merge(row, extract(row).copy(int2vector = value)))
-      override val int4 = new OptField[Int, Row](prefix, "int4", None, Some("int4"))(x => extract(x).int4, (row, value) => merge(row, extract(row).copy(int4 = value)))
-      override val int8 = new OptField[Long, Row](prefix, "int8", None, Some("int8"))(x => extract(x).int8, (row, value) => merge(row, extract(row).copy(int8 = value)))
-      override val interval = new OptField[TypoInterval, Row](prefix, "interval", None, Some("interval"))(x => extract(x).interval, (row, value) => merge(row, extract(row).copy(interval = value)))
-      override val json = new OptField[TypoJson, Row](prefix, "json", None, Some("json"))(x => extract(x).json, (row, value) => merge(row, extract(row).copy(json = value)))
-      override val jsonb = new OptField[TypoJsonb, Row](prefix, "jsonb", None, Some("jsonb"))(x => extract(x).jsonb, (row, value) => merge(row, extract(row).copy(jsonb = value)))
-      override val line = new OptField[TypoLine, Row](prefix, "line", None, Some("line"))(x => extract(x).line, (row, value) => merge(row, extract(row).copy(line = value)))
-      override val lseg = new OptField[TypoLineSegment, Row](prefix, "lseg", None, Some("lseg"))(x => extract(x).lseg, (row, value) => merge(row, extract(row).copy(lseg = value)))
-      override val money = new OptField[TypoMoney, Row](prefix, "money", Some("numeric"), Some("money"))(x => extract(x).money, (row, value) => merge(row, extract(row).copy(money = value)))
-      override val mydomain = new OptField[Mydomain, Row](prefix, "mydomain", None, Some("text"))(x => extract(x).mydomain, (row, value) => merge(row, extract(row).copy(mydomain = value)))
-      override val myenum = new OptField[Myenum, Row](prefix, "myenum", None, Some("public.myenum"))(x => extract(x).myenum, (row, value) => merge(row, extract(row).copy(myenum = value)))
-      override val name = new OptField[String, Row](prefix, "name", None, Some("name"))(x => extract(x).name, (row, value) => merge(row, extract(row).copy(name = value)))
-      override val numeric = new OptField[BigDecimal, Row](prefix, "numeric", None, Some("numeric"))(x => extract(x).numeric, (row, value) => merge(row, extract(row).copy(numeric = value)))
-      override val path = new OptField[TypoPath, Row](prefix, "path", None, Some("path"))(x => extract(x).path, (row, value) => merge(row, extract(row).copy(path = value)))
-      override val point = new OptField[TypoPoint, Row](prefix, "point", None, Some("point"))(x => extract(x).point, (row, value) => merge(row, extract(row).copy(point = value)))
-      override val polygon = new OptField[TypoPolygon, Row](prefix, "polygon", None, Some("polygon"))(x => extract(x).polygon, (row, value) => merge(row, extract(row).copy(polygon = value)))
-      override val text = new OptField[String, Row](prefix, "text", None, None)(x => extract(x).text, (row, value) => merge(row, extract(row).copy(text = value)))
-      override val time = new OptField[TypoLocalTime, Row](prefix, "time", Some("text"), Some("time"))(x => extract(x).time, (row, value) => merge(row, extract(row).copy(time = value)))
-      override val timestamp = new OptField[TypoLocalDateTime, Row](prefix, "timestamp", Some("text"), Some("timestamp"))(x => extract(x).timestamp, (row, value) => merge(row, extract(row).copy(timestamp = value)))
-      override val timestampz = new OptField[TypoInstant, Row](prefix, "timestampz", Some("text"), Some("timestamptz"))(x => extract(x).timestampz, (row, value) => merge(row, extract(row).copy(timestampz = value)))
-      override val timez = new OptField[TypoOffsetTime, Row](prefix, "timez", Some("text"), Some("timetz"))(x => extract(x).timez, (row, value) => merge(row, extract(row).copy(timez = value)))
-      override val uuid = new OptField[TypoUUID, Row](prefix, "uuid", None, Some("uuid"))(x => extract(x).uuid, (row, value) => merge(row, extract(row).copy(uuid = value)))
-      override val varchar = new OptField[String, Row](prefix, "varchar", None, None)(x => extract(x).varchar, (row, value) => merge(row, extract(row).copy(varchar = value)))
-      override val vector = new OptField[TypoVector, Row](prefix, "vector", Some("float4[]"), Some("vector"))(x => extract(x).vector, (row, value) => merge(row, extract(row).copy(vector = value)))
-      override val xml = new OptField[TypoXml, Row](prefix, "xml", None, Some("xml"))(x => extract(x).xml, (row, value) => merge(row, extract(row).copy(xml = value)))
-      override val boxes = new OptField[Array[TypoBox], Row](prefix, "boxes", None, Some("_box"))(x => extract(x).boxes, (row, value) => merge(row, extract(row).copy(boxes = value)))
-      override val bpchares = new OptField[Array[/* bpchar */ String], Row](prefix, "bpchares", None, Some("_bpchar"))(x => extract(x).bpchares, (row, value) => merge(row, extract(row).copy(bpchares = value)))
-      override val chares = new OptField[Array[/* bpchar */ String], Row](prefix, "chares", None, Some("_bpchar"))(x => extract(x).chares, (row, value) => merge(row, extract(row).copy(chares = value)))
-      override val circlees = new OptField[Array[TypoCircle], Row](prefix, "circlees", None, Some("_circle"))(x => extract(x).circlees, (row, value) => merge(row, extract(row).copy(circlees = value)))
-      override val datees = new OptField[Array[TypoLocalDate], Row](prefix, "datees", Some("text[]"), Some("_date"))(x => extract(x).datees, (row, value) => merge(row, extract(row).copy(datees = value)))
-      override val float4es = new OptField[Array[Float], Row](prefix, "float4es", None, Some("_float4"))(x => extract(x).float4es, (row, value) => merge(row, extract(row).copy(float4es = value)))
-      override val float8es = new OptField[Array[Double], Row](prefix, "float8es", None, Some("_float8"))(x => extract(x).float8es, (row, value) => merge(row, extract(row).copy(float8es = value)))
-      override val inetes = new OptField[Array[TypoInet], Row](prefix, "inetes", None, Some("_inet"))(x => extract(x).inetes, (row, value) => merge(row, extract(row).copy(inetes = value)))
-      override val int2es = new OptField[Array[TypoShort], Row](prefix, "int2es", None, Some("_int2"))(x => extract(x).int2es, (row, value) => merge(row, extract(row).copy(int2es = value)))
-      override val int2vectores = new OptField[Array[TypoInt2Vector], Row](prefix, "int2vectores", None, Some("_int2vector"))(x => extract(x).int2vectores, (row, value) => merge(row, extract(row).copy(int2vectores = value)))
-      override val int4es = new OptField[Array[Int], Row](prefix, "int4es", None, Some("_int4"))(x => extract(x).int4es, (row, value) => merge(row, extract(row).copy(int4es = value)))
-      override val int8es = new OptField[Array[Long], Row](prefix, "int8es", None, Some("_int8"))(x => extract(x).int8es, (row, value) => merge(row, extract(row).copy(int8es = value)))
-      override val intervales = new OptField[Array[TypoInterval], Row](prefix, "intervales", None, Some("_interval"))(x => extract(x).intervales, (row, value) => merge(row, extract(row).copy(intervales = value)))
-      override val jsones = new OptField[Array[TypoJson], Row](prefix, "jsones", None, Some("_json"))(x => extract(x).jsones, (row, value) => merge(row, extract(row).copy(jsones = value)))
-      override val jsonbes = new OptField[Array[TypoJsonb], Row](prefix, "jsonbes", None, Some("_jsonb"))(x => extract(x).jsonbes, (row, value) => merge(row, extract(row).copy(jsonbes = value)))
-      override val linees = new OptField[Array[TypoLine], Row](prefix, "linees", None, Some("_line"))(x => extract(x).linees, (row, value) => merge(row, extract(row).copy(linees = value)))
-      override val lseges = new OptField[Array[TypoLineSegment], Row](prefix, "lseges", None, Some("_lseg"))(x => extract(x).lseges, (row, value) => merge(row, extract(row).copy(lseges = value)))
-      override val moneyes = new OptField[Array[TypoMoney], Row](prefix, "moneyes", Some("numeric[]"), Some("_money"))(x => extract(x).moneyes, (row, value) => merge(row, extract(row).copy(moneyes = value)))
-      override val myenumes = new OptField[Array[Myenum], Row](prefix, "myenumes", None, Some("_myenum"))(x => extract(x).myenumes, (row, value) => merge(row, extract(row).copy(myenumes = value)))
-      override val namees = new OptField[Array[String], Row](prefix, "namees", None, Some("_name"))(x => extract(x).namees, (row, value) => merge(row, extract(row).copy(namees = value)))
-      override val numerices = new OptField[Array[BigDecimal], Row](prefix, "numerices", None, Some("_numeric"))(x => extract(x).numerices, (row, value) => merge(row, extract(row).copy(numerices = value)))
-      override val pathes = new OptField[Array[TypoPath], Row](prefix, "pathes", None, Some("_path"))(x => extract(x).pathes, (row, value) => merge(row, extract(row).copy(pathes = value)))
-      override val pointes = new OptField[Array[TypoPoint], Row](prefix, "pointes", None, Some("_point"))(x => extract(x).pointes, (row, value) => merge(row, extract(row).copy(pointes = value)))
-      override val polygones = new OptField[Array[TypoPolygon], Row](prefix, "polygones", None, Some("_polygon"))(x => extract(x).polygones, (row, value) => merge(row, extract(row).copy(polygones = value)))
-      override val textes = new OptField[Array[String], Row](prefix, "textes", None, Some("_text"))(x => extract(x).textes, (row, value) => merge(row, extract(row).copy(textes = value)))
-      override val timees = new OptField[Array[TypoLocalTime], Row](prefix, "timees", Some("text[]"), Some("_time"))(x => extract(x).timees, (row, value) => merge(row, extract(row).copy(timees = value)))
-      override val timestampes = new OptField[Array[TypoLocalDateTime], Row](prefix, "timestampes", Some("text[]"), Some("_timestamp"))(x => extract(x).timestampes, (row, value) => merge(row, extract(row).copy(timestampes = value)))
-      override val timestampzes = new OptField[Array[TypoInstant], Row](prefix, "timestampzes", Some("text[]"), Some("_timestamptz"))(x => extract(x).timestampzes, (row, value) => merge(row, extract(row).copy(timestampzes = value)))
-      override val timezes = new OptField[Array[TypoOffsetTime], Row](prefix, "timezes", Some("text[]"), Some("_timetz"))(x => extract(x).timezes, (row, value) => merge(row, extract(row).copy(timezes = value)))
-      override val uuides = new OptField[Array[TypoUUID], Row](prefix, "uuides", None, Some("_uuid"))(x => extract(x).uuides, (row, value) => merge(row, extract(row).copy(uuides = value)))
-      override val varchares = new OptField[Array[String], Row](prefix, "varchares", None, Some("_varchar"))(x => extract(x).varchares, (row, value) => merge(row, extract(row).copy(varchares = value)))
-      override val xmles = new OptField[Array[TypoXml], Row](prefix, "xmles", None, Some("_xml"))(x => extract(x).xmles, (row, value) => merge(row, extract(row).copy(xmles = value)))
+    override lazy val fields: PgtestnullFields = new PgtestnullFields {
+      override def bool = OptField[Boolean, PgtestnullRow](_path, "bool", None, None, x => x.bool, (row, value) => row.copy(bool = value))
+      override def box = OptField[TypoBox, PgtestnullRow](_path, "box", None, Some("box"), x => x.box, (row, value) => row.copy(box = value))
+      override def bpchar = OptField[/* bpchar, max 3 chars */ String, PgtestnullRow](_path, "bpchar", None, Some("bpchar"), x => x.bpchar, (row, value) => row.copy(bpchar = value))
+      override def bytea = OptField[TypoBytea, PgtestnullRow](_path, "bytea", None, Some("bytea"), x => x.bytea, (row, value) => row.copy(bytea = value))
+      override def char = OptField[/* bpchar, max 1 chars */ String, PgtestnullRow](_path, "char", None, Some("bpchar"), x => x.char, (row, value) => row.copy(char = value))
+      override def circle = OptField[TypoCircle, PgtestnullRow](_path, "circle", None, Some("circle"), x => x.circle, (row, value) => row.copy(circle = value))
+      override def date = OptField[TypoLocalDate, PgtestnullRow](_path, "date", Some("text"), Some("date"), x => x.date, (row, value) => row.copy(date = value))
+      override def float4 = OptField[Float, PgtestnullRow](_path, "float4", None, Some("float4"), x => x.float4, (row, value) => row.copy(float4 = value))
+      override def float8 = OptField[Double, PgtestnullRow](_path, "float8", None, Some("float8"), x => x.float8, (row, value) => row.copy(float8 = value))
+      override def hstore = OptField[TypoHStore, PgtestnullRow](_path, "hstore", None, Some("hstore"), x => x.hstore, (row, value) => row.copy(hstore = value))
+      override def inet = OptField[TypoInet, PgtestnullRow](_path, "inet", None, Some("inet"), x => x.inet, (row, value) => row.copy(inet = value))
+      override def int2 = OptField[TypoShort, PgtestnullRow](_path, "int2", None, Some("int2"), x => x.int2, (row, value) => row.copy(int2 = value))
+      override def int2vector = OptField[TypoInt2Vector, PgtestnullRow](_path, "int2vector", None, Some("int2vector"), x => x.int2vector, (row, value) => row.copy(int2vector = value))
+      override def int4 = OptField[Int, PgtestnullRow](_path, "int4", None, Some("int4"), x => x.int4, (row, value) => row.copy(int4 = value))
+      override def int8 = OptField[Long, PgtestnullRow](_path, "int8", None, Some("int8"), x => x.int8, (row, value) => row.copy(int8 = value))
+      override def interval = OptField[TypoInterval, PgtestnullRow](_path, "interval", None, Some("interval"), x => x.interval, (row, value) => row.copy(interval = value))
+      override def json = OptField[TypoJson, PgtestnullRow](_path, "json", None, Some("json"), x => x.json, (row, value) => row.copy(json = value))
+      override def jsonb = OptField[TypoJsonb, PgtestnullRow](_path, "jsonb", None, Some("jsonb"), x => x.jsonb, (row, value) => row.copy(jsonb = value))
+      override def line = OptField[TypoLine, PgtestnullRow](_path, "line", None, Some("line"), x => x.line, (row, value) => row.copy(line = value))
+      override def lseg = OptField[TypoLineSegment, PgtestnullRow](_path, "lseg", None, Some("lseg"), x => x.lseg, (row, value) => row.copy(lseg = value))
+      override def money = OptField[TypoMoney, PgtestnullRow](_path, "money", Some("numeric"), Some("money"), x => x.money, (row, value) => row.copy(money = value))
+      override def mydomain = OptField[Mydomain, PgtestnullRow](_path, "mydomain", None, Some("text"), x => x.mydomain, (row, value) => row.copy(mydomain = value))
+      override def myenum = OptField[Myenum, PgtestnullRow](_path, "myenum", None, Some("public.myenum"), x => x.myenum, (row, value) => row.copy(myenum = value))
+      override def name = OptField[String, PgtestnullRow](_path, "name", None, Some("name"), x => x.name, (row, value) => row.copy(name = value))
+      override def numeric = OptField[BigDecimal, PgtestnullRow](_path, "numeric", None, Some("numeric"), x => x.numeric, (row, value) => row.copy(numeric = value))
+      override def path = OptField[TypoPath, PgtestnullRow](_path, "path", None, Some("path"), x => x.path, (row, value) => row.copy(path = value))
+      override def point = OptField[TypoPoint, PgtestnullRow](_path, "point", None, Some("point"), x => x.point, (row, value) => row.copy(point = value))
+      override def polygon = OptField[TypoPolygon, PgtestnullRow](_path, "polygon", None, Some("polygon"), x => x.polygon, (row, value) => row.copy(polygon = value))
+      override def text = OptField[String, PgtestnullRow](_path, "text", None, None, x => x.text, (row, value) => row.copy(text = value))
+      override def time = OptField[TypoLocalTime, PgtestnullRow](_path, "time", Some("text"), Some("time"), x => x.time, (row, value) => row.copy(time = value))
+      override def timestamp = OptField[TypoLocalDateTime, PgtestnullRow](_path, "timestamp", Some("text"), Some("timestamp"), x => x.timestamp, (row, value) => row.copy(timestamp = value))
+      override def timestampz = OptField[TypoInstant, PgtestnullRow](_path, "timestampz", Some("text"), Some("timestamptz"), x => x.timestampz, (row, value) => row.copy(timestampz = value))
+      override def timez = OptField[TypoOffsetTime, PgtestnullRow](_path, "timez", Some("text"), Some("timetz"), x => x.timez, (row, value) => row.copy(timez = value))
+      override def uuid = OptField[TypoUUID, PgtestnullRow](_path, "uuid", None, Some("uuid"), x => x.uuid, (row, value) => row.copy(uuid = value))
+      override def varchar = OptField[String, PgtestnullRow](_path, "varchar", None, None, x => x.varchar, (row, value) => row.copy(varchar = value))
+      override def vector = OptField[TypoVector, PgtestnullRow](_path, "vector", Some("float4[]"), Some("vector"), x => x.vector, (row, value) => row.copy(vector = value))
+      override def xml = OptField[TypoXml, PgtestnullRow](_path, "xml", None, Some("xml"), x => x.xml, (row, value) => row.copy(xml = value))
+      override def boxes = OptField[Array[TypoBox], PgtestnullRow](_path, "boxes", None, Some("_box"), x => x.boxes, (row, value) => row.copy(boxes = value))
+      override def bpchares = OptField[Array[/* bpchar */ String], PgtestnullRow](_path, "bpchares", None, Some("_bpchar"), x => x.bpchares, (row, value) => row.copy(bpchares = value))
+      override def chares = OptField[Array[/* bpchar */ String], PgtestnullRow](_path, "chares", None, Some("_bpchar"), x => x.chares, (row, value) => row.copy(chares = value))
+      override def circlees = OptField[Array[TypoCircle], PgtestnullRow](_path, "circlees", None, Some("_circle"), x => x.circlees, (row, value) => row.copy(circlees = value))
+      override def datees = OptField[Array[TypoLocalDate], PgtestnullRow](_path, "datees", Some("text[]"), Some("_date"), x => x.datees, (row, value) => row.copy(datees = value))
+      override def float4es = OptField[Array[Float], PgtestnullRow](_path, "float4es", None, Some("_float4"), x => x.float4es, (row, value) => row.copy(float4es = value))
+      override def float8es = OptField[Array[Double], PgtestnullRow](_path, "float8es", None, Some("_float8"), x => x.float8es, (row, value) => row.copy(float8es = value))
+      override def inetes = OptField[Array[TypoInet], PgtestnullRow](_path, "inetes", None, Some("_inet"), x => x.inetes, (row, value) => row.copy(inetes = value))
+      override def int2es = OptField[Array[TypoShort], PgtestnullRow](_path, "int2es", None, Some("_int2"), x => x.int2es, (row, value) => row.copy(int2es = value))
+      override def int2vectores = OptField[Array[TypoInt2Vector], PgtestnullRow](_path, "int2vectores", None, Some("_int2vector"), x => x.int2vectores, (row, value) => row.copy(int2vectores = value))
+      override def int4es = OptField[Array[Int], PgtestnullRow](_path, "int4es", None, Some("_int4"), x => x.int4es, (row, value) => row.copy(int4es = value))
+      override def int8es = OptField[Array[Long], PgtestnullRow](_path, "int8es", None, Some("_int8"), x => x.int8es, (row, value) => row.copy(int8es = value))
+      override def intervales = OptField[Array[TypoInterval], PgtestnullRow](_path, "intervales", None, Some("_interval"), x => x.intervales, (row, value) => row.copy(intervales = value))
+      override def jsones = OptField[Array[TypoJson], PgtestnullRow](_path, "jsones", None, Some("_json"), x => x.jsones, (row, value) => row.copy(jsones = value))
+      override def jsonbes = OptField[Array[TypoJsonb], PgtestnullRow](_path, "jsonbes", None, Some("_jsonb"), x => x.jsonbes, (row, value) => row.copy(jsonbes = value))
+      override def linees = OptField[Array[TypoLine], PgtestnullRow](_path, "linees", None, Some("_line"), x => x.linees, (row, value) => row.copy(linees = value))
+      override def lseges = OptField[Array[TypoLineSegment], PgtestnullRow](_path, "lseges", None, Some("_lseg"), x => x.lseges, (row, value) => row.copy(lseges = value))
+      override def moneyes = OptField[Array[TypoMoney], PgtestnullRow](_path, "moneyes", Some("numeric[]"), Some("_money"), x => x.moneyes, (row, value) => row.copy(moneyes = value))
+      override def myenumes = OptField[Array[Myenum], PgtestnullRow](_path, "myenumes", None, Some("_myenum"), x => x.myenumes, (row, value) => row.copy(myenumes = value))
+      override def namees = OptField[Array[String], PgtestnullRow](_path, "namees", None, Some("_name"), x => x.namees, (row, value) => row.copy(namees = value))
+      override def numerices = OptField[Array[BigDecimal], PgtestnullRow](_path, "numerices", None, Some("_numeric"), x => x.numerices, (row, value) => row.copy(numerices = value))
+      override def pathes = OptField[Array[TypoPath], PgtestnullRow](_path, "pathes", None, Some("_path"), x => x.pathes, (row, value) => row.copy(pathes = value))
+      override def pointes = OptField[Array[TypoPoint], PgtestnullRow](_path, "pointes", None, Some("_point"), x => x.pointes, (row, value) => row.copy(pointes = value))
+      override def polygones = OptField[Array[TypoPolygon], PgtestnullRow](_path, "polygones", None, Some("_polygon"), x => x.polygones, (row, value) => row.copy(polygones = value))
+      override def textes = OptField[Array[String], PgtestnullRow](_path, "textes", None, Some("_text"), x => x.textes, (row, value) => row.copy(textes = value))
+      override def timees = OptField[Array[TypoLocalTime], PgtestnullRow](_path, "timees", Some("text[]"), Some("_time"), x => x.timees, (row, value) => row.copy(timees = value))
+      override def timestampes = OptField[Array[TypoLocalDateTime], PgtestnullRow](_path, "timestampes", Some("text[]"), Some("_timestamp"), x => x.timestampes, (row, value) => row.copy(timestampes = value))
+      override def timestampzes = OptField[Array[TypoInstant], PgtestnullRow](_path, "timestampzes", Some("text[]"), Some("_timestamptz"), x => x.timestampzes, (row, value) => row.copy(timestampzes = value))
+      override def timezes = OptField[Array[TypoOffsetTime], PgtestnullRow](_path, "timezes", Some("text[]"), Some("_timetz"), x => x.timezes, (row, value) => row.copy(timezes = value))
+      override def uuides = OptField[Array[TypoUUID], PgtestnullRow](_path, "uuides", None, Some("_uuid"), x => x.uuides, (row, value) => row.copy(uuides = value))
+      override def varchares = OptField[Array[String], PgtestnullRow](_path, "varchares", None, Some("_varchar"), x => x.varchares, (row, value) => row.copy(varchares = value))
+      override def xmles = OptField[Array[TypoXml], PgtestnullRow](_path, "xmles", None, Some("_xml"), x => x.xmles, (row, value) => row.copy(xmles = value))
     }
   
-    override val columns: List[FieldLikeNoHkt[?, Row]] =
-      List[FieldLikeNoHkt[?, Row]](fields.bool, fields.box, fields.bpchar, fields.bytea, fields.char, fields.circle, fields.date, fields.float4, fields.float8, fields.hstore, fields.inet, fields.int2, fields.int2vector, fields.int4, fields.int8, fields.interval, fields.json, fields.jsonb, fields.line, fields.lseg, fields.money, fields.mydomain, fields.myenum, fields.name, fields.numeric, fields.path, fields.point, fields.polygon, fields.text, fields.time, fields.timestamp, fields.timestampz, fields.timez, fields.uuid, fields.varchar, fields.vector, fields.xml, fields.boxes, fields.bpchares, fields.chares, fields.circlees, fields.datees, fields.float4es, fields.float8es, fields.inetes, fields.int2es, fields.int2vectores, fields.int4es, fields.int8es, fields.intervales, fields.jsones, fields.jsonbes, fields.linees, fields.lseges, fields.moneyes, fields.myenumes, fields.namees, fields.numerices, fields.pathes, fields.pointes, fields.polygones, fields.textes, fields.timees, fields.timestampes, fields.timestampzes, fields.timezes, fields.uuides, fields.varchares, fields.xmles)
+    override lazy val columns: List[FieldLikeNoHkt[?, PgtestnullRow]] =
+      List[FieldLikeNoHkt[?, PgtestnullRow]](fields.bool, fields.box, fields.bpchar, fields.bytea, fields.char, fields.circle, fields.date, fields.float4, fields.float8, fields.hstore, fields.inet, fields.int2, fields.int2vector, fields.int4, fields.int8, fields.interval, fields.json, fields.jsonb, fields.line, fields.lseg, fields.money, fields.mydomain, fields.myenum, fields.name, fields.numeric, fields.path, fields.point, fields.polygon, fields.text, fields.time, fields.timestamp, fields.timestampz, fields.timez, fields.uuid, fields.varchar, fields.vector, fields.xml, fields.boxes, fields.bpchares, fields.chares, fields.circlees, fields.datees, fields.float4es, fields.float8es, fields.inetes, fields.int2es, fields.int2vectores, fields.int4es, fields.int8es, fields.intervales, fields.jsones, fields.jsonbes, fields.linees, fields.lseges, fields.moneyes, fields.myenumes, fields.namees, fields.numerices, fields.pathes, fields.pointes, fields.polygones, fields.textes, fields.timees, fields.timestampes, fields.timestampzes, fields.timezes, fields.uuides, fields.varchares, fields.xmles)
   
-    override def copy[NewRow](prefix: Option[String], extract: NewRow => PgtestnullRow, merge: (NewRow, PgtestnullRow) => NewRow): Impl[NewRow] =
-      new Impl(prefix, extract, merge)
+    override def copy(path: List[Path]): Impl =
+      new Impl(path)
   }
   
 }

--- a/typo-tester-zio-jdbc/generated-and-checked-in/adventureworks/public/users/UsersFields.scala
+++ b/typo-tester-zio-jdbc/generated-and-checked-in/adventureworks/public/users/UsersFields.scala
@@ -9,44 +9,45 @@ package users
 
 import adventureworks.customtypes.TypoInstant
 import adventureworks.customtypes.TypoUnknownCitext
+import typo.dsl.Path
 import typo.dsl.SqlExpr.Field
 import typo.dsl.SqlExpr.FieldLikeNoHkt
 import typo.dsl.SqlExpr.IdField
 import typo.dsl.SqlExpr.OptField
 import typo.dsl.Structure.Relation
 
-trait UsersFields[Row] {
-  val userId: IdField[UsersId, Row]
-  val name: Field[String, Row]
-  val lastName: OptField[String, Row]
-  val email: Field[TypoUnknownCitext, Row]
-  val password: Field[String, Row]
-  val createdAt: Field[TypoInstant, Row]
-  val verifiedOn: OptField[TypoInstant, Row]
+trait UsersFields {
+  def userId: IdField[UsersId, UsersRow]
+  def name: Field[String, UsersRow]
+  def lastName: OptField[String, UsersRow]
+  def email: Field[TypoUnknownCitext, UsersRow]
+  def password: Field[String, UsersRow]
+  def createdAt: Field[TypoInstant, UsersRow]
+  def verifiedOn: OptField[TypoInstant, UsersRow]
 }
 
 object UsersFields {
-  val structure: Relation[UsersFields, UsersRow, UsersRow] = 
-    new Impl(None, identity, (_, x) => x)
+  lazy val structure: Relation[UsersFields, UsersRow] =
+    new Impl(Nil)
     
-  private final class Impl[Row](val prefix: Option[String], val extract: Row => UsersRow, val merge: (Row, UsersRow) => Row)
-    extends Relation[UsersFields, UsersRow, Row] { 
+  private final class Impl(val _path: List[Path])
+    extends Relation[UsersFields, UsersRow] {
   
-    override val fields: UsersFields[Row] = new UsersFields[Row] {
-      override val userId = new IdField[UsersId, Row](prefix, "user_id", None, Some("uuid"))(x => extract(x).userId, (row, value) => merge(row, extract(row).copy(userId = value)))
-      override val name = new Field[String, Row](prefix, "name", None, None)(x => extract(x).name, (row, value) => merge(row, extract(row).copy(name = value)))
-      override val lastName = new OptField[String, Row](prefix, "last_name", None, None)(x => extract(x).lastName, (row, value) => merge(row, extract(row).copy(lastName = value)))
-      override val email = new Field[TypoUnknownCitext, Row](prefix, "email", Some("text"), Some("citext"))(x => extract(x).email, (row, value) => merge(row, extract(row).copy(email = value)))
-      override val password = new Field[String, Row](prefix, "password", None, None)(x => extract(x).password, (row, value) => merge(row, extract(row).copy(password = value)))
-      override val createdAt = new Field[TypoInstant, Row](prefix, "created_at", Some("text"), Some("timestamptz"))(x => extract(x).createdAt, (row, value) => merge(row, extract(row).copy(createdAt = value)))
-      override val verifiedOn = new OptField[TypoInstant, Row](prefix, "verified_on", Some("text"), Some("timestamptz"))(x => extract(x).verifiedOn, (row, value) => merge(row, extract(row).copy(verifiedOn = value)))
+    override lazy val fields: UsersFields = new UsersFields {
+      override def userId = IdField[UsersId, UsersRow](_path, "user_id", None, Some("uuid"), x => x.userId, (row, value) => row.copy(userId = value))
+      override def name = Field[String, UsersRow](_path, "name", None, None, x => x.name, (row, value) => row.copy(name = value))
+      override def lastName = OptField[String, UsersRow](_path, "last_name", None, None, x => x.lastName, (row, value) => row.copy(lastName = value))
+      override def email = Field[TypoUnknownCitext, UsersRow](_path, "email", Some("text"), Some("citext"), x => x.email, (row, value) => row.copy(email = value))
+      override def password = Field[String, UsersRow](_path, "password", None, None, x => x.password, (row, value) => row.copy(password = value))
+      override def createdAt = Field[TypoInstant, UsersRow](_path, "created_at", Some("text"), Some("timestamptz"), x => x.createdAt, (row, value) => row.copy(createdAt = value))
+      override def verifiedOn = OptField[TypoInstant, UsersRow](_path, "verified_on", Some("text"), Some("timestamptz"), x => x.verifiedOn, (row, value) => row.copy(verifiedOn = value))
     }
   
-    override val columns: List[FieldLikeNoHkt[?, Row]] =
-      List[FieldLikeNoHkt[?, Row]](fields.userId, fields.name, fields.lastName, fields.email, fields.password, fields.createdAt, fields.verifiedOn)
+    override lazy val columns: List[FieldLikeNoHkt[?, UsersRow]] =
+      List[FieldLikeNoHkt[?, UsersRow]](fields.userId, fields.name, fields.lastName, fields.email, fields.password, fields.createdAt, fields.verifiedOn)
   
-    override def copy[NewRow](prefix: Option[String], extract: NewRow => UsersRow, merge: (NewRow, UsersRow) => NewRow): Impl[NewRow] =
-      new Impl(prefix, extract, merge)
+    override def copy(path: List[Path]): Impl =
+      new Impl(path)
   }
   
 }

--- a/typo-tester-zio-jdbc/generated-and-checked-in/adventureworks/public/users/UsersRepoMock.scala
+++ b/typo-tester-zio-jdbc/generated-and-checked-in/adventureworks/public/users/UsersRepoMock.scala
@@ -27,7 +27,7 @@ import zio.stream.ZStream
 class UsersRepoMock(toRow: Function1[UsersRowUnsaved, UsersRow],
                     map: scala.collection.mutable.Map[UsersId, UsersRow] = scala.collection.mutable.Map.empty) extends UsersRepo {
   override def delete: DeleteBuilder[UsersFields, UsersRow] = {
-    DeleteBuilderMock(DeleteParams.empty, UsersFields.structure.fields, map)
+    DeleteBuilderMock(DeleteParams.empty, UsersFields.structure, map)
   }
   override def deleteById(userId: UsersId): ZIO[ZConnection, Throwable, Boolean] = {
     ZIO.succeed(map.remove(userId).isDefined)
@@ -89,7 +89,7 @@ class UsersRepoMock(toRow: Function1[UsersRowUnsaved, UsersRow],
     ZIO.succeed(map.values.find(v => email == v.email))
   }
   override def update: UpdateBuilder[UsersFields, UsersRow] = {
-    UpdateBuilderMock(UpdateParams.empty, UsersFields.structure.fields, map)
+    UpdateBuilderMock(UpdateParams.empty, UsersFields.structure, map)
   }
   override def update(row: UsersRow): ZIO[ZConnection, Throwable, Boolean] = {
     ZIO.succeed {

--- a/typo-tester-zio-jdbc/generated-and-checked-in/adventureworks/purchasing/productvendor/ProductvendorFields.scala
+++ b/typo-tester-zio-jdbc/generated-and-checked-in/adventureworks/purchasing/productvendor/ProductvendorFields.scala
@@ -11,52 +11,53 @@ import adventureworks.customtypes.TypoLocalDateTime
 import adventureworks.person.businessentity.BusinessentityId
 import adventureworks.production.product.ProductId
 import adventureworks.production.unitmeasure.UnitmeasureId
+import typo.dsl.Path
 import typo.dsl.SqlExpr.Field
 import typo.dsl.SqlExpr.FieldLikeNoHkt
 import typo.dsl.SqlExpr.IdField
 import typo.dsl.SqlExpr.OptField
 import typo.dsl.Structure.Relation
 
-trait ProductvendorFields[Row] {
-  val productid: IdField[ProductId, Row]
-  val businessentityid: IdField[BusinessentityId, Row]
-  val averageleadtime: Field[Int, Row]
-  val standardprice: Field[BigDecimal, Row]
-  val lastreceiptcost: OptField[BigDecimal, Row]
-  val lastreceiptdate: OptField[TypoLocalDateTime, Row]
-  val minorderqty: Field[Int, Row]
-  val maxorderqty: Field[Int, Row]
-  val onorderqty: OptField[Int, Row]
-  val unitmeasurecode: Field[UnitmeasureId, Row]
-  val modifieddate: Field[TypoLocalDateTime, Row]
+trait ProductvendorFields {
+  def productid: IdField[ProductId, ProductvendorRow]
+  def businessentityid: IdField[BusinessentityId, ProductvendorRow]
+  def averageleadtime: Field[Int, ProductvendorRow]
+  def standardprice: Field[BigDecimal, ProductvendorRow]
+  def lastreceiptcost: OptField[BigDecimal, ProductvendorRow]
+  def lastreceiptdate: OptField[TypoLocalDateTime, ProductvendorRow]
+  def minorderqty: Field[Int, ProductvendorRow]
+  def maxorderqty: Field[Int, ProductvendorRow]
+  def onorderqty: OptField[Int, ProductvendorRow]
+  def unitmeasurecode: Field[UnitmeasureId, ProductvendorRow]
+  def modifieddate: Field[TypoLocalDateTime, ProductvendorRow]
 }
 
 object ProductvendorFields {
-  val structure: Relation[ProductvendorFields, ProductvendorRow, ProductvendorRow] = 
-    new Impl(None, identity, (_, x) => x)
+  lazy val structure: Relation[ProductvendorFields, ProductvendorRow] =
+    new Impl(Nil)
     
-  private final class Impl[Row](val prefix: Option[String], val extract: Row => ProductvendorRow, val merge: (Row, ProductvendorRow) => Row)
-    extends Relation[ProductvendorFields, ProductvendorRow, Row] { 
+  private final class Impl(val _path: List[Path])
+    extends Relation[ProductvendorFields, ProductvendorRow] {
   
-    override val fields: ProductvendorFields[Row] = new ProductvendorFields[Row] {
-      override val productid = new IdField[ProductId, Row](prefix, "productid", None, Some("int4"))(x => extract(x).productid, (row, value) => merge(row, extract(row).copy(productid = value)))
-      override val businessentityid = new IdField[BusinessentityId, Row](prefix, "businessentityid", None, Some("int4"))(x => extract(x).businessentityid, (row, value) => merge(row, extract(row).copy(businessentityid = value)))
-      override val averageleadtime = new Field[Int, Row](prefix, "averageleadtime", None, Some("int4"))(x => extract(x).averageleadtime, (row, value) => merge(row, extract(row).copy(averageleadtime = value)))
-      override val standardprice = new Field[BigDecimal, Row](prefix, "standardprice", None, Some("numeric"))(x => extract(x).standardprice, (row, value) => merge(row, extract(row).copy(standardprice = value)))
-      override val lastreceiptcost = new OptField[BigDecimal, Row](prefix, "lastreceiptcost", None, Some("numeric"))(x => extract(x).lastreceiptcost, (row, value) => merge(row, extract(row).copy(lastreceiptcost = value)))
-      override val lastreceiptdate = new OptField[TypoLocalDateTime, Row](prefix, "lastreceiptdate", Some("text"), Some("timestamp"))(x => extract(x).lastreceiptdate, (row, value) => merge(row, extract(row).copy(lastreceiptdate = value)))
-      override val minorderqty = new Field[Int, Row](prefix, "minorderqty", None, Some("int4"))(x => extract(x).minorderqty, (row, value) => merge(row, extract(row).copy(minorderqty = value)))
-      override val maxorderqty = new Field[Int, Row](prefix, "maxorderqty", None, Some("int4"))(x => extract(x).maxorderqty, (row, value) => merge(row, extract(row).copy(maxorderqty = value)))
-      override val onorderqty = new OptField[Int, Row](prefix, "onorderqty", None, Some("int4"))(x => extract(x).onorderqty, (row, value) => merge(row, extract(row).copy(onorderqty = value)))
-      override val unitmeasurecode = new Field[UnitmeasureId, Row](prefix, "unitmeasurecode", None, Some("bpchar"))(x => extract(x).unitmeasurecode, (row, value) => merge(row, extract(row).copy(unitmeasurecode = value)))
-      override val modifieddate = new Field[TypoLocalDateTime, Row](prefix, "modifieddate", Some("text"), Some("timestamp"))(x => extract(x).modifieddate, (row, value) => merge(row, extract(row).copy(modifieddate = value)))
+    override lazy val fields: ProductvendorFields = new ProductvendorFields {
+      override def productid = IdField[ProductId, ProductvendorRow](_path, "productid", None, Some("int4"), x => x.productid, (row, value) => row.copy(productid = value))
+      override def businessentityid = IdField[BusinessentityId, ProductvendorRow](_path, "businessentityid", None, Some("int4"), x => x.businessentityid, (row, value) => row.copy(businessentityid = value))
+      override def averageleadtime = Field[Int, ProductvendorRow](_path, "averageleadtime", None, Some("int4"), x => x.averageleadtime, (row, value) => row.copy(averageleadtime = value))
+      override def standardprice = Field[BigDecimal, ProductvendorRow](_path, "standardprice", None, Some("numeric"), x => x.standardprice, (row, value) => row.copy(standardprice = value))
+      override def lastreceiptcost = OptField[BigDecimal, ProductvendorRow](_path, "lastreceiptcost", None, Some("numeric"), x => x.lastreceiptcost, (row, value) => row.copy(lastreceiptcost = value))
+      override def lastreceiptdate = OptField[TypoLocalDateTime, ProductvendorRow](_path, "lastreceiptdate", Some("text"), Some("timestamp"), x => x.lastreceiptdate, (row, value) => row.copy(lastreceiptdate = value))
+      override def minorderqty = Field[Int, ProductvendorRow](_path, "minorderqty", None, Some("int4"), x => x.minorderqty, (row, value) => row.copy(minorderqty = value))
+      override def maxorderqty = Field[Int, ProductvendorRow](_path, "maxorderqty", None, Some("int4"), x => x.maxorderqty, (row, value) => row.copy(maxorderqty = value))
+      override def onorderqty = OptField[Int, ProductvendorRow](_path, "onorderqty", None, Some("int4"), x => x.onorderqty, (row, value) => row.copy(onorderqty = value))
+      override def unitmeasurecode = Field[UnitmeasureId, ProductvendorRow](_path, "unitmeasurecode", None, Some("bpchar"), x => x.unitmeasurecode, (row, value) => row.copy(unitmeasurecode = value))
+      override def modifieddate = Field[TypoLocalDateTime, ProductvendorRow](_path, "modifieddate", Some("text"), Some("timestamp"), x => x.modifieddate, (row, value) => row.copy(modifieddate = value))
     }
   
-    override val columns: List[FieldLikeNoHkt[?, Row]] =
-      List[FieldLikeNoHkt[?, Row]](fields.productid, fields.businessentityid, fields.averageleadtime, fields.standardprice, fields.lastreceiptcost, fields.lastreceiptdate, fields.minorderqty, fields.maxorderqty, fields.onorderqty, fields.unitmeasurecode, fields.modifieddate)
+    override lazy val columns: List[FieldLikeNoHkt[?, ProductvendorRow]] =
+      List[FieldLikeNoHkt[?, ProductvendorRow]](fields.productid, fields.businessentityid, fields.averageleadtime, fields.standardprice, fields.lastreceiptcost, fields.lastreceiptdate, fields.minorderqty, fields.maxorderqty, fields.onorderqty, fields.unitmeasurecode, fields.modifieddate)
   
-    override def copy[NewRow](prefix: Option[String], extract: NewRow => ProductvendorRow, merge: (NewRow, ProductvendorRow) => NewRow): Impl[NewRow] =
-      new Impl(prefix, extract, merge)
+    override def copy(path: List[Path]): Impl =
+      new Impl(path)
   }
   
 }

--- a/typo-tester-zio-jdbc/generated-and-checked-in/adventureworks/purchasing/productvendor/ProductvendorRepoMock.scala
+++ b/typo-tester-zio-jdbc/generated-and-checked-in/adventureworks/purchasing/productvendor/ProductvendorRepoMock.scala
@@ -26,7 +26,7 @@ import zio.stream.ZStream
 class ProductvendorRepoMock(toRow: Function1[ProductvendorRowUnsaved, ProductvendorRow],
                             map: scala.collection.mutable.Map[ProductvendorId, ProductvendorRow] = scala.collection.mutable.Map.empty) extends ProductvendorRepo {
   override def delete: DeleteBuilder[ProductvendorFields, ProductvendorRow] = {
-    DeleteBuilderMock(DeleteParams.empty, ProductvendorFields.structure.fields, map)
+    DeleteBuilderMock(DeleteParams.empty, ProductvendorFields.structure, map)
   }
   override def deleteById(compositeId: ProductvendorId): ZIO[ZConnection, Throwable, Boolean] = {
     ZIO.succeed(map.remove(compositeId).isDefined)
@@ -85,7 +85,7 @@ class ProductvendorRepoMock(toRow: Function1[ProductvendorRowUnsaved, Productven
     }
   }
   override def update: UpdateBuilder[ProductvendorFields, ProductvendorRow] = {
-    UpdateBuilderMock(UpdateParams.empty, ProductvendorFields.structure.fields, map)
+    UpdateBuilderMock(UpdateParams.empty, ProductvendorFields.structure, map)
   }
   override def update(row: ProductvendorRow): ZIO[ZConnection, Throwable, Boolean] = {
     ZIO.succeed {

--- a/typo-tester-zio-jdbc/generated-and-checked-in/adventureworks/purchasing/purchaseorderdetail/PurchaseorderdetailFields.scala
+++ b/typo-tester-zio-jdbc/generated-and-checked-in/adventureworks/purchasing/purchaseorderdetail/PurchaseorderdetailFields.scala
@@ -11,47 +11,48 @@ import adventureworks.customtypes.TypoLocalDateTime
 import adventureworks.customtypes.TypoShort
 import adventureworks.production.product.ProductId
 import adventureworks.purchasing.purchaseorderheader.PurchaseorderheaderId
+import typo.dsl.Path
 import typo.dsl.SqlExpr.Field
 import typo.dsl.SqlExpr.FieldLikeNoHkt
 import typo.dsl.SqlExpr.IdField
 import typo.dsl.Structure.Relation
 
-trait PurchaseorderdetailFields[Row] {
-  val purchaseorderid: IdField[PurchaseorderheaderId, Row]
-  val purchaseorderdetailid: IdField[Int, Row]
-  val duedate: Field[TypoLocalDateTime, Row]
-  val orderqty: Field[TypoShort, Row]
-  val productid: Field[ProductId, Row]
-  val unitprice: Field[BigDecimal, Row]
-  val receivedqty: Field[BigDecimal, Row]
-  val rejectedqty: Field[BigDecimal, Row]
-  val modifieddate: Field[TypoLocalDateTime, Row]
+trait PurchaseorderdetailFields {
+  def purchaseorderid: IdField[PurchaseorderheaderId, PurchaseorderdetailRow]
+  def purchaseorderdetailid: IdField[Int, PurchaseorderdetailRow]
+  def duedate: Field[TypoLocalDateTime, PurchaseorderdetailRow]
+  def orderqty: Field[TypoShort, PurchaseorderdetailRow]
+  def productid: Field[ProductId, PurchaseorderdetailRow]
+  def unitprice: Field[BigDecimal, PurchaseorderdetailRow]
+  def receivedqty: Field[BigDecimal, PurchaseorderdetailRow]
+  def rejectedqty: Field[BigDecimal, PurchaseorderdetailRow]
+  def modifieddate: Field[TypoLocalDateTime, PurchaseorderdetailRow]
 }
 
 object PurchaseorderdetailFields {
-  val structure: Relation[PurchaseorderdetailFields, PurchaseorderdetailRow, PurchaseorderdetailRow] = 
-    new Impl(None, identity, (_, x) => x)
+  lazy val structure: Relation[PurchaseorderdetailFields, PurchaseorderdetailRow] =
+    new Impl(Nil)
     
-  private final class Impl[Row](val prefix: Option[String], val extract: Row => PurchaseorderdetailRow, val merge: (Row, PurchaseorderdetailRow) => Row)
-    extends Relation[PurchaseorderdetailFields, PurchaseorderdetailRow, Row] { 
+  private final class Impl(val _path: List[Path])
+    extends Relation[PurchaseorderdetailFields, PurchaseorderdetailRow] {
   
-    override val fields: PurchaseorderdetailFields[Row] = new PurchaseorderdetailFields[Row] {
-      override val purchaseorderid = new IdField[PurchaseorderheaderId, Row](prefix, "purchaseorderid", None, Some("int4"))(x => extract(x).purchaseorderid, (row, value) => merge(row, extract(row).copy(purchaseorderid = value)))
-      override val purchaseorderdetailid = new IdField[Int, Row](prefix, "purchaseorderdetailid", None, Some("int4"))(x => extract(x).purchaseorderdetailid, (row, value) => merge(row, extract(row).copy(purchaseorderdetailid = value)))
-      override val duedate = new Field[TypoLocalDateTime, Row](prefix, "duedate", Some("text"), Some("timestamp"))(x => extract(x).duedate, (row, value) => merge(row, extract(row).copy(duedate = value)))
-      override val orderqty = new Field[TypoShort, Row](prefix, "orderqty", None, Some("int2"))(x => extract(x).orderqty, (row, value) => merge(row, extract(row).copy(orderqty = value)))
-      override val productid = new Field[ProductId, Row](prefix, "productid", None, Some("int4"))(x => extract(x).productid, (row, value) => merge(row, extract(row).copy(productid = value)))
-      override val unitprice = new Field[BigDecimal, Row](prefix, "unitprice", None, Some("numeric"))(x => extract(x).unitprice, (row, value) => merge(row, extract(row).copy(unitprice = value)))
-      override val receivedqty = new Field[BigDecimal, Row](prefix, "receivedqty", None, Some("numeric"))(x => extract(x).receivedqty, (row, value) => merge(row, extract(row).copy(receivedqty = value)))
-      override val rejectedqty = new Field[BigDecimal, Row](prefix, "rejectedqty", None, Some("numeric"))(x => extract(x).rejectedqty, (row, value) => merge(row, extract(row).copy(rejectedqty = value)))
-      override val modifieddate = new Field[TypoLocalDateTime, Row](prefix, "modifieddate", Some("text"), Some("timestamp"))(x => extract(x).modifieddate, (row, value) => merge(row, extract(row).copy(modifieddate = value)))
+    override lazy val fields: PurchaseorderdetailFields = new PurchaseorderdetailFields {
+      override def purchaseorderid = IdField[PurchaseorderheaderId, PurchaseorderdetailRow](_path, "purchaseorderid", None, Some("int4"), x => x.purchaseorderid, (row, value) => row.copy(purchaseorderid = value))
+      override def purchaseorderdetailid = IdField[Int, PurchaseorderdetailRow](_path, "purchaseorderdetailid", None, Some("int4"), x => x.purchaseorderdetailid, (row, value) => row.copy(purchaseorderdetailid = value))
+      override def duedate = Field[TypoLocalDateTime, PurchaseorderdetailRow](_path, "duedate", Some("text"), Some("timestamp"), x => x.duedate, (row, value) => row.copy(duedate = value))
+      override def orderqty = Field[TypoShort, PurchaseorderdetailRow](_path, "orderqty", None, Some("int2"), x => x.orderqty, (row, value) => row.copy(orderqty = value))
+      override def productid = Field[ProductId, PurchaseorderdetailRow](_path, "productid", None, Some("int4"), x => x.productid, (row, value) => row.copy(productid = value))
+      override def unitprice = Field[BigDecimal, PurchaseorderdetailRow](_path, "unitprice", None, Some("numeric"), x => x.unitprice, (row, value) => row.copy(unitprice = value))
+      override def receivedqty = Field[BigDecimal, PurchaseorderdetailRow](_path, "receivedqty", None, Some("numeric"), x => x.receivedqty, (row, value) => row.copy(receivedqty = value))
+      override def rejectedqty = Field[BigDecimal, PurchaseorderdetailRow](_path, "rejectedqty", None, Some("numeric"), x => x.rejectedqty, (row, value) => row.copy(rejectedqty = value))
+      override def modifieddate = Field[TypoLocalDateTime, PurchaseorderdetailRow](_path, "modifieddate", Some("text"), Some("timestamp"), x => x.modifieddate, (row, value) => row.copy(modifieddate = value))
     }
   
-    override val columns: List[FieldLikeNoHkt[?, Row]] =
-      List[FieldLikeNoHkt[?, Row]](fields.purchaseorderid, fields.purchaseorderdetailid, fields.duedate, fields.orderqty, fields.productid, fields.unitprice, fields.receivedqty, fields.rejectedqty, fields.modifieddate)
+    override lazy val columns: List[FieldLikeNoHkt[?, PurchaseorderdetailRow]] =
+      List[FieldLikeNoHkt[?, PurchaseorderdetailRow]](fields.purchaseorderid, fields.purchaseorderdetailid, fields.duedate, fields.orderqty, fields.productid, fields.unitprice, fields.receivedqty, fields.rejectedqty, fields.modifieddate)
   
-    override def copy[NewRow](prefix: Option[String], extract: NewRow => PurchaseorderdetailRow, merge: (NewRow, PurchaseorderdetailRow) => NewRow): Impl[NewRow] =
-      new Impl(prefix, extract, merge)
+    override def copy(path: List[Path]): Impl =
+      new Impl(path)
   }
   
 }

--- a/typo-tester-zio-jdbc/generated-and-checked-in/adventureworks/purchasing/purchaseorderheader/PurchaseorderheaderFields.scala
+++ b/typo-tester-zio-jdbc/generated-and-checked-in/adventureworks/purchasing/purchaseorderheader/PurchaseorderheaderFields.scala
@@ -11,54 +11,55 @@ import adventureworks.customtypes.TypoLocalDateTime
 import adventureworks.customtypes.TypoShort
 import adventureworks.person.businessentity.BusinessentityId
 import adventureworks.purchasing.shipmethod.ShipmethodId
+import typo.dsl.Path
 import typo.dsl.SqlExpr.Field
 import typo.dsl.SqlExpr.FieldLikeNoHkt
 import typo.dsl.SqlExpr.IdField
 import typo.dsl.SqlExpr.OptField
 import typo.dsl.Structure.Relation
 
-trait PurchaseorderheaderFields[Row] {
-  val purchaseorderid: IdField[PurchaseorderheaderId, Row]
-  val revisionnumber: Field[TypoShort, Row]
-  val status: Field[TypoShort, Row]
-  val employeeid: Field[BusinessentityId, Row]
-  val vendorid: Field[BusinessentityId, Row]
-  val shipmethodid: Field[ShipmethodId, Row]
-  val orderdate: Field[TypoLocalDateTime, Row]
-  val shipdate: OptField[TypoLocalDateTime, Row]
-  val subtotal: Field[BigDecimal, Row]
-  val taxamt: Field[BigDecimal, Row]
-  val freight: Field[BigDecimal, Row]
-  val modifieddate: Field[TypoLocalDateTime, Row]
+trait PurchaseorderheaderFields {
+  def purchaseorderid: IdField[PurchaseorderheaderId, PurchaseorderheaderRow]
+  def revisionnumber: Field[TypoShort, PurchaseorderheaderRow]
+  def status: Field[TypoShort, PurchaseorderheaderRow]
+  def employeeid: Field[BusinessentityId, PurchaseorderheaderRow]
+  def vendorid: Field[BusinessentityId, PurchaseorderheaderRow]
+  def shipmethodid: Field[ShipmethodId, PurchaseorderheaderRow]
+  def orderdate: Field[TypoLocalDateTime, PurchaseorderheaderRow]
+  def shipdate: OptField[TypoLocalDateTime, PurchaseorderheaderRow]
+  def subtotal: Field[BigDecimal, PurchaseorderheaderRow]
+  def taxamt: Field[BigDecimal, PurchaseorderheaderRow]
+  def freight: Field[BigDecimal, PurchaseorderheaderRow]
+  def modifieddate: Field[TypoLocalDateTime, PurchaseorderheaderRow]
 }
 
 object PurchaseorderheaderFields {
-  val structure: Relation[PurchaseorderheaderFields, PurchaseorderheaderRow, PurchaseorderheaderRow] = 
-    new Impl(None, identity, (_, x) => x)
+  lazy val structure: Relation[PurchaseorderheaderFields, PurchaseorderheaderRow] =
+    new Impl(Nil)
     
-  private final class Impl[Row](val prefix: Option[String], val extract: Row => PurchaseorderheaderRow, val merge: (Row, PurchaseorderheaderRow) => Row)
-    extends Relation[PurchaseorderheaderFields, PurchaseorderheaderRow, Row] { 
+  private final class Impl(val _path: List[Path])
+    extends Relation[PurchaseorderheaderFields, PurchaseorderheaderRow] {
   
-    override val fields: PurchaseorderheaderFields[Row] = new PurchaseorderheaderFields[Row] {
-      override val purchaseorderid = new IdField[PurchaseorderheaderId, Row](prefix, "purchaseorderid", None, Some("int4"))(x => extract(x).purchaseorderid, (row, value) => merge(row, extract(row).copy(purchaseorderid = value)))
-      override val revisionnumber = new Field[TypoShort, Row](prefix, "revisionnumber", None, Some("int2"))(x => extract(x).revisionnumber, (row, value) => merge(row, extract(row).copy(revisionnumber = value)))
-      override val status = new Field[TypoShort, Row](prefix, "status", None, Some("int2"))(x => extract(x).status, (row, value) => merge(row, extract(row).copy(status = value)))
-      override val employeeid = new Field[BusinessentityId, Row](prefix, "employeeid", None, Some("int4"))(x => extract(x).employeeid, (row, value) => merge(row, extract(row).copy(employeeid = value)))
-      override val vendorid = new Field[BusinessentityId, Row](prefix, "vendorid", None, Some("int4"))(x => extract(x).vendorid, (row, value) => merge(row, extract(row).copy(vendorid = value)))
-      override val shipmethodid = new Field[ShipmethodId, Row](prefix, "shipmethodid", None, Some("int4"))(x => extract(x).shipmethodid, (row, value) => merge(row, extract(row).copy(shipmethodid = value)))
-      override val orderdate = new Field[TypoLocalDateTime, Row](prefix, "orderdate", Some("text"), Some("timestamp"))(x => extract(x).orderdate, (row, value) => merge(row, extract(row).copy(orderdate = value)))
-      override val shipdate = new OptField[TypoLocalDateTime, Row](prefix, "shipdate", Some("text"), Some("timestamp"))(x => extract(x).shipdate, (row, value) => merge(row, extract(row).copy(shipdate = value)))
-      override val subtotal = new Field[BigDecimal, Row](prefix, "subtotal", None, Some("numeric"))(x => extract(x).subtotal, (row, value) => merge(row, extract(row).copy(subtotal = value)))
-      override val taxamt = new Field[BigDecimal, Row](prefix, "taxamt", None, Some("numeric"))(x => extract(x).taxamt, (row, value) => merge(row, extract(row).copy(taxamt = value)))
-      override val freight = new Field[BigDecimal, Row](prefix, "freight", None, Some("numeric"))(x => extract(x).freight, (row, value) => merge(row, extract(row).copy(freight = value)))
-      override val modifieddate = new Field[TypoLocalDateTime, Row](prefix, "modifieddate", Some("text"), Some("timestamp"))(x => extract(x).modifieddate, (row, value) => merge(row, extract(row).copy(modifieddate = value)))
+    override lazy val fields: PurchaseorderheaderFields = new PurchaseorderheaderFields {
+      override def purchaseorderid = IdField[PurchaseorderheaderId, PurchaseorderheaderRow](_path, "purchaseorderid", None, Some("int4"), x => x.purchaseorderid, (row, value) => row.copy(purchaseorderid = value))
+      override def revisionnumber = Field[TypoShort, PurchaseorderheaderRow](_path, "revisionnumber", None, Some("int2"), x => x.revisionnumber, (row, value) => row.copy(revisionnumber = value))
+      override def status = Field[TypoShort, PurchaseorderheaderRow](_path, "status", None, Some("int2"), x => x.status, (row, value) => row.copy(status = value))
+      override def employeeid = Field[BusinessentityId, PurchaseorderheaderRow](_path, "employeeid", None, Some("int4"), x => x.employeeid, (row, value) => row.copy(employeeid = value))
+      override def vendorid = Field[BusinessentityId, PurchaseorderheaderRow](_path, "vendorid", None, Some("int4"), x => x.vendorid, (row, value) => row.copy(vendorid = value))
+      override def shipmethodid = Field[ShipmethodId, PurchaseorderheaderRow](_path, "shipmethodid", None, Some("int4"), x => x.shipmethodid, (row, value) => row.copy(shipmethodid = value))
+      override def orderdate = Field[TypoLocalDateTime, PurchaseorderheaderRow](_path, "orderdate", Some("text"), Some("timestamp"), x => x.orderdate, (row, value) => row.copy(orderdate = value))
+      override def shipdate = OptField[TypoLocalDateTime, PurchaseorderheaderRow](_path, "shipdate", Some("text"), Some("timestamp"), x => x.shipdate, (row, value) => row.copy(shipdate = value))
+      override def subtotal = Field[BigDecimal, PurchaseorderheaderRow](_path, "subtotal", None, Some("numeric"), x => x.subtotal, (row, value) => row.copy(subtotal = value))
+      override def taxamt = Field[BigDecimal, PurchaseorderheaderRow](_path, "taxamt", None, Some("numeric"), x => x.taxamt, (row, value) => row.copy(taxamt = value))
+      override def freight = Field[BigDecimal, PurchaseorderheaderRow](_path, "freight", None, Some("numeric"), x => x.freight, (row, value) => row.copy(freight = value))
+      override def modifieddate = Field[TypoLocalDateTime, PurchaseorderheaderRow](_path, "modifieddate", Some("text"), Some("timestamp"), x => x.modifieddate, (row, value) => row.copy(modifieddate = value))
     }
   
-    override val columns: List[FieldLikeNoHkt[?, Row]] =
-      List[FieldLikeNoHkt[?, Row]](fields.purchaseorderid, fields.revisionnumber, fields.status, fields.employeeid, fields.vendorid, fields.shipmethodid, fields.orderdate, fields.shipdate, fields.subtotal, fields.taxamt, fields.freight, fields.modifieddate)
+    override lazy val columns: List[FieldLikeNoHkt[?, PurchaseorderheaderRow]] =
+      List[FieldLikeNoHkt[?, PurchaseorderheaderRow]](fields.purchaseorderid, fields.revisionnumber, fields.status, fields.employeeid, fields.vendorid, fields.shipmethodid, fields.orderdate, fields.shipdate, fields.subtotal, fields.taxamt, fields.freight, fields.modifieddate)
   
-    override def copy[NewRow](prefix: Option[String], extract: NewRow => PurchaseorderheaderRow, merge: (NewRow, PurchaseorderheaderRow) => NewRow): Impl[NewRow] =
-      new Impl(prefix, extract, merge)
+    override def copy(path: List[Path]): Impl =
+      new Impl(path)
   }
   
 }

--- a/typo-tester-zio-jdbc/generated-and-checked-in/adventureworks/purchasing/purchaseorderheader/PurchaseorderheaderRepoMock.scala
+++ b/typo-tester-zio-jdbc/generated-and-checked-in/adventureworks/purchasing/purchaseorderheader/PurchaseorderheaderRepoMock.scala
@@ -26,7 +26,7 @@ import zio.stream.ZStream
 class PurchaseorderheaderRepoMock(toRow: Function1[PurchaseorderheaderRowUnsaved, PurchaseorderheaderRow],
                                   map: scala.collection.mutable.Map[PurchaseorderheaderId, PurchaseorderheaderRow] = scala.collection.mutable.Map.empty) extends PurchaseorderheaderRepo {
   override def delete: DeleteBuilder[PurchaseorderheaderFields, PurchaseorderheaderRow] = {
-    DeleteBuilderMock(DeleteParams.empty, PurchaseorderheaderFields.structure.fields, map)
+    DeleteBuilderMock(DeleteParams.empty, PurchaseorderheaderFields.structure, map)
   }
   override def deleteById(purchaseorderid: PurchaseorderheaderId): ZIO[ZConnection, Throwable, Boolean] = {
     ZIO.succeed(map.remove(purchaseorderid).isDefined)
@@ -85,7 +85,7 @@ class PurchaseorderheaderRepoMock(toRow: Function1[PurchaseorderheaderRowUnsaved
     }
   }
   override def update: UpdateBuilder[PurchaseorderheaderFields, PurchaseorderheaderRow] = {
-    UpdateBuilderMock(UpdateParams.empty, PurchaseorderheaderFields.structure.fields, map)
+    UpdateBuilderMock(UpdateParams.empty, PurchaseorderheaderFields.structure, map)
   }
   override def update(row: PurchaseorderheaderRow): ZIO[ZConnection, Throwable, Boolean] = {
     ZIO.succeed {

--- a/typo-tester-zio-jdbc/generated-and-checked-in/adventureworks/purchasing/shipmethod/ShipmethodFields.scala
+++ b/typo-tester-zio-jdbc/generated-and-checked-in/adventureworks/purchasing/shipmethod/ShipmethodFields.scala
@@ -10,41 +10,42 @@ package shipmethod
 import adventureworks.customtypes.TypoLocalDateTime
 import adventureworks.customtypes.TypoUUID
 import adventureworks.public.Name
+import typo.dsl.Path
 import typo.dsl.SqlExpr.Field
 import typo.dsl.SqlExpr.FieldLikeNoHkt
 import typo.dsl.SqlExpr.IdField
 import typo.dsl.Structure.Relation
 
-trait ShipmethodFields[Row] {
-  val shipmethodid: IdField[ShipmethodId, Row]
-  val name: Field[Name, Row]
-  val shipbase: Field[BigDecimal, Row]
-  val shiprate: Field[BigDecimal, Row]
-  val rowguid: Field[TypoUUID, Row]
-  val modifieddate: Field[TypoLocalDateTime, Row]
+trait ShipmethodFields {
+  def shipmethodid: IdField[ShipmethodId, ShipmethodRow]
+  def name: Field[Name, ShipmethodRow]
+  def shipbase: Field[BigDecimal, ShipmethodRow]
+  def shiprate: Field[BigDecimal, ShipmethodRow]
+  def rowguid: Field[TypoUUID, ShipmethodRow]
+  def modifieddate: Field[TypoLocalDateTime, ShipmethodRow]
 }
 
 object ShipmethodFields {
-  val structure: Relation[ShipmethodFields, ShipmethodRow, ShipmethodRow] = 
-    new Impl(None, identity, (_, x) => x)
+  lazy val structure: Relation[ShipmethodFields, ShipmethodRow] =
+    new Impl(Nil)
     
-  private final class Impl[Row](val prefix: Option[String], val extract: Row => ShipmethodRow, val merge: (Row, ShipmethodRow) => Row)
-    extends Relation[ShipmethodFields, ShipmethodRow, Row] { 
+  private final class Impl(val _path: List[Path])
+    extends Relation[ShipmethodFields, ShipmethodRow] {
   
-    override val fields: ShipmethodFields[Row] = new ShipmethodFields[Row] {
-      override val shipmethodid = new IdField[ShipmethodId, Row](prefix, "shipmethodid", None, Some("int4"))(x => extract(x).shipmethodid, (row, value) => merge(row, extract(row).copy(shipmethodid = value)))
-      override val name = new Field[Name, Row](prefix, "name", None, Some("varchar"))(x => extract(x).name, (row, value) => merge(row, extract(row).copy(name = value)))
-      override val shipbase = new Field[BigDecimal, Row](prefix, "shipbase", None, Some("numeric"))(x => extract(x).shipbase, (row, value) => merge(row, extract(row).copy(shipbase = value)))
-      override val shiprate = new Field[BigDecimal, Row](prefix, "shiprate", None, Some("numeric"))(x => extract(x).shiprate, (row, value) => merge(row, extract(row).copy(shiprate = value)))
-      override val rowguid = new Field[TypoUUID, Row](prefix, "rowguid", None, Some("uuid"))(x => extract(x).rowguid, (row, value) => merge(row, extract(row).copy(rowguid = value)))
-      override val modifieddate = new Field[TypoLocalDateTime, Row](prefix, "modifieddate", Some("text"), Some("timestamp"))(x => extract(x).modifieddate, (row, value) => merge(row, extract(row).copy(modifieddate = value)))
+    override lazy val fields: ShipmethodFields = new ShipmethodFields {
+      override def shipmethodid = IdField[ShipmethodId, ShipmethodRow](_path, "shipmethodid", None, Some("int4"), x => x.shipmethodid, (row, value) => row.copy(shipmethodid = value))
+      override def name = Field[Name, ShipmethodRow](_path, "name", None, Some("varchar"), x => x.name, (row, value) => row.copy(name = value))
+      override def shipbase = Field[BigDecimal, ShipmethodRow](_path, "shipbase", None, Some("numeric"), x => x.shipbase, (row, value) => row.copy(shipbase = value))
+      override def shiprate = Field[BigDecimal, ShipmethodRow](_path, "shiprate", None, Some("numeric"), x => x.shiprate, (row, value) => row.copy(shiprate = value))
+      override def rowguid = Field[TypoUUID, ShipmethodRow](_path, "rowguid", None, Some("uuid"), x => x.rowguid, (row, value) => row.copy(rowguid = value))
+      override def modifieddate = Field[TypoLocalDateTime, ShipmethodRow](_path, "modifieddate", Some("text"), Some("timestamp"), x => x.modifieddate, (row, value) => row.copy(modifieddate = value))
     }
   
-    override val columns: List[FieldLikeNoHkt[?, Row]] =
-      List[FieldLikeNoHkt[?, Row]](fields.shipmethodid, fields.name, fields.shipbase, fields.shiprate, fields.rowguid, fields.modifieddate)
+    override lazy val columns: List[FieldLikeNoHkt[?, ShipmethodRow]] =
+      List[FieldLikeNoHkt[?, ShipmethodRow]](fields.shipmethodid, fields.name, fields.shipbase, fields.shiprate, fields.rowguid, fields.modifieddate)
   
-    override def copy[NewRow](prefix: Option[String], extract: NewRow => ShipmethodRow, merge: (NewRow, ShipmethodRow) => NewRow): Impl[NewRow] =
-      new Impl(prefix, extract, merge)
+    override def copy(path: List[Path]): Impl =
+      new Impl(path)
   }
   
 }

--- a/typo-tester-zio-jdbc/generated-and-checked-in/adventureworks/purchasing/shipmethod/ShipmethodRepoMock.scala
+++ b/typo-tester-zio-jdbc/generated-and-checked-in/adventureworks/purchasing/shipmethod/ShipmethodRepoMock.scala
@@ -26,7 +26,7 @@ import zio.stream.ZStream
 class ShipmethodRepoMock(toRow: Function1[ShipmethodRowUnsaved, ShipmethodRow],
                          map: scala.collection.mutable.Map[ShipmethodId, ShipmethodRow] = scala.collection.mutable.Map.empty) extends ShipmethodRepo {
   override def delete: DeleteBuilder[ShipmethodFields, ShipmethodRow] = {
-    DeleteBuilderMock(DeleteParams.empty, ShipmethodFields.structure.fields, map)
+    DeleteBuilderMock(DeleteParams.empty, ShipmethodFields.structure, map)
   }
   override def deleteById(shipmethodid: ShipmethodId): ZIO[ZConnection, Throwable, Boolean] = {
     ZIO.succeed(map.remove(shipmethodid).isDefined)
@@ -85,7 +85,7 @@ class ShipmethodRepoMock(toRow: Function1[ShipmethodRowUnsaved, ShipmethodRow],
     }
   }
   override def update: UpdateBuilder[ShipmethodFields, ShipmethodRow] = {
-    UpdateBuilderMock(UpdateParams.empty, ShipmethodFields.structure.fields, map)
+    UpdateBuilderMock(UpdateParams.empty, ShipmethodFields.structure, map)
   }
   override def update(row: ShipmethodRow): ZIO[ZConnection, Throwable, Boolean] = {
     ZIO.succeed {

--- a/typo-tester-zio-jdbc/generated-and-checked-in/adventureworks/purchasing/vendor/VendorFields.scala
+++ b/typo-tester-zio-jdbc/generated-and-checked-in/adventureworks/purchasing/vendor/VendorFields.scala
@@ -13,46 +13,47 @@ import adventureworks.person.businessentity.BusinessentityId
 import adventureworks.public.AccountNumber
 import adventureworks.public.Flag
 import adventureworks.public.Name
+import typo.dsl.Path
 import typo.dsl.SqlExpr.Field
 import typo.dsl.SqlExpr.FieldLikeNoHkt
 import typo.dsl.SqlExpr.IdField
 import typo.dsl.SqlExpr.OptField
 import typo.dsl.Structure.Relation
 
-trait VendorFields[Row] {
-  val businessentityid: IdField[BusinessentityId, Row]
-  val accountnumber: Field[AccountNumber, Row]
-  val name: Field[Name, Row]
-  val creditrating: Field[TypoShort, Row]
-  val preferredvendorstatus: Field[Flag, Row]
-  val activeflag: Field[Flag, Row]
-  val purchasingwebserviceurl: OptField[/* max 1024 chars */ String, Row]
-  val modifieddate: Field[TypoLocalDateTime, Row]
+trait VendorFields {
+  def businessentityid: IdField[BusinessentityId, VendorRow]
+  def accountnumber: Field[AccountNumber, VendorRow]
+  def name: Field[Name, VendorRow]
+  def creditrating: Field[TypoShort, VendorRow]
+  def preferredvendorstatus: Field[Flag, VendorRow]
+  def activeflag: Field[Flag, VendorRow]
+  def purchasingwebserviceurl: OptField[/* max 1024 chars */ String, VendorRow]
+  def modifieddate: Field[TypoLocalDateTime, VendorRow]
 }
 
 object VendorFields {
-  val structure: Relation[VendorFields, VendorRow, VendorRow] = 
-    new Impl(None, identity, (_, x) => x)
+  lazy val structure: Relation[VendorFields, VendorRow] =
+    new Impl(Nil)
     
-  private final class Impl[Row](val prefix: Option[String], val extract: Row => VendorRow, val merge: (Row, VendorRow) => Row)
-    extends Relation[VendorFields, VendorRow, Row] { 
+  private final class Impl(val _path: List[Path])
+    extends Relation[VendorFields, VendorRow] {
   
-    override val fields: VendorFields[Row] = new VendorFields[Row] {
-      override val businessentityid = new IdField[BusinessentityId, Row](prefix, "businessentityid", None, Some("int4"))(x => extract(x).businessentityid, (row, value) => merge(row, extract(row).copy(businessentityid = value)))
-      override val accountnumber = new Field[AccountNumber, Row](prefix, "accountnumber", None, Some("varchar"))(x => extract(x).accountnumber, (row, value) => merge(row, extract(row).copy(accountnumber = value)))
-      override val name = new Field[Name, Row](prefix, "name", None, Some("varchar"))(x => extract(x).name, (row, value) => merge(row, extract(row).copy(name = value)))
-      override val creditrating = new Field[TypoShort, Row](prefix, "creditrating", None, Some("int2"))(x => extract(x).creditrating, (row, value) => merge(row, extract(row).copy(creditrating = value)))
-      override val preferredvendorstatus = new Field[Flag, Row](prefix, "preferredvendorstatus", None, Some("bool"))(x => extract(x).preferredvendorstatus, (row, value) => merge(row, extract(row).copy(preferredvendorstatus = value)))
-      override val activeflag = new Field[Flag, Row](prefix, "activeflag", None, Some("bool"))(x => extract(x).activeflag, (row, value) => merge(row, extract(row).copy(activeflag = value)))
-      override val purchasingwebserviceurl = new OptField[/* max 1024 chars */ String, Row](prefix, "purchasingwebserviceurl", None, None)(x => extract(x).purchasingwebserviceurl, (row, value) => merge(row, extract(row).copy(purchasingwebserviceurl = value)))
-      override val modifieddate = new Field[TypoLocalDateTime, Row](prefix, "modifieddate", Some("text"), Some("timestamp"))(x => extract(x).modifieddate, (row, value) => merge(row, extract(row).copy(modifieddate = value)))
+    override lazy val fields: VendorFields = new VendorFields {
+      override def businessentityid = IdField[BusinessentityId, VendorRow](_path, "businessentityid", None, Some("int4"), x => x.businessentityid, (row, value) => row.copy(businessentityid = value))
+      override def accountnumber = Field[AccountNumber, VendorRow](_path, "accountnumber", None, Some("varchar"), x => x.accountnumber, (row, value) => row.copy(accountnumber = value))
+      override def name = Field[Name, VendorRow](_path, "name", None, Some("varchar"), x => x.name, (row, value) => row.copy(name = value))
+      override def creditrating = Field[TypoShort, VendorRow](_path, "creditrating", None, Some("int2"), x => x.creditrating, (row, value) => row.copy(creditrating = value))
+      override def preferredvendorstatus = Field[Flag, VendorRow](_path, "preferredvendorstatus", None, Some("bool"), x => x.preferredvendorstatus, (row, value) => row.copy(preferredvendorstatus = value))
+      override def activeflag = Field[Flag, VendorRow](_path, "activeflag", None, Some("bool"), x => x.activeflag, (row, value) => row.copy(activeflag = value))
+      override def purchasingwebserviceurl = OptField[/* max 1024 chars */ String, VendorRow](_path, "purchasingwebserviceurl", None, None, x => x.purchasingwebserviceurl, (row, value) => row.copy(purchasingwebserviceurl = value))
+      override def modifieddate = Field[TypoLocalDateTime, VendorRow](_path, "modifieddate", Some("text"), Some("timestamp"), x => x.modifieddate, (row, value) => row.copy(modifieddate = value))
     }
   
-    override val columns: List[FieldLikeNoHkt[?, Row]] =
-      List[FieldLikeNoHkt[?, Row]](fields.businessentityid, fields.accountnumber, fields.name, fields.creditrating, fields.preferredvendorstatus, fields.activeflag, fields.purchasingwebserviceurl, fields.modifieddate)
+    override lazy val columns: List[FieldLikeNoHkt[?, VendorRow]] =
+      List[FieldLikeNoHkt[?, VendorRow]](fields.businessentityid, fields.accountnumber, fields.name, fields.creditrating, fields.preferredvendorstatus, fields.activeflag, fields.purchasingwebserviceurl, fields.modifieddate)
   
-    override def copy[NewRow](prefix: Option[String], extract: NewRow => VendorRow, merge: (NewRow, VendorRow) => NewRow): Impl[NewRow] =
-      new Impl(prefix, extract, merge)
+    override def copy(path: List[Path]): Impl =
+      new Impl(path)
   }
   
 }

--- a/typo-tester-zio-jdbc/generated-and-checked-in/adventureworks/purchasing/vendor/VendorRepoMock.scala
+++ b/typo-tester-zio-jdbc/generated-and-checked-in/adventureworks/purchasing/vendor/VendorRepoMock.scala
@@ -27,7 +27,7 @@ import zio.stream.ZStream
 class VendorRepoMock(toRow: Function1[VendorRowUnsaved, VendorRow],
                      map: scala.collection.mutable.Map[BusinessentityId, VendorRow] = scala.collection.mutable.Map.empty) extends VendorRepo {
   override def delete: DeleteBuilder[VendorFields, VendorRow] = {
-    DeleteBuilderMock(DeleteParams.empty, VendorFields.structure.fields, map)
+    DeleteBuilderMock(DeleteParams.empty, VendorFields.structure, map)
   }
   override def deleteById(businessentityid: BusinessentityId): ZIO[ZConnection, Throwable, Boolean] = {
     ZIO.succeed(map.remove(businessentityid).isDefined)
@@ -86,7 +86,7 @@ class VendorRepoMock(toRow: Function1[VendorRowUnsaved, VendorRow],
     }
   }
   override def update: UpdateBuilder[VendorFields, VendorRow] = {
-    UpdateBuilderMock(UpdateParams.empty, VendorFields.structure.fields, map)
+    UpdateBuilderMock(UpdateParams.empty, VendorFields.structure, map)
   }
   override def update(row: VendorRow): ZIO[ZConnection, Throwable, Boolean] = {
     ZIO.succeed {

--- a/typo-tester-zio-jdbc/generated-and-checked-in/adventureworks/purchasing/vvendorwithaddresses/VvendorwithaddressesViewFields.scala
+++ b/typo-tester-zio-jdbc/generated-and-checked-in/adventureworks/purchasing/vvendorwithaddresses/VvendorwithaddressesViewFields.scala
@@ -9,47 +9,48 @@ package vvendorwithaddresses
 
 import adventureworks.person.businessentity.BusinessentityId
 import adventureworks.public.Name
+import typo.dsl.Path
 import typo.dsl.SqlExpr.Field
 import typo.dsl.SqlExpr.FieldLikeNoHkt
 import typo.dsl.SqlExpr.OptField
 import typo.dsl.Structure.Relation
 
-trait VvendorwithaddressesViewFields[Row] {
-  val businessentityid: Field[BusinessentityId, Row]
-  val name: Field[Name, Row]
-  val addresstype: Field[Name, Row]
-  val addressline1: Field[/* max 60 chars */ String, Row]
-  val addressline2: OptField[/* max 60 chars */ String, Row]
-  val city: Field[/* max 30 chars */ String, Row]
-  val stateprovincename: Field[Name, Row]
-  val postalcode: Field[/* max 15 chars */ String, Row]
-  val countryregionname: Field[Name, Row]
+trait VvendorwithaddressesViewFields {
+  def businessentityid: Field[BusinessentityId, VvendorwithaddressesViewRow]
+  def name: Field[Name, VvendorwithaddressesViewRow]
+  def addresstype: Field[Name, VvendorwithaddressesViewRow]
+  def addressline1: Field[/* max 60 chars */ String, VvendorwithaddressesViewRow]
+  def addressline2: OptField[/* max 60 chars */ String, VvendorwithaddressesViewRow]
+  def city: Field[/* max 30 chars */ String, VvendorwithaddressesViewRow]
+  def stateprovincename: Field[Name, VvendorwithaddressesViewRow]
+  def postalcode: Field[/* max 15 chars */ String, VvendorwithaddressesViewRow]
+  def countryregionname: Field[Name, VvendorwithaddressesViewRow]
 }
 
 object VvendorwithaddressesViewFields {
-  val structure: Relation[VvendorwithaddressesViewFields, VvendorwithaddressesViewRow, VvendorwithaddressesViewRow] = 
-    new Impl(None, identity, (_, x) => x)
+  lazy val structure: Relation[VvendorwithaddressesViewFields, VvendorwithaddressesViewRow] =
+    new Impl(Nil)
     
-  private final class Impl[Row](val prefix: Option[String], val extract: Row => VvendorwithaddressesViewRow, val merge: (Row, VvendorwithaddressesViewRow) => Row)
-    extends Relation[VvendorwithaddressesViewFields, VvendorwithaddressesViewRow, Row] { 
+  private final class Impl(val _path: List[Path])
+    extends Relation[VvendorwithaddressesViewFields, VvendorwithaddressesViewRow] {
   
-    override val fields: VvendorwithaddressesViewFields[Row] = new VvendorwithaddressesViewFields[Row] {
-      override val businessentityid = new Field[BusinessentityId, Row](prefix, "businessentityid", None, None)(x => extract(x).businessentityid, (row, value) => merge(row, extract(row).copy(businessentityid = value)))
-      override val name = new Field[Name, Row](prefix, "name", None, None)(x => extract(x).name, (row, value) => merge(row, extract(row).copy(name = value)))
-      override val addresstype = new Field[Name, Row](prefix, "addresstype", None, None)(x => extract(x).addresstype, (row, value) => merge(row, extract(row).copy(addresstype = value)))
-      override val addressline1 = new Field[/* max 60 chars */ String, Row](prefix, "addressline1", None, None)(x => extract(x).addressline1, (row, value) => merge(row, extract(row).copy(addressline1 = value)))
-      override val addressline2 = new OptField[/* max 60 chars */ String, Row](prefix, "addressline2", None, None)(x => extract(x).addressline2, (row, value) => merge(row, extract(row).copy(addressline2 = value)))
-      override val city = new Field[/* max 30 chars */ String, Row](prefix, "city", None, None)(x => extract(x).city, (row, value) => merge(row, extract(row).copy(city = value)))
-      override val stateprovincename = new Field[Name, Row](prefix, "stateprovincename", None, None)(x => extract(x).stateprovincename, (row, value) => merge(row, extract(row).copy(stateprovincename = value)))
-      override val postalcode = new Field[/* max 15 chars */ String, Row](prefix, "postalcode", None, None)(x => extract(x).postalcode, (row, value) => merge(row, extract(row).copy(postalcode = value)))
-      override val countryregionname = new Field[Name, Row](prefix, "countryregionname", None, None)(x => extract(x).countryregionname, (row, value) => merge(row, extract(row).copy(countryregionname = value)))
+    override lazy val fields: VvendorwithaddressesViewFields = new VvendorwithaddressesViewFields {
+      override def businessentityid = Field[BusinessentityId, VvendorwithaddressesViewRow](_path, "businessentityid", None, None, x => x.businessentityid, (row, value) => row.copy(businessentityid = value))
+      override def name = Field[Name, VvendorwithaddressesViewRow](_path, "name", None, None, x => x.name, (row, value) => row.copy(name = value))
+      override def addresstype = Field[Name, VvendorwithaddressesViewRow](_path, "addresstype", None, None, x => x.addresstype, (row, value) => row.copy(addresstype = value))
+      override def addressline1 = Field[/* max 60 chars */ String, VvendorwithaddressesViewRow](_path, "addressline1", None, None, x => x.addressline1, (row, value) => row.copy(addressline1 = value))
+      override def addressline2 = OptField[/* max 60 chars */ String, VvendorwithaddressesViewRow](_path, "addressline2", None, None, x => x.addressline2, (row, value) => row.copy(addressline2 = value))
+      override def city = Field[/* max 30 chars */ String, VvendorwithaddressesViewRow](_path, "city", None, None, x => x.city, (row, value) => row.copy(city = value))
+      override def stateprovincename = Field[Name, VvendorwithaddressesViewRow](_path, "stateprovincename", None, None, x => x.stateprovincename, (row, value) => row.copy(stateprovincename = value))
+      override def postalcode = Field[/* max 15 chars */ String, VvendorwithaddressesViewRow](_path, "postalcode", None, None, x => x.postalcode, (row, value) => row.copy(postalcode = value))
+      override def countryregionname = Field[Name, VvendorwithaddressesViewRow](_path, "countryregionname", None, None, x => x.countryregionname, (row, value) => row.copy(countryregionname = value))
     }
   
-    override val columns: List[FieldLikeNoHkt[?, Row]] =
-      List[FieldLikeNoHkt[?, Row]](fields.businessentityid, fields.name, fields.addresstype, fields.addressline1, fields.addressline2, fields.city, fields.stateprovincename, fields.postalcode, fields.countryregionname)
+    override lazy val columns: List[FieldLikeNoHkt[?, VvendorwithaddressesViewRow]] =
+      List[FieldLikeNoHkt[?, VvendorwithaddressesViewRow]](fields.businessentityid, fields.name, fields.addresstype, fields.addressline1, fields.addressline2, fields.city, fields.stateprovincename, fields.postalcode, fields.countryregionname)
   
-    override def copy[NewRow](prefix: Option[String], extract: NewRow => VvendorwithaddressesViewRow, merge: (NewRow, VvendorwithaddressesViewRow) => NewRow): Impl[NewRow] =
-      new Impl(prefix, extract, merge)
+    override def copy(path: List[Path]): Impl =
+      new Impl(path)
   }
   
 }

--- a/typo-tester-zio-jdbc/generated-and-checked-in/adventureworks/purchasing/vvendorwithcontacts/VvendorwithcontactsViewFields.scala
+++ b/typo-tester-zio-jdbc/generated-and-checked-in/adventureworks/purchasing/vvendorwithcontacts/VvendorwithcontactsViewFields.scala
@@ -11,53 +11,54 @@ import adventureworks.person.businessentity.BusinessentityId
 import adventureworks.public.Name
 import adventureworks.public.Phone
 import adventureworks.userdefined.FirstName
+import typo.dsl.Path
 import typo.dsl.SqlExpr.Field
 import typo.dsl.SqlExpr.FieldLikeNoHkt
 import typo.dsl.SqlExpr.OptField
 import typo.dsl.Structure.Relation
 
-trait VvendorwithcontactsViewFields[Row] {
-  val businessentityid: Field[BusinessentityId, Row]
-  val name: Field[Name, Row]
-  val contacttype: Field[Name, Row]
-  val title: OptField[/* max 8 chars */ String, Row]
-  val firstname: Field[/* user-picked */ FirstName, Row]
-  val middlename: OptField[Name, Row]
-  val lastname: Field[Name, Row]
-  val suffix: OptField[/* max 10 chars */ String, Row]
-  val phonenumber: OptField[Phone, Row]
-  val phonenumbertype: OptField[Name, Row]
-  val emailaddress: OptField[/* max 50 chars */ String, Row]
-  val emailpromotion: Field[Int, Row]
+trait VvendorwithcontactsViewFields {
+  def businessentityid: Field[BusinessentityId, VvendorwithcontactsViewRow]
+  def name: Field[Name, VvendorwithcontactsViewRow]
+  def contacttype: Field[Name, VvendorwithcontactsViewRow]
+  def title: OptField[/* max 8 chars */ String, VvendorwithcontactsViewRow]
+  def firstname: Field[/* user-picked */ FirstName, VvendorwithcontactsViewRow]
+  def middlename: OptField[Name, VvendorwithcontactsViewRow]
+  def lastname: Field[Name, VvendorwithcontactsViewRow]
+  def suffix: OptField[/* max 10 chars */ String, VvendorwithcontactsViewRow]
+  def phonenumber: OptField[Phone, VvendorwithcontactsViewRow]
+  def phonenumbertype: OptField[Name, VvendorwithcontactsViewRow]
+  def emailaddress: OptField[/* max 50 chars */ String, VvendorwithcontactsViewRow]
+  def emailpromotion: Field[Int, VvendorwithcontactsViewRow]
 }
 
 object VvendorwithcontactsViewFields {
-  val structure: Relation[VvendorwithcontactsViewFields, VvendorwithcontactsViewRow, VvendorwithcontactsViewRow] = 
-    new Impl(None, identity, (_, x) => x)
+  lazy val structure: Relation[VvendorwithcontactsViewFields, VvendorwithcontactsViewRow] =
+    new Impl(Nil)
     
-  private final class Impl[Row](val prefix: Option[String], val extract: Row => VvendorwithcontactsViewRow, val merge: (Row, VvendorwithcontactsViewRow) => Row)
-    extends Relation[VvendorwithcontactsViewFields, VvendorwithcontactsViewRow, Row] { 
+  private final class Impl(val _path: List[Path])
+    extends Relation[VvendorwithcontactsViewFields, VvendorwithcontactsViewRow] {
   
-    override val fields: VvendorwithcontactsViewFields[Row] = new VvendorwithcontactsViewFields[Row] {
-      override val businessentityid = new Field[BusinessentityId, Row](prefix, "businessentityid", None, None)(x => extract(x).businessentityid, (row, value) => merge(row, extract(row).copy(businessentityid = value)))
-      override val name = new Field[Name, Row](prefix, "name", None, None)(x => extract(x).name, (row, value) => merge(row, extract(row).copy(name = value)))
-      override val contacttype = new Field[Name, Row](prefix, "contacttype", None, None)(x => extract(x).contacttype, (row, value) => merge(row, extract(row).copy(contacttype = value)))
-      override val title = new OptField[/* max 8 chars */ String, Row](prefix, "title", None, None)(x => extract(x).title, (row, value) => merge(row, extract(row).copy(title = value)))
-      override val firstname = new Field[/* user-picked */ FirstName, Row](prefix, "firstname", None, None)(x => extract(x).firstname, (row, value) => merge(row, extract(row).copy(firstname = value)))
-      override val middlename = new OptField[Name, Row](prefix, "middlename", None, None)(x => extract(x).middlename, (row, value) => merge(row, extract(row).copy(middlename = value)))
-      override val lastname = new Field[Name, Row](prefix, "lastname", None, None)(x => extract(x).lastname, (row, value) => merge(row, extract(row).copy(lastname = value)))
-      override val suffix = new OptField[/* max 10 chars */ String, Row](prefix, "suffix", None, None)(x => extract(x).suffix, (row, value) => merge(row, extract(row).copy(suffix = value)))
-      override val phonenumber = new OptField[Phone, Row](prefix, "phonenumber", None, None)(x => extract(x).phonenumber, (row, value) => merge(row, extract(row).copy(phonenumber = value)))
-      override val phonenumbertype = new OptField[Name, Row](prefix, "phonenumbertype", None, None)(x => extract(x).phonenumbertype, (row, value) => merge(row, extract(row).copy(phonenumbertype = value)))
-      override val emailaddress = new OptField[/* max 50 chars */ String, Row](prefix, "emailaddress", None, None)(x => extract(x).emailaddress, (row, value) => merge(row, extract(row).copy(emailaddress = value)))
-      override val emailpromotion = new Field[Int, Row](prefix, "emailpromotion", None, None)(x => extract(x).emailpromotion, (row, value) => merge(row, extract(row).copy(emailpromotion = value)))
+    override lazy val fields: VvendorwithcontactsViewFields = new VvendorwithcontactsViewFields {
+      override def businessentityid = Field[BusinessentityId, VvendorwithcontactsViewRow](_path, "businessentityid", None, None, x => x.businessentityid, (row, value) => row.copy(businessentityid = value))
+      override def name = Field[Name, VvendorwithcontactsViewRow](_path, "name", None, None, x => x.name, (row, value) => row.copy(name = value))
+      override def contacttype = Field[Name, VvendorwithcontactsViewRow](_path, "contacttype", None, None, x => x.contacttype, (row, value) => row.copy(contacttype = value))
+      override def title = OptField[/* max 8 chars */ String, VvendorwithcontactsViewRow](_path, "title", None, None, x => x.title, (row, value) => row.copy(title = value))
+      override def firstname = Field[/* user-picked */ FirstName, VvendorwithcontactsViewRow](_path, "firstname", None, None, x => x.firstname, (row, value) => row.copy(firstname = value))
+      override def middlename = OptField[Name, VvendorwithcontactsViewRow](_path, "middlename", None, None, x => x.middlename, (row, value) => row.copy(middlename = value))
+      override def lastname = Field[Name, VvendorwithcontactsViewRow](_path, "lastname", None, None, x => x.lastname, (row, value) => row.copy(lastname = value))
+      override def suffix = OptField[/* max 10 chars */ String, VvendorwithcontactsViewRow](_path, "suffix", None, None, x => x.suffix, (row, value) => row.copy(suffix = value))
+      override def phonenumber = OptField[Phone, VvendorwithcontactsViewRow](_path, "phonenumber", None, None, x => x.phonenumber, (row, value) => row.copy(phonenumber = value))
+      override def phonenumbertype = OptField[Name, VvendorwithcontactsViewRow](_path, "phonenumbertype", None, None, x => x.phonenumbertype, (row, value) => row.copy(phonenumbertype = value))
+      override def emailaddress = OptField[/* max 50 chars */ String, VvendorwithcontactsViewRow](_path, "emailaddress", None, None, x => x.emailaddress, (row, value) => row.copy(emailaddress = value))
+      override def emailpromotion = Field[Int, VvendorwithcontactsViewRow](_path, "emailpromotion", None, None, x => x.emailpromotion, (row, value) => row.copy(emailpromotion = value))
     }
   
-    override val columns: List[FieldLikeNoHkt[?, Row]] =
-      List[FieldLikeNoHkt[?, Row]](fields.businessentityid, fields.name, fields.contacttype, fields.title, fields.firstname, fields.middlename, fields.lastname, fields.suffix, fields.phonenumber, fields.phonenumbertype, fields.emailaddress, fields.emailpromotion)
+    override lazy val columns: List[FieldLikeNoHkt[?, VvendorwithcontactsViewRow]] =
+      List[FieldLikeNoHkt[?, VvendorwithcontactsViewRow]](fields.businessentityid, fields.name, fields.contacttype, fields.title, fields.firstname, fields.middlename, fields.lastname, fields.suffix, fields.phonenumber, fields.phonenumbertype, fields.emailaddress, fields.emailpromotion)
   
-    override def copy[NewRow](prefix: Option[String], extract: NewRow => VvendorwithcontactsViewRow, merge: (NewRow, VvendorwithcontactsViewRow) => NewRow): Impl[NewRow] =
-      new Impl(prefix, extract, merge)
+    override def copy(path: List[Path]): Impl =
+      new Impl(path)
   }
   
 }

--- a/typo-tester-zio-jdbc/generated-and-checked-in/adventureworks/sa/c/CViewFields.scala
+++ b/typo-tester-zio-jdbc/generated-and-checked-in/adventureworks/sa/c/CViewFields.scala
@@ -12,43 +12,44 @@ import adventureworks.customtypes.TypoUUID
 import adventureworks.person.businessentity.BusinessentityId
 import adventureworks.sales.customer.CustomerId
 import adventureworks.sales.salesterritory.SalesterritoryId
+import typo.dsl.Path
 import typo.dsl.SqlExpr.Field
 import typo.dsl.SqlExpr.FieldLikeNoHkt
 import typo.dsl.SqlExpr.OptField
 import typo.dsl.Structure.Relation
 
-trait CViewFields[Row] {
-  val id: Field[CustomerId, Row]
-  val customerid: Field[CustomerId, Row]
-  val personid: OptField[BusinessentityId, Row]
-  val storeid: OptField[BusinessentityId, Row]
-  val territoryid: OptField[SalesterritoryId, Row]
-  val rowguid: Field[TypoUUID, Row]
-  val modifieddate: Field[TypoLocalDateTime, Row]
+trait CViewFields {
+  def id: Field[CustomerId, CViewRow]
+  def customerid: Field[CustomerId, CViewRow]
+  def personid: OptField[BusinessentityId, CViewRow]
+  def storeid: OptField[BusinessentityId, CViewRow]
+  def territoryid: OptField[SalesterritoryId, CViewRow]
+  def rowguid: Field[TypoUUID, CViewRow]
+  def modifieddate: Field[TypoLocalDateTime, CViewRow]
 }
 
 object CViewFields {
-  val structure: Relation[CViewFields, CViewRow, CViewRow] = 
-    new Impl(None, identity, (_, x) => x)
+  lazy val structure: Relation[CViewFields, CViewRow] =
+    new Impl(Nil)
     
-  private final class Impl[Row](val prefix: Option[String], val extract: Row => CViewRow, val merge: (Row, CViewRow) => Row)
-    extends Relation[CViewFields, CViewRow, Row] { 
+  private final class Impl(val _path: List[Path])
+    extends Relation[CViewFields, CViewRow] {
   
-    override val fields: CViewFields[Row] = new CViewFields[Row] {
-      override val id = new Field[CustomerId, Row](prefix, "id", None, None)(x => extract(x).id, (row, value) => merge(row, extract(row).copy(id = value)))
-      override val customerid = new Field[CustomerId, Row](prefix, "customerid", None, None)(x => extract(x).customerid, (row, value) => merge(row, extract(row).copy(customerid = value)))
-      override val personid = new OptField[BusinessentityId, Row](prefix, "personid", None, None)(x => extract(x).personid, (row, value) => merge(row, extract(row).copy(personid = value)))
-      override val storeid = new OptField[BusinessentityId, Row](prefix, "storeid", None, None)(x => extract(x).storeid, (row, value) => merge(row, extract(row).copy(storeid = value)))
-      override val territoryid = new OptField[SalesterritoryId, Row](prefix, "territoryid", None, None)(x => extract(x).territoryid, (row, value) => merge(row, extract(row).copy(territoryid = value)))
-      override val rowguid = new Field[TypoUUID, Row](prefix, "rowguid", None, None)(x => extract(x).rowguid, (row, value) => merge(row, extract(row).copy(rowguid = value)))
-      override val modifieddate = new Field[TypoLocalDateTime, Row](prefix, "modifieddate", Some("text"), None)(x => extract(x).modifieddate, (row, value) => merge(row, extract(row).copy(modifieddate = value)))
+    override lazy val fields: CViewFields = new CViewFields {
+      override def id = Field[CustomerId, CViewRow](_path, "id", None, None, x => x.id, (row, value) => row.copy(id = value))
+      override def customerid = Field[CustomerId, CViewRow](_path, "customerid", None, None, x => x.customerid, (row, value) => row.copy(customerid = value))
+      override def personid = OptField[BusinessentityId, CViewRow](_path, "personid", None, None, x => x.personid, (row, value) => row.copy(personid = value))
+      override def storeid = OptField[BusinessentityId, CViewRow](_path, "storeid", None, None, x => x.storeid, (row, value) => row.copy(storeid = value))
+      override def territoryid = OptField[SalesterritoryId, CViewRow](_path, "territoryid", None, None, x => x.territoryid, (row, value) => row.copy(territoryid = value))
+      override def rowguid = Field[TypoUUID, CViewRow](_path, "rowguid", None, None, x => x.rowguid, (row, value) => row.copy(rowguid = value))
+      override def modifieddate = Field[TypoLocalDateTime, CViewRow](_path, "modifieddate", Some("text"), None, x => x.modifieddate, (row, value) => row.copy(modifieddate = value))
     }
   
-    override val columns: List[FieldLikeNoHkt[?, Row]] =
-      List[FieldLikeNoHkt[?, Row]](fields.id, fields.customerid, fields.personid, fields.storeid, fields.territoryid, fields.rowguid, fields.modifieddate)
+    override lazy val columns: List[FieldLikeNoHkt[?, CViewRow]] =
+      List[FieldLikeNoHkt[?, CViewRow]](fields.id, fields.customerid, fields.personid, fields.storeid, fields.territoryid, fields.rowguid, fields.modifieddate)
   
-    override def copy[NewRow](prefix: Option[String], extract: NewRow => CViewRow, merge: (NewRow, CViewRow) => NewRow): Impl[NewRow] =
-      new Impl(prefix, extract, merge)
+    override def copy(path: List[Path]): Impl =
+      new Impl(path)
   }
   
 }

--- a/typo-tester-zio-jdbc/generated-and-checked-in/adventureworks/sa/cc/CcViewFields.scala
+++ b/typo-tester-zio-jdbc/generated-and-checked-in/adventureworks/sa/cc/CcViewFields.scala
@@ -10,42 +10,43 @@ package cc
 import adventureworks.customtypes.TypoLocalDateTime
 import adventureworks.customtypes.TypoShort
 import adventureworks.userdefined.CustomCreditcardId
+import typo.dsl.Path
 import typo.dsl.SqlExpr.Field
 import typo.dsl.SqlExpr.FieldLikeNoHkt
 import typo.dsl.Structure.Relation
 
-trait CcViewFields[Row] {
-  val id: Field[/* user-picked */ CustomCreditcardId, Row]
-  val creditcardid: Field[/* user-picked */ CustomCreditcardId, Row]
-  val cardtype: Field[/* max 50 chars */ String, Row]
-  val cardnumber: Field[/* max 25 chars */ String, Row]
-  val expmonth: Field[TypoShort, Row]
-  val expyear: Field[TypoShort, Row]
-  val modifieddate: Field[TypoLocalDateTime, Row]
+trait CcViewFields {
+  def id: Field[/* user-picked */ CustomCreditcardId, CcViewRow]
+  def creditcardid: Field[/* user-picked */ CustomCreditcardId, CcViewRow]
+  def cardtype: Field[/* max 50 chars */ String, CcViewRow]
+  def cardnumber: Field[/* max 25 chars */ String, CcViewRow]
+  def expmonth: Field[TypoShort, CcViewRow]
+  def expyear: Field[TypoShort, CcViewRow]
+  def modifieddate: Field[TypoLocalDateTime, CcViewRow]
 }
 
 object CcViewFields {
-  val structure: Relation[CcViewFields, CcViewRow, CcViewRow] = 
-    new Impl(None, identity, (_, x) => x)
+  lazy val structure: Relation[CcViewFields, CcViewRow] =
+    new Impl(Nil)
     
-  private final class Impl[Row](val prefix: Option[String], val extract: Row => CcViewRow, val merge: (Row, CcViewRow) => Row)
-    extends Relation[CcViewFields, CcViewRow, Row] { 
+  private final class Impl(val _path: List[Path])
+    extends Relation[CcViewFields, CcViewRow] {
   
-    override val fields: CcViewFields[Row] = new CcViewFields[Row] {
-      override val id = new Field[/* user-picked */ CustomCreditcardId, Row](prefix, "id", None, None)(x => extract(x).id, (row, value) => merge(row, extract(row).copy(id = value)))
-      override val creditcardid = new Field[/* user-picked */ CustomCreditcardId, Row](prefix, "creditcardid", None, None)(x => extract(x).creditcardid, (row, value) => merge(row, extract(row).copy(creditcardid = value)))
-      override val cardtype = new Field[/* max 50 chars */ String, Row](prefix, "cardtype", None, None)(x => extract(x).cardtype, (row, value) => merge(row, extract(row).copy(cardtype = value)))
-      override val cardnumber = new Field[/* max 25 chars */ String, Row](prefix, "cardnumber", None, None)(x => extract(x).cardnumber, (row, value) => merge(row, extract(row).copy(cardnumber = value)))
-      override val expmonth = new Field[TypoShort, Row](prefix, "expmonth", None, None)(x => extract(x).expmonth, (row, value) => merge(row, extract(row).copy(expmonth = value)))
-      override val expyear = new Field[TypoShort, Row](prefix, "expyear", None, None)(x => extract(x).expyear, (row, value) => merge(row, extract(row).copy(expyear = value)))
-      override val modifieddate = new Field[TypoLocalDateTime, Row](prefix, "modifieddate", Some("text"), None)(x => extract(x).modifieddate, (row, value) => merge(row, extract(row).copy(modifieddate = value)))
+    override lazy val fields: CcViewFields = new CcViewFields {
+      override def id = Field[/* user-picked */ CustomCreditcardId, CcViewRow](_path, "id", None, None, x => x.id, (row, value) => row.copy(id = value))
+      override def creditcardid = Field[/* user-picked */ CustomCreditcardId, CcViewRow](_path, "creditcardid", None, None, x => x.creditcardid, (row, value) => row.copy(creditcardid = value))
+      override def cardtype = Field[/* max 50 chars */ String, CcViewRow](_path, "cardtype", None, None, x => x.cardtype, (row, value) => row.copy(cardtype = value))
+      override def cardnumber = Field[/* max 25 chars */ String, CcViewRow](_path, "cardnumber", None, None, x => x.cardnumber, (row, value) => row.copy(cardnumber = value))
+      override def expmonth = Field[TypoShort, CcViewRow](_path, "expmonth", None, None, x => x.expmonth, (row, value) => row.copy(expmonth = value))
+      override def expyear = Field[TypoShort, CcViewRow](_path, "expyear", None, None, x => x.expyear, (row, value) => row.copy(expyear = value))
+      override def modifieddate = Field[TypoLocalDateTime, CcViewRow](_path, "modifieddate", Some("text"), None, x => x.modifieddate, (row, value) => row.copy(modifieddate = value))
     }
   
-    override val columns: List[FieldLikeNoHkt[?, Row]] =
-      List[FieldLikeNoHkt[?, Row]](fields.id, fields.creditcardid, fields.cardtype, fields.cardnumber, fields.expmonth, fields.expyear, fields.modifieddate)
+    override lazy val columns: List[FieldLikeNoHkt[?, CcViewRow]] =
+      List[FieldLikeNoHkt[?, CcViewRow]](fields.id, fields.creditcardid, fields.cardtype, fields.cardnumber, fields.expmonth, fields.expyear, fields.modifieddate)
   
-    override def copy[NewRow](prefix: Option[String], extract: NewRow => CcViewRow, merge: (NewRow, CcViewRow) => NewRow): Impl[NewRow] =
-      new Impl(prefix, extract, merge)
+    override def copy(path: List[Path]): Impl =
+      new Impl(path)
   }
   
 }

--- a/typo-tester-zio-jdbc/generated-and-checked-in/adventureworks/sa/cr/CrViewFields.scala
+++ b/typo-tester-zio-jdbc/generated-and-checked-in/adventureworks/sa/cr/CrViewFields.scala
@@ -10,42 +10,43 @@ package cr
 import adventureworks.customtypes.TypoLocalDateTime
 import adventureworks.sales.currency.CurrencyId
 import adventureworks.sales.currencyrate.CurrencyrateId
+import typo.dsl.Path
 import typo.dsl.SqlExpr.Field
 import typo.dsl.SqlExpr.FieldLikeNoHkt
 import typo.dsl.Structure.Relation
 
-trait CrViewFields[Row] {
-  val currencyrateid: Field[CurrencyrateId, Row]
-  val currencyratedate: Field[TypoLocalDateTime, Row]
-  val fromcurrencycode: Field[CurrencyId, Row]
-  val tocurrencycode: Field[CurrencyId, Row]
-  val averagerate: Field[BigDecimal, Row]
-  val endofdayrate: Field[BigDecimal, Row]
-  val modifieddate: Field[TypoLocalDateTime, Row]
+trait CrViewFields {
+  def currencyrateid: Field[CurrencyrateId, CrViewRow]
+  def currencyratedate: Field[TypoLocalDateTime, CrViewRow]
+  def fromcurrencycode: Field[CurrencyId, CrViewRow]
+  def tocurrencycode: Field[CurrencyId, CrViewRow]
+  def averagerate: Field[BigDecimal, CrViewRow]
+  def endofdayrate: Field[BigDecimal, CrViewRow]
+  def modifieddate: Field[TypoLocalDateTime, CrViewRow]
 }
 
 object CrViewFields {
-  val structure: Relation[CrViewFields, CrViewRow, CrViewRow] = 
-    new Impl(None, identity, (_, x) => x)
+  lazy val structure: Relation[CrViewFields, CrViewRow] =
+    new Impl(Nil)
     
-  private final class Impl[Row](val prefix: Option[String], val extract: Row => CrViewRow, val merge: (Row, CrViewRow) => Row)
-    extends Relation[CrViewFields, CrViewRow, Row] { 
+  private final class Impl(val _path: List[Path])
+    extends Relation[CrViewFields, CrViewRow] {
   
-    override val fields: CrViewFields[Row] = new CrViewFields[Row] {
-      override val currencyrateid = new Field[CurrencyrateId, Row](prefix, "currencyrateid", None, None)(x => extract(x).currencyrateid, (row, value) => merge(row, extract(row).copy(currencyrateid = value)))
-      override val currencyratedate = new Field[TypoLocalDateTime, Row](prefix, "currencyratedate", Some("text"), None)(x => extract(x).currencyratedate, (row, value) => merge(row, extract(row).copy(currencyratedate = value)))
-      override val fromcurrencycode = new Field[CurrencyId, Row](prefix, "fromcurrencycode", None, None)(x => extract(x).fromcurrencycode, (row, value) => merge(row, extract(row).copy(fromcurrencycode = value)))
-      override val tocurrencycode = new Field[CurrencyId, Row](prefix, "tocurrencycode", None, None)(x => extract(x).tocurrencycode, (row, value) => merge(row, extract(row).copy(tocurrencycode = value)))
-      override val averagerate = new Field[BigDecimal, Row](prefix, "averagerate", None, None)(x => extract(x).averagerate, (row, value) => merge(row, extract(row).copy(averagerate = value)))
-      override val endofdayrate = new Field[BigDecimal, Row](prefix, "endofdayrate", None, None)(x => extract(x).endofdayrate, (row, value) => merge(row, extract(row).copy(endofdayrate = value)))
-      override val modifieddate = new Field[TypoLocalDateTime, Row](prefix, "modifieddate", Some("text"), None)(x => extract(x).modifieddate, (row, value) => merge(row, extract(row).copy(modifieddate = value)))
+    override lazy val fields: CrViewFields = new CrViewFields {
+      override def currencyrateid = Field[CurrencyrateId, CrViewRow](_path, "currencyrateid", None, None, x => x.currencyrateid, (row, value) => row.copy(currencyrateid = value))
+      override def currencyratedate = Field[TypoLocalDateTime, CrViewRow](_path, "currencyratedate", Some("text"), None, x => x.currencyratedate, (row, value) => row.copy(currencyratedate = value))
+      override def fromcurrencycode = Field[CurrencyId, CrViewRow](_path, "fromcurrencycode", None, None, x => x.fromcurrencycode, (row, value) => row.copy(fromcurrencycode = value))
+      override def tocurrencycode = Field[CurrencyId, CrViewRow](_path, "tocurrencycode", None, None, x => x.tocurrencycode, (row, value) => row.copy(tocurrencycode = value))
+      override def averagerate = Field[BigDecimal, CrViewRow](_path, "averagerate", None, None, x => x.averagerate, (row, value) => row.copy(averagerate = value))
+      override def endofdayrate = Field[BigDecimal, CrViewRow](_path, "endofdayrate", None, None, x => x.endofdayrate, (row, value) => row.copy(endofdayrate = value))
+      override def modifieddate = Field[TypoLocalDateTime, CrViewRow](_path, "modifieddate", Some("text"), None, x => x.modifieddate, (row, value) => row.copy(modifieddate = value))
     }
   
-    override val columns: List[FieldLikeNoHkt[?, Row]] =
-      List[FieldLikeNoHkt[?, Row]](fields.currencyrateid, fields.currencyratedate, fields.fromcurrencycode, fields.tocurrencycode, fields.averagerate, fields.endofdayrate, fields.modifieddate)
+    override lazy val columns: List[FieldLikeNoHkt[?, CrViewRow]] =
+      List[FieldLikeNoHkt[?, CrViewRow]](fields.currencyrateid, fields.currencyratedate, fields.fromcurrencycode, fields.tocurrencycode, fields.averagerate, fields.endofdayrate, fields.modifieddate)
   
-    override def copy[NewRow](prefix: Option[String], extract: NewRow => CrViewRow, merge: (NewRow, CrViewRow) => NewRow): Impl[NewRow] =
-      new Impl(prefix, extract, merge)
+    override def copy(path: List[Path]): Impl =
+      new Impl(path)
   }
   
 }

--- a/typo-tester-zio-jdbc/generated-and-checked-in/adventureworks/sa/crc/CrcViewFields.scala
+++ b/typo-tester-zio-jdbc/generated-and-checked-in/adventureworks/sa/crc/CrcViewFields.scala
@@ -10,34 +10,35 @@ package crc
 import adventureworks.customtypes.TypoLocalDateTime
 import adventureworks.person.countryregion.CountryregionId
 import adventureworks.sales.currency.CurrencyId
+import typo.dsl.Path
 import typo.dsl.SqlExpr.Field
 import typo.dsl.SqlExpr.FieldLikeNoHkt
 import typo.dsl.Structure.Relation
 
-trait CrcViewFields[Row] {
-  val countryregioncode: Field[CountryregionId, Row]
-  val currencycode: Field[CurrencyId, Row]
-  val modifieddate: Field[TypoLocalDateTime, Row]
+trait CrcViewFields {
+  def countryregioncode: Field[CountryregionId, CrcViewRow]
+  def currencycode: Field[CurrencyId, CrcViewRow]
+  def modifieddate: Field[TypoLocalDateTime, CrcViewRow]
 }
 
 object CrcViewFields {
-  val structure: Relation[CrcViewFields, CrcViewRow, CrcViewRow] = 
-    new Impl(None, identity, (_, x) => x)
+  lazy val structure: Relation[CrcViewFields, CrcViewRow] =
+    new Impl(Nil)
     
-  private final class Impl[Row](val prefix: Option[String], val extract: Row => CrcViewRow, val merge: (Row, CrcViewRow) => Row)
-    extends Relation[CrcViewFields, CrcViewRow, Row] { 
+  private final class Impl(val _path: List[Path])
+    extends Relation[CrcViewFields, CrcViewRow] {
   
-    override val fields: CrcViewFields[Row] = new CrcViewFields[Row] {
-      override val countryregioncode = new Field[CountryregionId, Row](prefix, "countryregioncode", None, None)(x => extract(x).countryregioncode, (row, value) => merge(row, extract(row).copy(countryregioncode = value)))
-      override val currencycode = new Field[CurrencyId, Row](prefix, "currencycode", None, None)(x => extract(x).currencycode, (row, value) => merge(row, extract(row).copy(currencycode = value)))
-      override val modifieddate = new Field[TypoLocalDateTime, Row](prefix, "modifieddate", Some("text"), None)(x => extract(x).modifieddate, (row, value) => merge(row, extract(row).copy(modifieddate = value)))
+    override lazy val fields: CrcViewFields = new CrcViewFields {
+      override def countryregioncode = Field[CountryregionId, CrcViewRow](_path, "countryregioncode", None, None, x => x.countryregioncode, (row, value) => row.copy(countryregioncode = value))
+      override def currencycode = Field[CurrencyId, CrcViewRow](_path, "currencycode", None, None, x => x.currencycode, (row, value) => row.copy(currencycode = value))
+      override def modifieddate = Field[TypoLocalDateTime, CrcViewRow](_path, "modifieddate", Some("text"), None, x => x.modifieddate, (row, value) => row.copy(modifieddate = value))
     }
   
-    override val columns: List[FieldLikeNoHkt[?, Row]] =
-      List[FieldLikeNoHkt[?, Row]](fields.countryregioncode, fields.currencycode, fields.modifieddate)
+    override lazy val columns: List[FieldLikeNoHkt[?, CrcViewRow]] =
+      List[FieldLikeNoHkt[?, CrcViewRow]](fields.countryregioncode, fields.currencycode, fields.modifieddate)
   
-    override def copy[NewRow](prefix: Option[String], extract: NewRow => CrcViewRow, merge: (NewRow, CrcViewRow) => NewRow): Impl[NewRow] =
-      new Impl(prefix, extract, merge)
+    override def copy(path: List[Path]): Impl =
+      new Impl(path)
   }
   
 }

--- a/typo-tester-zio-jdbc/generated-and-checked-in/adventureworks/sa/cu/CuViewFields.scala
+++ b/typo-tester-zio-jdbc/generated-and-checked-in/adventureworks/sa/cu/CuViewFields.scala
@@ -10,36 +10,37 @@ package cu
 import adventureworks.customtypes.TypoLocalDateTime
 import adventureworks.public.Name
 import adventureworks.sales.currency.CurrencyId
+import typo.dsl.Path
 import typo.dsl.SqlExpr.Field
 import typo.dsl.SqlExpr.FieldLikeNoHkt
 import typo.dsl.Structure.Relation
 
-trait CuViewFields[Row] {
-  val id: Field[CurrencyId, Row]
-  val currencycode: Field[CurrencyId, Row]
-  val name: Field[Name, Row]
-  val modifieddate: Field[TypoLocalDateTime, Row]
+trait CuViewFields {
+  def id: Field[CurrencyId, CuViewRow]
+  def currencycode: Field[CurrencyId, CuViewRow]
+  def name: Field[Name, CuViewRow]
+  def modifieddate: Field[TypoLocalDateTime, CuViewRow]
 }
 
 object CuViewFields {
-  val structure: Relation[CuViewFields, CuViewRow, CuViewRow] = 
-    new Impl(None, identity, (_, x) => x)
+  lazy val structure: Relation[CuViewFields, CuViewRow] =
+    new Impl(Nil)
     
-  private final class Impl[Row](val prefix: Option[String], val extract: Row => CuViewRow, val merge: (Row, CuViewRow) => Row)
-    extends Relation[CuViewFields, CuViewRow, Row] { 
+  private final class Impl(val _path: List[Path])
+    extends Relation[CuViewFields, CuViewRow] {
   
-    override val fields: CuViewFields[Row] = new CuViewFields[Row] {
-      override val id = new Field[CurrencyId, Row](prefix, "id", None, None)(x => extract(x).id, (row, value) => merge(row, extract(row).copy(id = value)))
-      override val currencycode = new Field[CurrencyId, Row](prefix, "currencycode", None, None)(x => extract(x).currencycode, (row, value) => merge(row, extract(row).copy(currencycode = value)))
-      override val name = new Field[Name, Row](prefix, "name", None, None)(x => extract(x).name, (row, value) => merge(row, extract(row).copy(name = value)))
-      override val modifieddate = new Field[TypoLocalDateTime, Row](prefix, "modifieddate", Some("text"), None)(x => extract(x).modifieddate, (row, value) => merge(row, extract(row).copy(modifieddate = value)))
+    override lazy val fields: CuViewFields = new CuViewFields {
+      override def id = Field[CurrencyId, CuViewRow](_path, "id", None, None, x => x.id, (row, value) => row.copy(id = value))
+      override def currencycode = Field[CurrencyId, CuViewRow](_path, "currencycode", None, None, x => x.currencycode, (row, value) => row.copy(currencycode = value))
+      override def name = Field[Name, CuViewRow](_path, "name", None, None, x => x.name, (row, value) => row.copy(name = value))
+      override def modifieddate = Field[TypoLocalDateTime, CuViewRow](_path, "modifieddate", Some("text"), None, x => x.modifieddate, (row, value) => row.copy(modifieddate = value))
     }
   
-    override val columns: List[FieldLikeNoHkt[?, Row]] =
-      List[FieldLikeNoHkt[?, Row]](fields.id, fields.currencycode, fields.name, fields.modifieddate)
+    override lazy val columns: List[FieldLikeNoHkt[?, CuViewRow]] =
+      List[FieldLikeNoHkt[?, CuViewRow]](fields.id, fields.currencycode, fields.name, fields.modifieddate)
   
-    override def copy[NewRow](prefix: Option[String], extract: NewRow => CuViewRow, merge: (NewRow, CuViewRow) => NewRow): Impl[NewRow] =
-      new Impl(prefix, extract, merge)
+    override def copy(path: List[Path]): Impl =
+      new Impl(path)
   }
   
 }

--- a/typo-tester-zio-jdbc/generated-and-checked-in/adventureworks/sa/pcc/PccViewFields.scala
+++ b/typo-tester-zio-jdbc/generated-and-checked-in/adventureworks/sa/pcc/PccViewFields.scala
@@ -10,36 +10,37 @@ package pcc
 import adventureworks.customtypes.TypoLocalDateTime
 import adventureworks.person.businessentity.BusinessentityId
 import adventureworks.userdefined.CustomCreditcardId
+import typo.dsl.Path
 import typo.dsl.SqlExpr.Field
 import typo.dsl.SqlExpr.FieldLikeNoHkt
 import typo.dsl.Structure.Relation
 
-trait PccViewFields[Row] {
-  val id: Field[BusinessentityId, Row]
-  val businessentityid: Field[BusinessentityId, Row]
-  val creditcardid: Field[/* user-picked */ CustomCreditcardId, Row]
-  val modifieddate: Field[TypoLocalDateTime, Row]
+trait PccViewFields {
+  def id: Field[BusinessentityId, PccViewRow]
+  def businessentityid: Field[BusinessentityId, PccViewRow]
+  def creditcardid: Field[/* user-picked */ CustomCreditcardId, PccViewRow]
+  def modifieddate: Field[TypoLocalDateTime, PccViewRow]
 }
 
 object PccViewFields {
-  val structure: Relation[PccViewFields, PccViewRow, PccViewRow] = 
-    new Impl(None, identity, (_, x) => x)
+  lazy val structure: Relation[PccViewFields, PccViewRow] =
+    new Impl(Nil)
     
-  private final class Impl[Row](val prefix: Option[String], val extract: Row => PccViewRow, val merge: (Row, PccViewRow) => Row)
-    extends Relation[PccViewFields, PccViewRow, Row] { 
+  private final class Impl(val _path: List[Path])
+    extends Relation[PccViewFields, PccViewRow] {
   
-    override val fields: PccViewFields[Row] = new PccViewFields[Row] {
-      override val id = new Field[BusinessentityId, Row](prefix, "id", None, None)(x => extract(x).id, (row, value) => merge(row, extract(row).copy(id = value)))
-      override val businessentityid = new Field[BusinessentityId, Row](prefix, "businessentityid", None, None)(x => extract(x).businessentityid, (row, value) => merge(row, extract(row).copy(businessentityid = value)))
-      override val creditcardid = new Field[/* user-picked */ CustomCreditcardId, Row](prefix, "creditcardid", None, None)(x => extract(x).creditcardid, (row, value) => merge(row, extract(row).copy(creditcardid = value)))
-      override val modifieddate = new Field[TypoLocalDateTime, Row](prefix, "modifieddate", Some("text"), None)(x => extract(x).modifieddate, (row, value) => merge(row, extract(row).copy(modifieddate = value)))
+    override lazy val fields: PccViewFields = new PccViewFields {
+      override def id = Field[BusinessentityId, PccViewRow](_path, "id", None, None, x => x.id, (row, value) => row.copy(id = value))
+      override def businessentityid = Field[BusinessentityId, PccViewRow](_path, "businessentityid", None, None, x => x.businessentityid, (row, value) => row.copy(businessentityid = value))
+      override def creditcardid = Field[/* user-picked */ CustomCreditcardId, PccViewRow](_path, "creditcardid", None, None, x => x.creditcardid, (row, value) => row.copy(creditcardid = value))
+      override def modifieddate = Field[TypoLocalDateTime, PccViewRow](_path, "modifieddate", Some("text"), None, x => x.modifieddate, (row, value) => row.copy(modifieddate = value))
     }
   
-    override val columns: List[FieldLikeNoHkt[?, Row]] =
-      List[FieldLikeNoHkt[?, Row]](fields.id, fields.businessentityid, fields.creditcardid, fields.modifieddate)
+    override lazy val columns: List[FieldLikeNoHkt[?, PccViewRow]] =
+      List[FieldLikeNoHkt[?, PccViewRow]](fields.id, fields.businessentityid, fields.creditcardid, fields.modifieddate)
   
-    override def copy[NewRow](prefix: Option[String], extract: NewRow => PccViewRow, merge: (NewRow, PccViewRow) => NewRow): Impl[NewRow] =
-      new Impl(prefix, extract, merge)
+    override def copy(path: List[Path]): Impl =
+      new Impl(path)
   }
   
 }

--- a/typo-tester-zio-jdbc/generated-and-checked-in/adventureworks/sa/s/SViewFields.scala
+++ b/typo-tester-zio-jdbc/generated-and-checked-in/adventureworks/sa/s/SViewFields.scala
@@ -12,43 +12,44 @@ import adventureworks.customtypes.TypoUUID
 import adventureworks.customtypes.TypoXml
 import adventureworks.person.businessentity.BusinessentityId
 import adventureworks.public.Name
+import typo.dsl.Path
 import typo.dsl.SqlExpr.Field
 import typo.dsl.SqlExpr.FieldLikeNoHkt
 import typo.dsl.SqlExpr.OptField
 import typo.dsl.Structure.Relation
 
-trait SViewFields[Row] {
-  val id: Field[BusinessentityId, Row]
-  val businessentityid: Field[BusinessentityId, Row]
-  val name: Field[Name, Row]
-  val salespersonid: OptField[BusinessentityId, Row]
-  val demographics: OptField[TypoXml, Row]
-  val rowguid: Field[TypoUUID, Row]
-  val modifieddate: Field[TypoLocalDateTime, Row]
+trait SViewFields {
+  def id: Field[BusinessentityId, SViewRow]
+  def businessentityid: Field[BusinessentityId, SViewRow]
+  def name: Field[Name, SViewRow]
+  def salespersonid: OptField[BusinessentityId, SViewRow]
+  def demographics: OptField[TypoXml, SViewRow]
+  def rowguid: Field[TypoUUID, SViewRow]
+  def modifieddate: Field[TypoLocalDateTime, SViewRow]
 }
 
 object SViewFields {
-  val structure: Relation[SViewFields, SViewRow, SViewRow] = 
-    new Impl(None, identity, (_, x) => x)
+  lazy val structure: Relation[SViewFields, SViewRow] =
+    new Impl(Nil)
     
-  private final class Impl[Row](val prefix: Option[String], val extract: Row => SViewRow, val merge: (Row, SViewRow) => Row)
-    extends Relation[SViewFields, SViewRow, Row] { 
+  private final class Impl(val _path: List[Path])
+    extends Relation[SViewFields, SViewRow] {
   
-    override val fields: SViewFields[Row] = new SViewFields[Row] {
-      override val id = new Field[BusinessentityId, Row](prefix, "id", None, None)(x => extract(x).id, (row, value) => merge(row, extract(row).copy(id = value)))
-      override val businessentityid = new Field[BusinessentityId, Row](prefix, "businessentityid", None, None)(x => extract(x).businessentityid, (row, value) => merge(row, extract(row).copy(businessentityid = value)))
-      override val name = new Field[Name, Row](prefix, "name", None, None)(x => extract(x).name, (row, value) => merge(row, extract(row).copy(name = value)))
-      override val salespersonid = new OptField[BusinessentityId, Row](prefix, "salespersonid", None, None)(x => extract(x).salespersonid, (row, value) => merge(row, extract(row).copy(salespersonid = value)))
-      override val demographics = new OptField[TypoXml, Row](prefix, "demographics", None, None)(x => extract(x).demographics, (row, value) => merge(row, extract(row).copy(demographics = value)))
-      override val rowguid = new Field[TypoUUID, Row](prefix, "rowguid", None, None)(x => extract(x).rowguid, (row, value) => merge(row, extract(row).copy(rowguid = value)))
-      override val modifieddate = new Field[TypoLocalDateTime, Row](prefix, "modifieddate", Some("text"), None)(x => extract(x).modifieddate, (row, value) => merge(row, extract(row).copy(modifieddate = value)))
+    override lazy val fields: SViewFields = new SViewFields {
+      override def id = Field[BusinessentityId, SViewRow](_path, "id", None, None, x => x.id, (row, value) => row.copy(id = value))
+      override def businessentityid = Field[BusinessentityId, SViewRow](_path, "businessentityid", None, None, x => x.businessentityid, (row, value) => row.copy(businessentityid = value))
+      override def name = Field[Name, SViewRow](_path, "name", None, None, x => x.name, (row, value) => row.copy(name = value))
+      override def salespersonid = OptField[BusinessentityId, SViewRow](_path, "salespersonid", None, None, x => x.salespersonid, (row, value) => row.copy(salespersonid = value))
+      override def demographics = OptField[TypoXml, SViewRow](_path, "demographics", None, None, x => x.demographics, (row, value) => row.copy(demographics = value))
+      override def rowguid = Field[TypoUUID, SViewRow](_path, "rowguid", None, None, x => x.rowguid, (row, value) => row.copy(rowguid = value))
+      override def modifieddate = Field[TypoLocalDateTime, SViewRow](_path, "modifieddate", Some("text"), None, x => x.modifieddate, (row, value) => row.copy(modifieddate = value))
     }
   
-    override val columns: List[FieldLikeNoHkt[?, Row]] =
-      List[FieldLikeNoHkt[?, Row]](fields.id, fields.businessentityid, fields.name, fields.salespersonid, fields.demographics, fields.rowguid, fields.modifieddate)
+    override lazy val columns: List[FieldLikeNoHkt[?, SViewRow]] =
+      List[FieldLikeNoHkt[?, SViewRow]](fields.id, fields.businessentityid, fields.name, fields.salespersonid, fields.demographics, fields.rowguid, fields.modifieddate)
   
-    override def copy[NewRow](prefix: Option[String], extract: NewRow => SViewRow, merge: (NewRow, SViewRow) => NewRow): Impl[NewRow] =
-      new Impl(prefix, extract, merge)
+    override def copy(path: List[Path]): Impl =
+      new Impl(path)
   }
   
 }

--- a/typo-tester-zio-jdbc/generated-and-checked-in/adventureworks/sa/sci/SciViewFields.scala
+++ b/typo-tester-zio-jdbc/generated-and-checked-in/adventureworks/sa/sci/SciViewFields.scala
@@ -10,42 +10,43 @@ package sci
 import adventureworks.customtypes.TypoLocalDateTime
 import adventureworks.production.product.ProductId
 import adventureworks.sales.shoppingcartitem.ShoppingcartitemId
+import typo.dsl.Path
 import typo.dsl.SqlExpr.Field
 import typo.dsl.SqlExpr.FieldLikeNoHkt
 import typo.dsl.Structure.Relation
 
-trait SciViewFields[Row] {
-  val id: Field[ShoppingcartitemId, Row]
-  val shoppingcartitemid: Field[ShoppingcartitemId, Row]
-  val shoppingcartid: Field[/* max 50 chars */ String, Row]
-  val quantity: Field[Int, Row]
-  val productid: Field[ProductId, Row]
-  val datecreated: Field[TypoLocalDateTime, Row]
-  val modifieddate: Field[TypoLocalDateTime, Row]
+trait SciViewFields {
+  def id: Field[ShoppingcartitemId, SciViewRow]
+  def shoppingcartitemid: Field[ShoppingcartitemId, SciViewRow]
+  def shoppingcartid: Field[/* max 50 chars */ String, SciViewRow]
+  def quantity: Field[Int, SciViewRow]
+  def productid: Field[ProductId, SciViewRow]
+  def datecreated: Field[TypoLocalDateTime, SciViewRow]
+  def modifieddate: Field[TypoLocalDateTime, SciViewRow]
 }
 
 object SciViewFields {
-  val structure: Relation[SciViewFields, SciViewRow, SciViewRow] = 
-    new Impl(None, identity, (_, x) => x)
+  lazy val structure: Relation[SciViewFields, SciViewRow] =
+    new Impl(Nil)
     
-  private final class Impl[Row](val prefix: Option[String], val extract: Row => SciViewRow, val merge: (Row, SciViewRow) => Row)
-    extends Relation[SciViewFields, SciViewRow, Row] { 
+  private final class Impl(val _path: List[Path])
+    extends Relation[SciViewFields, SciViewRow] {
   
-    override val fields: SciViewFields[Row] = new SciViewFields[Row] {
-      override val id = new Field[ShoppingcartitemId, Row](prefix, "id", None, None)(x => extract(x).id, (row, value) => merge(row, extract(row).copy(id = value)))
-      override val shoppingcartitemid = new Field[ShoppingcartitemId, Row](prefix, "shoppingcartitemid", None, None)(x => extract(x).shoppingcartitemid, (row, value) => merge(row, extract(row).copy(shoppingcartitemid = value)))
-      override val shoppingcartid = new Field[/* max 50 chars */ String, Row](prefix, "shoppingcartid", None, None)(x => extract(x).shoppingcartid, (row, value) => merge(row, extract(row).copy(shoppingcartid = value)))
-      override val quantity = new Field[Int, Row](prefix, "quantity", None, None)(x => extract(x).quantity, (row, value) => merge(row, extract(row).copy(quantity = value)))
-      override val productid = new Field[ProductId, Row](prefix, "productid", None, None)(x => extract(x).productid, (row, value) => merge(row, extract(row).copy(productid = value)))
-      override val datecreated = new Field[TypoLocalDateTime, Row](prefix, "datecreated", Some("text"), None)(x => extract(x).datecreated, (row, value) => merge(row, extract(row).copy(datecreated = value)))
-      override val modifieddate = new Field[TypoLocalDateTime, Row](prefix, "modifieddate", Some("text"), None)(x => extract(x).modifieddate, (row, value) => merge(row, extract(row).copy(modifieddate = value)))
+    override lazy val fields: SciViewFields = new SciViewFields {
+      override def id = Field[ShoppingcartitemId, SciViewRow](_path, "id", None, None, x => x.id, (row, value) => row.copy(id = value))
+      override def shoppingcartitemid = Field[ShoppingcartitemId, SciViewRow](_path, "shoppingcartitemid", None, None, x => x.shoppingcartitemid, (row, value) => row.copy(shoppingcartitemid = value))
+      override def shoppingcartid = Field[/* max 50 chars */ String, SciViewRow](_path, "shoppingcartid", None, None, x => x.shoppingcartid, (row, value) => row.copy(shoppingcartid = value))
+      override def quantity = Field[Int, SciViewRow](_path, "quantity", None, None, x => x.quantity, (row, value) => row.copy(quantity = value))
+      override def productid = Field[ProductId, SciViewRow](_path, "productid", None, None, x => x.productid, (row, value) => row.copy(productid = value))
+      override def datecreated = Field[TypoLocalDateTime, SciViewRow](_path, "datecreated", Some("text"), None, x => x.datecreated, (row, value) => row.copy(datecreated = value))
+      override def modifieddate = Field[TypoLocalDateTime, SciViewRow](_path, "modifieddate", Some("text"), None, x => x.modifieddate, (row, value) => row.copy(modifieddate = value))
     }
   
-    override val columns: List[FieldLikeNoHkt[?, Row]] =
-      List[FieldLikeNoHkt[?, Row]](fields.id, fields.shoppingcartitemid, fields.shoppingcartid, fields.quantity, fields.productid, fields.datecreated, fields.modifieddate)
+    override lazy val columns: List[FieldLikeNoHkt[?, SciViewRow]] =
+      List[FieldLikeNoHkt[?, SciViewRow]](fields.id, fields.shoppingcartitemid, fields.shoppingcartid, fields.quantity, fields.productid, fields.datecreated, fields.modifieddate)
   
-    override def copy[NewRow](prefix: Option[String], extract: NewRow => SciViewRow, merge: (NewRow, SciViewRow) => NewRow): Impl[NewRow] =
-      new Impl(prefix, extract, merge)
+    override def copy(path: List[Path]): Impl =
+      new Impl(path)
   }
   
 }

--- a/typo-tester-zio-jdbc/generated-and-checked-in/adventureworks/sa/so/SoViewFields.scala
+++ b/typo-tester-zio-jdbc/generated-and-checked-in/adventureworks/sa/so/SoViewFields.scala
@@ -10,53 +10,54 @@ package so
 import adventureworks.customtypes.TypoLocalDateTime
 import adventureworks.customtypes.TypoUUID
 import adventureworks.sales.specialoffer.SpecialofferId
+import typo.dsl.Path
 import typo.dsl.SqlExpr.Field
 import typo.dsl.SqlExpr.FieldLikeNoHkt
 import typo.dsl.SqlExpr.OptField
 import typo.dsl.Structure.Relation
 
-trait SoViewFields[Row] {
-  val id: Field[SpecialofferId, Row]
-  val specialofferid: Field[SpecialofferId, Row]
-  val description: Field[/* max 255 chars */ String, Row]
-  val discountpct: Field[BigDecimal, Row]
-  val `type`: Field[/* max 50 chars */ String, Row]
-  val category: Field[/* max 50 chars */ String, Row]
-  val startdate: Field[TypoLocalDateTime, Row]
-  val enddate: Field[TypoLocalDateTime, Row]
-  val minqty: Field[Int, Row]
-  val maxqty: OptField[Int, Row]
-  val rowguid: Field[TypoUUID, Row]
-  val modifieddate: Field[TypoLocalDateTime, Row]
+trait SoViewFields {
+  def id: Field[SpecialofferId, SoViewRow]
+  def specialofferid: Field[SpecialofferId, SoViewRow]
+  def description: Field[/* max 255 chars */ String, SoViewRow]
+  def discountpct: Field[BigDecimal, SoViewRow]
+  def `type`: Field[/* max 50 chars */ String, SoViewRow]
+  def category: Field[/* max 50 chars */ String, SoViewRow]
+  def startdate: Field[TypoLocalDateTime, SoViewRow]
+  def enddate: Field[TypoLocalDateTime, SoViewRow]
+  def minqty: Field[Int, SoViewRow]
+  def maxqty: OptField[Int, SoViewRow]
+  def rowguid: Field[TypoUUID, SoViewRow]
+  def modifieddate: Field[TypoLocalDateTime, SoViewRow]
 }
 
 object SoViewFields {
-  val structure: Relation[SoViewFields, SoViewRow, SoViewRow] = 
-    new Impl(None, identity, (_, x) => x)
+  lazy val structure: Relation[SoViewFields, SoViewRow] =
+    new Impl(Nil)
     
-  private final class Impl[Row](val prefix: Option[String], val extract: Row => SoViewRow, val merge: (Row, SoViewRow) => Row)
-    extends Relation[SoViewFields, SoViewRow, Row] { 
+  private final class Impl(val _path: List[Path])
+    extends Relation[SoViewFields, SoViewRow] {
   
-    override val fields: SoViewFields[Row] = new SoViewFields[Row] {
-      override val id = new Field[SpecialofferId, Row](prefix, "id", None, None)(x => extract(x).id, (row, value) => merge(row, extract(row).copy(id = value)))
-      override val specialofferid = new Field[SpecialofferId, Row](prefix, "specialofferid", None, None)(x => extract(x).specialofferid, (row, value) => merge(row, extract(row).copy(specialofferid = value)))
-      override val description = new Field[/* max 255 chars */ String, Row](prefix, "description", None, None)(x => extract(x).description, (row, value) => merge(row, extract(row).copy(description = value)))
-      override val discountpct = new Field[BigDecimal, Row](prefix, "discountpct", None, None)(x => extract(x).discountpct, (row, value) => merge(row, extract(row).copy(discountpct = value)))
-      override val `type` = new Field[/* max 50 chars */ String, Row](prefix, "type", None, None)(x => extract(x).`type`, (row, value) => merge(row, extract(row).copy(`type` = value)))
-      override val category = new Field[/* max 50 chars */ String, Row](prefix, "category", None, None)(x => extract(x).category, (row, value) => merge(row, extract(row).copy(category = value)))
-      override val startdate = new Field[TypoLocalDateTime, Row](prefix, "startdate", Some("text"), None)(x => extract(x).startdate, (row, value) => merge(row, extract(row).copy(startdate = value)))
-      override val enddate = new Field[TypoLocalDateTime, Row](prefix, "enddate", Some("text"), None)(x => extract(x).enddate, (row, value) => merge(row, extract(row).copy(enddate = value)))
-      override val minqty = new Field[Int, Row](prefix, "minqty", None, None)(x => extract(x).minqty, (row, value) => merge(row, extract(row).copy(minqty = value)))
-      override val maxqty = new OptField[Int, Row](prefix, "maxqty", None, None)(x => extract(x).maxqty, (row, value) => merge(row, extract(row).copy(maxqty = value)))
-      override val rowguid = new Field[TypoUUID, Row](prefix, "rowguid", None, None)(x => extract(x).rowguid, (row, value) => merge(row, extract(row).copy(rowguid = value)))
-      override val modifieddate = new Field[TypoLocalDateTime, Row](prefix, "modifieddate", Some("text"), None)(x => extract(x).modifieddate, (row, value) => merge(row, extract(row).copy(modifieddate = value)))
+    override lazy val fields: SoViewFields = new SoViewFields {
+      override def id = Field[SpecialofferId, SoViewRow](_path, "id", None, None, x => x.id, (row, value) => row.copy(id = value))
+      override def specialofferid = Field[SpecialofferId, SoViewRow](_path, "specialofferid", None, None, x => x.specialofferid, (row, value) => row.copy(specialofferid = value))
+      override def description = Field[/* max 255 chars */ String, SoViewRow](_path, "description", None, None, x => x.description, (row, value) => row.copy(description = value))
+      override def discountpct = Field[BigDecimal, SoViewRow](_path, "discountpct", None, None, x => x.discountpct, (row, value) => row.copy(discountpct = value))
+      override def `type` = Field[/* max 50 chars */ String, SoViewRow](_path, "type", None, None, x => x.`type`, (row, value) => row.copy(`type` = value))
+      override def category = Field[/* max 50 chars */ String, SoViewRow](_path, "category", None, None, x => x.category, (row, value) => row.copy(category = value))
+      override def startdate = Field[TypoLocalDateTime, SoViewRow](_path, "startdate", Some("text"), None, x => x.startdate, (row, value) => row.copy(startdate = value))
+      override def enddate = Field[TypoLocalDateTime, SoViewRow](_path, "enddate", Some("text"), None, x => x.enddate, (row, value) => row.copy(enddate = value))
+      override def minqty = Field[Int, SoViewRow](_path, "minqty", None, None, x => x.minqty, (row, value) => row.copy(minqty = value))
+      override def maxqty = OptField[Int, SoViewRow](_path, "maxqty", None, None, x => x.maxqty, (row, value) => row.copy(maxqty = value))
+      override def rowguid = Field[TypoUUID, SoViewRow](_path, "rowguid", None, None, x => x.rowguid, (row, value) => row.copy(rowguid = value))
+      override def modifieddate = Field[TypoLocalDateTime, SoViewRow](_path, "modifieddate", Some("text"), None, x => x.modifieddate, (row, value) => row.copy(modifieddate = value))
     }
   
-    override val columns: List[FieldLikeNoHkt[?, Row]] =
-      List[FieldLikeNoHkt[?, Row]](fields.id, fields.specialofferid, fields.description, fields.discountpct, fields.`type`, fields.category, fields.startdate, fields.enddate, fields.minqty, fields.maxqty, fields.rowguid, fields.modifieddate)
+    override lazy val columns: List[FieldLikeNoHkt[?, SoViewRow]] =
+      List[FieldLikeNoHkt[?, SoViewRow]](fields.id, fields.specialofferid, fields.description, fields.discountpct, fields.`type`, fields.category, fields.startdate, fields.enddate, fields.minqty, fields.maxqty, fields.rowguid, fields.modifieddate)
   
-    override def copy[NewRow](prefix: Option[String], extract: NewRow => SoViewRow, merge: (NewRow, SoViewRow) => NewRow): Impl[NewRow] =
-      new Impl(prefix, extract, merge)
+    override def copy(path: List[Path]): Impl =
+      new Impl(path)
   }
   
 }

--- a/typo-tester-zio-jdbc/generated-and-checked-in/adventureworks/sa/sod/SodViewFields.scala
+++ b/typo-tester-zio-jdbc/generated-and-checked-in/adventureworks/sa/sod/SodViewFields.scala
@@ -13,51 +13,52 @@ import adventureworks.customtypes.TypoUUID
 import adventureworks.production.product.ProductId
 import adventureworks.sales.salesorderheader.SalesorderheaderId
 import adventureworks.sales.specialoffer.SpecialofferId
+import typo.dsl.Path
 import typo.dsl.SqlExpr.Field
 import typo.dsl.SqlExpr.FieldLikeNoHkt
 import typo.dsl.SqlExpr.OptField
 import typo.dsl.Structure.Relation
 
-trait SodViewFields[Row] {
-  val id: Field[Int, Row]
-  val salesorderid: Field[SalesorderheaderId, Row]
-  val salesorderdetailid: Field[Int, Row]
-  val carriertrackingnumber: OptField[/* max 25 chars */ String, Row]
-  val orderqty: Field[TypoShort, Row]
-  val productid: Field[ProductId, Row]
-  val specialofferid: Field[SpecialofferId, Row]
-  val unitprice: Field[BigDecimal, Row]
-  val unitpricediscount: Field[BigDecimal, Row]
-  val rowguid: Field[TypoUUID, Row]
-  val modifieddate: Field[TypoLocalDateTime, Row]
+trait SodViewFields {
+  def id: Field[Int, SodViewRow]
+  def salesorderid: Field[SalesorderheaderId, SodViewRow]
+  def salesorderdetailid: Field[Int, SodViewRow]
+  def carriertrackingnumber: OptField[/* max 25 chars */ String, SodViewRow]
+  def orderqty: Field[TypoShort, SodViewRow]
+  def productid: Field[ProductId, SodViewRow]
+  def specialofferid: Field[SpecialofferId, SodViewRow]
+  def unitprice: Field[BigDecimal, SodViewRow]
+  def unitpricediscount: Field[BigDecimal, SodViewRow]
+  def rowguid: Field[TypoUUID, SodViewRow]
+  def modifieddate: Field[TypoLocalDateTime, SodViewRow]
 }
 
 object SodViewFields {
-  val structure: Relation[SodViewFields, SodViewRow, SodViewRow] = 
-    new Impl(None, identity, (_, x) => x)
+  lazy val structure: Relation[SodViewFields, SodViewRow] =
+    new Impl(Nil)
     
-  private final class Impl[Row](val prefix: Option[String], val extract: Row => SodViewRow, val merge: (Row, SodViewRow) => Row)
-    extends Relation[SodViewFields, SodViewRow, Row] { 
+  private final class Impl(val _path: List[Path])
+    extends Relation[SodViewFields, SodViewRow] {
   
-    override val fields: SodViewFields[Row] = new SodViewFields[Row] {
-      override val id = new Field[Int, Row](prefix, "id", None, None)(x => extract(x).id, (row, value) => merge(row, extract(row).copy(id = value)))
-      override val salesorderid = new Field[SalesorderheaderId, Row](prefix, "salesorderid", None, None)(x => extract(x).salesorderid, (row, value) => merge(row, extract(row).copy(salesorderid = value)))
-      override val salesorderdetailid = new Field[Int, Row](prefix, "salesorderdetailid", None, None)(x => extract(x).salesorderdetailid, (row, value) => merge(row, extract(row).copy(salesorderdetailid = value)))
-      override val carriertrackingnumber = new OptField[/* max 25 chars */ String, Row](prefix, "carriertrackingnumber", None, None)(x => extract(x).carriertrackingnumber, (row, value) => merge(row, extract(row).copy(carriertrackingnumber = value)))
-      override val orderqty = new Field[TypoShort, Row](prefix, "orderqty", None, None)(x => extract(x).orderqty, (row, value) => merge(row, extract(row).copy(orderqty = value)))
-      override val productid = new Field[ProductId, Row](prefix, "productid", None, None)(x => extract(x).productid, (row, value) => merge(row, extract(row).copy(productid = value)))
-      override val specialofferid = new Field[SpecialofferId, Row](prefix, "specialofferid", None, None)(x => extract(x).specialofferid, (row, value) => merge(row, extract(row).copy(specialofferid = value)))
-      override val unitprice = new Field[BigDecimal, Row](prefix, "unitprice", None, None)(x => extract(x).unitprice, (row, value) => merge(row, extract(row).copy(unitprice = value)))
-      override val unitpricediscount = new Field[BigDecimal, Row](prefix, "unitpricediscount", None, None)(x => extract(x).unitpricediscount, (row, value) => merge(row, extract(row).copy(unitpricediscount = value)))
-      override val rowguid = new Field[TypoUUID, Row](prefix, "rowguid", None, None)(x => extract(x).rowguid, (row, value) => merge(row, extract(row).copy(rowguid = value)))
-      override val modifieddate = new Field[TypoLocalDateTime, Row](prefix, "modifieddate", Some("text"), None)(x => extract(x).modifieddate, (row, value) => merge(row, extract(row).copy(modifieddate = value)))
+    override lazy val fields: SodViewFields = new SodViewFields {
+      override def id = Field[Int, SodViewRow](_path, "id", None, None, x => x.id, (row, value) => row.copy(id = value))
+      override def salesorderid = Field[SalesorderheaderId, SodViewRow](_path, "salesorderid", None, None, x => x.salesorderid, (row, value) => row.copy(salesorderid = value))
+      override def salesorderdetailid = Field[Int, SodViewRow](_path, "salesorderdetailid", None, None, x => x.salesorderdetailid, (row, value) => row.copy(salesorderdetailid = value))
+      override def carriertrackingnumber = OptField[/* max 25 chars */ String, SodViewRow](_path, "carriertrackingnumber", None, None, x => x.carriertrackingnumber, (row, value) => row.copy(carriertrackingnumber = value))
+      override def orderqty = Field[TypoShort, SodViewRow](_path, "orderqty", None, None, x => x.orderqty, (row, value) => row.copy(orderqty = value))
+      override def productid = Field[ProductId, SodViewRow](_path, "productid", None, None, x => x.productid, (row, value) => row.copy(productid = value))
+      override def specialofferid = Field[SpecialofferId, SodViewRow](_path, "specialofferid", None, None, x => x.specialofferid, (row, value) => row.copy(specialofferid = value))
+      override def unitprice = Field[BigDecimal, SodViewRow](_path, "unitprice", None, None, x => x.unitprice, (row, value) => row.copy(unitprice = value))
+      override def unitpricediscount = Field[BigDecimal, SodViewRow](_path, "unitpricediscount", None, None, x => x.unitpricediscount, (row, value) => row.copy(unitpricediscount = value))
+      override def rowguid = Field[TypoUUID, SodViewRow](_path, "rowguid", None, None, x => x.rowguid, (row, value) => row.copy(rowguid = value))
+      override def modifieddate = Field[TypoLocalDateTime, SodViewRow](_path, "modifieddate", Some("text"), None, x => x.modifieddate, (row, value) => row.copy(modifieddate = value))
     }
   
-    override val columns: List[FieldLikeNoHkt[?, Row]] =
-      List[FieldLikeNoHkt[?, Row]](fields.id, fields.salesorderid, fields.salesorderdetailid, fields.carriertrackingnumber, fields.orderqty, fields.productid, fields.specialofferid, fields.unitprice, fields.unitpricediscount, fields.rowguid, fields.modifieddate)
+    override lazy val columns: List[FieldLikeNoHkt[?, SodViewRow]] =
+      List[FieldLikeNoHkt[?, SodViewRow]](fields.id, fields.salesorderid, fields.salesorderdetailid, fields.carriertrackingnumber, fields.orderqty, fields.productid, fields.specialofferid, fields.unitprice, fields.unitpricediscount, fields.rowguid, fields.modifieddate)
   
-    override def copy[NewRow](prefix: Option[String], extract: NewRow => SodViewRow, merge: (NewRow, SodViewRow) => NewRow): Impl[NewRow] =
-      new Impl(prefix, extract, merge)
+    override def copy(path: List[Path]): Impl =
+      new Impl(path)
   }
   
 }

--- a/typo-tester-zio-jdbc/generated-and-checked-in/adventureworks/sa/soh/SohViewFields.scala
+++ b/typo-tester-zio-jdbc/generated-and-checked-in/adventureworks/sa/soh/SohViewFields.scala
@@ -21,81 +21,82 @@ import adventureworks.sales.customer.CustomerId
 import adventureworks.sales.salesorderheader.SalesorderheaderId
 import adventureworks.sales.salesterritory.SalesterritoryId
 import adventureworks.userdefined.CustomCreditcardId
+import typo.dsl.Path
 import typo.dsl.SqlExpr.Field
 import typo.dsl.SqlExpr.FieldLikeNoHkt
 import typo.dsl.SqlExpr.OptField
 import typo.dsl.Structure.Relation
 
-trait SohViewFields[Row] {
-  val id: Field[SalesorderheaderId, Row]
-  val salesorderid: Field[SalesorderheaderId, Row]
-  val revisionnumber: Field[TypoShort, Row]
-  val orderdate: Field[TypoLocalDateTime, Row]
-  val duedate: Field[TypoLocalDateTime, Row]
-  val shipdate: OptField[TypoLocalDateTime, Row]
-  val status: Field[TypoShort, Row]
-  val onlineorderflag: Field[Flag, Row]
-  val purchaseordernumber: OptField[OrderNumber, Row]
-  val accountnumber: OptField[AccountNumber, Row]
-  val customerid: Field[CustomerId, Row]
-  val salespersonid: OptField[BusinessentityId, Row]
-  val territoryid: OptField[SalesterritoryId, Row]
-  val billtoaddressid: Field[AddressId, Row]
-  val shiptoaddressid: Field[AddressId, Row]
-  val shipmethodid: Field[ShipmethodId, Row]
-  val creditcardid: OptField[/* user-picked */ CustomCreditcardId, Row]
-  val creditcardapprovalcode: OptField[/* max 15 chars */ String, Row]
-  val currencyrateid: OptField[CurrencyrateId, Row]
-  val subtotal: Field[BigDecimal, Row]
-  val taxamt: Field[BigDecimal, Row]
-  val freight: Field[BigDecimal, Row]
-  val totaldue: OptField[BigDecimal, Row]
-  val comment: OptField[/* max 128 chars */ String, Row]
-  val rowguid: Field[TypoUUID, Row]
-  val modifieddate: Field[TypoLocalDateTime, Row]
+trait SohViewFields {
+  def id: Field[SalesorderheaderId, SohViewRow]
+  def salesorderid: Field[SalesorderheaderId, SohViewRow]
+  def revisionnumber: Field[TypoShort, SohViewRow]
+  def orderdate: Field[TypoLocalDateTime, SohViewRow]
+  def duedate: Field[TypoLocalDateTime, SohViewRow]
+  def shipdate: OptField[TypoLocalDateTime, SohViewRow]
+  def status: Field[TypoShort, SohViewRow]
+  def onlineorderflag: Field[Flag, SohViewRow]
+  def purchaseordernumber: OptField[OrderNumber, SohViewRow]
+  def accountnumber: OptField[AccountNumber, SohViewRow]
+  def customerid: Field[CustomerId, SohViewRow]
+  def salespersonid: OptField[BusinessentityId, SohViewRow]
+  def territoryid: OptField[SalesterritoryId, SohViewRow]
+  def billtoaddressid: Field[AddressId, SohViewRow]
+  def shiptoaddressid: Field[AddressId, SohViewRow]
+  def shipmethodid: Field[ShipmethodId, SohViewRow]
+  def creditcardid: OptField[/* user-picked */ CustomCreditcardId, SohViewRow]
+  def creditcardapprovalcode: OptField[/* max 15 chars */ String, SohViewRow]
+  def currencyrateid: OptField[CurrencyrateId, SohViewRow]
+  def subtotal: Field[BigDecimal, SohViewRow]
+  def taxamt: Field[BigDecimal, SohViewRow]
+  def freight: Field[BigDecimal, SohViewRow]
+  def totaldue: OptField[BigDecimal, SohViewRow]
+  def comment: OptField[/* max 128 chars */ String, SohViewRow]
+  def rowguid: Field[TypoUUID, SohViewRow]
+  def modifieddate: Field[TypoLocalDateTime, SohViewRow]
 }
 
 object SohViewFields {
-  val structure: Relation[SohViewFields, SohViewRow, SohViewRow] = 
-    new Impl(None, identity, (_, x) => x)
+  lazy val structure: Relation[SohViewFields, SohViewRow] =
+    new Impl(Nil)
     
-  private final class Impl[Row](val prefix: Option[String], val extract: Row => SohViewRow, val merge: (Row, SohViewRow) => Row)
-    extends Relation[SohViewFields, SohViewRow, Row] { 
+  private final class Impl(val _path: List[Path])
+    extends Relation[SohViewFields, SohViewRow] {
   
-    override val fields: SohViewFields[Row] = new SohViewFields[Row] {
-      override val id = new Field[SalesorderheaderId, Row](prefix, "id", None, None)(x => extract(x).id, (row, value) => merge(row, extract(row).copy(id = value)))
-      override val salesorderid = new Field[SalesorderheaderId, Row](prefix, "salesorderid", None, None)(x => extract(x).salesorderid, (row, value) => merge(row, extract(row).copy(salesorderid = value)))
-      override val revisionnumber = new Field[TypoShort, Row](prefix, "revisionnumber", None, None)(x => extract(x).revisionnumber, (row, value) => merge(row, extract(row).copy(revisionnumber = value)))
-      override val orderdate = new Field[TypoLocalDateTime, Row](prefix, "orderdate", Some("text"), None)(x => extract(x).orderdate, (row, value) => merge(row, extract(row).copy(orderdate = value)))
-      override val duedate = new Field[TypoLocalDateTime, Row](prefix, "duedate", Some("text"), None)(x => extract(x).duedate, (row, value) => merge(row, extract(row).copy(duedate = value)))
-      override val shipdate = new OptField[TypoLocalDateTime, Row](prefix, "shipdate", Some("text"), None)(x => extract(x).shipdate, (row, value) => merge(row, extract(row).copy(shipdate = value)))
-      override val status = new Field[TypoShort, Row](prefix, "status", None, None)(x => extract(x).status, (row, value) => merge(row, extract(row).copy(status = value)))
-      override val onlineorderflag = new Field[Flag, Row](prefix, "onlineorderflag", None, None)(x => extract(x).onlineorderflag, (row, value) => merge(row, extract(row).copy(onlineorderflag = value)))
-      override val purchaseordernumber = new OptField[OrderNumber, Row](prefix, "purchaseordernumber", None, None)(x => extract(x).purchaseordernumber, (row, value) => merge(row, extract(row).copy(purchaseordernumber = value)))
-      override val accountnumber = new OptField[AccountNumber, Row](prefix, "accountnumber", None, None)(x => extract(x).accountnumber, (row, value) => merge(row, extract(row).copy(accountnumber = value)))
-      override val customerid = new Field[CustomerId, Row](prefix, "customerid", None, None)(x => extract(x).customerid, (row, value) => merge(row, extract(row).copy(customerid = value)))
-      override val salespersonid = new OptField[BusinessentityId, Row](prefix, "salespersonid", None, None)(x => extract(x).salespersonid, (row, value) => merge(row, extract(row).copy(salespersonid = value)))
-      override val territoryid = new OptField[SalesterritoryId, Row](prefix, "territoryid", None, None)(x => extract(x).territoryid, (row, value) => merge(row, extract(row).copy(territoryid = value)))
-      override val billtoaddressid = new Field[AddressId, Row](prefix, "billtoaddressid", None, None)(x => extract(x).billtoaddressid, (row, value) => merge(row, extract(row).copy(billtoaddressid = value)))
-      override val shiptoaddressid = new Field[AddressId, Row](prefix, "shiptoaddressid", None, None)(x => extract(x).shiptoaddressid, (row, value) => merge(row, extract(row).copy(shiptoaddressid = value)))
-      override val shipmethodid = new Field[ShipmethodId, Row](prefix, "shipmethodid", None, None)(x => extract(x).shipmethodid, (row, value) => merge(row, extract(row).copy(shipmethodid = value)))
-      override val creditcardid = new OptField[/* user-picked */ CustomCreditcardId, Row](prefix, "creditcardid", None, None)(x => extract(x).creditcardid, (row, value) => merge(row, extract(row).copy(creditcardid = value)))
-      override val creditcardapprovalcode = new OptField[/* max 15 chars */ String, Row](prefix, "creditcardapprovalcode", None, None)(x => extract(x).creditcardapprovalcode, (row, value) => merge(row, extract(row).copy(creditcardapprovalcode = value)))
-      override val currencyrateid = new OptField[CurrencyrateId, Row](prefix, "currencyrateid", None, None)(x => extract(x).currencyrateid, (row, value) => merge(row, extract(row).copy(currencyrateid = value)))
-      override val subtotal = new Field[BigDecimal, Row](prefix, "subtotal", None, None)(x => extract(x).subtotal, (row, value) => merge(row, extract(row).copy(subtotal = value)))
-      override val taxamt = new Field[BigDecimal, Row](prefix, "taxamt", None, None)(x => extract(x).taxamt, (row, value) => merge(row, extract(row).copy(taxamt = value)))
-      override val freight = new Field[BigDecimal, Row](prefix, "freight", None, None)(x => extract(x).freight, (row, value) => merge(row, extract(row).copy(freight = value)))
-      override val totaldue = new OptField[BigDecimal, Row](prefix, "totaldue", None, None)(x => extract(x).totaldue, (row, value) => merge(row, extract(row).copy(totaldue = value)))
-      override val comment = new OptField[/* max 128 chars */ String, Row](prefix, "comment", None, None)(x => extract(x).comment, (row, value) => merge(row, extract(row).copy(comment = value)))
-      override val rowguid = new Field[TypoUUID, Row](prefix, "rowguid", None, None)(x => extract(x).rowguid, (row, value) => merge(row, extract(row).copy(rowguid = value)))
-      override val modifieddate = new Field[TypoLocalDateTime, Row](prefix, "modifieddate", Some("text"), None)(x => extract(x).modifieddate, (row, value) => merge(row, extract(row).copy(modifieddate = value)))
+    override lazy val fields: SohViewFields = new SohViewFields {
+      override def id = Field[SalesorderheaderId, SohViewRow](_path, "id", None, None, x => x.id, (row, value) => row.copy(id = value))
+      override def salesorderid = Field[SalesorderheaderId, SohViewRow](_path, "salesorderid", None, None, x => x.salesorderid, (row, value) => row.copy(salesorderid = value))
+      override def revisionnumber = Field[TypoShort, SohViewRow](_path, "revisionnumber", None, None, x => x.revisionnumber, (row, value) => row.copy(revisionnumber = value))
+      override def orderdate = Field[TypoLocalDateTime, SohViewRow](_path, "orderdate", Some("text"), None, x => x.orderdate, (row, value) => row.copy(orderdate = value))
+      override def duedate = Field[TypoLocalDateTime, SohViewRow](_path, "duedate", Some("text"), None, x => x.duedate, (row, value) => row.copy(duedate = value))
+      override def shipdate = OptField[TypoLocalDateTime, SohViewRow](_path, "shipdate", Some("text"), None, x => x.shipdate, (row, value) => row.copy(shipdate = value))
+      override def status = Field[TypoShort, SohViewRow](_path, "status", None, None, x => x.status, (row, value) => row.copy(status = value))
+      override def onlineorderflag = Field[Flag, SohViewRow](_path, "onlineorderflag", None, None, x => x.onlineorderflag, (row, value) => row.copy(onlineorderflag = value))
+      override def purchaseordernumber = OptField[OrderNumber, SohViewRow](_path, "purchaseordernumber", None, None, x => x.purchaseordernumber, (row, value) => row.copy(purchaseordernumber = value))
+      override def accountnumber = OptField[AccountNumber, SohViewRow](_path, "accountnumber", None, None, x => x.accountnumber, (row, value) => row.copy(accountnumber = value))
+      override def customerid = Field[CustomerId, SohViewRow](_path, "customerid", None, None, x => x.customerid, (row, value) => row.copy(customerid = value))
+      override def salespersonid = OptField[BusinessentityId, SohViewRow](_path, "salespersonid", None, None, x => x.salespersonid, (row, value) => row.copy(salespersonid = value))
+      override def territoryid = OptField[SalesterritoryId, SohViewRow](_path, "territoryid", None, None, x => x.territoryid, (row, value) => row.copy(territoryid = value))
+      override def billtoaddressid = Field[AddressId, SohViewRow](_path, "billtoaddressid", None, None, x => x.billtoaddressid, (row, value) => row.copy(billtoaddressid = value))
+      override def shiptoaddressid = Field[AddressId, SohViewRow](_path, "shiptoaddressid", None, None, x => x.shiptoaddressid, (row, value) => row.copy(shiptoaddressid = value))
+      override def shipmethodid = Field[ShipmethodId, SohViewRow](_path, "shipmethodid", None, None, x => x.shipmethodid, (row, value) => row.copy(shipmethodid = value))
+      override def creditcardid = OptField[/* user-picked */ CustomCreditcardId, SohViewRow](_path, "creditcardid", None, None, x => x.creditcardid, (row, value) => row.copy(creditcardid = value))
+      override def creditcardapprovalcode = OptField[/* max 15 chars */ String, SohViewRow](_path, "creditcardapprovalcode", None, None, x => x.creditcardapprovalcode, (row, value) => row.copy(creditcardapprovalcode = value))
+      override def currencyrateid = OptField[CurrencyrateId, SohViewRow](_path, "currencyrateid", None, None, x => x.currencyrateid, (row, value) => row.copy(currencyrateid = value))
+      override def subtotal = Field[BigDecimal, SohViewRow](_path, "subtotal", None, None, x => x.subtotal, (row, value) => row.copy(subtotal = value))
+      override def taxamt = Field[BigDecimal, SohViewRow](_path, "taxamt", None, None, x => x.taxamt, (row, value) => row.copy(taxamt = value))
+      override def freight = Field[BigDecimal, SohViewRow](_path, "freight", None, None, x => x.freight, (row, value) => row.copy(freight = value))
+      override def totaldue = OptField[BigDecimal, SohViewRow](_path, "totaldue", None, None, x => x.totaldue, (row, value) => row.copy(totaldue = value))
+      override def comment = OptField[/* max 128 chars */ String, SohViewRow](_path, "comment", None, None, x => x.comment, (row, value) => row.copy(comment = value))
+      override def rowguid = Field[TypoUUID, SohViewRow](_path, "rowguid", None, None, x => x.rowguid, (row, value) => row.copy(rowguid = value))
+      override def modifieddate = Field[TypoLocalDateTime, SohViewRow](_path, "modifieddate", Some("text"), None, x => x.modifieddate, (row, value) => row.copy(modifieddate = value))
     }
   
-    override val columns: List[FieldLikeNoHkt[?, Row]] =
-      List[FieldLikeNoHkt[?, Row]](fields.id, fields.salesorderid, fields.revisionnumber, fields.orderdate, fields.duedate, fields.shipdate, fields.status, fields.onlineorderflag, fields.purchaseordernumber, fields.accountnumber, fields.customerid, fields.salespersonid, fields.territoryid, fields.billtoaddressid, fields.shiptoaddressid, fields.shipmethodid, fields.creditcardid, fields.creditcardapprovalcode, fields.currencyrateid, fields.subtotal, fields.taxamt, fields.freight, fields.totaldue, fields.comment, fields.rowguid, fields.modifieddate)
+    override lazy val columns: List[FieldLikeNoHkt[?, SohViewRow]] =
+      List[FieldLikeNoHkt[?, SohViewRow]](fields.id, fields.salesorderid, fields.revisionnumber, fields.orderdate, fields.duedate, fields.shipdate, fields.status, fields.onlineorderflag, fields.purchaseordernumber, fields.accountnumber, fields.customerid, fields.salespersonid, fields.territoryid, fields.billtoaddressid, fields.shiptoaddressid, fields.shipmethodid, fields.creditcardid, fields.creditcardapprovalcode, fields.currencyrateid, fields.subtotal, fields.taxamt, fields.freight, fields.totaldue, fields.comment, fields.rowguid, fields.modifieddate)
   
-    override def copy[NewRow](prefix: Option[String], extract: NewRow => SohViewRow, merge: (NewRow, SohViewRow) => NewRow): Impl[NewRow] =
-      new Impl(prefix, extract, merge)
+    override def copy(path: List[Path]): Impl =
+      new Impl(path)
   }
   
 }

--- a/typo-tester-zio-jdbc/generated-and-checked-in/adventureworks/sa/sohsr/SohsrViewFields.scala
+++ b/typo-tester-zio-jdbc/generated-and-checked-in/adventureworks/sa/sohsr/SohsrViewFields.scala
@@ -10,34 +10,35 @@ package sohsr
 import adventureworks.customtypes.TypoLocalDateTime
 import adventureworks.sales.salesorderheader.SalesorderheaderId
 import adventureworks.sales.salesreason.SalesreasonId
+import typo.dsl.Path
 import typo.dsl.SqlExpr.Field
 import typo.dsl.SqlExpr.FieldLikeNoHkt
 import typo.dsl.Structure.Relation
 
-trait SohsrViewFields[Row] {
-  val salesorderid: Field[SalesorderheaderId, Row]
-  val salesreasonid: Field[SalesreasonId, Row]
-  val modifieddate: Field[TypoLocalDateTime, Row]
+trait SohsrViewFields {
+  def salesorderid: Field[SalesorderheaderId, SohsrViewRow]
+  def salesreasonid: Field[SalesreasonId, SohsrViewRow]
+  def modifieddate: Field[TypoLocalDateTime, SohsrViewRow]
 }
 
 object SohsrViewFields {
-  val structure: Relation[SohsrViewFields, SohsrViewRow, SohsrViewRow] = 
-    new Impl(None, identity, (_, x) => x)
+  lazy val structure: Relation[SohsrViewFields, SohsrViewRow] =
+    new Impl(Nil)
     
-  private final class Impl[Row](val prefix: Option[String], val extract: Row => SohsrViewRow, val merge: (Row, SohsrViewRow) => Row)
-    extends Relation[SohsrViewFields, SohsrViewRow, Row] { 
+  private final class Impl(val _path: List[Path])
+    extends Relation[SohsrViewFields, SohsrViewRow] {
   
-    override val fields: SohsrViewFields[Row] = new SohsrViewFields[Row] {
-      override val salesorderid = new Field[SalesorderheaderId, Row](prefix, "salesorderid", None, None)(x => extract(x).salesorderid, (row, value) => merge(row, extract(row).copy(salesorderid = value)))
-      override val salesreasonid = new Field[SalesreasonId, Row](prefix, "salesreasonid", None, None)(x => extract(x).salesreasonid, (row, value) => merge(row, extract(row).copy(salesreasonid = value)))
-      override val modifieddate = new Field[TypoLocalDateTime, Row](prefix, "modifieddate", Some("text"), None)(x => extract(x).modifieddate, (row, value) => merge(row, extract(row).copy(modifieddate = value)))
+    override lazy val fields: SohsrViewFields = new SohsrViewFields {
+      override def salesorderid = Field[SalesorderheaderId, SohsrViewRow](_path, "salesorderid", None, None, x => x.salesorderid, (row, value) => row.copy(salesorderid = value))
+      override def salesreasonid = Field[SalesreasonId, SohsrViewRow](_path, "salesreasonid", None, None, x => x.salesreasonid, (row, value) => row.copy(salesreasonid = value))
+      override def modifieddate = Field[TypoLocalDateTime, SohsrViewRow](_path, "modifieddate", Some("text"), None, x => x.modifieddate, (row, value) => row.copy(modifieddate = value))
     }
   
-    override val columns: List[FieldLikeNoHkt[?, Row]] =
-      List[FieldLikeNoHkt[?, Row]](fields.salesorderid, fields.salesreasonid, fields.modifieddate)
+    override lazy val columns: List[FieldLikeNoHkt[?, SohsrViewRow]] =
+      List[FieldLikeNoHkt[?, SohsrViewRow]](fields.salesorderid, fields.salesreasonid, fields.modifieddate)
   
-    override def copy[NewRow](prefix: Option[String], extract: NewRow => SohsrViewRow, merge: (NewRow, SohsrViewRow) => NewRow): Impl[NewRow] =
-      new Impl(prefix, extract, merge)
+    override def copy(path: List[Path]): Impl =
+      new Impl(path)
   }
   
 }

--- a/typo-tester-zio-jdbc/generated-and-checked-in/adventureworks/sa/sop/SopViewFields.scala
+++ b/typo-tester-zio-jdbc/generated-and-checked-in/adventureworks/sa/sop/SopViewFields.scala
@@ -11,38 +11,39 @@ import adventureworks.customtypes.TypoLocalDateTime
 import adventureworks.customtypes.TypoUUID
 import adventureworks.production.product.ProductId
 import adventureworks.sales.specialoffer.SpecialofferId
+import typo.dsl.Path
 import typo.dsl.SqlExpr.Field
 import typo.dsl.SqlExpr.FieldLikeNoHkt
 import typo.dsl.Structure.Relation
 
-trait SopViewFields[Row] {
-  val id: Field[SpecialofferId, Row]
-  val specialofferid: Field[SpecialofferId, Row]
-  val productid: Field[ProductId, Row]
-  val rowguid: Field[TypoUUID, Row]
-  val modifieddate: Field[TypoLocalDateTime, Row]
+trait SopViewFields {
+  def id: Field[SpecialofferId, SopViewRow]
+  def specialofferid: Field[SpecialofferId, SopViewRow]
+  def productid: Field[ProductId, SopViewRow]
+  def rowguid: Field[TypoUUID, SopViewRow]
+  def modifieddate: Field[TypoLocalDateTime, SopViewRow]
 }
 
 object SopViewFields {
-  val structure: Relation[SopViewFields, SopViewRow, SopViewRow] = 
-    new Impl(None, identity, (_, x) => x)
+  lazy val structure: Relation[SopViewFields, SopViewRow] =
+    new Impl(Nil)
     
-  private final class Impl[Row](val prefix: Option[String], val extract: Row => SopViewRow, val merge: (Row, SopViewRow) => Row)
-    extends Relation[SopViewFields, SopViewRow, Row] { 
+  private final class Impl(val _path: List[Path])
+    extends Relation[SopViewFields, SopViewRow] {
   
-    override val fields: SopViewFields[Row] = new SopViewFields[Row] {
-      override val id = new Field[SpecialofferId, Row](prefix, "id", None, None)(x => extract(x).id, (row, value) => merge(row, extract(row).copy(id = value)))
-      override val specialofferid = new Field[SpecialofferId, Row](prefix, "specialofferid", None, None)(x => extract(x).specialofferid, (row, value) => merge(row, extract(row).copy(specialofferid = value)))
-      override val productid = new Field[ProductId, Row](prefix, "productid", None, None)(x => extract(x).productid, (row, value) => merge(row, extract(row).copy(productid = value)))
-      override val rowguid = new Field[TypoUUID, Row](prefix, "rowguid", None, None)(x => extract(x).rowguid, (row, value) => merge(row, extract(row).copy(rowguid = value)))
-      override val modifieddate = new Field[TypoLocalDateTime, Row](prefix, "modifieddate", Some("text"), None)(x => extract(x).modifieddate, (row, value) => merge(row, extract(row).copy(modifieddate = value)))
+    override lazy val fields: SopViewFields = new SopViewFields {
+      override def id = Field[SpecialofferId, SopViewRow](_path, "id", None, None, x => x.id, (row, value) => row.copy(id = value))
+      override def specialofferid = Field[SpecialofferId, SopViewRow](_path, "specialofferid", None, None, x => x.specialofferid, (row, value) => row.copy(specialofferid = value))
+      override def productid = Field[ProductId, SopViewRow](_path, "productid", None, None, x => x.productid, (row, value) => row.copy(productid = value))
+      override def rowguid = Field[TypoUUID, SopViewRow](_path, "rowguid", None, None, x => x.rowguid, (row, value) => row.copy(rowguid = value))
+      override def modifieddate = Field[TypoLocalDateTime, SopViewRow](_path, "modifieddate", Some("text"), None, x => x.modifieddate, (row, value) => row.copy(modifieddate = value))
     }
   
-    override val columns: List[FieldLikeNoHkt[?, Row]] =
-      List[FieldLikeNoHkt[?, Row]](fields.id, fields.specialofferid, fields.productid, fields.rowguid, fields.modifieddate)
+    override lazy val columns: List[FieldLikeNoHkt[?, SopViewRow]] =
+      List[FieldLikeNoHkt[?, SopViewRow]](fields.id, fields.specialofferid, fields.productid, fields.rowguid, fields.modifieddate)
   
-    override def copy[NewRow](prefix: Option[String], extract: NewRow => SopViewRow, merge: (NewRow, SopViewRow) => NewRow): Impl[NewRow] =
-      new Impl(prefix, extract, merge)
+    override def copy(path: List[Path]): Impl =
+      new Impl(path)
   }
   
 }

--- a/typo-tester-zio-jdbc/generated-and-checked-in/adventureworks/sa/sp/SpViewFields.scala
+++ b/typo-tester-zio-jdbc/generated-and-checked-in/adventureworks/sa/sp/SpViewFields.scala
@@ -11,49 +11,50 @@ import adventureworks.customtypes.TypoLocalDateTime
 import adventureworks.customtypes.TypoUUID
 import adventureworks.person.businessentity.BusinessentityId
 import adventureworks.sales.salesterritory.SalesterritoryId
+import typo.dsl.Path
 import typo.dsl.SqlExpr.Field
 import typo.dsl.SqlExpr.FieldLikeNoHkt
 import typo.dsl.SqlExpr.OptField
 import typo.dsl.Structure.Relation
 
-trait SpViewFields[Row] {
-  val id: Field[BusinessentityId, Row]
-  val businessentityid: Field[BusinessentityId, Row]
-  val territoryid: OptField[SalesterritoryId, Row]
-  val salesquota: OptField[BigDecimal, Row]
-  val bonus: Field[BigDecimal, Row]
-  val commissionpct: Field[BigDecimal, Row]
-  val salesytd: Field[BigDecimal, Row]
-  val saleslastyear: Field[BigDecimal, Row]
-  val rowguid: Field[TypoUUID, Row]
-  val modifieddate: Field[TypoLocalDateTime, Row]
+trait SpViewFields {
+  def id: Field[BusinessentityId, SpViewRow]
+  def businessentityid: Field[BusinessentityId, SpViewRow]
+  def territoryid: OptField[SalesterritoryId, SpViewRow]
+  def salesquota: OptField[BigDecimal, SpViewRow]
+  def bonus: Field[BigDecimal, SpViewRow]
+  def commissionpct: Field[BigDecimal, SpViewRow]
+  def salesytd: Field[BigDecimal, SpViewRow]
+  def saleslastyear: Field[BigDecimal, SpViewRow]
+  def rowguid: Field[TypoUUID, SpViewRow]
+  def modifieddate: Field[TypoLocalDateTime, SpViewRow]
 }
 
 object SpViewFields {
-  val structure: Relation[SpViewFields, SpViewRow, SpViewRow] = 
-    new Impl(None, identity, (_, x) => x)
+  lazy val structure: Relation[SpViewFields, SpViewRow] =
+    new Impl(Nil)
     
-  private final class Impl[Row](val prefix: Option[String], val extract: Row => SpViewRow, val merge: (Row, SpViewRow) => Row)
-    extends Relation[SpViewFields, SpViewRow, Row] { 
+  private final class Impl(val _path: List[Path])
+    extends Relation[SpViewFields, SpViewRow] {
   
-    override val fields: SpViewFields[Row] = new SpViewFields[Row] {
-      override val id = new Field[BusinessentityId, Row](prefix, "id", None, None)(x => extract(x).id, (row, value) => merge(row, extract(row).copy(id = value)))
-      override val businessentityid = new Field[BusinessentityId, Row](prefix, "businessentityid", None, None)(x => extract(x).businessentityid, (row, value) => merge(row, extract(row).copy(businessentityid = value)))
-      override val territoryid = new OptField[SalesterritoryId, Row](prefix, "territoryid", None, None)(x => extract(x).territoryid, (row, value) => merge(row, extract(row).copy(territoryid = value)))
-      override val salesquota = new OptField[BigDecimal, Row](prefix, "salesquota", None, None)(x => extract(x).salesquota, (row, value) => merge(row, extract(row).copy(salesquota = value)))
-      override val bonus = new Field[BigDecimal, Row](prefix, "bonus", None, None)(x => extract(x).bonus, (row, value) => merge(row, extract(row).copy(bonus = value)))
-      override val commissionpct = new Field[BigDecimal, Row](prefix, "commissionpct", None, None)(x => extract(x).commissionpct, (row, value) => merge(row, extract(row).copy(commissionpct = value)))
-      override val salesytd = new Field[BigDecimal, Row](prefix, "salesytd", None, None)(x => extract(x).salesytd, (row, value) => merge(row, extract(row).copy(salesytd = value)))
-      override val saleslastyear = new Field[BigDecimal, Row](prefix, "saleslastyear", None, None)(x => extract(x).saleslastyear, (row, value) => merge(row, extract(row).copy(saleslastyear = value)))
-      override val rowguid = new Field[TypoUUID, Row](prefix, "rowguid", None, None)(x => extract(x).rowguid, (row, value) => merge(row, extract(row).copy(rowguid = value)))
-      override val modifieddate = new Field[TypoLocalDateTime, Row](prefix, "modifieddate", Some("text"), None)(x => extract(x).modifieddate, (row, value) => merge(row, extract(row).copy(modifieddate = value)))
+    override lazy val fields: SpViewFields = new SpViewFields {
+      override def id = Field[BusinessentityId, SpViewRow](_path, "id", None, None, x => x.id, (row, value) => row.copy(id = value))
+      override def businessentityid = Field[BusinessentityId, SpViewRow](_path, "businessentityid", None, None, x => x.businessentityid, (row, value) => row.copy(businessentityid = value))
+      override def territoryid = OptField[SalesterritoryId, SpViewRow](_path, "territoryid", None, None, x => x.territoryid, (row, value) => row.copy(territoryid = value))
+      override def salesquota = OptField[BigDecimal, SpViewRow](_path, "salesquota", None, None, x => x.salesquota, (row, value) => row.copy(salesquota = value))
+      override def bonus = Field[BigDecimal, SpViewRow](_path, "bonus", None, None, x => x.bonus, (row, value) => row.copy(bonus = value))
+      override def commissionpct = Field[BigDecimal, SpViewRow](_path, "commissionpct", None, None, x => x.commissionpct, (row, value) => row.copy(commissionpct = value))
+      override def salesytd = Field[BigDecimal, SpViewRow](_path, "salesytd", None, None, x => x.salesytd, (row, value) => row.copy(salesytd = value))
+      override def saleslastyear = Field[BigDecimal, SpViewRow](_path, "saleslastyear", None, None, x => x.saleslastyear, (row, value) => row.copy(saleslastyear = value))
+      override def rowguid = Field[TypoUUID, SpViewRow](_path, "rowguid", None, None, x => x.rowguid, (row, value) => row.copy(rowguid = value))
+      override def modifieddate = Field[TypoLocalDateTime, SpViewRow](_path, "modifieddate", Some("text"), None, x => x.modifieddate, (row, value) => row.copy(modifieddate = value))
     }
   
-    override val columns: List[FieldLikeNoHkt[?, Row]] =
-      List[FieldLikeNoHkt[?, Row]](fields.id, fields.businessentityid, fields.territoryid, fields.salesquota, fields.bonus, fields.commissionpct, fields.salesytd, fields.saleslastyear, fields.rowguid, fields.modifieddate)
+    override lazy val columns: List[FieldLikeNoHkt[?, SpViewRow]] =
+      List[FieldLikeNoHkt[?, SpViewRow]](fields.id, fields.businessentityid, fields.territoryid, fields.salesquota, fields.bonus, fields.commissionpct, fields.salesytd, fields.saleslastyear, fields.rowguid, fields.modifieddate)
   
-    override def copy[NewRow](prefix: Option[String], extract: NewRow => SpViewRow, merge: (NewRow, SpViewRow) => NewRow): Impl[NewRow] =
-      new Impl(prefix, extract, merge)
+    override def copy(path: List[Path]): Impl =
+      new Impl(path)
   }
   
 }

--- a/typo-tester-zio-jdbc/generated-and-checked-in/adventureworks/sa/spqh/SpqhViewFields.scala
+++ b/typo-tester-zio-jdbc/generated-and-checked-in/adventureworks/sa/spqh/SpqhViewFields.scala
@@ -10,40 +10,41 @@ package spqh
 import adventureworks.customtypes.TypoLocalDateTime
 import adventureworks.customtypes.TypoUUID
 import adventureworks.person.businessentity.BusinessentityId
+import typo.dsl.Path
 import typo.dsl.SqlExpr.Field
 import typo.dsl.SqlExpr.FieldLikeNoHkt
 import typo.dsl.Structure.Relation
 
-trait SpqhViewFields[Row] {
-  val id: Field[BusinessentityId, Row]
-  val businessentityid: Field[BusinessentityId, Row]
-  val quotadate: Field[TypoLocalDateTime, Row]
-  val salesquota: Field[BigDecimal, Row]
-  val rowguid: Field[TypoUUID, Row]
-  val modifieddate: Field[TypoLocalDateTime, Row]
+trait SpqhViewFields {
+  def id: Field[BusinessentityId, SpqhViewRow]
+  def businessentityid: Field[BusinessentityId, SpqhViewRow]
+  def quotadate: Field[TypoLocalDateTime, SpqhViewRow]
+  def salesquota: Field[BigDecimal, SpqhViewRow]
+  def rowguid: Field[TypoUUID, SpqhViewRow]
+  def modifieddate: Field[TypoLocalDateTime, SpqhViewRow]
 }
 
 object SpqhViewFields {
-  val structure: Relation[SpqhViewFields, SpqhViewRow, SpqhViewRow] = 
-    new Impl(None, identity, (_, x) => x)
+  lazy val structure: Relation[SpqhViewFields, SpqhViewRow] =
+    new Impl(Nil)
     
-  private final class Impl[Row](val prefix: Option[String], val extract: Row => SpqhViewRow, val merge: (Row, SpqhViewRow) => Row)
-    extends Relation[SpqhViewFields, SpqhViewRow, Row] { 
+  private final class Impl(val _path: List[Path])
+    extends Relation[SpqhViewFields, SpqhViewRow] {
   
-    override val fields: SpqhViewFields[Row] = new SpqhViewFields[Row] {
-      override val id = new Field[BusinessentityId, Row](prefix, "id", None, None)(x => extract(x).id, (row, value) => merge(row, extract(row).copy(id = value)))
-      override val businessentityid = new Field[BusinessentityId, Row](prefix, "businessentityid", None, None)(x => extract(x).businessentityid, (row, value) => merge(row, extract(row).copy(businessentityid = value)))
-      override val quotadate = new Field[TypoLocalDateTime, Row](prefix, "quotadate", Some("text"), None)(x => extract(x).quotadate, (row, value) => merge(row, extract(row).copy(quotadate = value)))
-      override val salesquota = new Field[BigDecimal, Row](prefix, "salesquota", None, None)(x => extract(x).salesquota, (row, value) => merge(row, extract(row).copy(salesquota = value)))
-      override val rowguid = new Field[TypoUUID, Row](prefix, "rowguid", None, None)(x => extract(x).rowguid, (row, value) => merge(row, extract(row).copy(rowguid = value)))
-      override val modifieddate = new Field[TypoLocalDateTime, Row](prefix, "modifieddate", Some("text"), None)(x => extract(x).modifieddate, (row, value) => merge(row, extract(row).copy(modifieddate = value)))
+    override lazy val fields: SpqhViewFields = new SpqhViewFields {
+      override def id = Field[BusinessentityId, SpqhViewRow](_path, "id", None, None, x => x.id, (row, value) => row.copy(id = value))
+      override def businessentityid = Field[BusinessentityId, SpqhViewRow](_path, "businessentityid", None, None, x => x.businessentityid, (row, value) => row.copy(businessentityid = value))
+      override def quotadate = Field[TypoLocalDateTime, SpqhViewRow](_path, "quotadate", Some("text"), None, x => x.quotadate, (row, value) => row.copy(quotadate = value))
+      override def salesquota = Field[BigDecimal, SpqhViewRow](_path, "salesquota", None, None, x => x.salesquota, (row, value) => row.copy(salesquota = value))
+      override def rowguid = Field[TypoUUID, SpqhViewRow](_path, "rowguid", None, None, x => x.rowguid, (row, value) => row.copy(rowguid = value))
+      override def modifieddate = Field[TypoLocalDateTime, SpqhViewRow](_path, "modifieddate", Some("text"), None, x => x.modifieddate, (row, value) => row.copy(modifieddate = value))
     }
   
-    override val columns: List[FieldLikeNoHkt[?, Row]] =
-      List[FieldLikeNoHkt[?, Row]](fields.id, fields.businessentityid, fields.quotadate, fields.salesquota, fields.rowguid, fields.modifieddate)
+    override lazy val columns: List[FieldLikeNoHkt[?, SpqhViewRow]] =
+      List[FieldLikeNoHkt[?, SpqhViewRow]](fields.id, fields.businessentityid, fields.quotadate, fields.salesquota, fields.rowguid, fields.modifieddate)
   
-    override def copy[NewRow](prefix: Option[String], extract: NewRow => SpqhViewRow, merge: (NewRow, SpqhViewRow) => NewRow): Impl[NewRow] =
-      new Impl(prefix, extract, merge)
+    override def copy(path: List[Path]): Impl =
+      new Impl(path)
   }
   
 }

--- a/typo-tester-zio-jdbc/generated-and-checked-in/adventureworks/sa/sr/SrViewFields.scala
+++ b/typo-tester-zio-jdbc/generated-and-checked-in/adventureworks/sa/sr/SrViewFields.scala
@@ -10,38 +10,39 @@ package sr
 import adventureworks.customtypes.TypoLocalDateTime
 import adventureworks.public.Name
 import adventureworks.sales.salesreason.SalesreasonId
+import typo.dsl.Path
 import typo.dsl.SqlExpr.Field
 import typo.dsl.SqlExpr.FieldLikeNoHkt
 import typo.dsl.Structure.Relation
 
-trait SrViewFields[Row] {
-  val id: Field[SalesreasonId, Row]
-  val salesreasonid: Field[SalesreasonId, Row]
-  val name: Field[Name, Row]
-  val reasontype: Field[Name, Row]
-  val modifieddate: Field[TypoLocalDateTime, Row]
+trait SrViewFields {
+  def id: Field[SalesreasonId, SrViewRow]
+  def salesreasonid: Field[SalesreasonId, SrViewRow]
+  def name: Field[Name, SrViewRow]
+  def reasontype: Field[Name, SrViewRow]
+  def modifieddate: Field[TypoLocalDateTime, SrViewRow]
 }
 
 object SrViewFields {
-  val structure: Relation[SrViewFields, SrViewRow, SrViewRow] = 
-    new Impl(None, identity, (_, x) => x)
+  lazy val structure: Relation[SrViewFields, SrViewRow] =
+    new Impl(Nil)
     
-  private final class Impl[Row](val prefix: Option[String], val extract: Row => SrViewRow, val merge: (Row, SrViewRow) => Row)
-    extends Relation[SrViewFields, SrViewRow, Row] { 
+  private final class Impl(val _path: List[Path])
+    extends Relation[SrViewFields, SrViewRow] {
   
-    override val fields: SrViewFields[Row] = new SrViewFields[Row] {
-      override val id = new Field[SalesreasonId, Row](prefix, "id", None, None)(x => extract(x).id, (row, value) => merge(row, extract(row).copy(id = value)))
-      override val salesreasonid = new Field[SalesreasonId, Row](prefix, "salesreasonid", None, None)(x => extract(x).salesreasonid, (row, value) => merge(row, extract(row).copy(salesreasonid = value)))
-      override val name = new Field[Name, Row](prefix, "name", None, None)(x => extract(x).name, (row, value) => merge(row, extract(row).copy(name = value)))
-      override val reasontype = new Field[Name, Row](prefix, "reasontype", None, None)(x => extract(x).reasontype, (row, value) => merge(row, extract(row).copy(reasontype = value)))
-      override val modifieddate = new Field[TypoLocalDateTime, Row](prefix, "modifieddate", Some("text"), None)(x => extract(x).modifieddate, (row, value) => merge(row, extract(row).copy(modifieddate = value)))
+    override lazy val fields: SrViewFields = new SrViewFields {
+      override def id = Field[SalesreasonId, SrViewRow](_path, "id", None, None, x => x.id, (row, value) => row.copy(id = value))
+      override def salesreasonid = Field[SalesreasonId, SrViewRow](_path, "salesreasonid", None, None, x => x.salesreasonid, (row, value) => row.copy(salesreasonid = value))
+      override def name = Field[Name, SrViewRow](_path, "name", None, None, x => x.name, (row, value) => row.copy(name = value))
+      override def reasontype = Field[Name, SrViewRow](_path, "reasontype", None, None, x => x.reasontype, (row, value) => row.copy(reasontype = value))
+      override def modifieddate = Field[TypoLocalDateTime, SrViewRow](_path, "modifieddate", Some("text"), None, x => x.modifieddate, (row, value) => row.copy(modifieddate = value))
     }
   
-    override val columns: List[FieldLikeNoHkt[?, Row]] =
-      List[FieldLikeNoHkt[?, Row]](fields.id, fields.salesreasonid, fields.name, fields.reasontype, fields.modifieddate)
+    override lazy val columns: List[FieldLikeNoHkt[?, SrViewRow]] =
+      List[FieldLikeNoHkt[?, SrViewRow]](fields.id, fields.salesreasonid, fields.name, fields.reasontype, fields.modifieddate)
   
-    override def copy[NewRow](prefix: Option[String], extract: NewRow => SrViewRow, merge: (NewRow, SrViewRow) => NewRow): Impl[NewRow] =
-      new Impl(prefix, extract, merge)
+    override def copy(path: List[Path]): Impl =
+      new Impl(path)
   }
   
 }

--- a/typo-tester-zio-jdbc/generated-and-checked-in/adventureworks/sa/st/StViewFields.scala
+++ b/typo-tester-zio-jdbc/generated-and-checked-in/adventureworks/sa/st/StViewFields.scala
@@ -12,50 +12,51 @@ import adventureworks.customtypes.TypoUUID
 import adventureworks.person.countryregion.CountryregionId
 import adventureworks.public.Name
 import adventureworks.sales.salesterritory.SalesterritoryId
+import typo.dsl.Path
 import typo.dsl.SqlExpr.Field
 import typo.dsl.SqlExpr.FieldLikeNoHkt
 import typo.dsl.Structure.Relation
 
-trait StViewFields[Row] {
-  val id: Field[SalesterritoryId, Row]
-  val territoryid: Field[SalesterritoryId, Row]
-  val name: Field[Name, Row]
-  val countryregioncode: Field[CountryregionId, Row]
-  val group: Field[/* max 50 chars */ String, Row]
-  val salesytd: Field[BigDecimal, Row]
-  val saleslastyear: Field[BigDecimal, Row]
-  val costytd: Field[BigDecimal, Row]
-  val costlastyear: Field[BigDecimal, Row]
-  val rowguid: Field[TypoUUID, Row]
-  val modifieddate: Field[TypoLocalDateTime, Row]
+trait StViewFields {
+  def id: Field[SalesterritoryId, StViewRow]
+  def territoryid: Field[SalesterritoryId, StViewRow]
+  def name: Field[Name, StViewRow]
+  def countryregioncode: Field[CountryregionId, StViewRow]
+  def group: Field[/* max 50 chars */ String, StViewRow]
+  def salesytd: Field[BigDecimal, StViewRow]
+  def saleslastyear: Field[BigDecimal, StViewRow]
+  def costytd: Field[BigDecimal, StViewRow]
+  def costlastyear: Field[BigDecimal, StViewRow]
+  def rowguid: Field[TypoUUID, StViewRow]
+  def modifieddate: Field[TypoLocalDateTime, StViewRow]
 }
 
 object StViewFields {
-  val structure: Relation[StViewFields, StViewRow, StViewRow] = 
-    new Impl(None, identity, (_, x) => x)
+  lazy val structure: Relation[StViewFields, StViewRow] =
+    new Impl(Nil)
     
-  private final class Impl[Row](val prefix: Option[String], val extract: Row => StViewRow, val merge: (Row, StViewRow) => Row)
-    extends Relation[StViewFields, StViewRow, Row] { 
+  private final class Impl(val _path: List[Path])
+    extends Relation[StViewFields, StViewRow] {
   
-    override val fields: StViewFields[Row] = new StViewFields[Row] {
-      override val id = new Field[SalesterritoryId, Row](prefix, "id", None, None)(x => extract(x).id, (row, value) => merge(row, extract(row).copy(id = value)))
-      override val territoryid = new Field[SalesterritoryId, Row](prefix, "territoryid", None, None)(x => extract(x).territoryid, (row, value) => merge(row, extract(row).copy(territoryid = value)))
-      override val name = new Field[Name, Row](prefix, "name", None, None)(x => extract(x).name, (row, value) => merge(row, extract(row).copy(name = value)))
-      override val countryregioncode = new Field[CountryregionId, Row](prefix, "countryregioncode", None, None)(x => extract(x).countryregioncode, (row, value) => merge(row, extract(row).copy(countryregioncode = value)))
-      override val group = new Field[/* max 50 chars */ String, Row](prefix, "group", None, None)(x => extract(x).group, (row, value) => merge(row, extract(row).copy(group = value)))
-      override val salesytd = new Field[BigDecimal, Row](prefix, "salesytd", None, None)(x => extract(x).salesytd, (row, value) => merge(row, extract(row).copy(salesytd = value)))
-      override val saleslastyear = new Field[BigDecimal, Row](prefix, "saleslastyear", None, None)(x => extract(x).saleslastyear, (row, value) => merge(row, extract(row).copy(saleslastyear = value)))
-      override val costytd = new Field[BigDecimal, Row](prefix, "costytd", None, None)(x => extract(x).costytd, (row, value) => merge(row, extract(row).copy(costytd = value)))
-      override val costlastyear = new Field[BigDecimal, Row](prefix, "costlastyear", None, None)(x => extract(x).costlastyear, (row, value) => merge(row, extract(row).copy(costlastyear = value)))
-      override val rowguid = new Field[TypoUUID, Row](prefix, "rowguid", None, None)(x => extract(x).rowguid, (row, value) => merge(row, extract(row).copy(rowguid = value)))
-      override val modifieddate = new Field[TypoLocalDateTime, Row](prefix, "modifieddate", Some("text"), None)(x => extract(x).modifieddate, (row, value) => merge(row, extract(row).copy(modifieddate = value)))
+    override lazy val fields: StViewFields = new StViewFields {
+      override def id = Field[SalesterritoryId, StViewRow](_path, "id", None, None, x => x.id, (row, value) => row.copy(id = value))
+      override def territoryid = Field[SalesterritoryId, StViewRow](_path, "territoryid", None, None, x => x.territoryid, (row, value) => row.copy(territoryid = value))
+      override def name = Field[Name, StViewRow](_path, "name", None, None, x => x.name, (row, value) => row.copy(name = value))
+      override def countryregioncode = Field[CountryregionId, StViewRow](_path, "countryregioncode", None, None, x => x.countryregioncode, (row, value) => row.copy(countryregioncode = value))
+      override def group = Field[/* max 50 chars */ String, StViewRow](_path, "group", None, None, x => x.group, (row, value) => row.copy(group = value))
+      override def salesytd = Field[BigDecimal, StViewRow](_path, "salesytd", None, None, x => x.salesytd, (row, value) => row.copy(salesytd = value))
+      override def saleslastyear = Field[BigDecimal, StViewRow](_path, "saleslastyear", None, None, x => x.saleslastyear, (row, value) => row.copy(saleslastyear = value))
+      override def costytd = Field[BigDecimal, StViewRow](_path, "costytd", None, None, x => x.costytd, (row, value) => row.copy(costytd = value))
+      override def costlastyear = Field[BigDecimal, StViewRow](_path, "costlastyear", None, None, x => x.costlastyear, (row, value) => row.copy(costlastyear = value))
+      override def rowguid = Field[TypoUUID, StViewRow](_path, "rowguid", None, None, x => x.rowguid, (row, value) => row.copy(rowguid = value))
+      override def modifieddate = Field[TypoLocalDateTime, StViewRow](_path, "modifieddate", Some("text"), None, x => x.modifieddate, (row, value) => row.copy(modifieddate = value))
     }
   
-    override val columns: List[FieldLikeNoHkt[?, Row]] =
-      List[FieldLikeNoHkt[?, Row]](fields.id, fields.territoryid, fields.name, fields.countryregioncode, fields.group, fields.salesytd, fields.saleslastyear, fields.costytd, fields.costlastyear, fields.rowguid, fields.modifieddate)
+    override lazy val columns: List[FieldLikeNoHkt[?, StViewRow]] =
+      List[FieldLikeNoHkt[?, StViewRow]](fields.id, fields.territoryid, fields.name, fields.countryregioncode, fields.group, fields.salesytd, fields.saleslastyear, fields.costytd, fields.costlastyear, fields.rowguid, fields.modifieddate)
   
-    override def copy[NewRow](prefix: Option[String], extract: NewRow => StViewRow, merge: (NewRow, StViewRow) => NewRow): Impl[NewRow] =
-      new Impl(prefix, extract, merge)
+    override def copy(path: List[Path]): Impl =
+      new Impl(path)
   }
   
 }

--- a/typo-tester-zio-jdbc/generated-and-checked-in/adventureworks/sa/sth/SthViewFields.scala
+++ b/typo-tester-zio-jdbc/generated-and-checked-in/adventureworks/sa/sth/SthViewFields.scala
@@ -11,43 +11,44 @@ import adventureworks.customtypes.TypoLocalDateTime
 import adventureworks.customtypes.TypoUUID
 import adventureworks.person.businessentity.BusinessentityId
 import adventureworks.sales.salesterritory.SalesterritoryId
+import typo.dsl.Path
 import typo.dsl.SqlExpr.Field
 import typo.dsl.SqlExpr.FieldLikeNoHkt
 import typo.dsl.SqlExpr.OptField
 import typo.dsl.Structure.Relation
 
-trait SthViewFields[Row] {
-  val id: Field[SalesterritoryId, Row]
-  val businessentityid: Field[BusinessentityId, Row]
-  val territoryid: Field[SalesterritoryId, Row]
-  val startdate: Field[TypoLocalDateTime, Row]
-  val enddate: OptField[TypoLocalDateTime, Row]
-  val rowguid: Field[TypoUUID, Row]
-  val modifieddate: Field[TypoLocalDateTime, Row]
+trait SthViewFields {
+  def id: Field[SalesterritoryId, SthViewRow]
+  def businessentityid: Field[BusinessentityId, SthViewRow]
+  def territoryid: Field[SalesterritoryId, SthViewRow]
+  def startdate: Field[TypoLocalDateTime, SthViewRow]
+  def enddate: OptField[TypoLocalDateTime, SthViewRow]
+  def rowguid: Field[TypoUUID, SthViewRow]
+  def modifieddate: Field[TypoLocalDateTime, SthViewRow]
 }
 
 object SthViewFields {
-  val structure: Relation[SthViewFields, SthViewRow, SthViewRow] = 
-    new Impl(None, identity, (_, x) => x)
+  lazy val structure: Relation[SthViewFields, SthViewRow] =
+    new Impl(Nil)
     
-  private final class Impl[Row](val prefix: Option[String], val extract: Row => SthViewRow, val merge: (Row, SthViewRow) => Row)
-    extends Relation[SthViewFields, SthViewRow, Row] { 
+  private final class Impl(val _path: List[Path])
+    extends Relation[SthViewFields, SthViewRow] {
   
-    override val fields: SthViewFields[Row] = new SthViewFields[Row] {
-      override val id = new Field[SalesterritoryId, Row](prefix, "id", None, None)(x => extract(x).id, (row, value) => merge(row, extract(row).copy(id = value)))
-      override val businessentityid = new Field[BusinessentityId, Row](prefix, "businessentityid", None, None)(x => extract(x).businessentityid, (row, value) => merge(row, extract(row).copy(businessentityid = value)))
-      override val territoryid = new Field[SalesterritoryId, Row](prefix, "territoryid", None, None)(x => extract(x).territoryid, (row, value) => merge(row, extract(row).copy(territoryid = value)))
-      override val startdate = new Field[TypoLocalDateTime, Row](prefix, "startdate", Some("text"), None)(x => extract(x).startdate, (row, value) => merge(row, extract(row).copy(startdate = value)))
-      override val enddate = new OptField[TypoLocalDateTime, Row](prefix, "enddate", Some("text"), None)(x => extract(x).enddate, (row, value) => merge(row, extract(row).copy(enddate = value)))
-      override val rowguid = new Field[TypoUUID, Row](prefix, "rowguid", None, None)(x => extract(x).rowguid, (row, value) => merge(row, extract(row).copy(rowguid = value)))
-      override val modifieddate = new Field[TypoLocalDateTime, Row](prefix, "modifieddate", Some("text"), None)(x => extract(x).modifieddate, (row, value) => merge(row, extract(row).copy(modifieddate = value)))
+    override lazy val fields: SthViewFields = new SthViewFields {
+      override def id = Field[SalesterritoryId, SthViewRow](_path, "id", None, None, x => x.id, (row, value) => row.copy(id = value))
+      override def businessentityid = Field[BusinessentityId, SthViewRow](_path, "businessentityid", None, None, x => x.businessentityid, (row, value) => row.copy(businessentityid = value))
+      override def territoryid = Field[SalesterritoryId, SthViewRow](_path, "territoryid", None, None, x => x.territoryid, (row, value) => row.copy(territoryid = value))
+      override def startdate = Field[TypoLocalDateTime, SthViewRow](_path, "startdate", Some("text"), None, x => x.startdate, (row, value) => row.copy(startdate = value))
+      override def enddate = OptField[TypoLocalDateTime, SthViewRow](_path, "enddate", Some("text"), None, x => x.enddate, (row, value) => row.copy(enddate = value))
+      override def rowguid = Field[TypoUUID, SthViewRow](_path, "rowguid", None, None, x => x.rowguid, (row, value) => row.copy(rowguid = value))
+      override def modifieddate = Field[TypoLocalDateTime, SthViewRow](_path, "modifieddate", Some("text"), None, x => x.modifieddate, (row, value) => row.copy(modifieddate = value))
     }
   
-    override val columns: List[FieldLikeNoHkt[?, Row]] =
-      List[FieldLikeNoHkt[?, Row]](fields.id, fields.businessentityid, fields.territoryid, fields.startdate, fields.enddate, fields.rowguid, fields.modifieddate)
+    override lazy val columns: List[FieldLikeNoHkt[?, SthViewRow]] =
+      List[FieldLikeNoHkt[?, SthViewRow]](fields.id, fields.businessentityid, fields.territoryid, fields.startdate, fields.enddate, fields.rowguid, fields.modifieddate)
   
-    override def copy[NewRow](prefix: Option[String], extract: NewRow => SthViewRow, merge: (NewRow, SthViewRow) => NewRow): Impl[NewRow] =
-      new Impl(prefix, extract, merge)
+    override def copy(path: List[Path]): Impl =
+      new Impl(path)
   }
   
 }

--- a/typo-tester-zio-jdbc/generated-and-checked-in/adventureworks/sa/tr/TrViewFields.scala
+++ b/typo-tester-zio-jdbc/generated-and-checked-in/adventureworks/sa/tr/TrViewFields.scala
@@ -13,44 +13,45 @@ import adventureworks.customtypes.TypoUUID
 import adventureworks.person.stateprovince.StateprovinceId
 import adventureworks.public.Name
 import adventureworks.sales.salestaxrate.SalestaxrateId
+import typo.dsl.Path
 import typo.dsl.SqlExpr.Field
 import typo.dsl.SqlExpr.FieldLikeNoHkt
 import typo.dsl.Structure.Relation
 
-trait TrViewFields[Row] {
-  val id: Field[SalestaxrateId, Row]
-  val salestaxrateid: Field[SalestaxrateId, Row]
-  val stateprovinceid: Field[StateprovinceId, Row]
-  val taxtype: Field[TypoShort, Row]
-  val taxrate: Field[BigDecimal, Row]
-  val name: Field[Name, Row]
-  val rowguid: Field[TypoUUID, Row]
-  val modifieddate: Field[TypoLocalDateTime, Row]
+trait TrViewFields {
+  def id: Field[SalestaxrateId, TrViewRow]
+  def salestaxrateid: Field[SalestaxrateId, TrViewRow]
+  def stateprovinceid: Field[StateprovinceId, TrViewRow]
+  def taxtype: Field[TypoShort, TrViewRow]
+  def taxrate: Field[BigDecimal, TrViewRow]
+  def name: Field[Name, TrViewRow]
+  def rowguid: Field[TypoUUID, TrViewRow]
+  def modifieddate: Field[TypoLocalDateTime, TrViewRow]
 }
 
 object TrViewFields {
-  val structure: Relation[TrViewFields, TrViewRow, TrViewRow] = 
-    new Impl(None, identity, (_, x) => x)
+  lazy val structure: Relation[TrViewFields, TrViewRow] =
+    new Impl(Nil)
     
-  private final class Impl[Row](val prefix: Option[String], val extract: Row => TrViewRow, val merge: (Row, TrViewRow) => Row)
-    extends Relation[TrViewFields, TrViewRow, Row] { 
+  private final class Impl(val _path: List[Path])
+    extends Relation[TrViewFields, TrViewRow] {
   
-    override val fields: TrViewFields[Row] = new TrViewFields[Row] {
-      override val id = new Field[SalestaxrateId, Row](prefix, "id", None, None)(x => extract(x).id, (row, value) => merge(row, extract(row).copy(id = value)))
-      override val salestaxrateid = new Field[SalestaxrateId, Row](prefix, "salestaxrateid", None, None)(x => extract(x).salestaxrateid, (row, value) => merge(row, extract(row).copy(salestaxrateid = value)))
-      override val stateprovinceid = new Field[StateprovinceId, Row](prefix, "stateprovinceid", None, None)(x => extract(x).stateprovinceid, (row, value) => merge(row, extract(row).copy(stateprovinceid = value)))
-      override val taxtype = new Field[TypoShort, Row](prefix, "taxtype", None, None)(x => extract(x).taxtype, (row, value) => merge(row, extract(row).copy(taxtype = value)))
-      override val taxrate = new Field[BigDecimal, Row](prefix, "taxrate", None, None)(x => extract(x).taxrate, (row, value) => merge(row, extract(row).copy(taxrate = value)))
-      override val name = new Field[Name, Row](prefix, "name", None, None)(x => extract(x).name, (row, value) => merge(row, extract(row).copy(name = value)))
-      override val rowguid = new Field[TypoUUID, Row](prefix, "rowguid", None, None)(x => extract(x).rowguid, (row, value) => merge(row, extract(row).copy(rowguid = value)))
-      override val modifieddate = new Field[TypoLocalDateTime, Row](prefix, "modifieddate", Some("text"), None)(x => extract(x).modifieddate, (row, value) => merge(row, extract(row).copy(modifieddate = value)))
+    override lazy val fields: TrViewFields = new TrViewFields {
+      override def id = Field[SalestaxrateId, TrViewRow](_path, "id", None, None, x => x.id, (row, value) => row.copy(id = value))
+      override def salestaxrateid = Field[SalestaxrateId, TrViewRow](_path, "salestaxrateid", None, None, x => x.salestaxrateid, (row, value) => row.copy(salestaxrateid = value))
+      override def stateprovinceid = Field[StateprovinceId, TrViewRow](_path, "stateprovinceid", None, None, x => x.stateprovinceid, (row, value) => row.copy(stateprovinceid = value))
+      override def taxtype = Field[TypoShort, TrViewRow](_path, "taxtype", None, None, x => x.taxtype, (row, value) => row.copy(taxtype = value))
+      override def taxrate = Field[BigDecimal, TrViewRow](_path, "taxrate", None, None, x => x.taxrate, (row, value) => row.copy(taxrate = value))
+      override def name = Field[Name, TrViewRow](_path, "name", None, None, x => x.name, (row, value) => row.copy(name = value))
+      override def rowguid = Field[TypoUUID, TrViewRow](_path, "rowguid", None, None, x => x.rowguid, (row, value) => row.copy(rowguid = value))
+      override def modifieddate = Field[TypoLocalDateTime, TrViewRow](_path, "modifieddate", Some("text"), None, x => x.modifieddate, (row, value) => row.copy(modifieddate = value))
     }
   
-    override val columns: List[FieldLikeNoHkt[?, Row]] =
-      List[FieldLikeNoHkt[?, Row]](fields.id, fields.salestaxrateid, fields.stateprovinceid, fields.taxtype, fields.taxrate, fields.name, fields.rowguid, fields.modifieddate)
+    override lazy val columns: List[FieldLikeNoHkt[?, TrViewRow]] =
+      List[FieldLikeNoHkt[?, TrViewRow]](fields.id, fields.salestaxrateid, fields.stateprovinceid, fields.taxtype, fields.taxrate, fields.name, fields.rowguid, fields.modifieddate)
   
-    override def copy[NewRow](prefix: Option[String], extract: NewRow => TrViewRow, merge: (NewRow, TrViewRow) => NewRow): Impl[NewRow] =
-      new Impl(prefix, extract, merge)
+    override def copy(path: List[Path]): Impl =
+      new Impl(path)
   }
   
 }

--- a/typo-tester-zio-jdbc/generated-and-checked-in/adventureworks/sales/countryregioncurrency/CountryregioncurrencyFields.scala
+++ b/typo-tester-zio-jdbc/generated-and-checked-in/adventureworks/sales/countryregioncurrency/CountryregioncurrencyFields.scala
@@ -10,35 +10,36 @@ package countryregioncurrency
 import adventureworks.customtypes.TypoLocalDateTime
 import adventureworks.person.countryregion.CountryregionId
 import adventureworks.sales.currency.CurrencyId
+import typo.dsl.Path
 import typo.dsl.SqlExpr.Field
 import typo.dsl.SqlExpr.FieldLikeNoHkt
 import typo.dsl.SqlExpr.IdField
 import typo.dsl.Structure.Relation
 
-trait CountryregioncurrencyFields[Row] {
-  val countryregioncode: IdField[CountryregionId, Row]
-  val currencycode: IdField[CurrencyId, Row]
-  val modifieddate: Field[TypoLocalDateTime, Row]
+trait CountryregioncurrencyFields {
+  def countryregioncode: IdField[CountryregionId, CountryregioncurrencyRow]
+  def currencycode: IdField[CurrencyId, CountryregioncurrencyRow]
+  def modifieddate: Field[TypoLocalDateTime, CountryregioncurrencyRow]
 }
 
 object CountryregioncurrencyFields {
-  val structure: Relation[CountryregioncurrencyFields, CountryregioncurrencyRow, CountryregioncurrencyRow] = 
-    new Impl(None, identity, (_, x) => x)
+  lazy val structure: Relation[CountryregioncurrencyFields, CountryregioncurrencyRow] =
+    new Impl(Nil)
     
-  private final class Impl[Row](val prefix: Option[String], val extract: Row => CountryregioncurrencyRow, val merge: (Row, CountryregioncurrencyRow) => Row)
-    extends Relation[CountryregioncurrencyFields, CountryregioncurrencyRow, Row] { 
+  private final class Impl(val _path: List[Path])
+    extends Relation[CountryregioncurrencyFields, CountryregioncurrencyRow] {
   
-    override val fields: CountryregioncurrencyFields[Row] = new CountryregioncurrencyFields[Row] {
-      override val countryregioncode = new IdField[CountryregionId, Row](prefix, "countryregioncode", None, None)(x => extract(x).countryregioncode, (row, value) => merge(row, extract(row).copy(countryregioncode = value)))
-      override val currencycode = new IdField[CurrencyId, Row](prefix, "currencycode", None, Some("bpchar"))(x => extract(x).currencycode, (row, value) => merge(row, extract(row).copy(currencycode = value)))
-      override val modifieddate = new Field[TypoLocalDateTime, Row](prefix, "modifieddate", Some("text"), Some("timestamp"))(x => extract(x).modifieddate, (row, value) => merge(row, extract(row).copy(modifieddate = value)))
+    override lazy val fields: CountryregioncurrencyFields = new CountryregioncurrencyFields {
+      override def countryregioncode = IdField[CountryregionId, CountryregioncurrencyRow](_path, "countryregioncode", None, None, x => x.countryregioncode, (row, value) => row.copy(countryregioncode = value))
+      override def currencycode = IdField[CurrencyId, CountryregioncurrencyRow](_path, "currencycode", None, Some("bpchar"), x => x.currencycode, (row, value) => row.copy(currencycode = value))
+      override def modifieddate = Field[TypoLocalDateTime, CountryregioncurrencyRow](_path, "modifieddate", Some("text"), Some("timestamp"), x => x.modifieddate, (row, value) => row.copy(modifieddate = value))
     }
   
-    override val columns: List[FieldLikeNoHkt[?, Row]] =
-      List[FieldLikeNoHkt[?, Row]](fields.countryregioncode, fields.currencycode, fields.modifieddate)
+    override lazy val columns: List[FieldLikeNoHkt[?, CountryregioncurrencyRow]] =
+      List[FieldLikeNoHkt[?, CountryregioncurrencyRow]](fields.countryregioncode, fields.currencycode, fields.modifieddate)
   
-    override def copy[NewRow](prefix: Option[String], extract: NewRow => CountryregioncurrencyRow, merge: (NewRow, CountryregioncurrencyRow) => NewRow): Impl[NewRow] =
-      new Impl(prefix, extract, merge)
+    override def copy(path: List[Path]): Impl =
+      new Impl(path)
   }
   
 }

--- a/typo-tester-zio-jdbc/generated-and-checked-in/adventureworks/sales/countryregioncurrency/CountryregioncurrencyRepoMock.scala
+++ b/typo-tester-zio-jdbc/generated-and-checked-in/adventureworks/sales/countryregioncurrency/CountryregioncurrencyRepoMock.scala
@@ -26,7 +26,7 @@ import zio.stream.ZStream
 class CountryregioncurrencyRepoMock(toRow: Function1[CountryregioncurrencyRowUnsaved, CountryregioncurrencyRow],
                                     map: scala.collection.mutable.Map[CountryregioncurrencyId, CountryregioncurrencyRow] = scala.collection.mutable.Map.empty) extends CountryregioncurrencyRepo {
   override def delete: DeleteBuilder[CountryregioncurrencyFields, CountryregioncurrencyRow] = {
-    DeleteBuilderMock(DeleteParams.empty, CountryregioncurrencyFields.structure.fields, map)
+    DeleteBuilderMock(DeleteParams.empty, CountryregioncurrencyFields.structure, map)
   }
   override def deleteById(compositeId: CountryregioncurrencyId): ZIO[ZConnection, Throwable, Boolean] = {
     ZIO.succeed(map.remove(compositeId).isDefined)
@@ -85,7 +85,7 @@ class CountryregioncurrencyRepoMock(toRow: Function1[CountryregioncurrencyRowUns
     }
   }
   override def update: UpdateBuilder[CountryregioncurrencyFields, CountryregioncurrencyRow] = {
-    UpdateBuilderMock(UpdateParams.empty, CountryregioncurrencyFields.structure.fields, map)
+    UpdateBuilderMock(UpdateParams.empty, CountryregioncurrencyFields.structure, map)
   }
   override def update(row: CountryregioncurrencyRow): ZIO[ZConnection, Throwable, Boolean] = {
     ZIO.succeed {

--- a/typo-tester-zio-jdbc/generated-and-checked-in/adventureworks/sales/creditcard/CreditcardFields.scala
+++ b/typo-tester-zio-jdbc/generated-and-checked-in/adventureworks/sales/creditcard/CreditcardFields.scala
@@ -10,41 +10,42 @@ package creditcard
 import adventureworks.customtypes.TypoLocalDateTime
 import adventureworks.customtypes.TypoShort
 import adventureworks.userdefined.CustomCreditcardId
+import typo.dsl.Path
 import typo.dsl.SqlExpr.Field
 import typo.dsl.SqlExpr.FieldLikeNoHkt
 import typo.dsl.SqlExpr.IdField
 import typo.dsl.Structure.Relation
 
-trait CreditcardFields[Row] {
-  val creditcardid: IdField[/* user-picked */ CustomCreditcardId, Row]
-  val cardtype: Field[/* max 50 chars */ String, Row]
-  val cardnumber: Field[/* max 25 chars */ String, Row]
-  val expmonth: Field[TypoShort, Row]
-  val expyear: Field[TypoShort, Row]
-  val modifieddate: Field[TypoLocalDateTime, Row]
+trait CreditcardFields {
+  def creditcardid: IdField[/* user-picked */ CustomCreditcardId, CreditcardRow]
+  def cardtype: Field[/* max 50 chars */ String, CreditcardRow]
+  def cardnumber: Field[/* max 25 chars */ String, CreditcardRow]
+  def expmonth: Field[TypoShort, CreditcardRow]
+  def expyear: Field[TypoShort, CreditcardRow]
+  def modifieddate: Field[TypoLocalDateTime, CreditcardRow]
 }
 
 object CreditcardFields {
-  val structure: Relation[CreditcardFields, CreditcardRow, CreditcardRow] = 
-    new Impl(None, identity, (_, x) => x)
+  lazy val structure: Relation[CreditcardFields, CreditcardRow] =
+    new Impl(Nil)
     
-  private final class Impl[Row](val prefix: Option[String], val extract: Row => CreditcardRow, val merge: (Row, CreditcardRow) => Row)
-    extends Relation[CreditcardFields, CreditcardRow, Row] { 
+  private final class Impl(val _path: List[Path])
+    extends Relation[CreditcardFields, CreditcardRow] {
   
-    override val fields: CreditcardFields[Row] = new CreditcardFields[Row] {
-      override val creditcardid = new IdField[/* user-picked */ CustomCreditcardId, Row](prefix, "creditcardid", None, Some("int4"))(x => extract(x).creditcardid, (row, value) => merge(row, extract(row).copy(creditcardid = value)))
-      override val cardtype = new Field[/* max 50 chars */ String, Row](prefix, "cardtype", None, None)(x => extract(x).cardtype, (row, value) => merge(row, extract(row).copy(cardtype = value)))
-      override val cardnumber = new Field[/* max 25 chars */ String, Row](prefix, "cardnumber", None, None)(x => extract(x).cardnumber, (row, value) => merge(row, extract(row).copy(cardnumber = value)))
-      override val expmonth = new Field[TypoShort, Row](prefix, "expmonth", None, Some("int2"))(x => extract(x).expmonth, (row, value) => merge(row, extract(row).copy(expmonth = value)))
-      override val expyear = new Field[TypoShort, Row](prefix, "expyear", None, Some("int2"))(x => extract(x).expyear, (row, value) => merge(row, extract(row).copy(expyear = value)))
-      override val modifieddate = new Field[TypoLocalDateTime, Row](prefix, "modifieddate", Some("text"), Some("timestamp"))(x => extract(x).modifieddate, (row, value) => merge(row, extract(row).copy(modifieddate = value)))
+    override lazy val fields: CreditcardFields = new CreditcardFields {
+      override def creditcardid = IdField[/* user-picked */ CustomCreditcardId, CreditcardRow](_path, "creditcardid", None, Some("int4"), x => x.creditcardid, (row, value) => row.copy(creditcardid = value))
+      override def cardtype = Field[/* max 50 chars */ String, CreditcardRow](_path, "cardtype", None, None, x => x.cardtype, (row, value) => row.copy(cardtype = value))
+      override def cardnumber = Field[/* max 25 chars */ String, CreditcardRow](_path, "cardnumber", None, None, x => x.cardnumber, (row, value) => row.copy(cardnumber = value))
+      override def expmonth = Field[TypoShort, CreditcardRow](_path, "expmonth", None, Some("int2"), x => x.expmonth, (row, value) => row.copy(expmonth = value))
+      override def expyear = Field[TypoShort, CreditcardRow](_path, "expyear", None, Some("int2"), x => x.expyear, (row, value) => row.copy(expyear = value))
+      override def modifieddate = Field[TypoLocalDateTime, CreditcardRow](_path, "modifieddate", Some("text"), Some("timestamp"), x => x.modifieddate, (row, value) => row.copy(modifieddate = value))
     }
   
-    override val columns: List[FieldLikeNoHkt[?, Row]] =
-      List[FieldLikeNoHkt[?, Row]](fields.creditcardid, fields.cardtype, fields.cardnumber, fields.expmonth, fields.expyear, fields.modifieddate)
+    override lazy val columns: List[FieldLikeNoHkt[?, CreditcardRow]] =
+      List[FieldLikeNoHkt[?, CreditcardRow]](fields.creditcardid, fields.cardtype, fields.cardnumber, fields.expmonth, fields.expyear, fields.modifieddate)
   
-    override def copy[NewRow](prefix: Option[String], extract: NewRow => CreditcardRow, merge: (NewRow, CreditcardRow) => NewRow): Impl[NewRow] =
-      new Impl(prefix, extract, merge)
+    override def copy(path: List[Path]): Impl =
+      new Impl(path)
   }
   
 }

--- a/typo-tester-zio-jdbc/generated-and-checked-in/adventureworks/sales/creditcard/CreditcardRepoMock.scala
+++ b/typo-tester-zio-jdbc/generated-and-checked-in/adventureworks/sales/creditcard/CreditcardRepoMock.scala
@@ -28,7 +28,7 @@ import zio.stream.ZStream
 class CreditcardRepoMock(toRow: Function1[CreditcardRowUnsaved, CreditcardRow],
                          map: scala.collection.mutable.Map[/* user-picked */ CustomCreditcardId, CreditcardRow] = scala.collection.mutable.Map.empty) extends CreditcardRepo {
   override def delete: DeleteBuilder[CreditcardFields, CreditcardRow] = {
-    DeleteBuilderMock(DeleteParams.empty, CreditcardFields.structure.fields, map)
+    DeleteBuilderMock(DeleteParams.empty, CreditcardFields.structure, map)
   }
   override def deleteById(creditcardid: /* user-picked */ CustomCreditcardId): ZIO[ZConnection, Throwable, Boolean] = {
     ZIO.succeed(map.remove(creditcardid).isDefined)
@@ -87,7 +87,7 @@ class CreditcardRepoMock(toRow: Function1[CreditcardRowUnsaved, CreditcardRow],
     }
   }
   override def update: UpdateBuilder[CreditcardFields, CreditcardRow] = {
-    UpdateBuilderMock(UpdateParams.empty, CreditcardFields.structure.fields, map)
+    UpdateBuilderMock(UpdateParams.empty, CreditcardFields.structure, map)
   }
   override def update(row: CreditcardRow): ZIO[ZConnection, Throwable, Boolean] = {
     ZIO.succeed {

--- a/typo-tester-zio-jdbc/generated-and-checked-in/adventureworks/sales/currency/CurrencyFields.scala
+++ b/typo-tester-zio-jdbc/generated-and-checked-in/adventureworks/sales/currency/CurrencyFields.scala
@@ -9,35 +9,36 @@ package currency
 
 import adventureworks.customtypes.TypoLocalDateTime
 import adventureworks.public.Name
+import typo.dsl.Path
 import typo.dsl.SqlExpr.Field
 import typo.dsl.SqlExpr.FieldLikeNoHkt
 import typo.dsl.SqlExpr.IdField
 import typo.dsl.Structure.Relation
 
-trait CurrencyFields[Row] {
-  val currencycode: IdField[CurrencyId, Row]
-  val name: Field[Name, Row]
-  val modifieddate: Field[TypoLocalDateTime, Row]
+trait CurrencyFields {
+  def currencycode: IdField[CurrencyId, CurrencyRow]
+  def name: Field[Name, CurrencyRow]
+  def modifieddate: Field[TypoLocalDateTime, CurrencyRow]
 }
 
 object CurrencyFields {
-  val structure: Relation[CurrencyFields, CurrencyRow, CurrencyRow] = 
-    new Impl(None, identity, (_, x) => x)
+  lazy val structure: Relation[CurrencyFields, CurrencyRow] =
+    new Impl(Nil)
     
-  private final class Impl[Row](val prefix: Option[String], val extract: Row => CurrencyRow, val merge: (Row, CurrencyRow) => Row)
-    extends Relation[CurrencyFields, CurrencyRow, Row] { 
+  private final class Impl(val _path: List[Path])
+    extends Relation[CurrencyFields, CurrencyRow] {
   
-    override val fields: CurrencyFields[Row] = new CurrencyFields[Row] {
-      override val currencycode = new IdField[CurrencyId, Row](prefix, "currencycode", None, Some("bpchar"))(x => extract(x).currencycode, (row, value) => merge(row, extract(row).copy(currencycode = value)))
-      override val name = new Field[Name, Row](prefix, "name", None, Some("varchar"))(x => extract(x).name, (row, value) => merge(row, extract(row).copy(name = value)))
-      override val modifieddate = new Field[TypoLocalDateTime, Row](prefix, "modifieddate", Some("text"), Some("timestamp"))(x => extract(x).modifieddate, (row, value) => merge(row, extract(row).copy(modifieddate = value)))
+    override lazy val fields: CurrencyFields = new CurrencyFields {
+      override def currencycode = IdField[CurrencyId, CurrencyRow](_path, "currencycode", None, Some("bpchar"), x => x.currencycode, (row, value) => row.copy(currencycode = value))
+      override def name = Field[Name, CurrencyRow](_path, "name", None, Some("varchar"), x => x.name, (row, value) => row.copy(name = value))
+      override def modifieddate = Field[TypoLocalDateTime, CurrencyRow](_path, "modifieddate", Some("text"), Some("timestamp"), x => x.modifieddate, (row, value) => row.copy(modifieddate = value))
     }
   
-    override val columns: List[FieldLikeNoHkt[?, Row]] =
-      List[FieldLikeNoHkt[?, Row]](fields.currencycode, fields.name, fields.modifieddate)
+    override lazy val columns: List[FieldLikeNoHkt[?, CurrencyRow]] =
+      List[FieldLikeNoHkt[?, CurrencyRow]](fields.currencycode, fields.name, fields.modifieddate)
   
-    override def copy[NewRow](prefix: Option[String], extract: NewRow => CurrencyRow, merge: (NewRow, CurrencyRow) => NewRow): Impl[NewRow] =
-      new Impl(prefix, extract, merge)
+    override def copy(path: List[Path]): Impl =
+      new Impl(path)
   }
   
 }

--- a/typo-tester-zio-jdbc/generated-and-checked-in/adventureworks/sales/currency/CurrencyRepoMock.scala
+++ b/typo-tester-zio-jdbc/generated-and-checked-in/adventureworks/sales/currency/CurrencyRepoMock.scala
@@ -26,7 +26,7 @@ import zio.stream.ZStream
 class CurrencyRepoMock(toRow: Function1[CurrencyRowUnsaved, CurrencyRow],
                        map: scala.collection.mutable.Map[CurrencyId, CurrencyRow] = scala.collection.mutable.Map.empty) extends CurrencyRepo {
   override def delete: DeleteBuilder[CurrencyFields, CurrencyRow] = {
-    DeleteBuilderMock(DeleteParams.empty, CurrencyFields.structure.fields, map)
+    DeleteBuilderMock(DeleteParams.empty, CurrencyFields.structure, map)
   }
   override def deleteById(currencycode: CurrencyId): ZIO[ZConnection, Throwable, Boolean] = {
     ZIO.succeed(map.remove(currencycode).isDefined)
@@ -85,7 +85,7 @@ class CurrencyRepoMock(toRow: Function1[CurrencyRowUnsaved, CurrencyRow],
     }
   }
   override def update: UpdateBuilder[CurrencyFields, CurrencyRow] = {
-    UpdateBuilderMock(UpdateParams.empty, CurrencyFields.structure.fields, map)
+    UpdateBuilderMock(UpdateParams.empty, CurrencyFields.structure, map)
   }
   override def update(row: CurrencyRow): ZIO[ZConnection, Throwable, Boolean] = {
     ZIO.succeed {

--- a/typo-tester-zio-jdbc/generated-and-checked-in/adventureworks/sales/currencyrate/CurrencyrateFields.scala
+++ b/typo-tester-zio-jdbc/generated-and-checked-in/adventureworks/sales/currencyrate/CurrencyrateFields.scala
@@ -9,43 +9,44 @@ package currencyrate
 
 import adventureworks.customtypes.TypoLocalDateTime
 import adventureworks.sales.currency.CurrencyId
+import typo.dsl.Path
 import typo.dsl.SqlExpr.Field
 import typo.dsl.SqlExpr.FieldLikeNoHkt
 import typo.dsl.SqlExpr.IdField
 import typo.dsl.Structure.Relation
 
-trait CurrencyrateFields[Row] {
-  val currencyrateid: IdField[CurrencyrateId, Row]
-  val currencyratedate: Field[TypoLocalDateTime, Row]
-  val fromcurrencycode: Field[CurrencyId, Row]
-  val tocurrencycode: Field[CurrencyId, Row]
-  val averagerate: Field[BigDecimal, Row]
-  val endofdayrate: Field[BigDecimal, Row]
-  val modifieddate: Field[TypoLocalDateTime, Row]
+trait CurrencyrateFields {
+  def currencyrateid: IdField[CurrencyrateId, CurrencyrateRow]
+  def currencyratedate: Field[TypoLocalDateTime, CurrencyrateRow]
+  def fromcurrencycode: Field[CurrencyId, CurrencyrateRow]
+  def tocurrencycode: Field[CurrencyId, CurrencyrateRow]
+  def averagerate: Field[BigDecimal, CurrencyrateRow]
+  def endofdayrate: Field[BigDecimal, CurrencyrateRow]
+  def modifieddate: Field[TypoLocalDateTime, CurrencyrateRow]
 }
 
 object CurrencyrateFields {
-  val structure: Relation[CurrencyrateFields, CurrencyrateRow, CurrencyrateRow] = 
-    new Impl(None, identity, (_, x) => x)
+  lazy val structure: Relation[CurrencyrateFields, CurrencyrateRow] =
+    new Impl(Nil)
     
-  private final class Impl[Row](val prefix: Option[String], val extract: Row => CurrencyrateRow, val merge: (Row, CurrencyrateRow) => Row)
-    extends Relation[CurrencyrateFields, CurrencyrateRow, Row] { 
+  private final class Impl(val _path: List[Path])
+    extends Relation[CurrencyrateFields, CurrencyrateRow] {
   
-    override val fields: CurrencyrateFields[Row] = new CurrencyrateFields[Row] {
-      override val currencyrateid = new IdField[CurrencyrateId, Row](prefix, "currencyrateid", None, Some("int4"))(x => extract(x).currencyrateid, (row, value) => merge(row, extract(row).copy(currencyrateid = value)))
-      override val currencyratedate = new Field[TypoLocalDateTime, Row](prefix, "currencyratedate", Some("text"), Some("timestamp"))(x => extract(x).currencyratedate, (row, value) => merge(row, extract(row).copy(currencyratedate = value)))
-      override val fromcurrencycode = new Field[CurrencyId, Row](prefix, "fromcurrencycode", None, Some("bpchar"))(x => extract(x).fromcurrencycode, (row, value) => merge(row, extract(row).copy(fromcurrencycode = value)))
-      override val tocurrencycode = new Field[CurrencyId, Row](prefix, "tocurrencycode", None, Some("bpchar"))(x => extract(x).tocurrencycode, (row, value) => merge(row, extract(row).copy(tocurrencycode = value)))
-      override val averagerate = new Field[BigDecimal, Row](prefix, "averagerate", None, Some("numeric"))(x => extract(x).averagerate, (row, value) => merge(row, extract(row).copy(averagerate = value)))
-      override val endofdayrate = new Field[BigDecimal, Row](prefix, "endofdayrate", None, Some("numeric"))(x => extract(x).endofdayrate, (row, value) => merge(row, extract(row).copy(endofdayrate = value)))
-      override val modifieddate = new Field[TypoLocalDateTime, Row](prefix, "modifieddate", Some("text"), Some("timestamp"))(x => extract(x).modifieddate, (row, value) => merge(row, extract(row).copy(modifieddate = value)))
+    override lazy val fields: CurrencyrateFields = new CurrencyrateFields {
+      override def currencyrateid = IdField[CurrencyrateId, CurrencyrateRow](_path, "currencyrateid", None, Some("int4"), x => x.currencyrateid, (row, value) => row.copy(currencyrateid = value))
+      override def currencyratedate = Field[TypoLocalDateTime, CurrencyrateRow](_path, "currencyratedate", Some("text"), Some("timestamp"), x => x.currencyratedate, (row, value) => row.copy(currencyratedate = value))
+      override def fromcurrencycode = Field[CurrencyId, CurrencyrateRow](_path, "fromcurrencycode", None, Some("bpchar"), x => x.fromcurrencycode, (row, value) => row.copy(fromcurrencycode = value))
+      override def tocurrencycode = Field[CurrencyId, CurrencyrateRow](_path, "tocurrencycode", None, Some("bpchar"), x => x.tocurrencycode, (row, value) => row.copy(tocurrencycode = value))
+      override def averagerate = Field[BigDecimal, CurrencyrateRow](_path, "averagerate", None, Some("numeric"), x => x.averagerate, (row, value) => row.copy(averagerate = value))
+      override def endofdayrate = Field[BigDecimal, CurrencyrateRow](_path, "endofdayrate", None, Some("numeric"), x => x.endofdayrate, (row, value) => row.copy(endofdayrate = value))
+      override def modifieddate = Field[TypoLocalDateTime, CurrencyrateRow](_path, "modifieddate", Some("text"), Some("timestamp"), x => x.modifieddate, (row, value) => row.copy(modifieddate = value))
     }
   
-    override val columns: List[FieldLikeNoHkt[?, Row]] =
-      List[FieldLikeNoHkt[?, Row]](fields.currencyrateid, fields.currencyratedate, fields.fromcurrencycode, fields.tocurrencycode, fields.averagerate, fields.endofdayrate, fields.modifieddate)
+    override lazy val columns: List[FieldLikeNoHkt[?, CurrencyrateRow]] =
+      List[FieldLikeNoHkt[?, CurrencyrateRow]](fields.currencyrateid, fields.currencyratedate, fields.fromcurrencycode, fields.tocurrencycode, fields.averagerate, fields.endofdayrate, fields.modifieddate)
   
-    override def copy[NewRow](prefix: Option[String], extract: NewRow => CurrencyrateRow, merge: (NewRow, CurrencyrateRow) => NewRow): Impl[NewRow] =
-      new Impl(prefix, extract, merge)
+    override def copy(path: List[Path]): Impl =
+      new Impl(path)
   }
   
 }

--- a/typo-tester-zio-jdbc/generated-and-checked-in/adventureworks/sales/currencyrate/CurrencyrateRepoMock.scala
+++ b/typo-tester-zio-jdbc/generated-and-checked-in/adventureworks/sales/currencyrate/CurrencyrateRepoMock.scala
@@ -26,7 +26,7 @@ import zio.stream.ZStream
 class CurrencyrateRepoMock(toRow: Function1[CurrencyrateRowUnsaved, CurrencyrateRow],
                            map: scala.collection.mutable.Map[CurrencyrateId, CurrencyrateRow] = scala.collection.mutable.Map.empty) extends CurrencyrateRepo {
   override def delete: DeleteBuilder[CurrencyrateFields, CurrencyrateRow] = {
-    DeleteBuilderMock(DeleteParams.empty, CurrencyrateFields.structure.fields, map)
+    DeleteBuilderMock(DeleteParams.empty, CurrencyrateFields.structure, map)
   }
   override def deleteById(currencyrateid: CurrencyrateId): ZIO[ZConnection, Throwable, Boolean] = {
     ZIO.succeed(map.remove(currencyrateid).isDefined)
@@ -85,7 +85,7 @@ class CurrencyrateRepoMock(toRow: Function1[CurrencyrateRowUnsaved, Currencyrate
     }
   }
   override def update: UpdateBuilder[CurrencyrateFields, CurrencyrateRow] = {
-    UpdateBuilderMock(UpdateParams.empty, CurrencyrateFields.structure.fields, map)
+    UpdateBuilderMock(UpdateParams.empty, CurrencyrateFields.structure, map)
   }
   override def update(row: CurrencyrateRow): ZIO[ZConnection, Throwable, Boolean] = {
     ZIO.succeed {

--- a/typo-tester-zio-jdbc/generated-and-checked-in/adventureworks/sales/customer/CustomerFields.scala
+++ b/typo-tester-zio-jdbc/generated-and-checked-in/adventureworks/sales/customer/CustomerFields.scala
@@ -11,42 +11,43 @@ import adventureworks.customtypes.TypoLocalDateTime
 import adventureworks.customtypes.TypoUUID
 import adventureworks.person.businessentity.BusinessentityId
 import adventureworks.sales.salesterritory.SalesterritoryId
+import typo.dsl.Path
 import typo.dsl.SqlExpr.Field
 import typo.dsl.SqlExpr.FieldLikeNoHkt
 import typo.dsl.SqlExpr.IdField
 import typo.dsl.SqlExpr.OptField
 import typo.dsl.Structure.Relation
 
-trait CustomerFields[Row] {
-  val customerid: IdField[CustomerId, Row]
-  val personid: OptField[BusinessentityId, Row]
-  val storeid: OptField[BusinessentityId, Row]
-  val territoryid: OptField[SalesterritoryId, Row]
-  val rowguid: Field[TypoUUID, Row]
-  val modifieddate: Field[TypoLocalDateTime, Row]
+trait CustomerFields {
+  def customerid: IdField[CustomerId, CustomerRow]
+  def personid: OptField[BusinessentityId, CustomerRow]
+  def storeid: OptField[BusinessentityId, CustomerRow]
+  def territoryid: OptField[SalesterritoryId, CustomerRow]
+  def rowguid: Field[TypoUUID, CustomerRow]
+  def modifieddate: Field[TypoLocalDateTime, CustomerRow]
 }
 
 object CustomerFields {
-  val structure: Relation[CustomerFields, CustomerRow, CustomerRow] = 
-    new Impl(None, identity, (_, x) => x)
+  lazy val structure: Relation[CustomerFields, CustomerRow] =
+    new Impl(Nil)
     
-  private final class Impl[Row](val prefix: Option[String], val extract: Row => CustomerRow, val merge: (Row, CustomerRow) => Row)
-    extends Relation[CustomerFields, CustomerRow, Row] { 
+  private final class Impl(val _path: List[Path])
+    extends Relation[CustomerFields, CustomerRow] {
   
-    override val fields: CustomerFields[Row] = new CustomerFields[Row] {
-      override val customerid = new IdField[CustomerId, Row](prefix, "customerid", None, Some("int4"))(x => extract(x).customerid, (row, value) => merge(row, extract(row).copy(customerid = value)))
-      override val personid = new OptField[BusinessentityId, Row](prefix, "personid", None, Some("int4"))(x => extract(x).personid, (row, value) => merge(row, extract(row).copy(personid = value)))
-      override val storeid = new OptField[BusinessentityId, Row](prefix, "storeid", None, Some("int4"))(x => extract(x).storeid, (row, value) => merge(row, extract(row).copy(storeid = value)))
-      override val territoryid = new OptField[SalesterritoryId, Row](prefix, "territoryid", None, Some("int4"))(x => extract(x).territoryid, (row, value) => merge(row, extract(row).copy(territoryid = value)))
-      override val rowguid = new Field[TypoUUID, Row](prefix, "rowguid", None, Some("uuid"))(x => extract(x).rowguid, (row, value) => merge(row, extract(row).copy(rowguid = value)))
-      override val modifieddate = new Field[TypoLocalDateTime, Row](prefix, "modifieddate", Some("text"), Some("timestamp"))(x => extract(x).modifieddate, (row, value) => merge(row, extract(row).copy(modifieddate = value)))
+    override lazy val fields: CustomerFields = new CustomerFields {
+      override def customerid = IdField[CustomerId, CustomerRow](_path, "customerid", None, Some("int4"), x => x.customerid, (row, value) => row.copy(customerid = value))
+      override def personid = OptField[BusinessentityId, CustomerRow](_path, "personid", None, Some("int4"), x => x.personid, (row, value) => row.copy(personid = value))
+      override def storeid = OptField[BusinessentityId, CustomerRow](_path, "storeid", None, Some("int4"), x => x.storeid, (row, value) => row.copy(storeid = value))
+      override def territoryid = OptField[SalesterritoryId, CustomerRow](_path, "territoryid", None, Some("int4"), x => x.territoryid, (row, value) => row.copy(territoryid = value))
+      override def rowguid = Field[TypoUUID, CustomerRow](_path, "rowguid", None, Some("uuid"), x => x.rowguid, (row, value) => row.copy(rowguid = value))
+      override def modifieddate = Field[TypoLocalDateTime, CustomerRow](_path, "modifieddate", Some("text"), Some("timestamp"), x => x.modifieddate, (row, value) => row.copy(modifieddate = value))
     }
   
-    override val columns: List[FieldLikeNoHkt[?, Row]] =
-      List[FieldLikeNoHkt[?, Row]](fields.customerid, fields.personid, fields.storeid, fields.territoryid, fields.rowguid, fields.modifieddate)
+    override lazy val columns: List[FieldLikeNoHkt[?, CustomerRow]] =
+      List[FieldLikeNoHkt[?, CustomerRow]](fields.customerid, fields.personid, fields.storeid, fields.territoryid, fields.rowguid, fields.modifieddate)
   
-    override def copy[NewRow](prefix: Option[String], extract: NewRow => CustomerRow, merge: (NewRow, CustomerRow) => NewRow): Impl[NewRow] =
-      new Impl(prefix, extract, merge)
+    override def copy(path: List[Path]): Impl =
+      new Impl(path)
   }
   
 }

--- a/typo-tester-zio-jdbc/generated-and-checked-in/adventureworks/sales/customer/CustomerRepoMock.scala
+++ b/typo-tester-zio-jdbc/generated-and-checked-in/adventureworks/sales/customer/CustomerRepoMock.scala
@@ -26,7 +26,7 @@ import zio.stream.ZStream
 class CustomerRepoMock(toRow: Function1[CustomerRowUnsaved, CustomerRow],
                        map: scala.collection.mutable.Map[CustomerId, CustomerRow] = scala.collection.mutable.Map.empty) extends CustomerRepo {
   override def delete: DeleteBuilder[CustomerFields, CustomerRow] = {
-    DeleteBuilderMock(DeleteParams.empty, CustomerFields.structure.fields, map)
+    DeleteBuilderMock(DeleteParams.empty, CustomerFields.structure, map)
   }
   override def deleteById(customerid: CustomerId): ZIO[ZConnection, Throwable, Boolean] = {
     ZIO.succeed(map.remove(customerid).isDefined)
@@ -85,7 +85,7 @@ class CustomerRepoMock(toRow: Function1[CustomerRowUnsaved, CustomerRow],
     }
   }
   override def update: UpdateBuilder[CustomerFields, CustomerRow] = {
-    UpdateBuilderMock(UpdateParams.empty, CustomerFields.structure.fields, map)
+    UpdateBuilderMock(UpdateParams.empty, CustomerFields.structure, map)
   }
   override def update(row: CustomerRow): ZIO[ZConnection, Throwable, Boolean] = {
     ZIO.succeed {

--- a/typo-tester-zio-jdbc/generated-and-checked-in/adventureworks/sales/personcreditcard/PersoncreditcardFields.scala
+++ b/typo-tester-zio-jdbc/generated-and-checked-in/adventureworks/sales/personcreditcard/PersoncreditcardFields.scala
@@ -10,35 +10,36 @@ package personcreditcard
 import adventureworks.customtypes.TypoLocalDateTime
 import adventureworks.person.businessentity.BusinessentityId
 import adventureworks.userdefined.CustomCreditcardId
+import typo.dsl.Path
 import typo.dsl.SqlExpr.Field
 import typo.dsl.SqlExpr.FieldLikeNoHkt
 import typo.dsl.SqlExpr.IdField
 import typo.dsl.Structure.Relation
 
-trait PersoncreditcardFields[Row] {
-  val businessentityid: IdField[BusinessentityId, Row]
-  val creditcardid: IdField[/* user-picked */ CustomCreditcardId, Row]
-  val modifieddate: Field[TypoLocalDateTime, Row]
+trait PersoncreditcardFields {
+  def businessentityid: IdField[BusinessentityId, PersoncreditcardRow]
+  def creditcardid: IdField[/* user-picked */ CustomCreditcardId, PersoncreditcardRow]
+  def modifieddate: Field[TypoLocalDateTime, PersoncreditcardRow]
 }
 
 object PersoncreditcardFields {
-  val structure: Relation[PersoncreditcardFields, PersoncreditcardRow, PersoncreditcardRow] = 
-    new Impl(None, identity, (_, x) => x)
+  lazy val structure: Relation[PersoncreditcardFields, PersoncreditcardRow] =
+    new Impl(Nil)
     
-  private final class Impl[Row](val prefix: Option[String], val extract: Row => PersoncreditcardRow, val merge: (Row, PersoncreditcardRow) => Row)
-    extends Relation[PersoncreditcardFields, PersoncreditcardRow, Row] { 
+  private final class Impl(val _path: List[Path])
+    extends Relation[PersoncreditcardFields, PersoncreditcardRow] {
   
-    override val fields: PersoncreditcardFields[Row] = new PersoncreditcardFields[Row] {
-      override val businessentityid = new IdField[BusinessentityId, Row](prefix, "businessentityid", None, Some("int4"))(x => extract(x).businessentityid, (row, value) => merge(row, extract(row).copy(businessentityid = value)))
-      override val creditcardid = new IdField[/* user-picked */ CustomCreditcardId, Row](prefix, "creditcardid", None, Some("int4"))(x => extract(x).creditcardid, (row, value) => merge(row, extract(row).copy(creditcardid = value)))
-      override val modifieddate = new Field[TypoLocalDateTime, Row](prefix, "modifieddate", Some("text"), Some("timestamp"))(x => extract(x).modifieddate, (row, value) => merge(row, extract(row).copy(modifieddate = value)))
+    override lazy val fields: PersoncreditcardFields = new PersoncreditcardFields {
+      override def businessentityid = IdField[BusinessentityId, PersoncreditcardRow](_path, "businessentityid", None, Some("int4"), x => x.businessentityid, (row, value) => row.copy(businessentityid = value))
+      override def creditcardid = IdField[/* user-picked */ CustomCreditcardId, PersoncreditcardRow](_path, "creditcardid", None, Some("int4"), x => x.creditcardid, (row, value) => row.copy(creditcardid = value))
+      override def modifieddate = Field[TypoLocalDateTime, PersoncreditcardRow](_path, "modifieddate", Some("text"), Some("timestamp"), x => x.modifieddate, (row, value) => row.copy(modifieddate = value))
     }
   
-    override val columns: List[FieldLikeNoHkt[?, Row]] =
-      List[FieldLikeNoHkt[?, Row]](fields.businessentityid, fields.creditcardid, fields.modifieddate)
+    override lazy val columns: List[FieldLikeNoHkt[?, PersoncreditcardRow]] =
+      List[FieldLikeNoHkt[?, PersoncreditcardRow]](fields.businessentityid, fields.creditcardid, fields.modifieddate)
   
-    override def copy[NewRow](prefix: Option[String], extract: NewRow => PersoncreditcardRow, merge: (NewRow, PersoncreditcardRow) => NewRow): Impl[NewRow] =
-      new Impl(prefix, extract, merge)
+    override def copy(path: List[Path]): Impl =
+      new Impl(path)
   }
   
 }

--- a/typo-tester-zio-jdbc/generated-and-checked-in/adventureworks/sales/personcreditcard/PersoncreditcardRepoMock.scala
+++ b/typo-tester-zio-jdbc/generated-and-checked-in/adventureworks/sales/personcreditcard/PersoncreditcardRepoMock.scala
@@ -28,7 +28,7 @@ import zio.stream.ZStream
 class PersoncreditcardRepoMock(toRow: Function1[PersoncreditcardRowUnsaved, PersoncreditcardRow],
                                map: scala.collection.mutable.Map[PersoncreditcardId, PersoncreditcardRow] = scala.collection.mutable.Map.empty) extends PersoncreditcardRepo {
   override def delete: DeleteBuilder[PersoncreditcardFields, PersoncreditcardRow] = {
-    DeleteBuilderMock(DeleteParams.empty, PersoncreditcardFields.structure.fields, map)
+    DeleteBuilderMock(DeleteParams.empty, PersoncreditcardFields.structure, map)
   }
   override def deleteById(compositeId: PersoncreditcardId): ZIO[ZConnection, Throwable, Boolean] = {
     ZIO.succeed(map.remove(compositeId).isDefined)
@@ -87,7 +87,7 @@ class PersoncreditcardRepoMock(toRow: Function1[PersoncreditcardRowUnsaved, Pers
     }
   }
   override def update: UpdateBuilder[PersoncreditcardFields, PersoncreditcardRow] = {
-    UpdateBuilderMock(UpdateParams.empty, PersoncreditcardFields.structure.fields, map)
+    UpdateBuilderMock(UpdateParams.empty, PersoncreditcardFields.structure, map)
   }
   override def update(row: PersoncreditcardRow): ZIO[ZConnection, Throwable, Boolean] = {
     ZIO.succeed {

--- a/typo-tester-zio-jdbc/generated-and-checked-in/adventureworks/sales/salesorderdetail/SalesorderdetailFields.scala
+++ b/typo-tester-zio-jdbc/generated-and-checked-in/adventureworks/sales/salesorderdetail/SalesorderdetailFields.scala
@@ -13,50 +13,51 @@ import adventureworks.customtypes.TypoUUID
 import adventureworks.production.product.ProductId
 import adventureworks.sales.salesorderheader.SalesorderheaderId
 import adventureworks.sales.specialoffer.SpecialofferId
+import typo.dsl.Path
 import typo.dsl.SqlExpr.Field
 import typo.dsl.SqlExpr.FieldLikeNoHkt
 import typo.dsl.SqlExpr.IdField
 import typo.dsl.SqlExpr.OptField
 import typo.dsl.Structure.Relation
 
-trait SalesorderdetailFields[Row] {
-  val salesorderid: IdField[SalesorderheaderId, Row]
-  val salesorderdetailid: IdField[Int, Row]
-  val carriertrackingnumber: OptField[/* max 25 chars */ String, Row]
-  val orderqty: Field[TypoShort, Row]
-  val productid: Field[ProductId, Row]
-  val specialofferid: Field[SpecialofferId, Row]
-  val unitprice: Field[BigDecimal, Row]
-  val unitpricediscount: Field[BigDecimal, Row]
-  val rowguid: Field[TypoUUID, Row]
-  val modifieddate: Field[TypoLocalDateTime, Row]
+trait SalesorderdetailFields {
+  def salesorderid: IdField[SalesorderheaderId, SalesorderdetailRow]
+  def salesorderdetailid: IdField[Int, SalesorderdetailRow]
+  def carriertrackingnumber: OptField[/* max 25 chars */ String, SalesorderdetailRow]
+  def orderqty: Field[TypoShort, SalesorderdetailRow]
+  def productid: Field[ProductId, SalesorderdetailRow]
+  def specialofferid: Field[SpecialofferId, SalesorderdetailRow]
+  def unitprice: Field[BigDecimal, SalesorderdetailRow]
+  def unitpricediscount: Field[BigDecimal, SalesorderdetailRow]
+  def rowguid: Field[TypoUUID, SalesorderdetailRow]
+  def modifieddate: Field[TypoLocalDateTime, SalesorderdetailRow]
 }
 
 object SalesorderdetailFields {
-  val structure: Relation[SalesorderdetailFields, SalesorderdetailRow, SalesorderdetailRow] = 
-    new Impl(None, identity, (_, x) => x)
+  lazy val structure: Relation[SalesorderdetailFields, SalesorderdetailRow] =
+    new Impl(Nil)
     
-  private final class Impl[Row](val prefix: Option[String], val extract: Row => SalesorderdetailRow, val merge: (Row, SalesorderdetailRow) => Row)
-    extends Relation[SalesorderdetailFields, SalesorderdetailRow, Row] { 
+  private final class Impl(val _path: List[Path])
+    extends Relation[SalesorderdetailFields, SalesorderdetailRow] {
   
-    override val fields: SalesorderdetailFields[Row] = new SalesorderdetailFields[Row] {
-      override val salesorderid = new IdField[SalesorderheaderId, Row](prefix, "salesorderid", None, Some("int4"))(x => extract(x).salesorderid, (row, value) => merge(row, extract(row).copy(salesorderid = value)))
-      override val salesorderdetailid = new IdField[Int, Row](prefix, "salesorderdetailid", None, Some("int4"))(x => extract(x).salesorderdetailid, (row, value) => merge(row, extract(row).copy(salesorderdetailid = value)))
-      override val carriertrackingnumber = new OptField[/* max 25 chars */ String, Row](prefix, "carriertrackingnumber", None, None)(x => extract(x).carriertrackingnumber, (row, value) => merge(row, extract(row).copy(carriertrackingnumber = value)))
-      override val orderqty = new Field[TypoShort, Row](prefix, "orderqty", None, Some("int2"))(x => extract(x).orderqty, (row, value) => merge(row, extract(row).copy(orderqty = value)))
-      override val productid = new Field[ProductId, Row](prefix, "productid", None, Some("int4"))(x => extract(x).productid, (row, value) => merge(row, extract(row).copy(productid = value)))
-      override val specialofferid = new Field[SpecialofferId, Row](prefix, "specialofferid", None, Some("int4"))(x => extract(x).specialofferid, (row, value) => merge(row, extract(row).copy(specialofferid = value)))
-      override val unitprice = new Field[BigDecimal, Row](prefix, "unitprice", None, Some("numeric"))(x => extract(x).unitprice, (row, value) => merge(row, extract(row).copy(unitprice = value)))
-      override val unitpricediscount = new Field[BigDecimal, Row](prefix, "unitpricediscount", None, Some("numeric"))(x => extract(x).unitpricediscount, (row, value) => merge(row, extract(row).copy(unitpricediscount = value)))
-      override val rowguid = new Field[TypoUUID, Row](prefix, "rowguid", None, Some("uuid"))(x => extract(x).rowguid, (row, value) => merge(row, extract(row).copy(rowguid = value)))
-      override val modifieddate = new Field[TypoLocalDateTime, Row](prefix, "modifieddate", Some("text"), Some("timestamp"))(x => extract(x).modifieddate, (row, value) => merge(row, extract(row).copy(modifieddate = value)))
+    override lazy val fields: SalesorderdetailFields = new SalesorderdetailFields {
+      override def salesorderid = IdField[SalesorderheaderId, SalesorderdetailRow](_path, "salesorderid", None, Some("int4"), x => x.salesorderid, (row, value) => row.copy(salesorderid = value))
+      override def salesorderdetailid = IdField[Int, SalesorderdetailRow](_path, "salesorderdetailid", None, Some("int4"), x => x.salesorderdetailid, (row, value) => row.copy(salesorderdetailid = value))
+      override def carriertrackingnumber = OptField[/* max 25 chars */ String, SalesorderdetailRow](_path, "carriertrackingnumber", None, None, x => x.carriertrackingnumber, (row, value) => row.copy(carriertrackingnumber = value))
+      override def orderqty = Field[TypoShort, SalesorderdetailRow](_path, "orderqty", None, Some("int2"), x => x.orderqty, (row, value) => row.copy(orderqty = value))
+      override def productid = Field[ProductId, SalesorderdetailRow](_path, "productid", None, Some("int4"), x => x.productid, (row, value) => row.copy(productid = value))
+      override def specialofferid = Field[SpecialofferId, SalesorderdetailRow](_path, "specialofferid", None, Some("int4"), x => x.specialofferid, (row, value) => row.copy(specialofferid = value))
+      override def unitprice = Field[BigDecimal, SalesorderdetailRow](_path, "unitprice", None, Some("numeric"), x => x.unitprice, (row, value) => row.copy(unitprice = value))
+      override def unitpricediscount = Field[BigDecimal, SalesorderdetailRow](_path, "unitpricediscount", None, Some("numeric"), x => x.unitpricediscount, (row, value) => row.copy(unitpricediscount = value))
+      override def rowguid = Field[TypoUUID, SalesorderdetailRow](_path, "rowguid", None, Some("uuid"), x => x.rowguid, (row, value) => row.copy(rowguid = value))
+      override def modifieddate = Field[TypoLocalDateTime, SalesorderdetailRow](_path, "modifieddate", Some("text"), Some("timestamp"), x => x.modifieddate, (row, value) => row.copy(modifieddate = value))
     }
   
-    override val columns: List[FieldLikeNoHkt[?, Row]] =
-      List[FieldLikeNoHkt[?, Row]](fields.salesorderid, fields.salesorderdetailid, fields.carriertrackingnumber, fields.orderqty, fields.productid, fields.specialofferid, fields.unitprice, fields.unitpricediscount, fields.rowguid, fields.modifieddate)
+    override lazy val columns: List[FieldLikeNoHkt[?, SalesorderdetailRow]] =
+      List[FieldLikeNoHkt[?, SalesorderdetailRow]](fields.salesorderid, fields.salesorderdetailid, fields.carriertrackingnumber, fields.orderqty, fields.productid, fields.specialofferid, fields.unitprice, fields.unitpricediscount, fields.rowguid, fields.modifieddate)
   
-    override def copy[NewRow](prefix: Option[String], extract: NewRow => SalesorderdetailRow, merge: (NewRow, SalesorderdetailRow) => NewRow): Impl[NewRow] =
-      new Impl(prefix, extract, merge)
+    override def copy(path: List[Path]): Impl =
+      new Impl(path)
   }
   
 }

--- a/typo-tester-zio-jdbc/generated-and-checked-in/adventureworks/sales/salesorderdetail/SalesorderdetailRepoMock.scala
+++ b/typo-tester-zio-jdbc/generated-and-checked-in/adventureworks/sales/salesorderdetail/SalesorderdetailRepoMock.scala
@@ -26,7 +26,7 @@ import zio.stream.ZStream
 class SalesorderdetailRepoMock(toRow: Function1[SalesorderdetailRowUnsaved, SalesorderdetailRow],
                                map: scala.collection.mutable.Map[SalesorderdetailId, SalesorderdetailRow] = scala.collection.mutable.Map.empty) extends SalesorderdetailRepo {
   override def delete: DeleteBuilder[SalesorderdetailFields, SalesorderdetailRow] = {
-    DeleteBuilderMock(DeleteParams.empty, SalesorderdetailFields.structure.fields, map)
+    DeleteBuilderMock(DeleteParams.empty, SalesorderdetailFields.structure, map)
   }
   override def deleteById(compositeId: SalesorderdetailId): ZIO[ZConnection, Throwable, Boolean] = {
     ZIO.succeed(map.remove(compositeId).isDefined)
@@ -85,7 +85,7 @@ class SalesorderdetailRepoMock(toRow: Function1[SalesorderdetailRowUnsaved, Sale
     }
   }
   override def update: UpdateBuilder[SalesorderdetailFields, SalesorderdetailRow] = {
-    UpdateBuilderMock(UpdateParams.empty, SalesorderdetailFields.structure.fields, map)
+    UpdateBuilderMock(UpdateParams.empty, SalesorderdetailFields.structure, map)
   }
   override def update(row: SalesorderdetailRow): ZIO[ZConnection, Throwable, Boolean] = {
     ZIO.succeed {

--- a/typo-tester-zio-jdbc/generated-and-checked-in/adventureworks/sales/salesorderheader/SalesorderheaderFields.scala
+++ b/typo-tester-zio-jdbc/generated-and-checked-in/adventureworks/sales/salesorderheader/SalesorderheaderFields.scala
@@ -20,80 +20,81 @@ import adventureworks.sales.currencyrate.CurrencyrateId
 import adventureworks.sales.customer.CustomerId
 import adventureworks.sales.salesterritory.SalesterritoryId
 import adventureworks.userdefined.CustomCreditcardId
+import typo.dsl.Path
 import typo.dsl.SqlExpr.Field
 import typo.dsl.SqlExpr.FieldLikeNoHkt
 import typo.dsl.SqlExpr.IdField
 import typo.dsl.SqlExpr.OptField
 import typo.dsl.Structure.Relation
 
-trait SalesorderheaderFields[Row] {
-  val salesorderid: IdField[SalesorderheaderId, Row]
-  val revisionnumber: Field[TypoShort, Row]
-  val orderdate: Field[TypoLocalDateTime, Row]
-  val duedate: Field[TypoLocalDateTime, Row]
-  val shipdate: OptField[TypoLocalDateTime, Row]
-  val status: Field[TypoShort, Row]
-  val onlineorderflag: Field[Flag, Row]
-  val purchaseordernumber: OptField[OrderNumber, Row]
-  val accountnumber: OptField[AccountNumber, Row]
-  val customerid: Field[CustomerId, Row]
-  val salespersonid: OptField[BusinessentityId, Row]
-  val territoryid: OptField[SalesterritoryId, Row]
-  val billtoaddressid: Field[AddressId, Row]
-  val shiptoaddressid: Field[AddressId, Row]
-  val shipmethodid: Field[ShipmethodId, Row]
-  val creditcardid: OptField[/* user-picked */ CustomCreditcardId, Row]
-  val creditcardapprovalcode: OptField[/* max 15 chars */ String, Row]
-  val currencyrateid: OptField[CurrencyrateId, Row]
-  val subtotal: Field[BigDecimal, Row]
-  val taxamt: Field[BigDecimal, Row]
-  val freight: Field[BigDecimal, Row]
-  val totaldue: OptField[BigDecimal, Row]
-  val comment: OptField[/* max 128 chars */ String, Row]
-  val rowguid: Field[TypoUUID, Row]
-  val modifieddate: Field[TypoLocalDateTime, Row]
+trait SalesorderheaderFields {
+  def salesorderid: IdField[SalesorderheaderId, SalesorderheaderRow]
+  def revisionnumber: Field[TypoShort, SalesorderheaderRow]
+  def orderdate: Field[TypoLocalDateTime, SalesorderheaderRow]
+  def duedate: Field[TypoLocalDateTime, SalesorderheaderRow]
+  def shipdate: OptField[TypoLocalDateTime, SalesorderheaderRow]
+  def status: Field[TypoShort, SalesorderheaderRow]
+  def onlineorderflag: Field[Flag, SalesorderheaderRow]
+  def purchaseordernumber: OptField[OrderNumber, SalesorderheaderRow]
+  def accountnumber: OptField[AccountNumber, SalesorderheaderRow]
+  def customerid: Field[CustomerId, SalesorderheaderRow]
+  def salespersonid: OptField[BusinessentityId, SalesorderheaderRow]
+  def territoryid: OptField[SalesterritoryId, SalesorderheaderRow]
+  def billtoaddressid: Field[AddressId, SalesorderheaderRow]
+  def shiptoaddressid: Field[AddressId, SalesorderheaderRow]
+  def shipmethodid: Field[ShipmethodId, SalesorderheaderRow]
+  def creditcardid: OptField[/* user-picked */ CustomCreditcardId, SalesorderheaderRow]
+  def creditcardapprovalcode: OptField[/* max 15 chars */ String, SalesorderheaderRow]
+  def currencyrateid: OptField[CurrencyrateId, SalesorderheaderRow]
+  def subtotal: Field[BigDecimal, SalesorderheaderRow]
+  def taxamt: Field[BigDecimal, SalesorderheaderRow]
+  def freight: Field[BigDecimal, SalesorderheaderRow]
+  def totaldue: OptField[BigDecimal, SalesorderheaderRow]
+  def comment: OptField[/* max 128 chars */ String, SalesorderheaderRow]
+  def rowguid: Field[TypoUUID, SalesorderheaderRow]
+  def modifieddate: Field[TypoLocalDateTime, SalesorderheaderRow]
 }
 
 object SalesorderheaderFields {
-  val structure: Relation[SalesorderheaderFields, SalesorderheaderRow, SalesorderheaderRow] = 
-    new Impl(None, identity, (_, x) => x)
+  lazy val structure: Relation[SalesorderheaderFields, SalesorderheaderRow] =
+    new Impl(Nil)
     
-  private final class Impl[Row](val prefix: Option[String], val extract: Row => SalesorderheaderRow, val merge: (Row, SalesorderheaderRow) => Row)
-    extends Relation[SalesorderheaderFields, SalesorderheaderRow, Row] { 
+  private final class Impl(val _path: List[Path])
+    extends Relation[SalesorderheaderFields, SalesorderheaderRow] {
   
-    override val fields: SalesorderheaderFields[Row] = new SalesorderheaderFields[Row] {
-      override val salesorderid = new IdField[SalesorderheaderId, Row](prefix, "salesorderid", None, Some("int4"))(x => extract(x).salesorderid, (row, value) => merge(row, extract(row).copy(salesorderid = value)))
-      override val revisionnumber = new Field[TypoShort, Row](prefix, "revisionnumber", None, Some("int2"))(x => extract(x).revisionnumber, (row, value) => merge(row, extract(row).copy(revisionnumber = value)))
-      override val orderdate = new Field[TypoLocalDateTime, Row](prefix, "orderdate", Some("text"), Some("timestamp"))(x => extract(x).orderdate, (row, value) => merge(row, extract(row).copy(orderdate = value)))
-      override val duedate = new Field[TypoLocalDateTime, Row](prefix, "duedate", Some("text"), Some("timestamp"))(x => extract(x).duedate, (row, value) => merge(row, extract(row).copy(duedate = value)))
-      override val shipdate = new OptField[TypoLocalDateTime, Row](prefix, "shipdate", Some("text"), Some("timestamp"))(x => extract(x).shipdate, (row, value) => merge(row, extract(row).copy(shipdate = value)))
-      override val status = new Field[TypoShort, Row](prefix, "status", None, Some("int2"))(x => extract(x).status, (row, value) => merge(row, extract(row).copy(status = value)))
-      override val onlineorderflag = new Field[Flag, Row](prefix, "onlineorderflag", None, Some("bool"))(x => extract(x).onlineorderflag, (row, value) => merge(row, extract(row).copy(onlineorderflag = value)))
-      override val purchaseordernumber = new OptField[OrderNumber, Row](prefix, "purchaseordernumber", None, Some("varchar"))(x => extract(x).purchaseordernumber, (row, value) => merge(row, extract(row).copy(purchaseordernumber = value)))
-      override val accountnumber = new OptField[AccountNumber, Row](prefix, "accountnumber", None, Some("varchar"))(x => extract(x).accountnumber, (row, value) => merge(row, extract(row).copy(accountnumber = value)))
-      override val customerid = new Field[CustomerId, Row](prefix, "customerid", None, Some("int4"))(x => extract(x).customerid, (row, value) => merge(row, extract(row).copy(customerid = value)))
-      override val salespersonid = new OptField[BusinessentityId, Row](prefix, "salespersonid", None, Some("int4"))(x => extract(x).salespersonid, (row, value) => merge(row, extract(row).copy(salespersonid = value)))
-      override val territoryid = new OptField[SalesterritoryId, Row](prefix, "territoryid", None, Some("int4"))(x => extract(x).territoryid, (row, value) => merge(row, extract(row).copy(territoryid = value)))
-      override val billtoaddressid = new Field[AddressId, Row](prefix, "billtoaddressid", None, Some("int4"))(x => extract(x).billtoaddressid, (row, value) => merge(row, extract(row).copy(billtoaddressid = value)))
-      override val shiptoaddressid = new Field[AddressId, Row](prefix, "shiptoaddressid", None, Some("int4"))(x => extract(x).shiptoaddressid, (row, value) => merge(row, extract(row).copy(shiptoaddressid = value)))
-      override val shipmethodid = new Field[ShipmethodId, Row](prefix, "shipmethodid", None, Some("int4"))(x => extract(x).shipmethodid, (row, value) => merge(row, extract(row).copy(shipmethodid = value)))
-      override val creditcardid = new OptField[/* user-picked */ CustomCreditcardId, Row](prefix, "creditcardid", None, Some("int4"))(x => extract(x).creditcardid, (row, value) => merge(row, extract(row).copy(creditcardid = value)))
-      override val creditcardapprovalcode = new OptField[/* max 15 chars */ String, Row](prefix, "creditcardapprovalcode", None, None)(x => extract(x).creditcardapprovalcode, (row, value) => merge(row, extract(row).copy(creditcardapprovalcode = value)))
-      override val currencyrateid = new OptField[CurrencyrateId, Row](prefix, "currencyrateid", None, Some("int4"))(x => extract(x).currencyrateid, (row, value) => merge(row, extract(row).copy(currencyrateid = value)))
-      override val subtotal = new Field[BigDecimal, Row](prefix, "subtotal", None, Some("numeric"))(x => extract(x).subtotal, (row, value) => merge(row, extract(row).copy(subtotal = value)))
-      override val taxamt = new Field[BigDecimal, Row](prefix, "taxamt", None, Some("numeric"))(x => extract(x).taxamt, (row, value) => merge(row, extract(row).copy(taxamt = value)))
-      override val freight = new Field[BigDecimal, Row](prefix, "freight", None, Some("numeric"))(x => extract(x).freight, (row, value) => merge(row, extract(row).copy(freight = value)))
-      override val totaldue = new OptField[BigDecimal, Row](prefix, "totaldue", None, Some("numeric"))(x => extract(x).totaldue, (row, value) => merge(row, extract(row).copy(totaldue = value)))
-      override val comment = new OptField[/* max 128 chars */ String, Row](prefix, "comment", None, None)(x => extract(x).comment, (row, value) => merge(row, extract(row).copy(comment = value)))
-      override val rowguid = new Field[TypoUUID, Row](prefix, "rowguid", None, Some("uuid"))(x => extract(x).rowguid, (row, value) => merge(row, extract(row).copy(rowguid = value)))
-      override val modifieddate = new Field[TypoLocalDateTime, Row](prefix, "modifieddate", Some("text"), Some("timestamp"))(x => extract(x).modifieddate, (row, value) => merge(row, extract(row).copy(modifieddate = value)))
+    override lazy val fields: SalesorderheaderFields = new SalesorderheaderFields {
+      override def salesorderid = IdField[SalesorderheaderId, SalesorderheaderRow](_path, "salesorderid", None, Some("int4"), x => x.salesorderid, (row, value) => row.copy(salesorderid = value))
+      override def revisionnumber = Field[TypoShort, SalesorderheaderRow](_path, "revisionnumber", None, Some("int2"), x => x.revisionnumber, (row, value) => row.copy(revisionnumber = value))
+      override def orderdate = Field[TypoLocalDateTime, SalesorderheaderRow](_path, "orderdate", Some("text"), Some("timestamp"), x => x.orderdate, (row, value) => row.copy(orderdate = value))
+      override def duedate = Field[TypoLocalDateTime, SalesorderheaderRow](_path, "duedate", Some("text"), Some("timestamp"), x => x.duedate, (row, value) => row.copy(duedate = value))
+      override def shipdate = OptField[TypoLocalDateTime, SalesorderheaderRow](_path, "shipdate", Some("text"), Some("timestamp"), x => x.shipdate, (row, value) => row.copy(shipdate = value))
+      override def status = Field[TypoShort, SalesorderheaderRow](_path, "status", None, Some("int2"), x => x.status, (row, value) => row.copy(status = value))
+      override def onlineorderflag = Field[Flag, SalesorderheaderRow](_path, "onlineorderflag", None, Some("bool"), x => x.onlineorderflag, (row, value) => row.copy(onlineorderflag = value))
+      override def purchaseordernumber = OptField[OrderNumber, SalesorderheaderRow](_path, "purchaseordernumber", None, Some("varchar"), x => x.purchaseordernumber, (row, value) => row.copy(purchaseordernumber = value))
+      override def accountnumber = OptField[AccountNumber, SalesorderheaderRow](_path, "accountnumber", None, Some("varchar"), x => x.accountnumber, (row, value) => row.copy(accountnumber = value))
+      override def customerid = Field[CustomerId, SalesorderheaderRow](_path, "customerid", None, Some("int4"), x => x.customerid, (row, value) => row.copy(customerid = value))
+      override def salespersonid = OptField[BusinessentityId, SalesorderheaderRow](_path, "salespersonid", None, Some("int4"), x => x.salespersonid, (row, value) => row.copy(salespersonid = value))
+      override def territoryid = OptField[SalesterritoryId, SalesorderheaderRow](_path, "territoryid", None, Some("int4"), x => x.territoryid, (row, value) => row.copy(territoryid = value))
+      override def billtoaddressid = Field[AddressId, SalesorderheaderRow](_path, "billtoaddressid", None, Some("int4"), x => x.billtoaddressid, (row, value) => row.copy(billtoaddressid = value))
+      override def shiptoaddressid = Field[AddressId, SalesorderheaderRow](_path, "shiptoaddressid", None, Some("int4"), x => x.shiptoaddressid, (row, value) => row.copy(shiptoaddressid = value))
+      override def shipmethodid = Field[ShipmethodId, SalesorderheaderRow](_path, "shipmethodid", None, Some("int4"), x => x.shipmethodid, (row, value) => row.copy(shipmethodid = value))
+      override def creditcardid = OptField[/* user-picked */ CustomCreditcardId, SalesorderheaderRow](_path, "creditcardid", None, Some("int4"), x => x.creditcardid, (row, value) => row.copy(creditcardid = value))
+      override def creditcardapprovalcode = OptField[/* max 15 chars */ String, SalesorderheaderRow](_path, "creditcardapprovalcode", None, None, x => x.creditcardapprovalcode, (row, value) => row.copy(creditcardapprovalcode = value))
+      override def currencyrateid = OptField[CurrencyrateId, SalesorderheaderRow](_path, "currencyrateid", None, Some("int4"), x => x.currencyrateid, (row, value) => row.copy(currencyrateid = value))
+      override def subtotal = Field[BigDecimal, SalesorderheaderRow](_path, "subtotal", None, Some("numeric"), x => x.subtotal, (row, value) => row.copy(subtotal = value))
+      override def taxamt = Field[BigDecimal, SalesorderheaderRow](_path, "taxamt", None, Some("numeric"), x => x.taxamt, (row, value) => row.copy(taxamt = value))
+      override def freight = Field[BigDecimal, SalesorderheaderRow](_path, "freight", None, Some("numeric"), x => x.freight, (row, value) => row.copy(freight = value))
+      override def totaldue = OptField[BigDecimal, SalesorderheaderRow](_path, "totaldue", None, Some("numeric"), x => x.totaldue, (row, value) => row.copy(totaldue = value))
+      override def comment = OptField[/* max 128 chars */ String, SalesorderheaderRow](_path, "comment", None, None, x => x.comment, (row, value) => row.copy(comment = value))
+      override def rowguid = Field[TypoUUID, SalesorderheaderRow](_path, "rowguid", None, Some("uuid"), x => x.rowguid, (row, value) => row.copy(rowguid = value))
+      override def modifieddate = Field[TypoLocalDateTime, SalesorderheaderRow](_path, "modifieddate", Some("text"), Some("timestamp"), x => x.modifieddate, (row, value) => row.copy(modifieddate = value))
     }
   
-    override val columns: List[FieldLikeNoHkt[?, Row]] =
-      List[FieldLikeNoHkt[?, Row]](fields.salesorderid, fields.revisionnumber, fields.orderdate, fields.duedate, fields.shipdate, fields.status, fields.onlineorderflag, fields.purchaseordernumber, fields.accountnumber, fields.customerid, fields.salespersonid, fields.territoryid, fields.billtoaddressid, fields.shiptoaddressid, fields.shipmethodid, fields.creditcardid, fields.creditcardapprovalcode, fields.currencyrateid, fields.subtotal, fields.taxamt, fields.freight, fields.totaldue, fields.comment, fields.rowguid, fields.modifieddate)
+    override lazy val columns: List[FieldLikeNoHkt[?, SalesorderheaderRow]] =
+      List[FieldLikeNoHkt[?, SalesorderheaderRow]](fields.salesorderid, fields.revisionnumber, fields.orderdate, fields.duedate, fields.shipdate, fields.status, fields.onlineorderflag, fields.purchaseordernumber, fields.accountnumber, fields.customerid, fields.salespersonid, fields.territoryid, fields.billtoaddressid, fields.shiptoaddressid, fields.shipmethodid, fields.creditcardid, fields.creditcardapprovalcode, fields.currencyrateid, fields.subtotal, fields.taxamt, fields.freight, fields.totaldue, fields.comment, fields.rowguid, fields.modifieddate)
   
-    override def copy[NewRow](prefix: Option[String], extract: NewRow => SalesorderheaderRow, merge: (NewRow, SalesorderheaderRow) => NewRow): Impl[NewRow] =
-      new Impl(prefix, extract, merge)
+    override def copy(path: List[Path]): Impl =
+      new Impl(path)
   }
   
 }

--- a/typo-tester-zio-jdbc/generated-and-checked-in/adventureworks/sales/salesorderheader/SalesorderheaderRepoMock.scala
+++ b/typo-tester-zio-jdbc/generated-and-checked-in/adventureworks/sales/salesorderheader/SalesorderheaderRepoMock.scala
@@ -26,7 +26,7 @@ import zio.stream.ZStream
 class SalesorderheaderRepoMock(toRow: Function1[SalesorderheaderRowUnsaved, SalesorderheaderRow],
                                map: scala.collection.mutable.Map[SalesorderheaderId, SalesorderheaderRow] = scala.collection.mutable.Map.empty) extends SalesorderheaderRepo {
   override def delete: DeleteBuilder[SalesorderheaderFields, SalesorderheaderRow] = {
-    DeleteBuilderMock(DeleteParams.empty, SalesorderheaderFields.structure.fields, map)
+    DeleteBuilderMock(DeleteParams.empty, SalesorderheaderFields.structure, map)
   }
   override def deleteById(salesorderid: SalesorderheaderId): ZIO[ZConnection, Throwable, Boolean] = {
     ZIO.succeed(map.remove(salesorderid).isDefined)
@@ -85,7 +85,7 @@ class SalesorderheaderRepoMock(toRow: Function1[SalesorderheaderRowUnsaved, Sale
     }
   }
   override def update: UpdateBuilder[SalesorderheaderFields, SalesorderheaderRow] = {
-    UpdateBuilderMock(UpdateParams.empty, SalesorderheaderFields.structure.fields, map)
+    UpdateBuilderMock(UpdateParams.empty, SalesorderheaderFields.structure, map)
   }
   override def update(row: SalesorderheaderRow): ZIO[ZConnection, Throwable, Boolean] = {
     ZIO.succeed {

--- a/typo-tester-zio-jdbc/generated-and-checked-in/adventureworks/sales/salesorderheadersalesreason/SalesorderheadersalesreasonFields.scala
+++ b/typo-tester-zio-jdbc/generated-and-checked-in/adventureworks/sales/salesorderheadersalesreason/SalesorderheadersalesreasonFields.scala
@@ -10,35 +10,36 @@ package salesorderheadersalesreason
 import adventureworks.customtypes.TypoLocalDateTime
 import adventureworks.sales.salesorderheader.SalesorderheaderId
 import adventureworks.sales.salesreason.SalesreasonId
+import typo.dsl.Path
 import typo.dsl.SqlExpr.Field
 import typo.dsl.SqlExpr.FieldLikeNoHkt
 import typo.dsl.SqlExpr.IdField
 import typo.dsl.Structure.Relation
 
-trait SalesorderheadersalesreasonFields[Row] {
-  val salesorderid: IdField[SalesorderheaderId, Row]
-  val salesreasonid: IdField[SalesreasonId, Row]
-  val modifieddate: Field[TypoLocalDateTime, Row]
+trait SalesorderheadersalesreasonFields {
+  def salesorderid: IdField[SalesorderheaderId, SalesorderheadersalesreasonRow]
+  def salesreasonid: IdField[SalesreasonId, SalesorderheadersalesreasonRow]
+  def modifieddate: Field[TypoLocalDateTime, SalesorderheadersalesreasonRow]
 }
 
 object SalesorderheadersalesreasonFields {
-  val structure: Relation[SalesorderheadersalesreasonFields, SalesorderheadersalesreasonRow, SalesorderheadersalesreasonRow] = 
-    new Impl(None, identity, (_, x) => x)
+  lazy val structure: Relation[SalesorderheadersalesreasonFields, SalesorderheadersalesreasonRow] =
+    new Impl(Nil)
     
-  private final class Impl[Row](val prefix: Option[String], val extract: Row => SalesorderheadersalesreasonRow, val merge: (Row, SalesorderheadersalesreasonRow) => Row)
-    extends Relation[SalesorderheadersalesreasonFields, SalesorderheadersalesreasonRow, Row] { 
+  private final class Impl(val _path: List[Path])
+    extends Relation[SalesorderheadersalesreasonFields, SalesorderheadersalesreasonRow] {
   
-    override val fields: SalesorderheadersalesreasonFields[Row] = new SalesorderheadersalesreasonFields[Row] {
-      override val salesorderid = new IdField[SalesorderheaderId, Row](prefix, "salesorderid", None, Some("int4"))(x => extract(x).salesorderid, (row, value) => merge(row, extract(row).copy(salesorderid = value)))
-      override val salesreasonid = new IdField[SalesreasonId, Row](prefix, "salesreasonid", None, Some("int4"))(x => extract(x).salesreasonid, (row, value) => merge(row, extract(row).copy(salesreasonid = value)))
-      override val modifieddate = new Field[TypoLocalDateTime, Row](prefix, "modifieddate", Some("text"), Some("timestamp"))(x => extract(x).modifieddate, (row, value) => merge(row, extract(row).copy(modifieddate = value)))
+    override lazy val fields: SalesorderheadersalesreasonFields = new SalesorderheadersalesreasonFields {
+      override def salesorderid = IdField[SalesorderheaderId, SalesorderheadersalesreasonRow](_path, "salesorderid", None, Some("int4"), x => x.salesorderid, (row, value) => row.copy(salesorderid = value))
+      override def salesreasonid = IdField[SalesreasonId, SalesorderheadersalesreasonRow](_path, "salesreasonid", None, Some("int4"), x => x.salesreasonid, (row, value) => row.copy(salesreasonid = value))
+      override def modifieddate = Field[TypoLocalDateTime, SalesorderheadersalesreasonRow](_path, "modifieddate", Some("text"), Some("timestamp"), x => x.modifieddate, (row, value) => row.copy(modifieddate = value))
     }
   
-    override val columns: List[FieldLikeNoHkt[?, Row]] =
-      List[FieldLikeNoHkt[?, Row]](fields.salesorderid, fields.salesreasonid, fields.modifieddate)
+    override lazy val columns: List[FieldLikeNoHkt[?, SalesorderheadersalesreasonRow]] =
+      List[FieldLikeNoHkt[?, SalesorderheadersalesreasonRow]](fields.salesorderid, fields.salesreasonid, fields.modifieddate)
   
-    override def copy[NewRow](prefix: Option[String], extract: NewRow => SalesorderheadersalesreasonRow, merge: (NewRow, SalesorderheadersalesreasonRow) => NewRow): Impl[NewRow] =
-      new Impl(prefix, extract, merge)
+    override def copy(path: List[Path]): Impl =
+      new Impl(path)
   }
   
 }

--- a/typo-tester-zio-jdbc/generated-and-checked-in/adventureworks/sales/salesorderheadersalesreason/SalesorderheadersalesreasonRepoMock.scala
+++ b/typo-tester-zio-jdbc/generated-and-checked-in/adventureworks/sales/salesorderheadersalesreason/SalesorderheadersalesreasonRepoMock.scala
@@ -26,7 +26,7 @@ import zio.stream.ZStream
 class SalesorderheadersalesreasonRepoMock(toRow: Function1[SalesorderheadersalesreasonRowUnsaved, SalesorderheadersalesreasonRow],
                                           map: scala.collection.mutable.Map[SalesorderheadersalesreasonId, SalesorderheadersalesreasonRow] = scala.collection.mutable.Map.empty) extends SalesorderheadersalesreasonRepo {
   override def delete: DeleteBuilder[SalesorderheadersalesreasonFields, SalesorderheadersalesreasonRow] = {
-    DeleteBuilderMock(DeleteParams.empty, SalesorderheadersalesreasonFields.structure.fields, map)
+    DeleteBuilderMock(DeleteParams.empty, SalesorderheadersalesreasonFields.structure, map)
   }
   override def deleteById(compositeId: SalesorderheadersalesreasonId): ZIO[ZConnection, Throwable, Boolean] = {
     ZIO.succeed(map.remove(compositeId).isDefined)
@@ -85,7 +85,7 @@ class SalesorderheadersalesreasonRepoMock(toRow: Function1[Salesorderheadersales
     }
   }
   override def update: UpdateBuilder[SalesorderheadersalesreasonFields, SalesorderheadersalesreasonRow] = {
-    UpdateBuilderMock(UpdateParams.empty, SalesorderheadersalesreasonFields.structure.fields, map)
+    UpdateBuilderMock(UpdateParams.empty, SalesorderheadersalesreasonFields.structure, map)
   }
   override def update(row: SalesorderheadersalesreasonRow): ZIO[ZConnection, Throwable, Boolean] = {
     ZIO.succeed {

--- a/typo-tester-zio-jdbc/generated-and-checked-in/adventureworks/sales/salesperson/SalespersonFields.scala
+++ b/typo-tester-zio-jdbc/generated-and-checked-in/adventureworks/sales/salesperson/SalespersonFields.scala
@@ -11,48 +11,49 @@ import adventureworks.customtypes.TypoLocalDateTime
 import adventureworks.customtypes.TypoUUID
 import adventureworks.person.businessentity.BusinessentityId
 import adventureworks.sales.salesterritory.SalesterritoryId
+import typo.dsl.Path
 import typo.dsl.SqlExpr.Field
 import typo.dsl.SqlExpr.FieldLikeNoHkt
 import typo.dsl.SqlExpr.IdField
 import typo.dsl.SqlExpr.OptField
 import typo.dsl.Structure.Relation
 
-trait SalespersonFields[Row] {
-  val businessentityid: IdField[BusinessentityId, Row]
-  val territoryid: OptField[SalesterritoryId, Row]
-  val salesquota: OptField[BigDecimal, Row]
-  val bonus: Field[BigDecimal, Row]
-  val commissionpct: Field[BigDecimal, Row]
-  val salesytd: Field[BigDecimal, Row]
-  val saleslastyear: Field[BigDecimal, Row]
-  val rowguid: Field[TypoUUID, Row]
-  val modifieddate: Field[TypoLocalDateTime, Row]
+trait SalespersonFields {
+  def businessentityid: IdField[BusinessentityId, SalespersonRow]
+  def territoryid: OptField[SalesterritoryId, SalespersonRow]
+  def salesquota: OptField[BigDecimal, SalespersonRow]
+  def bonus: Field[BigDecimal, SalespersonRow]
+  def commissionpct: Field[BigDecimal, SalespersonRow]
+  def salesytd: Field[BigDecimal, SalespersonRow]
+  def saleslastyear: Field[BigDecimal, SalespersonRow]
+  def rowguid: Field[TypoUUID, SalespersonRow]
+  def modifieddate: Field[TypoLocalDateTime, SalespersonRow]
 }
 
 object SalespersonFields {
-  val structure: Relation[SalespersonFields, SalespersonRow, SalespersonRow] = 
-    new Impl(None, identity, (_, x) => x)
+  lazy val structure: Relation[SalespersonFields, SalespersonRow] =
+    new Impl(Nil)
     
-  private final class Impl[Row](val prefix: Option[String], val extract: Row => SalespersonRow, val merge: (Row, SalespersonRow) => Row)
-    extends Relation[SalespersonFields, SalespersonRow, Row] { 
+  private final class Impl(val _path: List[Path])
+    extends Relation[SalespersonFields, SalespersonRow] {
   
-    override val fields: SalespersonFields[Row] = new SalespersonFields[Row] {
-      override val businessentityid = new IdField[BusinessentityId, Row](prefix, "businessentityid", None, Some("int4"))(x => extract(x).businessentityid, (row, value) => merge(row, extract(row).copy(businessentityid = value)))
-      override val territoryid = new OptField[SalesterritoryId, Row](prefix, "territoryid", None, Some("int4"))(x => extract(x).territoryid, (row, value) => merge(row, extract(row).copy(territoryid = value)))
-      override val salesquota = new OptField[BigDecimal, Row](prefix, "salesquota", None, Some("numeric"))(x => extract(x).salesquota, (row, value) => merge(row, extract(row).copy(salesquota = value)))
-      override val bonus = new Field[BigDecimal, Row](prefix, "bonus", None, Some("numeric"))(x => extract(x).bonus, (row, value) => merge(row, extract(row).copy(bonus = value)))
-      override val commissionpct = new Field[BigDecimal, Row](prefix, "commissionpct", None, Some("numeric"))(x => extract(x).commissionpct, (row, value) => merge(row, extract(row).copy(commissionpct = value)))
-      override val salesytd = new Field[BigDecimal, Row](prefix, "salesytd", None, Some("numeric"))(x => extract(x).salesytd, (row, value) => merge(row, extract(row).copy(salesytd = value)))
-      override val saleslastyear = new Field[BigDecimal, Row](prefix, "saleslastyear", None, Some("numeric"))(x => extract(x).saleslastyear, (row, value) => merge(row, extract(row).copy(saleslastyear = value)))
-      override val rowguid = new Field[TypoUUID, Row](prefix, "rowguid", None, Some("uuid"))(x => extract(x).rowguid, (row, value) => merge(row, extract(row).copy(rowguid = value)))
-      override val modifieddate = new Field[TypoLocalDateTime, Row](prefix, "modifieddate", Some("text"), Some("timestamp"))(x => extract(x).modifieddate, (row, value) => merge(row, extract(row).copy(modifieddate = value)))
+    override lazy val fields: SalespersonFields = new SalespersonFields {
+      override def businessentityid = IdField[BusinessentityId, SalespersonRow](_path, "businessentityid", None, Some("int4"), x => x.businessentityid, (row, value) => row.copy(businessentityid = value))
+      override def territoryid = OptField[SalesterritoryId, SalespersonRow](_path, "territoryid", None, Some("int4"), x => x.territoryid, (row, value) => row.copy(territoryid = value))
+      override def salesquota = OptField[BigDecimal, SalespersonRow](_path, "salesquota", None, Some("numeric"), x => x.salesquota, (row, value) => row.copy(salesquota = value))
+      override def bonus = Field[BigDecimal, SalespersonRow](_path, "bonus", None, Some("numeric"), x => x.bonus, (row, value) => row.copy(bonus = value))
+      override def commissionpct = Field[BigDecimal, SalespersonRow](_path, "commissionpct", None, Some("numeric"), x => x.commissionpct, (row, value) => row.copy(commissionpct = value))
+      override def salesytd = Field[BigDecimal, SalespersonRow](_path, "salesytd", None, Some("numeric"), x => x.salesytd, (row, value) => row.copy(salesytd = value))
+      override def saleslastyear = Field[BigDecimal, SalespersonRow](_path, "saleslastyear", None, Some("numeric"), x => x.saleslastyear, (row, value) => row.copy(saleslastyear = value))
+      override def rowguid = Field[TypoUUID, SalespersonRow](_path, "rowguid", None, Some("uuid"), x => x.rowguid, (row, value) => row.copy(rowguid = value))
+      override def modifieddate = Field[TypoLocalDateTime, SalespersonRow](_path, "modifieddate", Some("text"), Some("timestamp"), x => x.modifieddate, (row, value) => row.copy(modifieddate = value))
     }
   
-    override val columns: List[FieldLikeNoHkt[?, Row]] =
-      List[FieldLikeNoHkt[?, Row]](fields.businessentityid, fields.territoryid, fields.salesquota, fields.bonus, fields.commissionpct, fields.salesytd, fields.saleslastyear, fields.rowguid, fields.modifieddate)
+    override lazy val columns: List[FieldLikeNoHkt[?, SalespersonRow]] =
+      List[FieldLikeNoHkt[?, SalespersonRow]](fields.businessentityid, fields.territoryid, fields.salesquota, fields.bonus, fields.commissionpct, fields.salesytd, fields.saleslastyear, fields.rowguid, fields.modifieddate)
   
-    override def copy[NewRow](prefix: Option[String], extract: NewRow => SalespersonRow, merge: (NewRow, SalespersonRow) => NewRow): Impl[NewRow] =
-      new Impl(prefix, extract, merge)
+    override def copy(path: List[Path]): Impl =
+      new Impl(path)
   }
   
 }

--- a/typo-tester-zio-jdbc/generated-and-checked-in/adventureworks/sales/salesperson/SalespersonRepoMock.scala
+++ b/typo-tester-zio-jdbc/generated-and-checked-in/adventureworks/sales/salesperson/SalespersonRepoMock.scala
@@ -27,7 +27,7 @@ import zio.stream.ZStream
 class SalespersonRepoMock(toRow: Function1[SalespersonRowUnsaved, SalespersonRow],
                           map: scala.collection.mutable.Map[BusinessentityId, SalespersonRow] = scala.collection.mutable.Map.empty) extends SalespersonRepo {
   override def delete: DeleteBuilder[SalespersonFields, SalespersonRow] = {
-    DeleteBuilderMock(DeleteParams.empty, SalespersonFields.structure.fields, map)
+    DeleteBuilderMock(DeleteParams.empty, SalespersonFields.structure, map)
   }
   override def deleteById(businessentityid: BusinessentityId): ZIO[ZConnection, Throwable, Boolean] = {
     ZIO.succeed(map.remove(businessentityid).isDefined)
@@ -86,7 +86,7 @@ class SalespersonRepoMock(toRow: Function1[SalespersonRowUnsaved, SalespersonRow
     }
   }
   override def update: UpdateBuilder[SalespersonFields, SalespersonRow] = {
-    UpdateBuilderMock(UpdateParams.empty, SalespersonFields.structure.fields, map)
+    UpdateBuilderMock(UpdateParams.empty, SalespersonFields.structure, map)
   }
   override def update(row: SalespersonRow): ZIO[ZConnection, Throwable, Boolean] = {
     ZIO.succeed {

--- a/typo-tester-zio-jdbc/generated-and-checked-in/adventureworks/sales/salespersonquotahistory/SalespersonquotahistoryFields.scala
+++ b/typo-tester-zio-jdbc/generated-and-checked-in/adventureworks/sales/salespersonquotahistory/SalespersonquotahistoryFields.scala
@@ -10,39 +10,40 @@ package salespersonquotahistory
 import adventureworks.customtypes.TypoLocalDateTime
 import adventureworks.customtypes.TypoUUID
 import adventureworks.person.businessentity.BusinessentityId
+import typo.dsl.Path
 import typo.dsl.SqlExpr.Field
 import typo.dsl.SqlExpr.FieldLikeNoHkt
 import typo.dsl.SqlExpr.IdField
 import typo.dsl.Structure.Relation
 
-trait SalespersonquotahistoryFields[Row] {
-  val businessentityid: IdField[BusinessentityId, Row]
-  val quotadate: IdField[TypoLocalDateTime, Row]
-  val salesquota: Field[BigDecimal, Row]
-  val rowguid: Field[TypoUUID, Row]
-  val modifieddate: Field[TypoLocalDateTime, Row]
+trait SalespersonquotahistoryFields {
+  def businessentityid: IdField[BusinessentityId, SalespersonquotahistoryRow]
+  def quotadate: IdField[TypoLocalDateTime, SalespersonquotahistoryRow]
+  def salesquota: Field[BigDecimal, SalespersonquotahistoryRow]
+  def rowguid: Field[TypoUUID, SalespersonquotahistoryRow]
+  def modifieddate: Field[TypoLocalDateTime, SalespersonquotahistoryRow]
 }
 
 object SalespersonquotahistoryFields {
-  val structure: Relation[SalespersonquotahistoryFields, SalespersonquotahistoryRow, SalespersonquotahistoryRow] = 
-    new Impl(None, identity, (_, x) => x)
+  lazy val structure: Relation[SalespersonquotahistoryFields, SalespersonquotahistoryRow] =
+    new Impl(Nil)
     
-  private final class Impl[Row](val prefix: Option[String], val extract: Row => SalespersonquotahistoryRow, val merge: (Row, SalespersonquotahistoryRow) => Row)
-    extends Relation[SalespersonquotahistoryFields, SalespersonquotahistoryRow, Row] { 
+  private final class Impl(val _path: List[Path])
+    extends Relation[SalespersonquotahistoryFields, SalespersonquotahistoryRow] {
   
-    override val fields: SalespersonquotahistoryFields[Row] = new SalespersonquotahistoryFields[Row] {
-      override val businessentityid = new IdField[BusinessentityId, Row](prefix, "businessentityid", None, Some("int4"))(x => extract(x).businessentityid, (row, value) => merge(row, extract(row).copy(businessentityid = value)))
-      override val quotadate = new IdField[TypoLocalDateTime, Row](prefix, "quotadate", Some("text"), Some("timestamp"))(x => extract(x).quotadate, (row, value) => merge(row, extract(row).copy(quotadate = value)))
-      override val salesquota = new Field[BigDecimal, Row](prefix, "salesquota", None, Some("numeric"))(x => extract(x).salesquota, (row, value) => merge(row, extract(row).copy(salesquota = value)))
-      override val rowguid = new Field[TypoUUID, Row](prefix, "rowguid", None, Some("uuid"))(x => extract(x).rowguid, (row, value) => merge(row, extract(row).copy(rowguid = value)))
-      override val modifieddate = new Field[TypoLocalDateTime, Row](prefix, "modifieddate", Some("text"), Some("timestamp"))(x => extract(x).modifieddate, (row, value) => merge(row, extract(row).copy(modifieddate = value)))
+    override lazy val fields: SalespersonquotahistoryFields = new SalespersonquotahistoryFields {
+      override def businessentityid = IdField[BusinessentityId, SalespersonquotahistoryRow](_path, "businessentityid", None, Some("int4"), x => x.businessentityid, (row, value) => row.copy(businessentityid = value))
+      override def quotadate = IdField[TypoLocalDateTime, SalespersonquotahistoryRow](_path, "quotadate", Some("text"), Some("timestamp"), x => x.quotadate, (row, value) => row.copy(quotadate = value))
+      override def salesquota = Field[BigDecimal, SalespersonquotahistoryRow](_path, "salesquota", None, Some("numeric"), x => x.salesquota, (row, value) => row.copy(salesquota = value))
+      override def rowguid = Field[TypoUUID, SalespersonquotahistoryRow](_path, "rowguid", None, Some("uuid"), x => x.rowguid, (row, value) => row.copy(rowguid = value))
+      override def modifieddate = Field[TypoLocalDateTime, SalespersonquotahistoryRow](_path, "modifieddate", Some("text"), Some("timestamp"), x => x.modifieddate, (row, value) => row.copy(modifieddate = value))
     }
   
-    override val columns: List[FieldLikeNoHkt[?, Row]] =
-      List[FieldLikeNoHkt[?, Row]](fields.businessentityid, fields.quotadate, fields.salesquota, fields.rowguid, fields.modifieddate)
+    override lazy val columns: List[FieldLikeNoHkt[?, SalespersonquotahistoryRow]] =
+      List[FieldLikeNoHkt[?, SalespersonquotahistoryRow]](fields.businessentityid, fields.quotadate, fields.salesquota, fields.rowguid, fields.modifieddate)
   
-    override def copy[NewRow](prefix: Option[String], extract: NewRow => SalespersonquotahistoryRow, merge: (NewRow, SalespersonquotahistoryRow) => NewRow): Impl[NewRow] =
-      new Impl(prefix, extract, merge)
+    override def copy(path: List[Path]): Impl =
+      new Impl(path)
   }
   
 }

--- a/typo-tester-zio-jdbc/generated-and-checked-in/adventureworks/sales/salespersonquotahistory/SalespersonquotahistoryRepoMock.scala
+++ b/typo-tester-zio-jdbc/generated-and-checked-in/adventureworks/sales/salespersonquotahistory/SalespersonquotahistoryRepoMock.scala
@@ -26,7 +26,7 @@ import zio.stream.ZStream
 class SalespersonquotahistoryRepoMock(toRow: Function1[SalespersonquotahistoryRowUnsaved, SalespersonquotahistoryRow],
                                       map: scala.collection.mutable.Map[SalespersonquotahistoryId, SalespersonquotahistoryRow] = scala.collection.mutable.Map.empty) extends SalespersonquotahistoryRepo {
   override def delete: DeleteBuilder[SalespersonquotahistoryFields, SalespersonquotahistoryRow] = {
-    DeleteBuilderMock(DeleteParams.empty, SalespersonquotahistoryFields.structure.fields, map)
+    DeleteBuilderMock(DeleteParams.empty, SalespersonquotahistoryFields.structure, map)
   }
   override def deleteById(compositeId: SalespersonquotahistoryId): ZIO[ZConnection, Throwable, Boolean] = {
     ZIO.succeed(map.remove(compositeId).isDefined)
@@ -85,7 +85,7 @@ class SalespersonquotahistoryRepoMock(toRow: Function1[SalespersonquotahistoryRo
     }
   }
   override def update: UpdateBuilder[SalespersonquotahistoryFields, SalespersonquotahistoryRow] = {
-    UpdateBuilderMock(UpdateParams.empty, SalespersonquotahistoryFields.structure.fields, map)
+    UpdateBuilderMock(UpdateParams.empty, SalespersonquotahistoryFields.structure, map)
   }
   override def update(row: SalespersonquotahistoryRow): ZIO[ZConnection, Throwable, Boolean] = {
     ZIO.succeed {

--- a/typo-tester-zio-jdbc/generated-and-checked-in/adventureworks/sales/salesreason/SalesreasonFields.scala
+++ b/typo-tester-zio-jdbc/generated-and-checked-in/adventureworks/sales/salesreason/SalesreasonFields.scala
@@ -9,37 +9,38 @@ package salesreason
 
 import adventureworks.customtypes.TypoLocalDateTime
 import adventureworks.public.Name
+import typo.dsl.Path
 import typo.dsl.SqlExpr.Field
 import typo.dsl.SqlExpr.FieldLikeNoHkt
 import typo.dsl.SqlExpr.IdField
 import typo.dsl.Structure.Relation
 
-trait SalesreasonFields[Row] {
-  val salesreasonid: IdField[SalesreasonId, Row]
-  val name: Field[Name, Row]
-  val reasontype: Field[Name, Row]
-  val modifieddate: Field[TypoLocalDateTime, Row]
+trait SalesreasonFields {
+  def salesreasonid: IdField[SalesreasonId, SalesreasonRow]
+  def name: Field[Name, SalesreasonRow]
+  def reasontype: Field[Name, SalesreasonRow]
+  def modifieddate: Field[TypoLocalDateTime, SalesreasonRow]
 }
 
 object SalesreasonFields {
-  val structure: Relation[SalesreasonFields, SalesreasonRow, SalesreasonRow] = 
-    new Impl(None, identity, (_, x) => x)
+  lazy val structure: Relation[SalesreasonFields, SalesreasonRow] =
+    new Impl(Nil)
     
-  private final class Impl[Row](val prefix: Option[String], val extract: Row => SalesreasonRow, val merge: (Row, SalesreasonRow) => Row)
-    extends Relation[SalesreasonFields, SalesreasonRow, Row] { 
+  private final class Impl(val _path: List[Path])
+    extends Relation[SalesreasonFields, SalesreasonRow] {
   
-    override val fields: SalesreasonFields[Row] = new SalesreasonFields[Row] {
-      override val salesreasonid = new IdField[SalesreasonId, Row](prefix, "salesreasonid", None, Some("int4"))(x => extract(x).salesreasonid, (row, value) => merge(row, extract(row).copy(salesreasonid = value)))
-      override val name = new Field[Name, Row](prefix, "name", None, Some("varchar"))(x => extract(x).name, (row, value) => merge(row, extract(row).copy(name = value)))
-      override val reasontype = new Field[Name, Row](prefix, "reasontype", None, Some("varchar"))(x => extract(x).reasontype, (row, value) => merge(row, extract(row).copy(reasontype = value)))
-      override val modifieddate = new Field[TypoLocalDateTime, Row](prefix, "modifieddate", Some("text"), Some("timestamp"))(x => extract(x).modifieddate, (row, value) => merge(row, extract(row).copy(modifieddate = value)))
+    override lazy val fields: SalesreasonFields = new SalesreasonFields {
+      override def salesreasonid = IdField[SalesreasonId, SalesreasonRow](_path, "salesreasonid", None, Some("int4"), x => x.salesreasonid, (row, value) => row.copy(salesreasonid = value))
+      override def name = Field[Name, SalesreasonRow](_path, "name", None, Some("varchar"), x => x.name, (row, value) => row.copy(name = value))
+      override def reasontype = Field[Name, SalesreasonRow](_path, "reasontype", None, Some("varchar"), x => x.reasontype, (row, value) => row.copy(reasontype = value))
+      override def modifieddate = Field[TypoLocalDateTime, SalesreasonRow](_path, "modifieddate", Some("text"), Some("timestamp"), x => x.modifieddate, (row, value) => row.copy(modifieddate = value))
     }
   
-    override val columns: List[FieldLikeNoHkt[?, Row]] =
-      List[FieldLikeNoHkt[?, Row]](fields.salesreasonid, fields.name, fields.reasontype, fields.modifieddate)
+    override lazy val columns: List[FieldLikeNoHkt[?, SalesreasonRow]] =
+      List[FieldLikeNoHkt[?, SalesreasonRow]](fields.salesreasonid, fields.name, fields.reasontype, fields.modifieddate)
   
-    override def copy[NewRow](prefix: Option[String], extract: NewRow => SalesreasonRow, merge: (NewRow, SalesreasonRow) => NewRow): Impl[NewRow] =
-      new Impl(prefix, extract, merge)
+    override def copy(path: List[Path]): Impl =
+      new Impl(path)
   }
   
 }

--- a/typo-tester-zio-jdbc/generated-and-checked-in/adventureworks/sales/salesreason/SalesreasonRepoMock.scala
+++ b/typo-tester-zio-jdbc/generated-and-checked-in/adventureworks/sales/salesreason/SalesreasonRepoMock.scala
@@ -26,7 +26,7 @@ import zio.stream.ZStream
 class SalesreasonRepoMock(toRow: Function1[SalesreasonRowUnsaved, SalesreasonRow],
                           map: scala.collection.mutable.Map[SalesreasonId, SalesreasonRow] = scala.collection.mutable.Map.empty) extends SalesreasonRepo {
   override def delete: DeleteBuilder[SalesreasonFields, SalesreasonRow] = {
-    DeleteBuilderMock(DeleteParams.empty, SalesreasonFields.structure.fields, map)
+    DeleteBuilderMock(DeleteParams.empty, SalesreasonFields.structure, map)
   }
   override def deleteById(salesreasonid: SalesreasonId): ZIO[ZConnection, Throwable, Boolean] = {
     ZIO.succeed(map.remove(salesreasonid).isDefined)
@@ -85,7 +85,7 @@ class SalesreasonRepoMock(toRow: Function1[SalesreasonRowUnsaved, SalesreasonRow
     }
   }
   override def update: UpdateBuilder[SalesreasonFields, SalesreasonRow] = {
-    UpdateBuilderMock(UpdateParams.empty, SalesreasonFields.structure.fields, map)
+    UpdateBuilderMock(UpdateParams.empty, SalesreasonFields.structure, map)
   }
   override def update(row: SalesreasonRow): ZIO[ZConnection, Throwable, Boolean] = {
     ZIO.succeed {

--- a/typo-tester-zio-jdbc/generated-and-checked-in/adventureworks/sales/salestaxrate/SalestaxrateFields.scala
+++ b/typo-tester-zio-jdbc/generated-and-checked-in/adventureworks/sales/salestaxrate/SalestaxrateFields.scala
@@ -12,43 +12,44 @@ import adventureworks.customtypes.TypoShort
 import adventureworks.customtypes.TypoUUID
 import adventureworks.person.stateprovince.StateprovinceId
 import adventureworks.public.Name
+import typo.dsl.Path
 import typo.dsl.SqlExpr.Field
 import typo.dsl.SqlExpr.FieldLikeNoHkt
 import typo.dsl.SqlExpr.IdField
 import typo.dsl.Structure.Relation
 
-trait SalestaxrateFields[Row] {
-  val salestaxrateid: IdField[SalestaxrateId, Row]
-  val stateprovinceid: Field[StateprovinceId, Row]
-  val taxtype: Field[TypoShort, Row]
-  val taxrate: Field[BigDecimal, Row]
-  val name: Field[Name, Row]
-  val rowguid: Field[TypoUUID, Row]
-  val modifieddate: Field[TypoLocalDateTime, Row]
+trait SalestaxrateFields {
+  def salestaxrateid: IdField[SalestaxrateId, SalestaxrateRow]
+  def stateprovinceid: Field[StateprovinceId, SalestaxrateRow]
+  def taxtype: Field[TypoShort, SalestaxrateRow]
+  def taxrate: Field[BigDecimal, SalestaxrateRow]
+  def name: Field[Name, SalestaxrateRow]
+  def rowguid: Field[TypoUUID, SalestaxrateRow]
+  def modifieddate: Field[TypoLocalDateTime, SalestaxrateRow]
 }
 
 object SalestaxrateFields {
-  val structure: Relation[SalestaxrateFields, SalestaxrateRow, SalestaxrateRow] = 
-    new Impl(None, identity, (_, x) => x)
+  lazy val structure: Relation[SalestaxrateFields, SalestaxrateRow] =
+    new Impl(Nil)
     
-  private final class Impl[Row](val prefix: Option[String], val extract: Row => SalestaxrateRow, val merge: (Row, SalestaxrateRow) => Row)
-    extends Relation[SalestaxrateFields, SalestaxrateRow, Row] { 
+  private final class Impl(val _path: List[Path])
+    extends Relation[SalestaxrateFields, SalestaxrateRow] {
   
-    override val fields: SalestaxrateFields[Row] = new SalestaxrateFields[Row] {
-      override val salestaxrateid = new IdField[SalestaxrateId, Row](prefix, "salestaxrateid", None, Some("int4"))(x => extract(x).salestaxrateid, (row, value) => merge(row, extract(row).copy(salestaxrateid = value)))
-      override val stateprovinceid = new Field[StateprovinceId, Row](prefix, "stateprovinceid", None, Some("int4"))(x => extract(x).stateprovinceid, (row, value) => merge(row, extract(row).copy(stateprovinceid = value)))
-      override val taxtype = new Field[TypoShort, Row](prefix, "taxtype", None, Some("int2"))(x => extract(x).taxtype, (row, value) => merge(row, extract(row).copy(taxtype = value)))
-      override val taxrate = new Field[BigDecimal, Row](prefix, "taxrate", None, Some("numeric"))(x => extract(x).taxrate, (row, value) => merge(row, extract(row).copy(taxrate = value)))
-      override val name = new Field[Name, Row](prefix, "name", None, Some("varchar"))(x => extract(x).name, (row, value) => merge(row, extract(row).copy(name = value)))
-      override val rowguid = new Field[TypoUUID, Row](prefix, "rowguid", None, Some("uuid"))(x => extract(x).rowguid, (row, value) => merge(row, extract(row).copy(rowguid = value)))
-      override val modifieddate = new Field[TypoLocalDateTime, Row](prefix, "modifieddate", Some("text"), Some("timestamp"))(x => extract(x).modifieddate, (row, value) => merge(row, extract(row).copy(modifieddate = value)))
+    override lazy val fields: SalestaxrateFields = new SalestaxrateFields {
+      override def salestaxrateid = IdField[SalestaxrateId, SalestaxrateRow](_path, "salestaxrateid", None, Some("int4"), x => x.salestaxrateid, (row, value) => row.copy(salestaxrateid = value))
+      override def stateprovinceid = Field[StateprovinceId, SalestaxrateRow](_path, "stateprovinceid", None, Some("int4"), x => x.stateprovinceid, (row, value) => row.copy(stateprovinceid = value))
+      override def taxtype = Field[TypoShort, SalestaxrateRow](_path, "taxtype", None, Some("int2"), x => x.taxtype, (row, value) => row.copy(taxtype = value))
+      override def taxrate = Field[BigDecimal, SalestaxrateRow](_path, "taxrate", None, Some("numeric"), x => x.taxrate, (row, value) => row.copy(taxrate = value))
+      override def name = Field[Name, SalestaxrateRow](_path, "name", None, Some("varchar"), x => x.name, (row, value) => row.copy(name = value))
+      override def rowguid = Field[TypoUUID, SalestaxrateRow](_path, "rowguid", None, Some("uuid"), x => x.rowguid, (row, value) => row.copy(rowguid = value))
+      override def modifieddate = Field[TypoLocalDateTime, SalestaxrateRow](_path, "modifieddate", Some("text"), Some("timestamp"), x => x.modifieddate, (row, value) => row.copy(modifieddate = value))
     }
   
-    override val columns: List[FieldLikeNoHkt[?, Row]] =
-      List[FieldLikeNoHkt[?, Row]](fields.salestaxrateid, fields.stateprovinceid, fields.taxtype, fields.taxrate, fields.name, fields.rowguid, fields.modifieddate)
+    override lazy val columns: List[FieldLikeNoHkt[?, SalestaxrateRow]] =
+      List[FieldLikeNoHkt[?, SalestaxrateRow]](fields.salestaxrateid, fields.stateprovinceid, fields.taxtype, fields.taxrate, fields.name, fields.rowguid, fields.modifieddate)
   
-    override def copy[NewRow](prefix: Option[String], extract: NewRow => SalestaxrateRow, merge: (NewRow, SalestaxrateRow) => NewRow): Impl[NewRow] =
-      new Impl(prefix, extract, merge)
+    override def copy(path: List[Path]): Impl =
+      new Impl(path)
   }
   
 }

--- a/typo-tester-zio-jdbc/generated-and-checked-in/adventureworks/sales/salestaxrate/SalestaxrateRepoMock.scala
+++ b/typo-tester-zio-jdbc/generated-and-checked-in/adventureworks/sales/salestaxrate/SalestaxrateRepoMock.scala
@@ -26,7 +26,7 @@ import zio.stream.ZStream
 class SalestaxrateRepoMock(toRow: Function1[SalestaxrateRowUnsaved, SalestaxrateRow],
                            map: scala.collection.mutable.Map[SalestaxrateId, SalestaxrateRow] = scala.collection.mutable.Map.empty) extends SalestaxrateRepo {
   override def delete: DeleteBuilder[SalestaxrateFields, SalestaxrateRow] = {
-    DeleteBuilderMock(DeleteParams.empty, SalestaxrateFields.structure.fields, map)
+    DeleteBuilderMock(DeleteParams.empty, SalestaxrateFields.structure, map)
   }
   override def deleteById(salestaxrateid: SalestaxrateId): ZIO[ZConnection, Throwable, Boolean] = {
     ZIO.succeed(map.remove(salestaxrateid).isDefined)
@@ -85,7 +85,7 @@ class SalestaxrateRepoMock(toRow: Function1[SalestaxrateRowUnsaved, Salestaxrate
     }
   }
   override def update: UpdateBuilder[SalestaxrateFields, SalestaxrateRow] = {
-    UpdateBuilderMock(UpdateParams.empty, SalestaxrateFields.structure.fields, map)
+    UpdateBuilderMock(UpdateParams.empty, SalestaxrateFields.structure, map)
   }
   override def update(row: SalestaxrateRow): ZIO[ZConnection, Throwable, Boolean] = {
     ZIO.succeed {

--- a/typo-tester-zio-jdbc/generated-and-checked-in/adventureworks/sales/salesterritory/SalesterritoryFields.scala
+++ b/typo-tester-zio-jdbc/generated-and-checked-in/adventureworks/sales/salesterritory/SalesterritoryFields.scala
@@ -11,49 +11,50 @@ import adventureworks.customtypes.TypoLocalDateTime
 import adventureworks.customtypes.TypoUUID
 import adventureworks.person.countryregion.CountryregionId
 import adventureworks.public.Name
+import typo.dsl.Path
 import typo.dsl.SqlExpr.Field
 import typo.dsl.SqlExpr.FieldLikeNoHkt
 import typo.dsl.SqlExpr.IdField
 import typo.dsl.Structure.Relation
 
-trait SalesterritoryFields[Row] {
-  val territoryid: IdField[SalesterritoryId, Row]
-  val name: Field[Name, Row]
-  val countryregioncode: Field[CountryregionId, Row]
-  val group: Field[/* max 50 chars */ String, Row]
-  val salesytd: Field[BigDecimal, Row]
-  val saleslastyear: Field[BigDecimal, Row]
-  val costytd: Field[BigDecimal, Row]
-  val costlastyear: Field[BigDecimal, Row]
-  val rowguid: Field[TypoUUID, Row]
-  val modifieddate: Field[TypoLocalDateTime, Row]
+trait SalesterritoryFields {
+  def territoryid: IdField[SalesterritoryId, SalesterritoryRow]
+  def name: Field[Name, SalesterritoryRow]
+  def countryregioncode: Field[CountryregionId, SalesterritoryRow]
+  def group: Field[/* max 50 chars */ String, SalesterritoryRow]
+  def salesytd: Field[BigDecimal, SalesterritoryRow]
+  def saleslastyear: Field[BigDecimal, SalesterritoryRow]
+  def costytd: Field[BigDecimal, SalesterritoryRow]
+  def costlastyear: Field[BigDecimal, SalesterritoryRow]
+  def rowguid: Field[TypoUUID, SalesterritoryRow]
+  def modifieddate: Field[TypoLocalDateTime, SalesterritoryRow]
 }
 
 object SalesterritoryFields {
-  val structure: Relation[SalesterritoryFields, SalesterritoryRow, SalesterritoryRow] = 
-    new Impl(None, identity, (_, x) => x)
+  lazy val structure: Relation[SalesterritoryFields, SalesterritoryRow] =
+    new Impl(Nil)
     
-  private final class Impl[Row](val prefix: Option[String], val extract: Row => SalesterritoryRow, val merge: (Row, SalesterritoryRow) => Row)
-    extends Relation[SalesterritoryFields, SalesterritoryRow, Row] { 
+  private final class Impl(val _path: List[Path])
+    extends Relation[SalesterritoryFields, SalesterritoryRow] {
   
-    override val fields: SalesterritoryFields[Row] = new SalesterritoryFields[Row] {
-      override val territoryid = new IdField[SalesterritoryId, Row](prefix, "territoryid", None, Some("int4"))(x => extract(x).territoryid, (row, value) => merge(row, extract(row).copy(territoryid = value)))
-      override val name = new Field[Name, Row](prefix, "name", None, Some("varchar"))(x => extract(x).name, (row, value) => merge(row, extract(row).copy(name = value)))
-      override val countryregioncode = new Field[CountryregionId, Row](prefix, "countryregioncode", None, None)(x => extract(x).countryregioncode, (row, value) => merge(row, extract(row).copy(countryregioncode = value)))
-      override val group = new Field[/* max 50 chars */ String, Row](prefix, "group", None, None)(x => extract(x).group, (row, value) => merge(row, extract(row).copy(group = value)))
-      override val salesytd = new Field[BigDecimal, Row](prefix, "salesytd", None, Some("numeric"))(x => extract(x).salesytd, (row, value) => merge(row, extract(row).copy(salesytd = value)))
-      override val saleslastyear = new Field[BigDecimal, Row](prefix, "saleslastyear", None, Some("numeric"))(x => extract(x).saleslastyear, (row, value) => merge(row, extract(row).copy(saleslastyear = value)))
-      override val costytd = new Field[BigDecimal, Row](prefix, "costytd", None, Some("numeric"))(x => extract(x).costytd, (row, value) => merge(row, extract(row).copy(costytd = value)))
-      override val costlastyear = new Field[BigDecimal, Row](prefix, "costlastyear", None, Some("numeric"))(x => extract(x).costlastyear, (row, value) => merge(row, extract(row).copy(costlastyear = value)))
-      override val rowguid = new Field[TypoUUID, Row](prefix, "rowguid", None, Some("uuid"))(x => extract(x).rowguid, (row, value) => merge(row, extract(row).copy(rowguid = value)))
-      override val modifieddate = new Field[TypoLocalDateTime, Row](prefix, "modifieddate", Some("text"), Some("timestamp"))(x => extract(x).modifieddate, (row, value) => merge(row, extract(row).copy(modifieddate = value)))
+    override lazy val fields: SalesterritoryFields = new SalesterritoryFields {
+      override def territoryid = IdField[SalesterritoryId, SalesterritoryRow](_path, "territoryid", None, Some("int4"), x => x.territoryid, (row, value) => row.copy(territoryid = value))
+      override def name = Field[Name, SalesterritoryRow](_path, "name", None, Some("varchar"), x => x.name, (row, value) => row.copy(name = value))
+      override def countryregioncode = Field[CountryregionId, SalesterritoryRow](_path, "countryregioncode", None, None, x => x.countryregioncode, (row, value) => row.copy(countryregioncode = value))
+      override def group = Field[/* max 50 chars */ String, SalesterritoryRow](_path, "group", None, None, x => x.group, (row, value) => row.copy(group = value))
+      override def salesytd = Field[BigDecimal, SalesterritoryRow](_path, "salesytd", None, Some("numeric"), x => x.salesytd, (row, value) => row.copy(salesytd = value))
+      override def saleslastyear = Field[BigDecimal, SalesterritoryRow](_path, "saleslastyear", None, Some("numeric"), x => x.saleslastyear, (row, value) => row.copy(saleslastyear = value))
+      override def costytd = Field[BigDecimal, SalesterritoryRow](_path, "costytd", None, Some("numeric"), x => x.costytd, (row, value) => row.copy(costytd = value))
+      override def costlastyear = Field[BigDecimal, SalesterritoryRow](_path, "costlastyear", None, Some("numeric"), x => x.costlastyear, (row, value) => row.copy(costlastyear = value))
+      override def rowguid = Field[TypoUUID, SalesterritoryRow](_path, "rowguid", None, Some("uuid"), x => x.rowguid, (row, value) => row.copy(rowguid = value))
+      override def modifieddate = Field[TypoLocalDateTime, SalesterritoryRow](_path, "modifieddate", Some("text"), Some("timestamp"), x => x.modifieddate, (row, value) => row.copy(modifieddate = value))
     }
   
-    override val columns: List[FieldLikeNoHkt[?, Row]] =
-      List[FieldLikeNoHkt[?, Row]](fields.territoryid, fields.name, fields.countryregioncode, fields.group, fields.salesytd, fields.saleslastyear, fields.costytd, fields.costlastyear, fields.rowguid, fields.modifieddate)
+    override lazy val columns: List[FieldLikeNoHkt[?, SalesterritoryRow]] =
+      List[FieldLikeNoHkt[?, SalesterritoryRow]](fields.territoryid, fields.name, fields.countryregioncode, fields.group, fields.salesytd, fields.saleslastyear, fields.costytd, fields.costlastyear, fields.rowguid, fields.modifieddate)
   
-    override def copy[NewRow](prefix: Option[String], extract: NewRow => SalesterritoryRow, merge: (NewRow, SalesterritoryRow) => NewRow): Impl[NewRow] =
-      new Impl(prefix, extract, merge)
+    override def copy(path: List[Path]): Impl =
+      new Impl(path)
   }
   
 }

--- a/typo-tester-zio-jdbc/generated-and-checked-in/adventureworks/sales/salesterritory/SalesterritoryRepoMock.scala
+++ b/typo-tester-zio-jdbc/generated-and-checked-in/adventureworks/sales/salesterritory/SalesterritoryRepoMock.scala
@@ -26,7 +26,7 @@ import zio.stream.ZStream
 class SalesterritoryRepoMock(toRow: Function1[SalesterritoryRowUnsaved, SalesterritoryRow],
                              map: scala.collection.mutable.Map[SalesterritoryId, SalesterritoryRow] = scala.collection.mutable.Map.empty) extends SalesterritoryRepo {
   override def delete: DeleteBuilder[SalesterritoryFields, SalesterritoryRow] = {
-    DeleteBuilderMock(DeleteParams.empty, SalesterritoryFields.structure.fields, map)
+    DeleteBuilderMock(DeleteParams.empty, SalesterritoryFields.structure, map)
   }
   override def deleteById(territoryid: SalesterritoryId): ZIO[ZConnection, Throwable, Boolean] = {
     ZIO.succeed(map.remove(territoryid).isDefined)
@@ -85,7 +85,7 @@ class SalesterritoryRepoMock(toRow: Function1[SalesterritoryRowUnsaved, Salester
     }
   }
   override def update: UpdateBuilder[SalesterritoryFields, SalesterritoryRow] = {
-    UpdateBuilderMock(UpdateParams.empty, SalesterritoryFields.structure.fields, map)
+    UpdateBuilderMock(UpdateParams.empty, SalesterritoryFields.structure, map)
   }
   override def update(row: SalesterritoryRow): ZIO[ZConnection, Throwable, Boolean] = {
     ZIO.succeed {

--- a/typo-tester-zio-jdbc/generated-and-checked-in/adventureworks/sales/salesterritoryhistory/SalesterritoryhistoryFields.scala
+++ b/typo-tester-zio-jdbc/generated-and-checked-in/adventureworks/sales/salesterritoryhistory/SalesterritoryhistoryFields.scala
@@ -11,42 +11,43 @@ import adventureworks.customtypes.TypoLocalDateTime
 import adventureworks.customtypes.TypoUUID
 import adventureworks.person.businessentity.BusinessentityId
 import adventureworks.sales.salesterritory.SalesterritoryId
+import typo.dsl.Path
 import typo.dsl.SqlExpr.Field
 import typo.dsl.SqlExpr.FieldLikeNoHkt
 import typo.dsl.SqlExpr.IdField
 import typo.dsl.SqlExpr.OptField
 import typo.dsl.Structure.Relation
 
-trait SalesterritoryhistoryFields[Row] {
-  val businessentityid: IdField[BusinessentityId, Row]
-  val territoryid: IdField[SalesterritoryId, Row]
-  val startdate: IdField[TypoLocalDateTime, Row]
-  val enddate: OptField[TypoLocalDateTime, Row]
-  val rowguid: Field[TypoUUID, Row]
-  val modifieddate: Field[TypoLocalDateTime, Row]
+trait SalesterritoryhistoryFields {
+  def businessentityid: IdField[BusinessentityId, SalesterritoryhistoryRow]
+  def territoryid: IdField[SalesterritoryId, SalesterritoryhistoryRow]
+  def startdate: IdField[TypoLocalDateTime, SalesterritoryhistoryRow]
+  def enddate: OptField[TypoLocalDateTime, SalesterritoryhistoryRow]
+  def rowguid: Field[TypoUUID, SalesterritoryhistoryRow]
+  def modifieddate: Field[TypoLocalDateTime, SalesterritoryhistoryRow]
 }
 
 object SalesterritoryhistoryFields {
-  val structure: Relation[SalesterritoryhistoryFields, SalesterritoryhistoryRow, SalesterritoryhistoryRow] = 
-    new Impl(None, identity, (_, x) => x)
+  lazy val structure: Relation[SalesterritoryhistoryFields, SalesterritoryhistoryRow] =
+    new Impl(Nil)
     
-  private final class Impl[Row](val prefix: Option[String], val extract: Row => SalesterritoryhistoryRow, val merge: (Row, SalesterritoryhistoryRow) => Row)
-    extends Relation[SalesterritoryhistoryFields, SalesterritoryhistoryRow, Row] { 
+  private final class Impl(val _path: List[Path])
+    extends Relation[SalesterritoryhistoryFields, SalesterritoryhistoryRow] {
   
-    override val fields: SalesterritoryhistoryFields[Row] = new SalesterritoryhistoryFields[Row] {
-      override val businessentityid = new IdField[BusinessentityId, Row](prefix, "businessentityid", None, Some("int4"))(x => extract(x).businessentityid, (row, value) => merge(row, extract(row).copy(businessentityid = value)))
-      override val territoryid = new IdField[SalesterritoryId, Row](prefix, "territoryid", None, Some("int4"))(x => extract(x).territoryid, (row, value) => merge(row, extract(row).copy(territoryid = value)))
-      override val startdate = new IdField[TypoLocalDateTime, Row](prefix, "startdate", Some("text"), Some("timestamp"))(x => extract(x).startdate, (row, value) => merge(row, extract(row).copy(startdate = value)))
-      override val enddate = new OptField[TypoLocalDateTime, Row](prefix, "enddate", Some("text"), Some("timestamp"))(x => extract(x).enddate, (row, value) => merge(row, extract(row).copy(enddate = value)))
-      override val rowguid = new Field[TypoUUID, Row](prefix, "rowguid", None, Some("uuid"))(x => extract(x).rowguid, (row, value) => merge(row, extract(row).copy(rowguid = value)))
-      override val modifieddate = new Field[TypoLocalDateTime, Row](prefix, "modifieddate", Some("text"), Some("timestamp"))(x => extract(x).modifieddate, (row, value) => merge(row, extract(row).copy(modifieddate = value)))
+    override lazy val fields: SalesterritoryhistoryFields = new SalesterritoryhistoryFields {
+      override def businessentityid = IdField[BusinessentityId, SalesterritoryhistoryRow](_path, "businessentityid", None, Some("int4"), x => x.businessentityid, (row, value) => row.copy(businessentityid = value))
+      override def territoryid = IdField[SalesterritoryId, SalesterritoryhistoryRow](_path, "territoryid", None, Some("int4"), x => x.territoryid, (row, value) => row.copy(territoryid = value))
+      override def startdate = IdField[TypoLocalDateTime, SalesterritoryhistoryRow](_path, "startdate", Some("text"), Some("timestamp"), x => x.startdate, (row, value) => row.copy(startdate = value))
+      override def enddate = OptField[TypoLocalDateTime, SalesterritoryhistoryRow](_path, "enddate", Some("text"), Some("timestamp"), x => x.enddate, (row, value) => row.copy(enddate = value))
+      override def rowguid = Field[TypoUUID, SalesterritoryhistoryRow](_path, "rowguid", None, Some("uuid"), x => x.rowguid, (row, value) => row.copy(rowguid = value))
+      override def modifieddate = Field[TypoLocalDateTime, SalesterritoryhistoryRow](_path, "modifieddate", Some("text"), Some("timestamp"), x => x.modifieddate, (row, value) => row.copy(modifieddate = value))
     }
   
-    override val columns: List[FieldLikeNoHkt[?, Row]] =
-      List[FieldLikeNoHkt[?, Row]](fields.businessentityid, fields.territoryid, fields.startdate, fields.enddate, fields.rowguid, fields.modifieddate)
+    override lazy val columns: List[FieldLikeNoHkt[?, SalesterritoryhistoryRow]] =
+      List[FieldLikeNoHkt[?, SalesterritoryhistoryRow]](fields.businessentityid, fields.territoryid, fields.startdate, fields.enddate, fields.rowguid, fields.modifieddate)
   
-    override def copy[NewRow](prefix: Option[String], extract: NewRow => SalesterritoryhistoryRow, merge: (NewRow, SalesterritoryhistoryRow) => NewRow): Impl[NewRow] =
-      new Impl(prefix, extract, merge)
+    override def copy(path: List[Path]): Impl =
+      new Impl(path)
   }
   
 }

--- a/typo-tester-zio-jdbc/generated-and-checked-in/adventureworks/sales/salesterritoryhistory/SalesterritoryhistoryRepoMock.scala
+++ b/typo-tester-zio-jdbc/generated-and-checked-in/adventureworks/sales/salesterritoryhistory/SalesterritoryhistoryRepoMock.scala
@@ -26,7 +26,7 @@ import zio.stream.ZStream
 class SalesterritoryhistoryRepoMock(toRow: Function1[SalesterritoryhistoryRowUnsaved, SalesterritoryhistoryRow],
                                     map: scala.collection.mutable.Map[SalesterritoryhistoryId, SalesterritoryhistoryRow] = scala.collection.mutable.Map.empty) extends SalesterritoryhistoryRepo {
   override def delete: DeleteBuilder[SalesterritoryhistoryFields, SalesterritoryhistoryRow] = {
-    DeleteBuilderMock(DeleteParams.empty, SalesterritoryhistoryFields.structure.fields, map)
+    DeleteBuilderMock(DeleteParams.empty, SalesterritoryhistoryFields.structure, map)
   }
   override def deleteById(compositeId: SalesterritoryhistoryId): ZIO[ZConnection, Throwable, Boolean] = {
     ZIO.succeed(map.remove(compositeId).isDefined)
@@ -85,7 +85,7 @@ class SalesterritoryhistoryRepoMock(toRow: Function1[SalesterritoryhistoryRowUns
     }
   }
   override def update: UpdateBuilder[SalesterritoryhistoryFields, SalesterritoryhistoryRow] = {
-    UpdateBuilderMock(UpdateParams.empty, SalesterritoryhistoryFields.structure.fields, map)
+    UpdateBuilderMock(UpdateParams.empty, SalesterritoryhistoryFields.structure, map)
   }
   override def update(row: SalesterritoryhistoryRow): ZIO[ZConnection, Throwable, Boolean] = {
     ZIO.succeed {

--- a/typo-tester-zio-jdbc/generated-and-checked-in/adventureworks/sales/shoppingcartitem/ShoppingcartitemFields.scala
+++ b/typo-tester-zio-jdbc/generated-and-checked-in/adventureworks/sales/shoppingcartitem/ShoppingcartitemFields.scala
@@ -9,41 +9,42 @@ package shoppingcartitem
 
 import adventureworks.customtypes.TypoLocalDateTime
 import adventureworks.production.product.ProductId
+import typo.dsl.Path
 import typo.dsl.SqlExpr.Field
 import typo.dsl.SqlExpr.FieldLikeNoHkt
 import typo.dsl.SqlExpr.IdField
 import typo.dsl.Structure.Relation
 
-trait ShoppingcartitemFields[Row] {
-  val shoppingcartitemid: IdField[ShoppingcartitemId, Row]
-  val shoppingcartid: Field[/* max 50 chars */ String, Row]
-  val quantity: Field[Int, Row]
-  val productid: Field[ProductId, Row]
-  val datecreated: Field[TypoLocalDateTime, Row]
-  val modifieddate: Field[TypoLocalDateTime, Row]
+trait ShoppingcartitemFields {
+  def shoppingcartitemid: IdField[ShoppingcartitemId, ShoppingcartitemRow]
+  def shoppingcartid: Field[/* max 50 chars */ String, ShoppingcartitemRow]
+  def quantity: Field[Int, ShoppingcartitemRow]
+  def productid: Field[ProductId, ShoppingcartitemRow]
+  def datecreated: Field[TypoLocalDateTime, ShoppingcartitemRow]
+  def modifieddate: Field[TypoLocalDateTime, ShoppingcartitemRow]
 }
 
 object ShoppingcartitemFields {
-  val structure: Relation[ShoppingcartitemFields, ShoppingcartitemRow, ShoppingcartitemRow] = 
-    new Impl(None, identity, (_, x) => x)
+  lazy val structure: Relation[ShoppingcartitemFields, ShoppingcartitemRow] =
+    new Impl(Nil)
     
-  private final class Impl[Row](val prefix: Option[String], val extract: Row => ShoppingcartitemRow, val merge: (Row, ShoppingcartitemRow) => Row)
-    extends Relation[ShoppingcartitemFields, ShoppingcartitemRow, Row] { 
+  private final class Impl(val _path: List[Path])
+    extends Relation[ShoppingcartitemFields, ShoppingcartitemRow] {
   
-    override val fields: ShoppingcartitemFields[Row] = new ShoppingcartitemFields[Row] {
-      override val shoppingcartitemid = new IdField[ShoppingcartitemId, Row](prefix, "shoppingcartitemid", None, Some("int4"))(x => extract(x).shoppingcartitemid, (row, value) => merge(row, extract(row).copy(shoppingcartitemid = value)))
-      override val shoppingcartid = new Field[/* max 50 chars */ String, Row](prefix, "shoppingcartid", None, None)(x => extract(x).shoppingcartid, (row, value) => merge(row, extract(row).copy(shoppingcartid = value)))
-      override val quantity = new Field[Int, Row](prefix, "quantity", None, Some("int4"))(x => extract(x).quantity, (row, value) => merge(row, extract(row).copy(quantity = value)))
-      override val productid = new Field[ProductId, Row](prefix, "productid", None, Some("int4"))(x => extract(x).productid, (row, value) => merge(row, extract(row).copy(productid = value)))
-      override val datecreated = new Field[TypoLocalDateTime, Row](prefix, "datecreated", Some("text"), Some("timestamp"))(x => extract(x).datecreated, (row, value) => merge(row, extract(row).copy(datecreated = value)))
-      override val modifieddate = new Field[TypoLocalDateTime, Row](prefix, "modifieddate", Some("text"), Some("timestamp"))(x => extract(x).modifieddate, (row, value) => merge(row, extract(row).copy(modifieddate = value)))
+    override lazy val fields: ShoppingcartitemFields = new ShoppingcartitemFields {
+      override def shoppingcartitemid = IdField[ShoppingcartitemId, ShoppingcartitemRow](_path, "shoppingcartitemid", None, Some("int4"), x => x.shoppingcartitemid, (row, value) => row.copy(shoppingcartitemid = value))
+      override def shoppingcartid = Field[/* max 50 chars */ String, ShoppingcartitemRow](_path, "shoppingcartid", None, None, x => x.shoppingcartid, (row, value) => row.copy(shoppingcartid = value))
+      override def quantity = Field[Int, ShoppingcartitemRow](_path, "quantity", None, Some("int4"), x => x.quantity, (row, value) => row.copy(quantity = value))
+      override def productid = Field[ProductId, ShoppingcartitemRow](_path, "productid", None, Some("int4"), x => x.productid, (row, value) => row.copy(productid = value))
+      override def datecreated = Field[TypoLocalDateTime, ShoppingcartitemRow](_path, "datecreated", Some("text"), Some("timestamp"), x => x.datecreated, (row, value) => row.copy(datecreated = value))
+      override def modifieddate = Field[TypoLocalDateTime, ShoppingcartitemRow](_path, "modifieddate", Some("text"), Some("timestamp"), x => x.modifieddate, (row, value) => row.copy(modifieddate = value))
     }
   
-    override val columns: List[FieldLikeNoHkt[?, Row]] =
-      List[FieldLikeNoHkt[?, Row]](fields.shoppingcartitemid, fields.shoppingcartid, fields.quantity, fields.productid, fields.datecreated, fields.modifieddate)
+    override lazy val columns: List[FieldLikeNoHkt[?, ShoppingcartitemRow]] =
+      List[FieldLikeNoHkt[?, ShoppingcartitemRow]](fields.shoppingcartitemid, fields.shoppingcartid, fields.quantity, fields.productid, fields.datecreated, fields.modifieddate)
   
-    override def copy[NewRow](prefix: Option[String], extract: NewRow => ShoppingcartitemRow, merge: (NewRow, ShoppingcartitemRow) => NewRow): Impl[NewRow] =
-      new Impl(prefix, extract, merge)
+    override def copy(path: List[Path]): Impl =
+      new Impl(path)
   }
   
 }

--- a/typo-tester-zio-jdbc/generated-and-checked-in/adventureworks/sales/shoppingcartitem/ShoppingcartitemRepoMock.scala
+++ b/typo-tester-zio-jdbc/generated-and-checked-in/adventureworks/sales/shoppingcartitem/ShoppingcartitemRepoMock.scala
@@ -26,7 +26,7 @@ import zio.stream.ZStream
 class ShoppingcartitemRepoMock(toRow: Function1[ShoppingcartitemRowUnsaved, ShoppingcartitemRow],
                                map: scala.collection.mutable.Map[ShoppingcartitemId, ShoppingcartitemRow] = scala.collection.mutable.Map.empty) extends ShoppingcartitemRepo {
   override def delete: DeleteBuilder[ShoppingcartitemFields, ShoppingcartitemRow] = {
-    DeleteBuilderMock(DeleteParams.empty, ShoppingcartitemFields.structure.fields, map)
+    DeleteBuilderMock(DeleteParams.empty, ShoppingcartitemFields.structure, map)
   }
   override def deleteById(shoppingcartitemid: ShoppingcartitemId): ZIO[ZConnection, Throwable, Boolean] = {
     ZIO.succeed(map.remove(shoppingcartitemid).isDefined)
@@ -85,7 +85,7 @@ class ShoppingcartitemRepoMock(toRow: Function1[ShoppingcartitemRowUnsaved, Shop
     }
   }
   override def update: UpdateBuilder[ShoppingcartitemFields, ShoppingcartitemRow] = {
-    UpdateBuilderMock(UpdateParams.empty, ShoppingcartitemFields.structure.fields, map)
+    UpdateBuilderMock(UpdateParams.empty, ShoppingcartitemFields.structure, map)
   }
   override def update(row: ShoppingcartitemRow): ZIO[ZConnection, Throwable, Boolean] = {
     ZIO.succeed {

--- a/typo-tester-zio-jdbc/generated-and-checked-in/adventureworks/sales/specialoffer/SpecialofferFields.scala
+++ b/typo-tester-zio-jdbc/generated-and-checked-in/adventureworks/sales/specialoffer/SpecialofferFields.scala
@@ -9,52 +9,53 @@ package specialoffer
 
 import adventureworks.customtypes.TypoLocalDateTime
 import adventureworks.customtypes.TypoUUID
+import typo.dsl.Path
 import typo.dsl.SqlExpr.Field
 import typo.dsl.SqlExpr.FieldLikeNoHkt
 import typo.dsl.SqlExpr.IdField
 import typo.dsl.SqlExpr.OptField
 import typo.dsl.Structure.Relation
 
-trait SpecialofferFields[Row] {
-  val specialofferid: IdField[SpecialofferId, Row]
-  val description: Field[/* max 255 chars */ String, Row]
-  val discountpct: Field[BigDecimal, Row]
-  val `type`: Field[/* max 50 chars */ String, Row]
-  val category: Field[/* max 50 chars */ String, Row]
-  val startdate: Field[TypoLocalDateTime, Row]
-  val enddate: Field[TypoLocalDateTime, Row]
-  val minqty: Field[Int, Row]
-  val maxqty: OptField[Int, Row]
-  val rowguid: Field[TypoUUID, Row]
-  val modifieddate: Field[TypoLocalDateTime, Row]
+trait SpecialofferFields {
+  def specialofferid: IdField[SpecialofferId, SpecialofferRow]
+  def description: Field[/* max 255 chars */ String, SpecialofferRow]
+  def discountpct: Field[BigDecimal, SpecialofferRow]
+  def `type`: Field[/* max 50 chars */ String, SpecialofferRow]
+  def category: Field[/* max 50 chars */ String, SpecialofferRow]
+  def startdate: Field[TypoLocalDateTime, SpecialofferRow]
+  def enddate: Field[TypoLocalDateTime, SpecialofferRow]
+  def minqty: Field[Int, SpecialofferRow]
+  def maxqty: OptField[Int, SpecialofferRow]
+  def rowguid: Field[TypoUUID, SpecialofferRow]
+  def modifieddate: Field[TypoLocalDateTime, SpecialofferRow]
 }
 
 object SpecialofferFields {
-  val structure: Relation[SpecialofferFields, SpecialofferRow, SpecialofferRow] = 
-    new Impl(None, identity, (_, x) => x)
+  lazy val structure: Relation[SpecialofferFields, SpecialofferRow] =
+    new Impl(Nil)
     
-  private final class Impl[Row](val prefix: Option[String], val extract: Row => SpecialofferRow, val merge: (Row, SpecialofferRow) => Row)
-    extends Relation[SpecialofferFields, SpecialofferRow, Row] { 
+  private final class Impl(val _path: List[Path])
+    extends Relation[SpecialofferFields, SpecialofferRow] {
   
-    override val fields: SpecialofferFields[Row] = new SpecialofferFields[Row] {
-      override val specialofferid = new IdField[SpecialofferId, Row](prefix, "specialofferid", None, Some("int4"))(x => extract(x).specialofferid, (row, value) => merge(row, extract(row).copy(specialofferid = value)))
-      override val description = new Field[/* max 255 chars */ String, Row](prefix, "description", None, None)(x => extract(x).description, (row, value) => merge(row, extract(row).copy(description = value)))
-      override val discountpct = new Field[BigDecimal, Row](prefix, "discountpct", None, Some("numeric"))(x => extract(x).discountpct, (row, value) => merge(row, extract(row).copy(discountpct = value)))
-      override val `type` = new Field[/* max 50 chars */ String, Row](prefix, "type", None, None)(x => extract(x).`type`, (row, value) => merge(row, extract(row).copy(`type` = value)))
-      override val category = new Field[/* max 50 chars */ String, Row](prefix, "category", None, None)(x => extract(x).category, (row, value) => merge(row, extract(row).copy(category = value)))
-      override val startdate = new Field[TypoLocalDateTime, Row](prefix, "startdate", Some("text"), Some("timestamp"))(x => extract(x).startdate, (row, value) => merge(row, extract(row).copy(startdate = value)))
-      override val enddate = new Field[TypoLocalDateTime, Row](prefix, "enddate", Some("text"), Some("timestamp"))(x => extract(x).enddate, (row, value) => merge(row, extract(row).copy(enddate = value)))
-      override val minqty = new Field[Int, Row](prefix, "minqty", None, Some("int4"))(x => extract(x).minqty, (row, value) => merge(row, extract(row).copy(minqty = value)))
-      override val maxqty = new OptField[Int, Row](prefix, "maxqty", None, Some("int4"))(x => extract(x).maxqty, (row, value) => merge(row, extract(row).copy(maxqty = value)))
-      override val rowguid = new Field[TypoUUID, Row](prefix, "rowguid", None, Some("uuid"))(x => extract(x).rowguid, (row, value) => merge(row, extract(row).copy(rowguid = value)))
-      override val modifieddate = new Field[TypoLocalDateTime, Row](prefix, "modifieddate", Some("text"), Some("timestamp"))(x => extract(x).modifieddate, (row, value) => merge(row, extract(row).copy(modifieddate = value)))
+    override lazy val fields: SpecialofferFields = new SpecialofferFields {
+      override def specialofferid = IdField[SpecialofferId, SpecialofferRow](_path, "specialofferid", None, Some("int4"), x => x.specialofferid, (row, value) => row.copy(specialofferid = value))
+      override def description = Field[/* max 255 chars */ String, SpecialofferRow](_path, "description", None, None, x => x.description, (row, value) => row.copy(description = value))
+      override def discountpct = Field[BigDecimal, SpecialofferRow](_path, "discountpct", None, Some("numeric"), x => x.discountpct, (row, value) => row.copy(discountpct = value))
+      override def `type` = Field[/* max 50 chars */ String, SpecialofferRow](_path, "type", None, None, x => x.`type`, (row, value) => row.copy(`type` = value))
+      override def category = Field[/* max 50 chars */ String, SpecialofferRow](_path, "category", None, None, x => x.category, (row, value) => row.copy(category = value))
+      override def startdate = Field[TypoLocalDateTime, SpecialofferRow](_path, "startdate", Some("text"), Some("timestamp"), x => x.startdate, (row, value) => row.copy(startdate = value))
+      override def enddate = Field[TypoLocalDateTime, SpecialofferRow](_path, "enddate", Some("text"), Some("timestamp"), x => x.enddate, (row, value) => row.copy(enddate = value))
+      override def minqty = Field[Int, SpecialofferRow](_path, "minqty", None, Some("int4"), x => x.minqty, (row, value) => row.copy(minqty = value))
+      override def maxqty = OptField[Int, SpecialofferRow](_path, "maxqty", None, Some("int4"), x => x.maxqty, (row, value) => row.copy(maxqty = value))
+      override def rowguid = Field[TypoUUID, SpecialofferRow](_path, "rowguid", None, Some("uuid"), x => x.rowguid, (row, value) => row.copy(rowguid = value))
+      override def modifieddate = Field[TypoLocalDateTime, SpecialofferRow](_path, "modifieddate", Some("text"), Some("timestamp"), x => x.modifieddate, (row, value) => row.copy(modifieddate = value))
     }
   
-    override val columns: List[FieldLikeNoHkt[?, Row]] =
-      List[FieldLikeNoHkt[?, Row]](fields.specialofferid, fields.description, fields.discountpct, fields.`type`, fields.category, fields.startdate, fields.enddate, fields.minqty, fields.maxqty, fields.rowguid, fields.modifieddate)
+    override lazy val columns: List[FieldLikeNoHkt[?, SpecialofferRow]] =
+      List[FieldLikeNoHkt[?, SpecialofferRow]](fields.specialofferid, fields.description, fields.discountpct, fields.`type`, fields.category, fields.startdate, fields.enddate, fields.minqty, fields.maxqty, fields.rowguid, fields.modifieddate)
   
-    override def copy[NewRow](prefix: Option[String], extract: NewRow => SpecialofferRow, merge: (NewRow, SpecialofferRow) => NewRow): Impl[NewRow] =
-      new Impl(prefix, extract, merge)
+    override def copy(path: List[Path]): Impl =
+      new Impl(path)
   }
   
 }

--- a/typo-tester-zio-jdbc/generated-and-checked-in/adventureworks/sales/specialoffer/SpecialofferRepoMock.scala
+++ b/typo-tester-zio-jdbc/generated-and-checked-in/adventureworks/sales/specialoffer/SpecialofferRepoMock.scala
@@ -26,7 +26,7 @@ import zio.stream.ZStream
 class SpecialofferRepoMock(toRow: Function1[SpecialofferRowUnsaved, SpecialofferRow],
                            map: scala.collection.mutable.Map[SpecialofferId, SpecialofferRow] = scala.collection.mutable.Map.empty) extends SpecialofferRepo {
   override def delete: DeleteBuilder[SpecialofferFields, SpecialofferRow] = {
-    DeleteBuilderMock(DeleteParams.empty, SpecialofferFields.structure.fields, map)
+    DeleteBuilderMock(DeleteParams.empty, SpecialofferFields.structure, map)
   }
   override def deleteById(specialofferid: SpecialofferId): ZIO[ZConnection, Throwable, Boolean] = {
     ZIO.succeed(map.remove(specialofferid).isDefined)
@@ -85,7 +85,7 @@ class SpecialofferRepoMock(toRow: Function1[SpecialofferRowUnsaved, Specialoffer
     }
   }
   override def update: UpdateBuilder[SpecialofferFields, SpecialofferRow] = {
-    UpdateBuilderMock(UpdateParams.empty, SpecialofferFields.structure.fields, map)
+    UpdateBuilderMock(UpdateParams.empty, SpecialofferFields.structure, map)
   }
   override def update(row: SpecialofferRow): ZIO[ZConnection, Throwable, Boolean] = {
     ZIO.succeed {

--- a/typo-tester-zio-jdbc/generated-and-checked-in/adventureworks/sales/specialofferproduct/SpecialofferproductFields.scala
+++ b/typo-tester-zio-jdbc/generated-and-checked-in/adventureworks/sales/specialofferproduct/SpecialofferproductFields.scala
@@ -11,37 +11,38 @@ import adventureworks.customtypes.TypoLocalDateTime
 import adventureworks.customtypes.TypoUUID
 import adventureworks.production.product.ProductId
 import adventureworks.sales.specialoffer.SpecialofferId
+import typo.dsl.Path
 import typo.dsl.SqlExpr.Field
 import typo.dsl.SqlExpr.FieldLikeNoHkt
 import typo.dsl.SqlExpr.IdField
 import typo.dsl.Structure.Relation
 
-trait SpecialofferproductFields[Row] {
-  val specialofferid: IdField[SpecialofferId, Row]
-  val productid: IdField[ProductId, Row]
-  val rowguid: Field[TypoUUID, Row]
-  val modifieddate: Field[TypoLocalDateTime, Row]
+trait SpecialofferproductFields {
+  def specialofferid: IdField[SpecialofferId, SpecialofferproductRow]
+  def productid: IdField[ProductId, SpecialofferproductRow]
+  def rowguid: Field[TypoUUID, SpecialofferproductRow]
+  def modifieddate: Field[TypoLocalDateTime, SpecialofferproductRow]
 }
 
 object SpecialofferproductFields {
-  val structure: Relation[SpecialofferproductFields, SpecialofferproductRow, SpecialofferproductRow] = 
-    new Impl(None, identity, (_, x) => x)
+  lazy val structure: Relation[SpecialofferproductFields, SpecialofferproductRow] =
+    new Impl(Nil)
     
-  private final class Impl[Row](val prefix: Option[String], val extract: Row => SpecialofferproductRow, val merge: (Row, SpecialofferproductRow) => Row)
-    extends Relation[SpecialofferproductFields, SpecialofferproductRow, Row] { 
+  private final class Impl(val _path: List[Path])
+    extends Relation[SpecialofferproductFields, SpecialofferproductRow] {
   
-    override val fields: SpecialofferproductFields[Row] = new SpecialofferproductFields[Row] {
-      override val specialofferid = new IdField[SpecialofferId, Row](prefix, "specialofferid", None, Some("int4"))(x => extract(x).specialofferid, (row, value) => merge(row, extract(row).copy(specialofferid = value)))
-      override val productid = new IdField[ProductId, Row](prefix, "productid", None, Some("int4"))(x => extract(x).productid, (row, value) => merge(row, extract(row).copy(productid = value)))
-      override val rowguid = new Field[TypoUUID, Row](prefix, "rowguid", None, Some("uuid"))(x => extract(x).rowguid, (row, value) => merge(row, extract(row).copy(rowguid = value)))
-      override val modifieddate = new Field[TypoLocalDateTime, Row](prefix, "modifieddate", Some("text"), Some("timestamp"))(x => extract(x).modifieddate, (row, value) => merge(row, extract(row).copy(modifieddate = value)))
+    override lazy val fields: SpecialofferproductFields = new SpecialofferproductFields {
+      override def specialofferid = IdField[SpecialofferId, SpecialofferproductRow](_path, "specialofferid", None, Some("int4"), x => x.specialofferid, (row, value) => row.copy(specialofferid = value))
+      override def productid = IdField[ProductId, SpecialofferproductRow](_path, "productid", None, Some("int4"), x => x.productid, (row, value) => row.copy(productid = value))
+      override def rowguid = Field[TypoUUID, SpecialofferproductRow](_path, "rowguid", None, Some("uuid"), x => x.rowguid, (row, value) => row.copy(rowguid = value))
+      override def modifieddate = Field[TypoLocalDateTime, SpecialofferproductRow](_path, "modifieddate", Some("text"), Some("timestamp"), x => x.modifieddate, (row, value) => row.copy(modifieddate = value))
     }
   
-    override val columns: List[FieldLikeNoHkt[?, Row]] =
-      List[FieldLikeNoHkt[?, Row]](fields.specialofferid, fields.productid, fields.rowguid, fields.modifieddate)
+    override lazy val columns: List[FieldLikeNoHkt[?, SpecialofferproductRow]] =
+      List[FieldLikeNoHkt[?, SpecialofferproductRow]](fields.specialofferid, fields.productid, fields.rowguid, fields.modifieddate)
   
-    override def copy[NewRow](prefix: Option[String], extract: NewRow => SpecialofferproductRow, merge: (NewRow, SpecialofferproductRow) => NewRow): Impl[NewRow] =
-      new Impl(prefix, extract, merge)
+    override def copy(path: List[Path]): Impl =
+      new Impl(path)
   }
   
 }

--- a/typo-tester-zio-jdbc/generated-and-checked-in/adventureworks/sales/specialofferproduct/SpecialofferproductRepoMock.scala
+++ b/typo-tester-zio-jdbc/generated-and-checked-in/adventureworks/sales/specialofferproduct/SpecialofferproductRepoMock.scala
@@ -26,7 +26,7 @@ import zio.stream.ZStream
 class SpecialofferproductRepoMock(toRow: Function1[SpecialofferproductRowUnsaved, SpecialofferproductRow],
                                   map: scala.collection.mutable.Map[SpecialofferproductId, SpecialofferproductRow] = scala.collection.mutable.Map.empty) extends SpecialofferproductRepo {
   override def delete: DeleteBuilder[SpecialofferproductFields, SpecialofferproductRow] = {
-    DeleteBuilderMock(DeleteParams.empty, SpecialofferproductFields.structure.fields, map)
+    DeleteBuilderMock(DeleteParams.empty, SpecialofferproductFields.structure, map)
   }
   override def deleteById(compositeId: SpecialofferproductId): ZIO[ZConnection, Throwable, Boolean] = {
     ZIO.succeed(map.remove(compositeId).isDefined)
@@ -85,7 +85,7 @@ class SpecialofferproductRepoMock(toRow: Function1[SpecialofferproductRowUnsaved
     }
   }
   override def update: UpdateBuilder[SpecialofferproductFields, SpecialofferproductRow] = {
-    UpdateBuilderMock(UpdateParams.empty, SpecialofferproductFields.structure.fields, map)
+    UpdateBuilderMock(UpdateParams.empty, SpecialofferproductFields.structure, map)
   }
   override def update(row: SpecialofferproductRow): ZIO[ZConnection, Throwable, Boolean] = {
     ZIO.succeed {

--- a/typo-tester-zio-jdbc/generated-and-checked-in/adventureworks/sales/store/StoreRepoMock.scala
+++ b/typo-tester-zio-jdbc/generated-and-checked-in/adventureworks/sales/store/StoreRepoMock.scala
@@ -27,7 +27,7 @@ import zio.stream.ZStream
 class StoreRepoMock(toRow: Function1[StoreRowUnsaved, StoreRow],
                     map: scala.collection.mutable.Map[BusinessentityId, StoreRow] = scala.collection.mutable.Map.empty) extends StoreRepo {
   override def delete: DeleteBuilder[StoreFields, StoreRow] = {
-    DeleteBuilderMock(DeleteParams.empty, StoreFields.structure.fields, map)
+    DeleteBuilderMock(DeleteParams.empty, StoreFields.structure, map)
   }
   override def deleteById(businessentityid: BusinessentityId): ZIO[ZConnection, Throwable, Boolean] = {
     ZIO.succeed(map.remove(businessentityid).isDefined)
@@ -86,7 +86,7 @@ class StoreRepoMock(toRow: Function1[StoreRowUnsaved, StoreRow],
     }
   }
   override def update: UpdateBuilder[StoreFields, StoreRow] = {
-    UpdateBuilderMock(UpdateParams.empty, StoreFields.structure.fields, map)
+    UpdateBuilderMock(UpdateParams.empty, StoreFields.structure, map)
   }
   override def update(row: StoreRow): ZIO[ZConnection, Throwable, Boolean] = {
     ZIO.succeed {

--- a/typo-tester-zio-jdbc/generated-and-checked-in/adventureworks/sales/vindividualcustomer/VindividualcustomerViewFields.scala
+++ b/typo-tester-zio-jdbc/generated-and-checked-in/adventureworks/sales/vindividualcustomer/VindividualcustomerViewFields.scala
@@ -12,65 +12,66 @@ import adventureworks.person.businessentity.BusinessentityId
 import adventureworks.public.Name
 import adventureworks.public.Phone
 import adventureworks.userdefined.FirstName
+import typo.dsl.Path
 import typo.dsl.SqlExpr.Field
 import typo.dsl.SqlExpr.FieldLikeNoHkt
 import typo.dsl.SqlExpr.OptField
 import typo.dsl.Structure.Relation
 
-trait VindividualcustomerViewFields[Row] {
-  val businessentityid: Field[BusinessentityId, Row]
-  val title: OptField[/* max 8 chars */ String, Row]
-  val firstname: Field[/* user-picked */ FirstName, Row]
-  val middlename: OptField[Name, Row]
-  val lastname: Field[Name, Row]
-  val suffix: OptField[/* max 10 chars */ String, Row]
-  val phonenumber: OptField[Phone, Row]
-  val phonenumbertype: OptField[Name, Row]
-  val emailaddress: OptField[/* max 50 chars */ String, Row]
-  val emailpromotion: Field[Int, Row]
-  val addresstype: Field[Name, Row]
-  val addressline1: Field[/* max 60 chars */ String, Row]
-  val addressline2: OptField[/* max 60 chars */ String, Row]
-  val city: Field[/* max 30 chars */ String, Row]
-  val stateprovincename: Field[Name, Row]
-  val postalcode: Field[/* max 15 chars */ String, Row]
-  val countryregionname: Field[Name, Row]
-  val demographics: OptField[TypoXml, Row]
+trait VindividualcustomerViewFields {
+  def businessentityid: Field[BusinessentityId, VindividualcustomerViewRow]
+  def title: OptField[/* max 8 chars */ String, VindividualcustomerViewRow]
+  def firstname: Field[/* user-picked */ FirstName, VindividualcustomerViewRow]
+  def middlename: OptField[Name, VindividualcustomerViewRow]
+  def lastname: Field[Name, VindividualcustomerViewRow]
+  def suffix: OptField[/* max 10 chars */ String, VindividualcustomerViewRow]
+  def phonenumber: OptField[Phone, VindividualcustomerViewRow]
+  def phonenumbertype: OptField[Name, VindividualcustomerViewRow]
+  def emailaddress: OptField[/* max 50 chars */ String, VindividualcustomerViewRow]
+  def emailpromotion: Field[Int, VindividualcustomerViewRow]
+  def addresstype: Field[Name, VindividualcustomerViewRow]
+  def addressline1: Field[/* max 60 chars */ String, VindividualcustomerViewRow]
+  def addressline2: OptField[/* max 60 chars */ String, VindividualcustomerViewRow]
+  def city: Field[/* max 30 chars */ String, VindividualcustomerViewRow]
+  def stateprovincename: Field[Name, VindividualcustomerViewRow]
+  def postalcode: Field[/* max 15 chars */ String, VindividualcustomerViewRow]
+  def countryregionname: Field[Name, VindividualcustomerViewRow]
+  def demographics: OptField[TypoXml, VindividualcustomerViewRow]
 }
 
 object VindividualcustomerViewFields {
-  val structure: Relation[VindividualcustomerViewFields, VindividualcustomerViewRow, VindividualcustomerViewRow] = 
-    new Impl(None, identity, (_, x) => x)
+  lazy val structure: Relation[VindividualcustomerViewFields, VindividualcustomerViewRow] =
+    new Impl(Nil)
     
-  private final class Impl[Row](val prefix: Option[String], val extract: Row => VindividualcustomerViewRow, val merge: (Row, VindividualcustomerViewRow) => Row)
-    extends Relation[VindividualcustomerViewFields, VindividualcustomerViewRow, Row] { 
+  private final class Impl(val _path: List[Path])
+    extends Relation[VindividualcustomerViewFields, VindividualcustomerViewRow] {
   
-    override val fields: VindividualcustomerViewFields[Row] = new VindividualcustomerViewFields[Row] {
-      override val businessentityid = new Field[BusinessentityId, Row](prefix, "businessentityid", None, None)(x => extract(x).businessentityid, (row, value) => merge(row, extract(row).copy(businessentityid = value)))
-      override val title = new OptField[/* max 8 chars */ String, Row](prefix, "title", None, None)(x => extract(x).title, (row, value) => merge(row, extract(row).copy(title = value)))
-      override val firstname = new Field[/* user-picked */ FirstName, Row](prefix, "firstname", None, None)(x => extract(x).firstname, (row, value) => merge(row, extract(row).copy(firstname = value)))
-      override val middlename = new OptField[Name, Row](prefix, "middlename", None, None)(x => extract(x).middlename, (row, value) => merge(row, extract(row).copy(middlename = value)))
-      override val lastname = new Field[Name, Row](prefix, "lastname", None, None)(x => extract(x).lastname, (row, value) => merge(row, extract(row).copy(lastname = value)))
-      override val suffix = new OptField[/* max 10 chars */ String, Row](prefix, "suffix", None, None)(x => extract(x).suffix, (row, value) => merge(row, extract(row).copy(suffix = value)))
-      override val phonenumber = new OptField[Phone, Row](prefix, "phonenumber", None, None)(x => extract(x).phonenumber, (row, value) => merge(row, extract(row).copy(phonenumber = value)))
-      override val phonenumbertype = new OptField[Name, Row](prefix, "phonenumbertype", None, None)(x => extract(x).phonenumbertype, (row, value) => merge(row, extract(row).copy(phonenumbertype = value)))
-      override val emailaddress = new OptField[/* max 50 chars */ String, Row](prefix, "emailaddress", None, None)(x => extract(x).emailaddress, (row, value) => merge(row, extract(row).copy(emailaddress = value)))
-      override val emailpromotion = new Field[Int, Row](prefix, "emailpromotion", None, None)(x => extract(x).emailpromotion, (row, value) => merge(row, extract(row).copy(emailpromotion = value)))
-      override val addresstype = new Field[Name, Row](prefix, "addresstype", None, None)(x => extract(x).addresstype, (row, value) => merge(row, extract(row).copy(addresstype = value)))
-      override val addressline1 = new Field[/* max 60 chars */ String, Row](prefix, "addressline1", None, None)(x => extract(x).addressline1, (row, value) => merge(row, extract(row).copy(addressline1 = value)))
-      override val addressline2 = new OptField[/* max 60 chars */ String, Row](prefix, "addressline2", None, None)(x => extract(x).addressline2, (row, value) => merge(row, extract(row).copy(addressline2 = value)))
-      override val city = new Field[/* max 30 chars */ String, Row](prefix, "city", None, None)(x => extract(x).city, (row, value) => merge(row, extract(row).copy(city = value)))
-      override val stateprovincename = new Field[Name, Row](prefix, "stateprovincename", None, None)(x => extract(x).stateprovincename, (row, value) => merge(row, extract(row).copy(stateprovincename = value)))
-      override val postalcode = new Field[/* max 15 chars */ String, Row](prefix, "postalcode", None, None)(x => extract(x).postalcode, (row, value) => merge(row, extract(row).copy(postalcode = value)))
-      override val countryregionname = new Field[Name, Row](prefix, "countryregionname", None, None)(x => extract(x).countryregionname, (row, value) => merge(row, extract(row).copy(countryregionname = value)))
-      override val demographics = new OptField[TypoXml, Row](prefix, "demographics", None, None)(x => extract(x).demographics, (row, value) => merge(row, extract(row).copy(demographics = value)))
+    override lazy val fields: VindividualcustomerViewFields = new VindividualcustomerViewFields {
+      override def businessentityid = Field[BusinessentityId, VindividualcustomerViewRow](_path, "businessentityid", None, None, x => x.businessentityid, (row, value) => row.copy(businessentityid = value))
+      override def title = OptField[/* max 8 chars */ String, VindividualcustomerViewRow](_path, "title", None, None, x => x.title, (row, value) => row.copy(title = value))
+      override def firstname = Field[/* user-picked */ FirstName, VindividualcustomerViewRow](_path, "firstname", None, None, x => x.firstname, (row, value) => row.copy(firstname = value))
+      override def middlename = OptField[Name, VindividualcustomerViewRow](_path, "middlename", None, None, x => x.middlename, (row, value) => row.copy(middlename = value))
+      override def lastname = Field[Name, VindividualcustomerViewRow](_path, "lastname", None, None, x => x.lastname, (row, value) => row.copy(lastname = value))
+      override def suffix = OptField[/* max 10 chars */ String, VindividualcustomerViewRow](_path, "suffix", None, None, x => x.suffix, (row, value) => row.copy(suffix = value))
+      override def phonenumber = OptField[Phone, VindividualcustomerViewRow](_path, "phonenumber", None, None, x => x.phonenumber, (row, value) => row.copy(phonenumber = value))
+      override def phonenumbertype = OptField[Name, VindividualcustomerViewRow](_path, "phonenumbertype", None, None, x => x.phonenumbertype, (row, value) => row.copy(phonenumbertype = value))
+      override def emailaddress = OptField[/* max 50 chars */ String, VindividualcustomerViewRow](_path, "emailaddress", None, None, x => x.emailaddress, (row, value) => row.copy(emailaddress = value))
+      override def emailpromotion = Field[Int, VindividualcustomerViewRow](_path, "emailpromotion", None, None, x => x.emailpromotion, (row, value) => row.copy(emailpromotion = value))
+      override def addresstype = Field[Name, VindividualcustomerViewRow](_path, "addresstype", None, None, x => x.addresstype, (row, value) => row.copy(addresstype = value))
+      override def addressline1 = Field[/* max 60 chars */ String, VindividualcustomerViewRow](_path, "addressline1", None, None, x => x.addressline1, (row, value) => row.copy(addressline1 = value))
+      override def addressline2 = OptField[/* max 60 chars */ String, VindividualcustomerViewRow](_path, "addressline2", None, None, x => x.addressline2, (row, value) => row.copy(addressline2 = value))
+      override def city = Field[/* max 30 chars */ String, VindividualcustomerViewRow](_path, "city", None, None, x => x.city, (row, value) => row.copy(city = value))
+      override def stateprovincename = Field[Name, VindividualcustomerViewRow](_path, "stateprovincename", None, None, x => x.stateprovincename, (row, value) => row.copy(stateprovincename = value))
+      override def postalcode = Field[/* max 15 chars */ String, VindividualcustomerViewRow](_path, "postalcode", None, None, x => x.postalcode, (row, value) => row.copy(postalcode = value))
+      override def countryregionname = Field[Name, VindividualcustomerViewRow](_path, "countryregionname", None, None, x => x.countryregionname, (row, value) => row.copy(countryregionname = value))
+      override def demographics = OptField[TypoXml, VindividualcustomerViewRow](_path, "demographics", None, None, x => x.demographics, (row, value) => row.copy(demographics = value))
     }
   
-    override val columns: List[FieldLikeNoHkt[?, Row]] =
-      List[FieldLikeNoHkt[?, Row]](fields.businessentityid, fields.title, fields.firstname, fields.middlename, fields.lastname, fields.suffix, fields.phonenumber, fields.phonenumbertype, fields.emailaddress, fields.emailpromotion, fields.addresstype, fields.addressline1, fields.addressline2, fields.city, fields.stateprovincename, fields.postalcode, fields.countryregionname, fields.demographics)
+    override lazy val columns: List[FieldLikeNoHkt[?, VindividualcustomerViewRow]] =
+      List[FieldLikeNoHkt[?, VindividualcustomerViewRow]](fields.businessentityid, fields.title, fields.firstname, fields.middlename, fields.lastname, fields.suffix, fields.phonenumber, fields.phonenumbertype, fields.emailaddress, fields.emailpromotion, fields.addresstype, fields.addressline1, fields.addressline2, fields.city, fields.stateprovincename, fields.postalcode, fields.countryregionname, fields.demographics)
   
-    override def copy[NewRow](prefix: Option[String], extract: NewRow => VindividualcustomerViewRow, merge: (NewRow, VindividualcustomerViewRow) => NewRow): Impl[NewRow] =
-      new Impl(prefix, extract, merge)
+    override def copy(path: List[Path]): Impl =
+      new Impl(path)
   }
   
 }

--- a/typo-tester-zio-jdbc/generated-and-checked-in/adventureworks/sales/vpersondemographics/VpersondemographicsViewFields.scala
+++ b/typo-tester-zio-jdbc/generated-and-checked-in/adventureworks/sales/vpersondemographics/VpersondemographicsViewFields.scala
@@ -10,55 +10,56 @@ package vpersondemographics
 import adventureworks.customtypes.TypoLocalDate
 import adventureworks.customtypes.TypoMoney
 import adventureworks.person.businessentity.BusinessentityId
+import typo.dsl.Path
 import typo.dsl.SqlExpr.Field
 import typo.dsl.SqlExpr.FieldLikeNoHkt
 import typo.dsl.SqlExpr.OptField
 import typo.dsl.Structure.Relation
 
-trait VpersondemographicsViewFields[Row] {
-  val businessentityid: Field[BusinessentityId, Row]
-  val totalpurchaseytd: OptField[TypoMoney, Row]
-  val datefirstpurchase: OptField[TypoLocalDate, Row]
-  val birthdate: OptField[TypoLocalDate, Row]
-  val maritalstatus: OptField[/* max 1 chars */ String, Row]
-  val yearlyincome: OptField[/* max 30 chars */ String, Row]
-  val gender: OptField[/* max 1 chars */ String, Row]
-  val totalchildren: OptField[Int, Row]
-  val numberchildrenathome: OptField[Int, Row]
-  val education: OptField[/* max 30 chars */ String, Row]
-  val occupation: OptField[/* max 30 chars */ String, Row]
-  val homeownerflag: OptField[Boolean, Row]
-  val numbercarsowned: OptField[Int, Row]
+trait VpersondemographicsViewFields {
+  def businessentityid: Field[BusinessentityId, VpersondemographicsViewRow]
+  def totalpurchaseytd: OptField[TypoMoney, VpersondemographicsViewRow]
+  def datefirstpurchase: OptField[TypoLocalDate, VpersondemographicsViewRow]
+  def birthdate: OptField[TypoLocalDate, VpersondemographicsViewRow]
+  def maritalstatus: OptField[/* max 1 chars */ String, VpersondemographicsViewRow]
+  def yearlyincome: OptField[/* max 30 chars */ String, VpersondemographicsViewRow]
+  def gender: OptField[/* max 1 chars */ String, VpersondemographicsViewRow]
+  def totalchildren: OptField[Int, VpersondemographicsViewRow]
+  def numberchildrenathome: OptField[Int, VpersondemographicsViewRow]
+  def education: OptField[/* max 30 chars */ String, VpersondemographicsViewRow]
+  def occupation: OptField[/* max 30 chars */ String, VpersondemographicsViewRow]
+  def homeownerflag: OptField[Boolean, VpersondemographicsViewRow]
+  def numbercarsowned: OptField[Int, VpersondemographicsViewRow]
 }
 
 object VpersondemographicsViewFields {
-  val structure: Relation[VpersondemographicsViewFields, VpersondemographicsViewRow, VpersondemographicsViewRow] = 
-    new Impl(None, identity, (_, x) => x)
+  lazy val structure: Relation[VpersondemographicsViewFields, VpersondemographicsViewRow] =
+    new Impl(Nil)
     
-  private final class Impl[Row](val prefix: Option[String], val extract: Row => VpersondemographicsViewRow, val merge: (Row, VpersondemographicsViewRow) => Row)
-    extends Relation[VpersondemographicsViewFields, VpersondemographicsViewRow, Row] { 
+  private final class Impl(val _path: List[Path])
+    extends Relation[VpersondemographicsViewFields, VpersondemographicsViewRow] {
   
-    override val fields: VpersondemographicsViewFields[Row] = new VpersondemographicsViewFields[Row] {
-      override val businessentityid = new Field[BusinessentityId, Row](prefix, "businessentityid", None, None)(x => extract(x).businessentityid, (row, value) => merge(row, extract(row).copy(businessentityid = value)))
-      override val totalpurchaseytd = new OptField[TypoMoney, Row](prefix, "totalpurchaseytd", Some("numeric"), None)(x => extract(x).totalpurchaseytd, (row, value) => merge(row, extract(row).copy(totalpurchaseytd = value)))
-      override val datefirstpurchase = new OptField[TypoLocalDate, Row](prefix, "datefirstpurchase", Some("text"), None)(x => extract(x).datefirstpurchase, (row, value) => merge(row, extract(row).copy(datefirstpurchase = value)))
-      override val birthdate = new OptField[TypoLocalDate, Row](prefix, "birthdate", Some("text"), None)(x => extract(x).birthdate, (row, value) => merge(row, extract(row).copy(birthdate = value)))
-      override val maritalstatus = new OptField[/* max 1 chars */ String, Row](prefix, "maritalstatus", None, None)(x => extract(x).maritalstatus, (row, value) => merge(row, extract(row).copy(maritalstatus = value)))
-      override val yearlyincome = new OptField[/* max 30 chars */ String, Row](prefix, "yearlyincome", None, None)(x => extract(x).yearlyincome, (row, value) => merge(row, extract(row).copy(yearlyincome = value)))
-      override val gender = new OptField[/* max 1 chars */ String, Row](prefix, "gender", None, None)(x => extract(x).gender, (row, value) => merge(row, extract(row).copy(gender = value)))
-      override val totalchildren = new OptField[Int, Row](prefix, "totalchildren", None, None)(x => extract(x).totalchildren, (row, value) => merge(row, extract(row).copy(totalchildren = value)))
-      override val numberchildrenathome = new OptField[Int, Row](prefix, "numberchildrenathome", None, None)(x => extract(x).numberchildrenathome, (row, value) => merge(row, extract(row).copy(numberchildrenathome = value)))
-      override val education = new OptField[/* max 30 chars */ String, Row](prefix, "education", None, None)(x => extract(x).education, (row, value) => merge(row, extract(row).copy(education = value)))
-      override val occupation = new OptField[/* max 30 chars */ String, Row](prefix, "occupation", None, None)(x => extract(x).occupation, (row, value) => merge(row, extract(row).copy(occupation = value)))
-      override val homeownerflag = new OptField[Boolean, Row](prefix, "homeownerflag", None, None)(x => extract(x).homeownerflag, (row, value) => merge(row, extract(row).copy(homeownerflag = value)))
-      override val numbercarsowned = new OptField[Int, Row](prefix, "numbercarsowned", None, None)(x => extract(x).numbercarsowned, (row, value) => merge(row, extract(row).copy(numbercarsowned = value)))
+    override lazy val fields: VpersondemographicsViewFields = new VpersondemographicsViewFields {
+      override def businessentityid = Field[BusinessentityId, VpersondemographicsViewRow](_path, "businessentityid", None, None, x => x.businessentityid, (row, value) => row.copy(businessentityid = value))
+      override def totalpurchaseytd = OptField[TypoMoney, VpersondemographicsViewRow](_path, "totalpurchaseytd", Some("numeric"), None, x => x.totalpurchaseytd, (row, value) => row.copy(totalpurchaseytd = value))
+      override def datefirstpurchase = OptField[TypoLocalDate, VpersondemographicsViewRow](_path, "datefirstpurchase", Some("text"), None, x => x.datefirstpurchase, (row, value) => row.copy(datefirstpurchase = value))
+      override def birthdate = OptField[TypoLocalDate, VpersondemographicsViewRow](_path, "birthdate", Some("text"), None, x => x.birthdate, (row, value) => row.copy(birthdate = value))
+      override def maritalstatus = OptField[/* max 1 chars */ String, VpersondemographicsViewRow](_path, "maritalstatus", None, None, x => x.maritalstatus, (row, value) => row.copy(maritalstatus = value))
+      override def yearlyincome = OptField[/* max 30 chars */ String, VpersondemographicsViewRow](_path, "yearlyincome", None, None, x => x.yearlyincome, (row, value) => row.copy(yearlyincome = value))
+      override def gender = OptField[/* max 1 chars */ String, VpersondemographicsViewRow](_path, "gender", None, None, x => x.gender, (row, value) => row.copy(gender = value))
+      override def totalchildren = OptField[Int, VpersondemographicsViewRow](_path, "totalchildren", None, None, x => x.totalchildren, (row, value) => row.copy(totalchildren = value))
+      override def numberchildrenathome = OptField[Int, VpersondemographicsViewRow](_path, "numberchildrenathome", None, None, x => x.numberchildrenathome, (row, value) => row.copy(numberchildrenathome = value))
+      override def education = OptField[/* max 30 chars */ String, VpersondemographicsViewRow](_path, "education", None, None, x => x.education, (row, value) => row.copy(education = value))
+      override def occupation = OptField[/* max 30 chars */ String, VpersondemographicsViewRow](_path, "occupation", None, None, x => x.occupation, (row, value) => row.copy(occupation = value))
+      override def homeownerflag = OptField[Boolean, VpersondemographicsViewRow](_path, "homeownerflag", None, None, x => x.homeownerflag, (row, value) => row.copy(homeownerflag = value))
+      override def numbercarsowned = OptField[Int, VpersondemographicsViewRow](_path, "numbercarsowned", None, None, x => x.numbercarsowned, (row, value) => row.copy(numbercarsowned = value))
     }
   
-    override val columns: List[FieldLikeNoHkt[?, Row]] =
-      List[FieldLikeNoHkt[?, Row]](fields.businessentityid, fields.totalpurchaseytd, fields.datefirstpurchase, fields.birthdate, fields.maritalstatus, fields.yearlyincome, fields.gender, fields.totalchildren, fields.numberchildrenathome, fields.education, fields.occupation, fields.homeownerflag, fields.numbercarsowned)
+    override lazy val columns: List[FieldLikeNoHkt[?, VpersondemographicsViewRow]] =
+      List[FieldLikeNoHkt[?, VpersondemographicsViewRow]](fields.businessentityid, fields.totalpurchaseytd, fields.datefirstpurchase, fields.birthdate, fields.maritalstatus, fields.yearlyincome, fields.gender, fields.totalchildren, fields.numberchildrenathome, fields.education, fields.occupation, fields.homeownerflag, fields.numbercarsowned)
   
-    override def copy[NewRow](prefix: Option[String], extract: NewRow => VpersondemographicsViewRow, merge: (NewRow, VpersondemographicsViewRow) => NewRow): Impl[NewRow] =
-      new Impl(prefix, extract, merge)
+    override def copy(path: List[Path]): Impl =
+      new Impl(path)
   }
   
 }

--- a/typo-tester-zio-jdbc/generated-and-checked-in/adventureworks/sales/vsalesperson/VsalespersonViewFields.scala
+++ b/typo-tester-zio-jdbc/generated-and-checked-in/adventureworks/sales/vsalesperson/VsalespersonViewFields.scala
@@ -11,73 +11,74 @@ import adventureworks.person.businessentity.BusinessentityId
 import adventureworks.public.Name
 import adventureworks.public.Phone
 import adventureworks.userdefined.FirstName
+import typo.dsl.Path
 import typo.dsl.SqlExpr.Field
 import typo.dsl.SqlExpr.FieldLikeNoHkt
 import typo.dsl.SqlExpr.OptField
 import typo.dsl.Structure.Relation
 
-trait VsalespersonViewFields[Row] {
-  val businessentityid: Field[BusinessentityId, Row]
-  val title: OptField[/* max 8 chars */ String, Row]
-  val firstname: Field[/* user-picked */ FirstName, Row]
-  val middlename: OptField[Name, Row]
-  val lastname: Field[Name, Row]
-  val suffix: OptField[/* max 10 chars */ String, Row]
-  val jobtitle: Field[/* max 50 chars */ String, Row]
-  val phonenumber: OptField[Phone, Row]
-  val phonenumbertype: OptField[Name, Row]
-  val emailaddress: OptField[/* max 50 chars */ String, Row]
-  val emailpromotion: Field[Int, Row]
-  val addressline1: Field[/* max 60 chars */ String, Row]
-  val addressline2: OptField[/* max 60 chars */ String, Row]
-  val city: Field[/* max 30 chars */ String, Row]
-  val stateprovincename: Field[Name, Row]
-  val postalcode: Field[/* max 15 chars */ String, Row]
-  val countryregionname: Field[Name, Row]
-  val territoryname: OptField[Name, Row]
-  val territorygroup: OptField[/* max 50 chars */ String, Row]
-  val salesquota: OptField[BigDecimal, Row]
-  val salesytd: Field[BigDecimal, Row]
-  val saleslastyear: Field[BigDecimal, Row]
+trait VsalespersonViewFields {
+  def businessentityid: Field[BusinessentityId, VsalespersonViewRow]
+  def title: OptField[/* max 8 chars */ String, VsalespersonViewRow]
+  def firstname: Field[/* user-picked */ FirstName, VsalespersonViewRow]
+  def middlename: OptField[Name, VsalespersonViewRow]
+  def lastname: Field[Name, VsalespersonViewRow]
+  def suffix: OptField[/* max 10 chars */ String, VsalespersonViewRow]
+  def jobtitle: Field[/* max 50 chars */ String, VsalespersonViewRow]
+  def phonenumber: OptField[Phone, VsalespersonViewRow]
+  def phonenumbertype: OptField[Name, VsalespersonViewRow]
+  def emailaddress: OptField[/* max 50 chars */ String, VsalespersonViewRow]
+  def emailpromotion: Field[Int, VsalespersonViewRow]
+  def addressline1: Field[/* max 60 chars */ String, VsalespersonViewRow]
+  def addressline2: OptField[/* max 60 chars */ String, VsalespersonViewRow]
+  def city: Field[/* max 30 chars */ String, VsalespersonViewRow]
+  def stateprovincename: Field[Name, VsalespersonViewRow]
+  def postalcode: Field[/* max 15 chars */ String, VsalespersonViewRow]
+  def countryregionname: Field[Name, VsalespersonViewRow]
+  def territoryname: OptField[Name, VsalespersonViewRow]
+  def territorygroup: OptField[/* max 50 chars */ String, VsalespersonViewRow]
+  def salesquota: OptField[BigDecimal, VsalespersonViewRow]
+  def salesytd: Field[BigDecimal, VsalespersonViewRow]
+  def saleslastyear: Field[BigDecimal, VsalespersonViewRow]
 }
 
 object VsalespersonViewFields {
-  val structure: Relation[VsalespersonViewFields, VsalespersonViewRow, VsalespersonViewRow] = 
-    new Impl(None, identity, (_, x) => x)
+  lazy val structure: Relation[VsalespersonViewFields, VsalespersonViewRow] =
+    new Impl(Nil)
     
-  private final class Impl[Row](val prefix: Option[String], val extract: Row => VsalespersonViewRow, val merge: (Row, VsalespersonViewRow) => Row)
-    extends Relation[VsalespersonViewFields, VsalespersonViewRow, Row] { 
+  private final class Impl(val _path: List[Path])
+    extends Relation[VsalespersonViewFields, VsalespersonViewRow] {
   
-    override val fields: VsalespersonViewFields[Row] = new VsalespersonViewFields[Row] {
-      override val businessentityid = new Field[BusinessentityId, Row](prefix, "businessentityid", None, None)(x => extract(x).businessentityid, (row, value) => merge(row, extract(row).copy(businessentityid = value)))
-      override val title = new OptField[/* max 8 chars */ String, Row](prefix, "title", None, None)(x => extract(x).title, (row, value) => merge(row, extract(row).copy(title = value)))
-      override val firstname = new Field[/* user-picked */ FirstName, Row](prefix, "firstname", None, None)(x => extract(x).firstname, (row, value) => merge(row, extract(row).copy(firstname = value)))
-      override val middlename = new OptField[Name, Row](prefix, "middlename", None, None)(x => extract(x).middlename, (row, value) => merge(row, extract(row).copy(middlename = value)))
-      override val lastname = new Field[Name, Row](prefix, "lastname", None, None)(x => extract(x).lastname, (row, value) => merge(row, extract(row).copy(lastname = value)))
-      override val suffix = new OptField[/* max 10 chars */ String, Row](prefix, "suffix", None, None)(x => extract(x).suffix, (row, value) => merge(row, extract(row).copy(suffix = value)))
-      override val jobtitle = new Field[/* max 50 chars */ String, Row](prefix, "jobtitle", None, None)(x => extract(x).jobtitle, (row, value) => merge(row, extract(row).copy(jobtitle = value)))
-      override val phonenumber = new OptField[Phone, Row](prefix, "phonenumber", None, None)(x => extract(x).phonenumber, (row, value) => merge(row, extract(row).copy(phonenumber = value)))
-      override val phonenumbertype = new OptField[Name, Row](prefix, "phonenumbertype", None, None)(x => extract(x).phonenumbertype, (row, value) => merge(row, extract(row).copy(phonenumbertype = value)))
-      override val emailaddress = new OptField[/* max 50 chars */ String, Row](prefix, "emailaddress", None, None)(x => extract(x).emailaddress, (row, value) => merge(row, extract(row).copy(emailaddress = value)))
-      override val emailpromotion = new Field[Int, Row](prefix, "emailpromotion", None, None)(x => extract(x).emailpromotion, (row, value) => merge(row, extract(row).copy(emailpromotion = value)))
-      override val addressline1 = new Field[/* max 60 chars */ String, Row](prefix, "addressline1", None, None)(x => extract(x).addressline1, (row, value) => merge(row, extract(row).copy(addressline1 = value)))
-      override val addressline2 = new OptField[/* max 60 chars */ String, Row](prefix, "addressline2", None, None)(x => extract(x).addressline2, (row, value) => merge(row, extract(row).copy(addressline2 = value)))
-      override val city = new Field[/* max 30 chars */ String, Row](prefix, "city", None, None)(x => extract(x).city, (row, value) => merge(row, extract(row).copy(city = value)))
-      override val stateprovincename = new Field[Name, Row](prefix, "stateprovincename", None, None)(x => extract(x).stateprovincename, (row, value) => merge(row, extract(row).copy(stateprovincename = value)))
-      override val postalcode = new Field[/* max 15 chars */ String, Row](prefix, "postalcode", None, None)(x => extract(x).postalcode, (row, value) => merge(row, extract(row).copy(postalcode = value)))
-      override val countryregionname = new Field[Name, Row](prefix, "countryregionname", None, None)(x => extract(x).countryregionname, (row, value) => merge(row, extract(row).copy(countryregionname = value)))
-      override val territoryname = new OptField[Name, Row](prefix, "territoryname", None, None)(x => extract(x).territoryname, (row, value) => merge(row, extract(row).copy(territoryname = value)))
-      override val territorygroup = new OptField[/* max 50 chars */ String, Row](prefix, "territorygroup", None, None)(x => extract(x).territorygroup, (row, value) => merge(row, extract(row).copy(territorygroup = value)))
-      override val salesquota = new OptField[BigDecimal, Row](prefix, "salesquota", None, None)(x => extract(x).salesquota, (row, value) => merge(row, extract(row).copy(salesquota = value)))
-      override val salesytd = new Field[BigDecimal, Row](prefix, "salesytd", None, None)(x => extract(x).salesytd, (row, value) => merge(row, extract(row).copy(salesytd = value)))
-      override val saleslastyear = new Field[BigDecimal, Row](prefix, "saleslastyear", None, None)(x => extract(x).saleslastyear, (row, value) => merge(row, extract(row).copy(saleslastyear = value)))
+    override lazy val fields: VsalespersonViewFields = new VsalespersonViewFields {
+      override def businessentityid = Field[BusinessentityId, VsalespersonViewRow](_path, "businessentityid", None, None, x => x.businessentityid, (row, value) => row.copy(businessentityid = value))
+      override def title = OptField[/* max 8 chars */ String, VsalespersonViewRow](_path, "title", None, None, x => x.title, (row, value) => row.copy(title = value))
+      override def firstname = Field[/* user-picked */ FirstName, VsalespersonViewRow](_path, "firstname", None, None, x => x.firstname, (row, value) => row.copy(firstname = value))
+      override def middlename = OptField[Name, VsalespersonViewRow](_path, "middlename", None, None, x => x.middlename, (row, value) => row.copy(middlename = value))
+      override def lastname = Field[Name, VsalespersonViewRow](_path, "lastname", None, None, x => x.lastname, (row, value) => row.copy(lastname = value))
+      override def suffix = OptField[/* max 10 chars */ String, VsalespersonViewRow](_path, "suffix", None, None, x => x.suffix, (row, value) => row.copy(suffix = value))
+      override def jobtitle = Field[/* max 50 chars */ String, VsalespersonViewRow](_path, "jobtitle", None, None, x => x.jobtitle, (row, value) => row.copy(jobtitle = value))
+      override def phonenumber = OptField[Phone, VsalespersonViewRow](_path, "phonenumber", None, None, x => x.phonenumber, (row, value) => row.copy(phonenumber = value))
+      override def phonenumbertype = OptField[Name, VsalespersonViewRow](_path, "phonenumbertype", None, None, x => x.phonenumbertype, (row, value) => row.copy(phonenumbertype = value))
+      override def emailaddress = OptField[/* max 50 chars */ String, VsalespersonViewRow](_path, "emailaddress", None, None, x => x.emailaddress, (row, value) => row.copy(emailaddress = value))
+      override def emailpromotion = Field[Int, VsalespersonViewRow](_path, "emailpromotion", None, None, x => x.emailpromotion, (row, value) => row.copy(emailpromotion = value))
+      override def addressline1 = Field[/* max 60 chars */ String, VsalespersonViewRow](_path, "addressline1", None, None, x => x.addressline1, (row, value) => row.copy(addressline1 = value))
+      override def addressline2 = OptField[/* max 60 chars */ String, VsalespersonViewRow](_path, "addressline2", None, None, x => x.addressline2, (row, value) => row.copy(addressline2 = value))
+      override def city = Field[/* max 30 chars */ String, VsalespersonViewRow](_path, "city", None, None, x => x.city, (row, value) => row.copy(city = value))
+      override def stateprovincename = Field[Name, VsalespersonViewRow](_path, "stateprovincename", None, None, x => x.stateprovincename, (row, value) => row.copy(stateprovincename = value))
+      override def postalcode = Field[/* max 15 chars */ String, VsalespersonViewRow](_path, "postalcode", None, None, x => x.postalcode, (row, value) => row.copy(postalcode = value))
+      override def countryregionname = Field[Name, VsalespersonViewRow](_path, "countryregionname", None, None, x => x.countryregionname, (row, value) => row.copy(countryregionname = value))
+      override def territoryname = OptField[Name, VsalespersonViewRow](_path, "territoryname", None, None, x => x.territoryname, (row, value) => row.copy(territoryname = value))
+      override def territorygroup = OptField[/* max 50 chars */ String, VsalespersonViewRow](_path, "territorygroup", None, None, x => x.territorygroup, (row, value) => row.copy(territorygroup = value))
+      override def salesquota = OptField[BigDecimal, VsalespersonViewRow](_path, "salesquota", None, None, x => x.salesquota, (row, value) => row.copy(salesquota = value))
+      override def salesytd = Field[BigDecimal, VsalespersonViewRow](_path, "salesytd", None, None, x => x.salesytd, (row, value) => row.copy(salesytd = value))
+      override def saleslastyear = Field[BigDecimal, VsalespersonViewRow](_path, "saleslastyear", None, None, x => x.saleslastyear, (row, value) => row.copy(saleslastyear = value))
     }
   
-    override val columns: List[FieldLikeNoHkt[?, Row]] =
-      List[FieldLikeNoHkt[?, Row]](fields.businessentityid, fields.title, fields.firstname, fields.middlename, fields.lastname, fields.suffix, fields.jobtitle, fields.phonenumber, fields.phonenumbertype, fields.emailaddress, fields.emailpromotion, fields.addressline1, fields.addressline2, fields.city, fields.stateprovincename, fields.postalcode, fields.countryregionname, fields.territoryname, fields.territorygroup, fields.salesquota, fields.salesytd, fields.saleslastyear)
+    override lazy val columns: List[FieldLikeNoHkt[?, VsalespersonViewRow]] =
+      List[FieldLikeNoHkt[?, VsalespersonViewRow]](fields.businessentityid, fields.title, fields.firstname, fields.middlename, fields.lastname, fields.suffix, fields.jobtitle, fields.phonenumber, fields.phonenumbertype, fields.emailaddress, fields.emailpromotion, fields.addressline1, fields.addressline2, fields.city, fields.stateprovincename, fields.postalcode, fields.countryregionname, fields.territoryname, fields.territorygroup, fields.salesquota, fields.salesytd, fields.saleslastyear)
   
-    override def copy[NewRow](prefix: Option[String], extract: NewRow => VsalespersonViewRow, merge: (NewRow, VsalespersonViewRow) => NewRow): Impl[NewRow] =
-      new Impl(prefix, extract, merge)
+    override def copy(path: List[Path]): Impl =
+      new Impl(path)
   }
   
 }

--- a/typo-tester-zio-jdbc/generated-and-checked-in/adventureworks/sales/vsalespersonsalesbyfiscalyears/VsalespersonsalesbyfiscalyearsViewFields.scala
+++ b/typo-tester-zio-jdbc/generated-and-checked-in/adventureworks/sales/vsalespersonsalesbyfiscalyears/VsalespersonsalesbyfiscalyearsViewFields.scala
@@ -7,42 +7,43 @@ package adventureworks
 package sales
 package vsalespersonsalesbyfiscalyears
 
+import typo.dsl.Path
 import typo.dsl.SqlExpr.FieldLikeNoHkt
 import typo.dsl.SqlExpr.OptField
 import typo.dsl.Structure.Relation
 
-trait VsalespersonsalesbyfiscalyearsViewFields[Row] {
-  val SalesPersonID: OptField[Int, Row]
-  val FullName: OptField[String, Row]
-  val JobTitle: OptField[String, Row]
-  val SalesTerritory: OptField[String, Row]
-  val `2012`: OptField[BigDecimal, Row]
-  val `2013`: OptField[BigDecimal, Row]
-  val `2014`: OptField[BigDecimal, Row]
+trait VsalespersonsalesbyfiscalyearsViewFields {
+  def SalesPersonID: OptField[Int, VsalespersonsalesbyfiscalyearsViewRow]
+  def FullName: OptField[String, VsalespersonsalesbyfiscalyearsViewRow]
+  def JobTitle: OptField[String, VsalespersonsalesbyfiscalyearsViewRow]
+  def SalesTerritory: OptField[String, VsalespersonsalesbyfiscalyearsViewRow]
+  def `2012`: OptField[BigDecimal, VsalespersonsalesbyfiscalyearsViewRow]
+  def `2013`: OptField[BigDecimal, VsalespersonsalesbyfiscalyearsViewRow]
+  def `2014`: OptField[BigDecimal, VsalespersonsalesbyfiscalyearsViewRow]
 }
 
 object VsalespersonsalesbyfiscalyearsViewFields {
-  val structure: Relation[VsalespersonsalesbyfiscalyearsViewFields, VsalespersonsalesbyfiscalyearsViewRow, VsalespersonsalesbyfiscalyearsViewRow] = 
-    new Impl(None, identity, (_, x) => x)
+  lazy val structure: Relation[VsalespersonsalesbyfiscalyearsViewFields, VsalespersonsalesbyfiscalyearsViewRow] =
+    new Impl(Nil)
     
-  private final class Impl[Row](val prefix: Option[String], val extract: Row => VsalespersonsalesbyfiscalyearsViewRow, val merge: (Row, VsalespersonsalesbyfiscalyearsViewRow) => Row)
-    extends Relation[VsalespersonsalesbyfiscalyearsViewFields, VsalespersonsalesbyfiscalyearsViewRow, Row] { 
+  private final class Impl(val _path: List[Path])
+    extends Relation[VsalespersonsalesbyfiscalyearsViewFields, VsalespersonsalesbyfiscalyearsViewRow] {
   
-    override val fields: VsalespersonsalesbyfiscalyearsViewFields[Row] = new VsalespersonsalesbyfiscalyearsViewFields[Row] {
-      override val SalesPersonID = new OptField[Int, Row](prefix, "SalesPersonID", None, None)(x => extract(x).SalesPersonID, (row, value) => merge(row, extract(row).copy(SalesPersonID = value)))
-      override val FullName = new OptField[String, Row](prefix, "FullName", None, None)(x => extract(x).FullName, (row, value) => merge(row, extract(row).copy(FullName = value)))
-      override val JobTitle = new OptField[String, Row](prefix, "JobTitle", None, None)(x => extract(x).JobTitle, (row, value) => merge(row, extract(row).copy(JobTitle = value)))
-      override val SalesTerritory = new OptField[String, Row](prefix, "SalesTerritory", None, None)(x => extract(x).SalesTerritory, (row, value) => merge(row, extract(row).copy(SalesTerritory = value)))
-      override val `2012` = new OptField[BigDecimal, Row](prefix, "2012", None, None)(x => extract(x).`2012`, (row, value) => merge(row, extract(row).copy(`2012` = value)))
-      override val `2013` = new OptField[BigDecimal, Row](prefix, "2013", None, None)(x => extract(x).`2013`, (row, value) => merge(row, extract(row).copy(`2013` = value)))
-      override val `2014` = new OptField[BigDecimal, Row](prefix, "2014", None, None)(x => extract(x).`2014`, (row, value) => merge(row, extract(row).copy(`2014` = value)))
+    override lazy val fields: VsalespersonsalesbyfiscalyearsViewFields = new VsalespersonsalesbyfiscalyearsViewFields {
+      override def SalesPersonID = OptField[Int, VsalespersonsalesbyfiscalyearsViewRow](_path, "SalesPersonID", None, None, x => x.SalesPersonID, (row, value) => row.copy(SalesPersonID = value))
+      override def FullName = OptField[String, VsalespersonsalesbyfiscalyearsViewRow](_path, "FullName", None, None, x => x.FullName, (row, value) => row.copy(FullName = value))
+      override def JobTitle = OptField[String, VsalespersonsalesbyfiscalyearsViewRow](_path, "JobTitle", None, None, x => x.JobTitle, (row, value) => row.copy(JobTitle = value))
+      override def SalesTerritory = OptField[String, VsalespersonsalesbyfiscalyearsViewRow](_path, "SalesTerritory", None, None, x => x.SalesTerritory, (row, value) => row.copy(SalesTerritory = value))
+      override def `2012` = OptField[BigDecimal, VsalespersonsalesbyfiscalyearsViewRow](_path, "2012", None, None, x => x.`2012`, (row, value) => row.copy(`2012` = value))
+      override def `2013` = OptField[BigDecimal, VsalespersonsalesbyfiscalyearsViewRow](_path, "2013", None, None, x => x.`2013`, (row, value) => row.copy(`2013` = value))
+      override def `2014` = OptField[BigDecimal, VsalespersonsalesbyfiscalyearsViewRow](_path, "2014", None, None, x => x.`2014`, (row, value) => row.copy(`2014` = value))
     }
   
-    override val columns: List[FieldLikeNoHkt[?, Row]] =
-      List[FieldLikeNoHkt[?, Row]](fields.SalesPersonID, fields.FullName, fields.JobTitle, fields.SalesTerritory, fields.`2012`, fields.`2013`, fields.`2014`)
+    override lazy val columns: List[FieldLikeNoHkt[?, VsalespersonsalesbyfiscalyearsViewRow]] =
+      List[FieldLikeNoHkt[?, VsalespersonsalesbyfiscalyearsViewRow]](fields.SalesPersonID, fields.FullName, fields.JobTitle, fields.SalesTerritory, fields.`2012`, fields.`2013`, fields.`2014`)
   
-    override def copy[NewRow](prefix: Option[String], extract: NewRow => VsalespersonsalesbyfiscalyearsViewRow, merge: (NewRow, VsalespersonsalesbyfiscalyearsViewRow) => NewRow): Impl[NewRow] =
-      new Impl(prefix, extract, merge)
+    override def copy(path: List[Path]): Impl =
+      new Impl(path)
   }
   
 }

--- a/typo-tester-zio-jdbc/generated-and-checked-in/adventureworks/sales/vsalespersonsalesbyfiscalyearsdata/VsalespersonsalesbyfiscalyearsdataViewFields.scala
+++ b/typo-tester-zio-jdbc/generated-and-checked-in/adventureworks/sales/vsalespersonsalesbyfiscalyearsdata/VsalespersonsalesbyfiscalyearsdataViewFields.scala
@@ -9,41 +9,42 @@ package vsalespersonsalesbyfiscalyearsdata
 
 import adventureworks.person.businessentity.BusinessentityId
 import adventureworks.public.Name
+import typo.dsl.Path
 import typo.dsl.SqlExpr.Field
 import typo.dsl.SqlExpr.FieldLikeNoHkt
 import typo.dsl.SqlExpr.OptField
 import typo.dsl.Structure.Relation
 
-trait VsalespersonsalesbyfiscalyearsdataViewFields[Row] {
-  val salespersonid: OptField[BusinessentityId, Row]
-  val fullname: OptField[String, Row]
-  val jobtitle: Field[/* max 50 chars */ String, Row]
-  val salesterritory: Field[Name, Row]
-  val salestotal: OptField[BigDecimal, Row]
-  val fiscalyear: OptField[BigDecimal, Row]
+trait VsalespersonsalesbyfiscalyearsdataViewFields {
+  def salespersonid: OptField[BusinessentityId, VsalespersonsalesbyfiscalyearsdataViewRow]
+  def fullname: OptField[String, VsalespersonsalesbyfiscalyearsdataViewRow]
+  def jobtitle: Field[/* max 50 chars */ String, VsalespersonsalesbyfiscalyearsdataViewRow]
+  def salesterritory: Field[Name, VsalespersonsalesbyfiscalyearsdataViewRow]
+  def salestotal: OptField[BigDecimal, VsalespersonsalesbyfiscalyearsdataViewRow]
+  def fiscalyear: OptField[BigDecimal, VsalespersonsalesbyfiscalyearsdataViewRow]
 }
 
 object VsalespersonsalesbyfiscalyearsdataViewFields {
-  val structure: Relation[VsalespersonsalesbyfiscalyearsdataViewFields, VsalespersonsalesbyfiscalyearsdataViewRow, VsalespersonsalesbyfiscalyearsdataViewRow] = 
-    new Impl(None, identity, (_, x) => x)
+  lazy val structure: Relation[VsalespersonsalesbyfiscalyearsdataViewFields, VsalespersonsalesbyfiscalyearsdataViewRow] =
+    new Impl(Nil)
     
-  private final class Impl[Row](val prefix: Option[String], val extract: Row => VsalespersonsalesbyfiscalyearsdataViewRow, val merge: (Row, VsalespersonsalesbyfiscalyearsdataViewRow) => Row)
-    extends Relation[VsalespersonsalesbyfiscalyearsdataViewFields, VsalespersonsalesbyfiscalyearsdataViewRow, Row] { 
+  private final class Impl(val _path: List[Path])
+    extends Relation[VsalespersonsalesbyfiscalyearsdataViewFields, VsalespersonsalesbyfiscalyearsdataViewRow] {
   
-    override val fields: VsalespersonsalesbyfiscalyearsdataViewFields[Row] = new VsalespersonsalesbyfiscalyearsdataViewFields[Row] {
-      override val salespersonid = new OptField[BusinessentityId, Row](prefix, "salespersonid", None, None)(x => extract(x).salespersonid, (row, value) => merge(row, extract(row).copy(salespersonid = value)))
-      override val fullname = new OptField[String, Row](prefix, "fullname", None, None)(x => extract(x).fullname, (row, value) => merge(row, extract(row).copy(fullname = value)))
-      override val jobtitle = new Field[/* max 50 chars */ String, Row](prefix, "jobtitle", None, None)(x => extract(x).jobtitle, (row, value) => merge(row, extract(row).copy(jobtitle = value)))
-      override val salesterritory = new Field[Name, Row](prefix, "salesterritory", None, None)(x => extract(x).salesterritory, (row, value) => merge(row, extract(row).copy(salesterritory = value)))
-      override val salestotal = new OptField[BigDecimal, Row](prefix, "salestotal", None, None)(x => extract(x).salestotal, (row, value) => merge(row, extract(row).copy(salestotal = value)))
-      override val fiscalyear = new OptField[BigDecimal, Row](prefix, "fiscalyear", None, None)(x => extract(x).fiscalyear, (row, value) => merge(row, extract(row).copy(fiscalyear = value)))
+    override lazy val fields: VsalespersonsalesbyfiscalyearsdataViewFields = new VsalespersonsalesbyfiscalyearsdataViewFields {
+      override def salespersonid = OptField[BusinessentityId, VsalespersonsalesbyfiscalyearsdataViewRow](_path, "salespersonid", None, None, x => x.salespersonid, (row, value) => row.copy(salespersonid = value))
+      override def fullname = OptField[String, VsalespersonsalesbyfiscalyearsdataViewRow](_path, "fullname", None, None, x => x.fullname, (row, value) => row.copy(fullname = value))
+      override def jobtitle = Field[/* max 50 chars */ String, VsalespersonsalesbyfiscalyearsdataViewRow](_path, "jobtitle", None, None, x => x.jobtitle, (row, value) => row.copy(jobtitle = value))
+      override def salesterritory = Field[Name, VsalespersonsalesbyfiscalyearsdataViewRow](_path, "salesterritory", None, None, x => x.salesterritory, (row, value) => row.copy(salesterritory = value))
+      override def salestotal = OptField[BigDecimal, VsalespersonsalesbyfiscalyearsdataViewRow](_path, "salestotal", None, None, x => x.salestotal, (row, value) => row.copy(salestotal = value))
+      override def fiscalyear = OptField[BigDecimal, VsalespersonsalesbyfiscalyearsdataViewRow](_path, "fiscalyear", None, None, x => x.fiscalyear, (row, value) => row.copy(fiscalyear = value))
     }
   
-    override val columns: List[FieldLikeNoHkt[?, Row]] =
-      List[FieldLikeNoHkt[?, Row]](fields.salespersonid, fields.fullname, fields.jobtitle, fields.salesterritory, fields.salestotal, fields.fiscalyear)
+    override lazy val columns: List[FieldLikeNoHkt[?, VsalespersonsalesbyfiscalyearsdataViewRow]] =
+      List[FieldLikeNoHkt[?, VsalespersonsalesbyfiscalyearsdataViewRow]](fields.salespersonid, fields.fullname, fields.jobtitle, fields.salesterritory, fields.salestotal, fields.fiscalyear)
   
-    override def copy[NewRow](prefix: Option[String], extract: NewRow => VsalespersonsalesbyfiscalyearsdataViewRow, merge: (NewRow, VsalespersonsalesbyfiscalyearsdataViewRow) => NewRow): Impl[NewRow] =
-      new Impl(prefix, extract, merge)
+    override def copy(path: List[Path]): Impl =
+      new Impl(path)
   }
   
 }

--- a/typo-tester-zio-jdbc/generated-and-checked-in/adventureworks/sales/vstorewithaddresses/VstorewithaddressesViewFields.scala
+++ b/typo-tester-zio-jdbc/generated-and-checked-in/adventureworks/sales/vstorewithaddresses/VstorewithaddressesViewFields.scala
@@ -9,47 +9,48 @@ package vstorewithaddresses
 
 import adventureworks.person.businessentity.BusinessentityId
 import adventureworks.public.Name
+import typo.dsl.Path
 import typo.dsl.SqlExpr.Field
 import typo.dsl.SqlExpr.FieldLikeNoHkt
 import typo.dsl.SqlExpr.OptField
 import typo.dsl.Structure.Relation
 
-trait VstorewithaddressesViewFields[Row] {
-  val businessentityid: Field[BusinessentityId, Row]
-  val name: Field[Name, Row]
-  val addresstype: Field[Name, Row]
-  val addressline1: Field[/* max 60 chars */ String, Row]
-  val addressline2: OptField[/* max 60 chars */ String, Row]
-  val city: Field[/* max 30 chars */ String, Row]
-  val stateprovincename: Field[Name, Row]
-  val postalcode: Field[/* max 15 chars */ String, Row]
-  val countryregionname: Field[Name, Row]
+trait VstorewithaddressesViewFields {
+  def businessentityid: Field[BusinessentityId, VstorewithaddressesViewRow]
+  def name: Field[Name, VstorewithaddressesViewRow]
+  def addresstype: Field[Name, VstorewithaddressesViewRow]
+  def addressline1: Field[/* max 60 chars */ String, VstorewithaddressesViewRow]
+  def addressline2: OptField[/* max 60 chars */ String, VstorewithaddressesViewRow]
+  def city: Field[/* max 30 chars */ String, VstorewithaddressesViewRow]
+  def stateprovincename: Field[Name, VstorewithaddressesViewRow]
+  def postalcode: Field[/* max 15 chars */ String, VstorewithaddressesViewRow]
+  def countryregionname: Field[Name, VstorewithaddressesViewRow]
 }
 
 object VstorewithaddressesViewFields {
-  val structure: Relation[VstorewithaddressesViewFields, VstorewithaddressesViewRow, VstorewithaddressesViewRow] = 
-    new Impl(None, identity, (_, x) => x)
+  lazy val structure: Relation[VstorewithaddressesViewFields, VstorewithaddressesViewRow] =
+    new Impl(Nil)
     
-  private final class Impl[Row](val prefix: Option[String], val extract: Row => VstorewithaddressesViewRow, val merge: (Row, VstorewithaddressesViewRow) => Row)
-    extends Relation[VstorewithaddressesViewFields, VstorewithaddressesViewRow, Row] { 
+  private final class Impl(val _path: List[Path])
+    extends Relation[VstorewithaddressesViewFields, VstorewithaddressesViewRow] {
   
-    override val fields: VstorewithaddressesViewFields[Row] = new VstorewithaddressesViewFields[Row] {
-      override val businessentityid = new Field[BusinessentityId, Row](prefix, "businessentityid", None, None)(x => extract(x).businessentityid, (row, value) => merge(row, extract(row).copy(businessentityid = value)))
-      override val name = new Field[Name, Row](prefix, "name", None, None)(x => extract(x).name, (row, value) => merge(row, extract(row).copy(name = value)))
-      override val addresstype = new Field[Name, Row](prefix, "addresstype", None, None)(x => extract(x).addresstype, (row, value) => merge(row, extract(row).copy(addresstype = value)))
-      override val addressline1 = new Field[/* max 60 chars */ String, Row](prefix, "addressline1", None, None)(x => extract(x).addressline1, (row, value) => merge(row, extract(row).copy(addressline1 = value)))
-      override val addressline2 = new OptField[/* max 60 chars */ String, Row](prefix, "addressline2", None, None)(x => extract(x).addressline2, (row, value) => merge(row, extract(row).copy(addressline2 = value)))
-      override val city = new Field[/* max 30 chars */ String, Row](prefix, "city", None, None)(x => extract(x).city, (row, value) => merge(row, extract(row).copy(city = value)))
-      override val stateprovincename = new Field[Name, Row](prefix, "stateprovincename", None, None)(x => extract(x).stateprovincename, (row, value) => merge(row, extract(row).copy(stateprovincename = value)))
-      override val postalcode = new Field[/* max 15 chars */ String, Row](prefix, "postalcode", None, None)(x => extract(x).postalcode, (row, value) => merge(row, extract(row).copy(postalcode = value)))
-      override val countryregionname = new Field[Name, Row](prefix, "countryregionname", None, None)(x => extract(x).countryregionname, (row, value) => merge(row, extract(row).copy(countryregionname = value)))
+    override lazy val fields: VstorewithaddressesViewFields = new VstorewithaddressesViewFields {
+      override def businessentityid = Field[BusinessentityId, VstorewithaddressesViewRow](_path, "businessentityid", None, None, x => x.businessentityid, (row, value) => row.copy(businessentityid = value))
+      override def name = Field[Name, VstorewithaddressesViewRow](_path, "name", None, None, x => x.name, (row, value) => row.copy(name = value))
+      override def addresstype = Field[Name, VstorewithaddressesViewRow](_path, "addresstype", None, None, x => x.addresstype, (row, value) => row.copy(addresstype = value))
+      override def addressline1 = Field[/* max 60 chars */ String, VstorewithaddressesViewRow](_path, "addressline1", None, None, x => x.addressline1, (row, value) => row.copy(addressline1 = value))
+      override def addressline2 = OptField[/* max 60 chars */ String, VstorewithaddressesViewRow](_path, "addressline2", None, None, x => x.addressline2, (row, value) => row.copy(addressline2 = value))
+      override def city = Field[/* max 30 chars */ String, VstorewithaddressesViewRow](_path, "city", None, None, x => x.city, (row, value) => row.copy(city = value))
+      override def stateprovincename = Field[Name, VstorewithaddressesViewRow](_path, "stateprovincename", None, None, x => x.stateprovincename, (row, value) => row.copy(stateprovincename = value))
+      override def postalcode = Field[/* max 15 chars */ String, VstorewithaddressesViewRow](_path, "postalcode", None, None, x => x.postalcode, (row, value) => row.copy(postalcode = value))
+      override def countryregionname = Field[Name, VstorewithaddressesViewRow](_path, "countryregionname", None, None, x => x.countryregionname, (row, value) => row.copy(countryregionname = value))
     }
   
-    override val columns: List[FieldLikeNoHkt[?, Row]] =
-      List[FieldLikeNoHkt[?, Row]](fields.businessentityid, fields.name, fields.addresstype, fields.addressline1, fields.addressline2, fields.city, fields.stateprovincename, fields.postalcode, fields.countryregionname)
+    override lazy val columns: List[FieldLikeNoHkt[?, VstorewithaddressesViewRow]] =
+      List[FieldLikeNoHkt[?, VstorewithaddressesViewRow]](fields.businessentityid, fields.name, fields.addresstype, fields.addressline1, fields.addressline2, fields.city, fields.stateprovincename, fields.postalcode, fields.countryregionname)
   
-    override def copy[NewRow](prefix: Option[String], extract: NewRow => VstorewithaddressesViewRow, merge: (NewRow, VstorewithaddressesViewRow) => NewRow): Impl[NewRow] =
-      new Impl(prefix, extract, merge)
+    override def copy(path: List[Path]): Impl =
+      new Impl(path)
   }
   
 }

--- a/typo-tester-zio-jdbc/generated-and-checked-in/adventureworks/sales/vstorewithcontacts/VstorewithcontactsViewFields.scala
+++ b/typo-tester-zio-jdbc/generated-and-checked-in/adventureworks/sales/vstorewithcontacts/VstorewithcontactsViewFields.scala
@@ -11,53 +11,54 @@ import adventureworks.person.businessentity.BusinessentityId
 import adventureworks.public.Name
 import adventureworks.public.Phone
 import adventureworks.userdefined.FirstName
+import typo.dsl.Path
 import typo.dsl.SqlExpr.Field
 import typo.dsl.SqlExpr.FieldLikeNoHkt
 import typo.dsl.SqlExpr.OptField
 import typo.dsl.Structure.Relation
 
-trait VstorewithcontactsViewFields[Row] {
-  val businessentityid: Field[BusinessentityId, Row]
-  val name: Field[Name, Row]
-  val contacttype: Field[Name, Row]
-  val title: OptField[/* max 8 chars */ String, Row]
-  val firstname: Field[/* user-picked */ FirstName, Row]
-  val middlename: OptField[Name, Row]
-  val lastname: Field[Name, Row]
-  val suffix: OptField[/* max 10 chars */ String, Row]
-  val phonenumber: OptField[Phone, Row]
-  val phonenumbertype: OptField[Name, Row]
-  val emailaddress: OptField[/* max 50 chars */ String, Row]
-  val emailpromotion: Field[Int, Row]
+trait VstorewithcontactsViewFields {
+  def businessentityid: Field[BusinessentityId, VstorewithcontactsViewRow]
+  def name: Field[Name, VstorewithcontactsViewRow]
+  def contacttype: Field[Name, VstorewithcontactsViewRow]
+  def title: OptField[/* max 8 chars */ String, VstorewithcontactsViewRow]
+  def firstname: Field[/* user-picked */ FirstName, VstorewithcontactsViewRow]
+  def middlename: OptField[Name, VstorewithcontactsViewRow]
+  def lastname: Field[Name, VstorewithcontactsViewRow]
+  def suffix: OptField[/* max 10 chars */ String, VstorewithcontactsViewRow]
+  def phonenumber: OptField[Phone, VstorewithcontactsViewRow]
+  def phonenumbertype: OptField[Name, VstorewithcontactsViewRow]
+  def emailaddress: OptField[/* max 50 chars */ String, VstorewithcontactsViewRow]
+  def emailpromotion: Field[Int, VstorewithcontactsViewRow]
 }
 
 object VstorewithcontactsViewFields {
-  val structure: Relation[VstorewithcontactsViewFields, VstorewithcontactsViewRow, VstorewithcontactsViewRow] = 
-    new Impl(None, identity, (_, x) => x)
+  lazy val structure: Relation[VstorewithcontactsViewFields, VstorewithcontactsViewRow] =
+    new Impl(Nil)
     
-  private final class Impl[Row](val prefix: Option[String], val extract: Row => VstorewithcontactsViewRow, val merge: (Row, VstorewithcontactsViewRow) => Row)
-    extends Relation[VstorewithcontactsViewFields, VstorewithcontactsViewRow, Row] { 
+  private final class Impl(val _path: List[Path])
+    extends Relation[VstorewithcontactsViewFields, VstorewithcontactsViewRow] {
   
-    override val fields: VstorewithcontactsViewFields[Row] = new VstorewithcontactsViewFields[Row] {
-      override val businessentityid = new Field[BusinessentityId, Row](prefix, "businessentityid", None, None)(x => extract(x).businessentityid, (row, value) => merge(row, extract(row).copy(businessentityid = value)))
-      override val name = new Field[Name, Row](prefix, "name", None, None)(x => extract(x).name, (row, value) => merge(row, extract(row).copy(name = value)))
-      override val contacttype = new Field[Name, Row](prefix, "contacttype", None, None)(x => extract(x).contacttype, (row, value) => merge(row, extract(row).copy(contacttype = value)))
-      override val title = new OptField[/* max 8 chars */ String, Row](prefix, "title", None, None)(x => extract(x).title, (row, value) => merge(row, extract(row).copy(title = value)))
-      override val firstname = new Field[/* user-picked */ FirstName, Row](prefix, "firstname", None, None)(x => extract(x).firstname, (row, value) => merge(row, extract(row).copy(firstname = value)))
-      override val middlename = new OptField[Name, Row](prefix, "middlename", None, None)(x => extract(x).middlename, (row, value) => merge(row, extract(row).copy(middlename = value)))
-      override val lastname = new Field[Name, Row](prefix, "lastname", None, None)(x => extract(x).lastname, (row, value) => merge(row, extract(row).copy(lastname = value)))
-      override val suffix = new OptField[/* max 10 chars */ String, Row](prefix, "suffix", None, None)(x => extract(x).suffix, (row, value) => merge(row, extract(row).copy(suffix = value)))
-      override val phonenumber = new OptField[Phone, Row](prefix, "phonenumber", None, None)(x => extract(x).phonenumber, (row, value) => merge(row, extract(row).copy(phonenumber = value)))
-      override val phonenumbertype = new OptField[Name, Row](prefix, "phonenumbertype", None, None)(x => extract(x).phonenumbertype, (row, value) => merge(row, extract(row).copy(phonenumbertype = value)))
-      override val emailaddress = new OptField[/* max 50 chars */ String, Row](prefix, "emailaddress", None, None)(x => extract(x).emailaddress, (row, value) => merge(row, extract(row).copy(emailaddress = value)))
-      override val emailpromotion = new Field[Int, Row](prefix, "emailpromotion", None, None)(x => extract(x).emailpromotion, (row, value) => merge(row, extract(row).copy(emailpromotion = value)))
+    override lazy val fields: VstorewithcontactsViewFields = new VstorewithcontactsViewFields {
+      override def businessentityid = Field[BusinessentityId, VstorewithcontactsViewRow](_path, "businessentityid", None, None, x => x.businessentityid, (row, value) => row.copy(businessentityid = value))
+      override def name = Field[Name, VstorewithcontactsViewRow](_path, "name", None, None, x => x.name, (row, value) => row.copy(name = value))
+      override def contacttype = Field[Name, VstorewithcontactsViewRow](_path, "contacttype", None, None, x => x.contacttype, (row, value) => row.copy(contacttype = value))
+      override def title = OptField[/* max 8 chars */ String, VstorewithcontactsViewRow](_path, "title", None, None, x => x.title, (row, value) => row.copy(title = value))
+      override def firstname = Field[/* user-picked */ FirstName, VstorewithcontactsViewRow](_path, "firstname", None, None, x => x.firstname, (row, value) => row.copy(firstname = value))
+      override def middlename = OptField[Name, VstorewithcontactsViewRow](_path, "middlename", None, None, x => x.middlename, (row, value) => row.copy(middlename = value))
+      override def lastname = Field[Name, VstorewithcontactsViewRow](_path, "lastname", None, None, x => x.lastname, (row, value) => row.copy(lastname = value))
+      override def suffix = OptField[/* max 10 chars */ String, VstorewithcontactsViewRow](_path, "suffix", None, None, x => x.suffix, (row, value) => row.copy(suffix = value))
+      override def phonenumber = OptField[Phone, VstorewithcontactsViewRow](_path, "phonenumber", None, None, x => x.phonenumber, (row, value) => row.copy(phonenumber = value))
+      override def phonenumbertype = OptField[Name, VstorewithcontactsViewRow](_path, "phonenumbertype", None, None, x => x.phonenumbertype, (row, value) => row.copy(phonenumbertype = value))
+      override def emailaddress = OptField[/* max 50 chars */ String, VstorewithcontactsViewRow](_path, "emailaddress", None, None, x => x.emailaddress, (row, value) => row.copy(emailaddress = value))
+      override def emailpromotion = Field[Int, VstorewithcontactsViewRow](_path, "emailpromotion", None, None, x => x.emailpromotion, (row, value) => row.copy(emailpromotion = value))
     }
   
-    override val columns: List[FieldLikeNoHkt[?, Row]] =
-      List[FieldLikeNoHkt[?, Row]](fields.businessentityid, fields.name, fields.contacttype, fields.title, fields.firstname, fields.middlename, fields.lastname, fields.suffix, fields.phonenumber, fields.phonenumbertype, fields.emailaddress, fields.emailpromotion)
+    override lazy val columns: List[FieldLikeNoHkt[?, VstorewithcontactsViewRow]] =
+      List[FieldLikeNoHkt[?, VstorewithcontactsViewRow]](fields.businessentityid, fields.name, fields.contacttype, fields.title, fields.firstname, fields.middlename, fields.lastname, fields.suffix, fields.phonenumber, fields.phonenumbertype, fields.emailaddress, fields.emailpromotion)
   
-    override def copy[NewRow](prefix: Option[String], extract: NewRow => VstorewithcontactsViewRow, merge: (NewRow, VstorewithcontactsViewRow) => NewRow): Impl[NewRow] =
-      new Impl(prefix, extract, merge)
+    override def copy(path: List[Path]): Impl =
+      new Impl(path)
   }
   
 }

--- a/typo-tester-zio-jdbc/generated-and-checked-in/adventureworks/sales/vstorewithdemographics/VstorewithdemographicsViewFields.scala
+++ b/typo-tester-zio-jdbc/generated-and-checked-in/adventureworks/sales/vstorewithdemographics/VstorewithdemographicsViewFields.scala
@@ -10,53 +10,54 @@ package vstorewithdemographics
 import adventureworks.customtypes.TypoMoney
 import adventureworks.person.businessentity.BusinessentityId
 import adventureworks.public.Name
+import typo.dsl.Path
 import typo.dsl.SqlExpr.Field
 import typo.dsl.SqlExpr.FieldLikeNoHkt
 import typo.dsl.SqlExpr.OptField
 import typo.dsl.Structure.Relation
 
-trait VstorewithdemographicsViewFields[Row] {
-  val businessentityid: Field[BusinessentityId, Row]
-  val name: Field[Name, Row]
-  val AnnualSales: OptField[TypoMoney, Row]
-  val AnnualRevenue: OptField[TypoMoney, Row]
-  val BankName: OptField[/* max 50 chars */ String, Row]
-  val BusinessType: OptField[/* max 5 chars */ String, Row]
-  val YearOpened: OptField[Int, Row]
-  val Specialty: OptField[/* max 50 chars */ String, Row]
-  val SquareFeet: OptField[Int, Row]
-  val Brands: OptField[/* max 30 chars */ String, Row]
-  val Internet: OptField[/* max 30 chars */ String, Row]
-  val NumberEmployees: OptField[Int, Row]
+trait VstorewithdemographicsViewFields {
+  def businessentityid: Field[BusinessentityId, VstorewithdemographicsViewRow]
+  def name: Field[Name, VstorewithdemographicsViewRow]
+  def AnnualSales: OptField[TypoMoney, VstorewithdemographicsViewRow]
+  def AnnualRevenue: OptField[TypoMoney, VstorewithdemographicsViewRow]
+  def BankName: OptField[/* max 50 chars */ String, VstorewithdemographicsViewRow]
+  def BusinessType: OptField[/* max 5 chars */ String, VstorewithdemographicsViewRow]
+  def YearOpened: OptField[Int, VstorewithdemographicsViewRow]
+  def Specialty: OptField[/* max 50 chars */ String, VstorewithdemographicsViewRow]
+  def SquareFeet: OptField[Int, VstorewithdemographicsViewRow]
+  def Brands: OptField[/* max 30 chars */ String, VstorewithdemographicsViewRow]
+  def Internet: OptField[/* max 30 chars */ String, VstorewithdemographicsViewRow]
+  def NumberEmployees: OptField[Int, VstorewithdemographicsViewRow]
 }
 
 object VstorewithdemographicsViewFields {
-  val structure: Relation[VstorewithdemographicsViewFields, VstorewithdemographicsViewRow, VstorewithdemographicsViewRow] = 
-    new Impl(None, identity, (_, x) => x)
+  lazy val structure: Relation[VstorewithdemographicsViewFields, VstorewithdemographicsViewRow] =
+    new Impl(Nil)
     
-  private final class Impl[Row](val prefix: Option[String], val extract: Row => VstorewithdemographicsViewRow, val merge: (Row, VstorewithdemographicsViewRow) => Row)
-    extends Relation[VstorewithdemographicsViewFields, VstorewithdemographicsViewRow, Row] { 
+  private final class Impl(val _path: List[Path])
+    extends Relation[VstorewithdemographicsViewFields, VstorewithdemographicsViewRow] {
   
-    override val fields: VstorewithdemographicsViewFields[Row] = new VstorewithdemographicsViewFields[Row] {
-      override val businessentityid = new Field[BusinessentityId, Row](prefix, "businessentityid", None, None)(x => extract(x).businessentityid, (row, value) => merge(row, extract(row).copy(businessentityid = value)))
-      override val name = new Field[Name, Row](prefix, "name", None, None)(x => extract(x).name, (row, value) => merge(row, extract(row).copy(name = value)))
-      override val AnnualSales = new OptField[TypoMoney, Row](prefix, "AnnualSales", Some("numeric"), None)(x => extract(x).AnnualSales, (row, value) => merge(row, extract(row).copy(AnnualSales = value)))
-      override val AnnualRevenue = new OptField[TypoMoney, Row](prefix, "AnnualRevenue", Some("numeric"), None)(x => extract(x).AnnualRevenue, (row, value) => merge(row, extract(row).copy(AnnualRevenue = value)))
-      override val BankName = new OptField[/* max 50 chars */ String, Row](prefix, "BankName", None, None)(x => extract(x).BankName, (row, value) => merge(row, extract(row).copy(BankName = value)))
-      override val BusinessType = new OptField[/* max 5 chars */ String, Row](prefix, "BusinessType", None, None)(x => extract(x).BusinessType, (row, value) => merge(row, extract(row).copy(BusinessType = value)))
-      override val YearOpened = new OptField[Int, Row](prefix, "YearOpened", None, None)(x => extract(x).YearOpened, (row, value) => merge(row, extract(row).copy(YearOpened = value)))
-      override val Specialty = new OptField[/* max 50 chars */ String, Row](prefix, "Specialty", None, None)(x => extract(x).Specialty, (row, value) => merge(row, extract(row).copy(Specialty = value)))
-      override val SquareFeet = new OptField[Int, Row](prefix, "SquareFeet", None, None)(x => extract(x).SquareFeet, (row, value) => merge(row, extract(row).copy(SquareFeet = value)))
-      override val Brands = new OptField[/* max 30 chars */ String, Row](prefix, "Brands", None, None)(x => extract(x).Brands, (row, value) => merge(row, extract(row).copy(Brands = value)))
-      override val Internet = new OptField[/* max 30 chars */ String, Row](prefix, "Internet", None, None)(x => extract(x).Internet, (row, value) => merge(row, extract(row).copy(Internet = value)))
-      override val NumberEmployees = new OptField[Int, Row](prefix, "NumberEmployees", None, None)(x => extract(x).NumberEmployees, (row, value) => merge(row, extract(row).copy(NumberEmployees = value)))
+    override lazy val fields: VstorewithdemographicsViewFields = new VstorewithdemographicsViewFields {
+      override def businessentityid = Field[BusinessentityId, VstorewithdemographicsViewRow](_path, "businessentityid", None, None, x => x.businessentityid, (row, value) => row.copy(businessentityid = value))
+      override def name = Field[Name, VstorewithdemographicsViewRow](_path, "name", None, None, x => x.name, (row, value) => row.copy(name = value))
+      override def AnnualSales = OptField[TypoMoney, VstorewithdemographicsViewRow](_path, "AnnualSales", Some("numeric"), None, x => x.AnnualSales, (row, value) => row.copy(AnnualSales = value))
+      override def AnnualRevenue = OptField[TypoMoney, VstorewithdemographicsViewRow](_path, "AnnualRevenue", Some("numeric"), None, x => x.AnnualRevenue, (row, value) => row.copy(AnnualRevenue = value))
+      override def BankName = OptField[/* max 50 chars */ String, VstorewithdemographicsViewRow](_path, "BankName", None, None, x => x.BankName, (row, value) => row.copy(BankName = value))
+      override def BusinessType = OptField[/* max 5 chars */ String, VstorewithdemographicsViewRow](_path, "BusinessType", None, None, x => x.BusinessType, (row, value) => row.copy(BusinessType = value))
+      override def YearOpened = OptField[Int, VstorewithdemographicsViewRow](_path, "YearOpened", None, None, x => x.YearOpened, (row, value) => row.copy(YearOpened = value))
+      override def Specialty = OptField[/* max 50 chars */ String, VstorewithdemographicsViewRow](_path, "Specialty", None, None, x => x.Specialty, (row, value) => row.copy(Specialty = value))
+      override def SquareFeet = OptField[Int, VstorewithdemographicsViewRow](_path, "SquareFeet", None, None, x => x.SquareFeet, (row, value) => row.copy(SquareFeet = value))
+      override def Brands = OptField[/* max 30 chars */ String, VstorewithdemographicsViewRow](_path, "Brands", None, None, x => x.Brands, (row, value) => row.copy(Brands = value))
+      override def Internet = OptField[/* max 30 chars */ String, VstorewithdemographicsViewRow](_path, "Internet", None, None, x => x.Internet, (row, value) => row.copy(Internet = value))
+      override def NumberEmployees = OptField[Int, VstorewithdemographicsViewRow](_path, "NumberEmployees", None, None, x => x.NumberEmployees, (row, value) => row.copy(NumberEmployees = value))
     }
   
-    override val columns: List[FieldLikeNoHkt[?, Row]] =
-      List[FieldLikeNoHkt[?, Row]](fields.businessentityid, fields.name, fields.AnnualSales, fields.AnnualRevenue, fields.BankName, fields.BusinessType, fields.YearOpened, fields.Specialty, fields.SquareFeet, fields.Brands, fields.Internet, fields.NumberEmployees)
+    override lazy val columns: List[FieldLikeNoHkt[?, VstorewithdemographicsViewRow]] =
+      List[FieldLikeNoHkt[?, VstorewithdemographicsViewRow]](fields.businessentityid, fields.name, fields.AnnualSales, fields.AnnualRevenue, fields.BankName, fields.BusinessType, fields.YearOpened, fields.Specialty, fields.SquareFeet, fields.Brands, fields.Internet, fields.NumberEmployees)
   
-    override def copy[NewRow](prefix: Option[String], extract: NewRow => VstorewithdemographicsViewRow, merge: (NewRow, VstorewithdemographicsViewRow) => NewRow): Impl[NewRow] =
-      new Impl(prefix, extract, merge)
+    override def copy(path: List[Path]): Impl =
+      new Impl(path)
   }
   
 }

--- a/typo-tester-zio-jdbc/src/scala/adventureworks/PaginationTest.scala
+++ b/typo-tester-zio-jdbc/src/scala/adventureworks/PaginationTest.scala
@@ -28,7 +28,7 @@ class PaginationTest extends AnyFunSuite with TypeCheckedTripleEquals {
     def patch(c: ClientCursor[Json]): ClientCursor[Json] =
       businessentityRepo match {
         case _: BusinessentityRepoMock =>
-          c.copy(parts = c.parts.map { case (k, v) => (SortOrderRepr(k.expr.replace("businessentity1.", "")), v) })
+          c.copy(parts = c.parts.map { case (k, v) => (SortOrderRepr(k.expr.replace("businessentity0.", "")), v) })
         case _ => c
       }
 
@@ -65,8 +65,8 @@ class PaginationTest extends AnyFunSuite with TypeCheckedTripleEquals {
               patch(
                 ClientCursor(
                   Map(
-                    SortOrderRepr("businessentity1.modifieddate") -> new Json.Str("2020-12-29T00:00:00"),
-                    SortOrderRepr("(businessentity1.businessentityid - 2::INTEGER)") -> new Json.Num(java.math.BigDecimal.valueOf(1))
+                    SortOrderRepr("businessentity0.modifieddate") -> new Json.Str("2020-12-29T00:00:00"),
+                    SortOrderRepr("(businessentity0.businessentityid - 2::INTEGER)") -> new Json.Num(java.math.BigDecimal.valueOf(1))
                   )
                 )
               )
@@ -83,8 +83,8 @@ class PaginationTest extends AnyFunSuite with TypeCheckedTripleEquals {
               patch(
                 ClientCursor(
                   Map(
-                    SortOrderRepr("businessentity1.modifieddate") -> new Json.Str("2020-12-25T00:00:00"),
-                    SortOrderRepr("(businessentity1.businessentityid - 2::INTEGER)") -> new Json.Num(java.math.BigDecimal.valueOf(15))
+                    SortOrderRepr("businessentity0.modifieddate") -> new Json.Str("2020-12-25T00:00:00"),
+                    SortOrderRepr("(businessentity0.businessentityid - 2::INTEGER)") -> new Json.Num(java.math.BigDecimal.valueOf(15))
                   )
                 )
               )

--- a/typo-tester-zio-jdbc/src/scala/adventureworks/production/product/ProductTest.scala
+++ b/typo-tester-zio-jdbc/src/scala/adventureworks/production/product/ProductTest.scala
@@ -95,7 +95,7 @@ class ProductTest extends AnyFunSuite with TypeCheckedTripleEquals {
           .where(x => (x.daystomanufacture > 25).or(x.daystomanufacture <= 0))
           .where(x => x.productline === "foo")
           .join(unitmeasureRepo.select.where(_.name.like("name%")))
-          .on { case (p, um) => p.sizeunitmeasurecode === um.unitmeasurecode }
+          .on { case (p, um) => p.sizeunitmeasurecode.isEqual(um.unitmeasurecode) }
           .join(projectModelRepo.select)
           .leftOn { case ((product, _), productModel) => product.productmodelid === productModel.productmodelid }
           .where { case ((product, _), productModel) => product.productmodelid === productModel(_.productmodelid) }

--- a/typo-tester-zio-jdbc/src/scala/adventureworks/production/product/SeekTest.scala
+++ b/typo-tester-zio-jdbc/src/scala/adventureworks/production/product/SeekTest.scala
@@ -7,16 +7,13 @@ import org.scalatest.funsuite.AnyFunSuite
 class SeekTest extends AnyFunSuite with TypeCheckedTripleEquals {
   val productRepo = new ProductRepoImpl
 
-  val base =
-    """select "productid", "name", "productnumber", "makeflag", "finishedgoodsflag", "color", "safetystocklevel", "reorderpoint", "standardcost", "listprice", "size", "sizeunitmeasurecode", "weightunitmeasurecode", "weight", "daystomanufacture", "productline", "class", "style", "productsubcategoryid", "productmodelid", "sellstartdate"::text, "sellenddate"::text, "discontinueddate"::text, "rowguid", "modifieddate"::text from production.product"""
-
   test("uniform ascending") {
     val query = productRepo.select
       .seek(_.name.asc)(Name("foo"))
       .seek(_.weight.asc)(Some(BigDecimal(22.2)))
       .seek(_.listprice.asc)(BigDecimal(33.3))
     assertResult(query.sql.get.toString)(
-      s"""Sql($base WHERE ((name,weight,listprice) > (?::VARCHAR,?::DECIMAL,?::DECIMAL)) ORDER BY name ASC , weight ASC , listprice ASC , foo, Some(22.2), 33.3)"""
+      s"""Sql(select "productid", "name", "productnumber", "makeflag", "finishedgoodsflag", "color", "safetystocklevel", "reorderpoint", "standardcost", "listprice", "size", "sizeunitmeasurecode", "weightunitmeasurecode", "weight", "daystomanufacture", "productline", "class", "style", "productsubcategoryid", "productmodelid", "sellstartdate"::text, "sellenddate"::text, "discontinueddate"::text, "rowguid", "modifieddate"::text from production.product product0 WHERE ((product0.name,product0.weight,product0.listprice) > (?::VARCHAR,?::DECIMAL,?::DECIMAL)) ORDER BY product0.name ASC , product0.weight ASC , product0.listprice ASC , foo, Some(22.2), 33.3)"""
     )
   }
 
@@ -26,7 +23,7 @@ class SeekTest extends AnyFunSuite with TypeCheckedTripleEquals {
       .seek(_.weight.desc)(Some(BigDecimal(22.2)))
       .seek(_.listprice.desc)(BigDecimal(33.3))
     assertResult(query.sql.get.toString)(
-      s"""Sql($base WHERE ((name,weight,listprice) < (?::VARCHAR,?::DECIMAL,?::DECIMAL)) ORDER BY name DESC , weight DESC , listprice DESC , foo, Some(22.2), 33.3)"""
+      s"""Sql(select "productid", "name", "productnumber", "makeflag", "finishedgoodsflag", "color", "safetystocklevel", "reorderpoint", "standardcost", "listprice", "size", "sizeunitmeasurecode", "weightunitmeasurecode", "weight", "daystomanufacture", "productline", "class", "style", "productsubcategoryid", "productmodelid", "sellstartdate"::text, "sellenddate"::text, "discontinueddate"::text, "rowguid", "modifieddate"::text from production.product product0 WHERE ((product0.name,product0.weight,product0.listprice) < (?::VARCHAR,?::DECIMAL,?::DECIMAL)) ORDER BY product0.name DESC , product0.weight DESC , product0.listprice DESC , foo, Some(22.2), 33.3)"""
     )
   }
 
@@ -36,7 +33,7 @@ class SeekTest extends AnyFunSuite with TypeCheckedTripleEquals {
       .seek(_.weight.desc)(Some(BigDecimal(22.2)))
       .seek(_.listprice.desc)(BigDecimal(33.3))
     assertResult(query.sql.get.toString)(
-      s"""Sql($base WHERE (((name > ?::VARCHAR) OR ((name = ?::VARCHAR) AND (weight < ?::DECIMAL))) OR (((name = ?::VARCHAR) AND (weight = ?::DECIMAL)) AND (listprice < ?::DECIMAL))) ORDER BY name ASC , weight DESC , listprice DESC , foo, foo, Some(22.2), foo, Some(22.2), 33.3)"""
+      s"""Sql(select "productid", "name", "productnumber", "makeflag", "finishedgoodsflag", "color", "safetystocklevel", "reorderpoint", "standardcost", "listprice", "size", "sizeunitmeasurecode", "weightunitmeasurecode", "weight", "daystomanufacture", "productline", "class", "style", "productsubcategoryid", "productmodelid", "sellstartdate"::text, "sellenddate"::text, "discontinueddate"::text, "rowguid", "modifieddate"::text from production.product product0 WHERE (((product0.name > ?::VARCHAR) OR ((product0.name = ?::VARCHAR) AND (product0.weight < ?::DECIMAL))) OR (((product0.name = ?::VARCHAR) AND (product0.weight = ?::DECIMAL)) AND (product0.listprice < ?::DECIMAL))) ORDER BY product0.name ASC , product0.weight DESC , product0.listprice DESC , foo, foo, Some(22.2), foo, Some(22.2), 33.3)"""
     )
   }
 }

--- a/typo/src/scala/typo/TypesScala.scala
+++ b/typo/src/scala/typo/TypesScala.scala
@@ -20,6 +20,7 @@ object TypesScala {
   val ListMap = sc.Type.Qualified("scala.collection.immutable.ListMap")
   val Long = sc.Type.Qualified("scala.Long")
   val Map = sc.Type.Qualified("scala.collection.immutable.Map")
+  val Nil = sc.Type.Qualified("scala.collection.immutable.Nil")
   val None = sc.Type.Qualified("scala.None")
   val Numeric = sc.Type.Qualified("scala.math.Numeric")
   val Option = sc.Type.Qualified("scala.Option")

--- a/typo/src/scala/typo/internal/codegen/DbLibAnorm.scala
+++ b/typo/src/scala/typo/internal/codegen/DbLibAnorm.scala
@@ -553,7 +553,7 @@ class DbLibAnorm(pkg: sc.QIdent, inlineImplicits: Boolean, default: ComputedDefa
                |  case ${TypesScala.None} => false
                |}""".stripMargin
       case RepoMethod.UpdateBuilder(_, fieldsType, _) =>
-        code"${sc.Type.dsl.UpdateBuilderMock}(${sc.Type.dsl.UpdateParams}.empty, $fieldsType.structure.fields, map)"
+        code"${sc.Type.dsl.UpdateBuilderMock}(${sc.Type.dsl.UpdateParams}.empty, $fieldsType.structure, map)"
       case RepoMethod.Update(_, _, _, param, _) =>
         code"""map.get(${param.name}.${id.paramName}) match {
               |  case ${TypesScala.Some}(`${param.name}`) => false
@@ -586,7 +586,7 @@ class DbLibAnorm(pkg: sc.QIdent, inlineImplicits: Boolean, default: ComputedDefa
                |}
                |unsaved.size.toLong""".stripMargin
       case RepoMethod.DeleteBuilder(_, fieldsType, _) =>
-        code"${sc.Type.dsl.DeleteBuilderMock}(${sc.Type.dsl.DeleteParams}.empty, $fieldsType.structure.fields, map)"
+        code"${sc.Type.dsl.DeleteBuilderMock}(${sc.Type.dsl.DeleteParams}.empty, $fieldsType.structure, map)"
       case RepoMethod.Delete(_, id) =>
         code"map.remove(${id.paramName}).isDefined"
       case RepoMethod.DeleteByIds(_, _, idsParam) =>

--- a/typo/src/scala/typo/internal/codegen/DbLibDoobie.scala
+++ b/typo/src/scala/typo/internal/codegen/DbLibDoobie.scala
@@ -419,7 +419,7 @@ class DbLibDoobie(pkg: sc.QIdent, inlineImplicits: Boolean, default: ComputedDef
               |  }.toList
               |}""".stripMargin
       case RepoMethod.UpdateBuilder(_, fieldsType, _) =>
-        code"${sc.Type.dsl.UpdateBuilderMock}(${sc.Type.dsl.UpdateParams}.empty, $fieldsType.structure.fields, map)"
+        code"${sc.Type.dsl.UpdateBuilderMock}(${sc.Type.dsl.UpdateParams}.empty, $fieldsType.structure, map)"
       case RepoMethod.UpdateFieldValues(_, id, varargs, fieldValue, cases0, _) =>
         val cases = cases0.map { col =>
           code"case (acc, $fieldValue.${col.name}(value)) => acc.copy(${col.name} = value)"
@@ -487,7 +487,7 @@ class DbLibDoobie(pkg: sc.QIdent, inlineImplicits: Boolean, default: ComputedDef
                |}""".stripMargin
 
       case RepoMethod.DeleteBuilder(_, fieldsType, _) =>
-        code"${sc.Type.dsl.DeleteBuilderMock}(${sc.Type.dsl.DeleteParams}.empty, $fieldsType.structure.fields, map)"
+        code"${sc.Type.dsl.DeleteBuilderMock}(${sc.Type.dsl.DeleteParams}.empty, $fieldsType.structure, map)"
       case RepoMethod.Delete(_, id) =>
         code"$delayCIO(map.remove(${id.paramName}).isDefined)"
       case RepoMethod.DeleteByIds(_, _, idsParam) =>

--- a/typo/src/scala/typo/internal/codegen/DbLibZioJdbc.scala
+++ b/typo/src/scala/typo/internal/codegen/DbLibZioJdbc.scala
@@ -535,7 +535,7 @@ class DbLibZioJdbc(pkg: sc.QIdent, inlineImplicits: Boolean, dslEnabled: Boolean
               |  }
               |}""".stripMargin
       case RepoMethod.UpdateBuilder(_, fieldsType, _) =>
-        code"${sc.Type.dsl.UpdateBuilderMock}(${sc.Type.dsl.UpdateParams}.empty, $fieldsType.structure.fields, map)"
+        code"${sc.Type.dsl.UpdateBuilderMock}(${sc.Type.dsl.UpdateParams}.empty, $fieldsType.structure, map)"
       case RepoMethod.UpdateFieldValues(_, id, varargs, fieldValue, cases0, _) =>
         val cases = cases0.map { col =>
           code"case (acc, $fieldValue.${col.name}(value)) => acc.copy(${col.name} = value)"
@@ -585,7 +585,7 @@ class DbLibZioJdbc(pkg: sc.QIdent, inlineImplicits: Boolean, dslEnabled: Boolean
         code"insert(${maybeToRow.get.name}(${unsavedParam.name}))"
 
       case RepoMethod.DeleteBuilder(_, fieldsType, _) =>
-        code"${sc.Type.dsl.DeleteBuilderMock}(${sc.Type.dsl.DeleteParams}.empty, $fieldsType.structure.fields, map)"
+        code"${sc.Type.dsl.DeleteBuilderMock}(${sc.Type.dsl.DeleteParams}.empty, $fieldsType.structure, map)"
       case RepoMethod.Delete(_, id) =>
         code"$ZIO.succeed(map.remove(${id.paramName}).isDefined)"
       case RepoMethod.DeleteByIds(_, _, idsParam) =>

--- a/typo/src/scala/typo/internal/codegen/FilesSqlFile.scala
+++ b/typo/src/scala/typo/internal/codegen/FilesSqlFile.scala
@@ -5,7 +5,7 @@ package codegen
 import typo.internal.codegen.DbLib.RowType
 
 case class FilesSqlFile(script: ComputedSqlFile, naming: Naming, options: InternalOptions) {
-  val relation = FilesRelation(naming, script.names, script.maybeCols.toOption, options)
+  val relation = FilesRelation(naming, script.names, script.maybeCols.toOption, options, fks = Nil)
   val all: List[sc.File] = List(
     relation.RowFile(RowType.Readable, comment = None, maybeUnsavedRow = None),
     relation.FieldsFile,

--- a/typo/src/scala/typo/internal/codegen/FilesTable.scala
+++ b/typo/src/scala/typo/internal/codegen/FilesTable.scala
@@ -6,7 +6,7 @@ import play.api.libs.json.Json
 import typo.internal.codegen.DbLib.RowType
 
 case class FilesTable(table: ComputedTable, options: InternalOptions, genOrdering: GenOrdering) {
-  val relation = FilesRelation(table.naming, table.names, Some(table.cols), options)
+  val relation = FilesRelation(table.naming, table.names, Some(table.cols), options, table.dbTable.foreignKeys)
   val RowFile = relation.RowFile(RowType.ReadWriteable, table.dbTable.comment, maybeUnsavedRow = table.maybeUnsavedRow.map(u => (u, table.default)))
 
   val UnsavedRowFile: Option[sc.File] =

--- a/typo/src/scala/typo/internal/codegen/FilesView.scala
+++ b/typo/src/scala/typo/internal/codegen/FilesView.scala
@@ -5,7 +5,7 @@ package codegen
 import typo.internal.codegen.DbLib.RowType
 
 case class FilesView(view: ComputedView, options: InternalOptions) {
-  val relation = FilesRelation(view.naming, view.names, Some(view.cols), options)
+  val relation = FilesRelation(view.naming, view.names, Some(view.cols), options, fks = Nil)
   val all: List[sc.File] = List(
     relation.RowFile(RowType.Readable, view.view.comment, maybeUnsavedRow = None),
     relation.FieldsFile,

--- a/typo/src/scala/typo/sc.scala
+++ b/typo/src/scala/typo/sc.scala
@@ -103,9 +103,11 @@ object sc {
       val DeleteParams = Qualified("typo.dsl.DeleteParams")
       val Field = Qualified("typo.dsl.SqlExpr.Field")
       val FieldLikeNoHkt = Qualified("typo.dsl.SqlExpr.FieldLikeNoHkt")
-      val FieldValue = Qualified("typo.dsl.FieldValue")
+      val ForeignKey = Qualified("typo.dsl.ForeignKey")
       val IdField = Qualified("typo.dsl.SqlExpr.IdField")
       val OptField = Qualified("typo.dsl.SqlExpr.OptField")
+      val Path = Qualified("typo.dsl.Path")
+      val Required = Qualified("typo.dsl.Required")
       val SelectBuilder = Qualified("typo.dsl.SelectBuilder")
       val SelectBuilderMock = Qualified("typo.dsl.SelectBuilderMock")
       val SelectBuilderSql = Qualified("typo.dsl.SelectBuilderSql")
@@ -140,6 +142,8 @@ object sc {
         TypesScala.Long,
         TypesScala.Map,
         TypesScala.None,
+        TypesScala.Nil,
+        TypesScala.Numeric,
         TypesScala.Option,
         TypesScala.Ordering,
         TypesScala.Right,


### PR DESCRIPTION
- This avoids need for kind-projector
- Remove `Fields` type-level connection to `Row`. This simplifies the interface a *lot*, but removes some type-safety for code which is mostly used for mocks
- Change and simplify `Field` interface
