### PR TITLE
Parallelize database handling (breaking, fixes #49)

### DIFF
--- a/bleep.yaml
+++ b/bleep.yaml
@@ -15,6 +15,8 @@ projects:
     - com.typesafe.play::play-json:2.10.6
     - org.playframework.anorm::anorm:2.7.0
     - org.postgresql:postgresql:42.7.3
+    - com.zaxxer:HikariCP:4.0.3
+    - org.slf4j:slf4j-nop:2.0.13
     extends: template-cross
     platform:
       mainClass: com.foo.App

--- a/site-in/other-features/generate-into-multiple-projects.md
+++ b/site-in/other-features/generate-into-multiple-projects.md
@@ -19,10 +19,11 @@ import typo.*
 import java.nio.file.Path
 import java.sql.Connection
 
-def generate(implicit c: Connection): String = {
+def generate(ds: TypoDataSource): String = {
   val cwd: Path = Path.of(sys.props("user.dir"))
 
   val generated = generateFromDb(
+    ds,
     Options(
       pkg = "org.mypkg",
       jsonLibs = Nil,

--- a/site-in/setup.md
+++ b/site-in/setup.md
@@ -40,8 +40,13 @@ put it in `gen-db.sc` and run `scala-cli gen-db.sc`
 import typo.*
 
 // adapt to your instance and credentials
-implicit val c: java.sql.Connection =
-  java.sql.DriverManager.getConnection("jdbc:postgresql://localhost:6432/postgres?user=postgres&password=password")
+val ds = TypoDataSource.hikari(
+  server = "localhost", 
+  port = 6432, 
+  databaseName = "Adventureworks", 
+  username = "postgres", 
+  password = "password"
+)
 
 val options = Options(
   // customize package name for generated code
@@ -67,6 +72,7 @@ val scriptsFolder = location.resolve("sql")
 val selector = Selector.ExcludePostgresInternal
 
 generateFromDb(
+  ds,
   options, 
   targetFolder = targetDir,
   testTargetFolder = Some(testTargetDir),

--- a/typo-scripts/src/scala/scripts/GeneratedSources.scala
+++ b/typo-scripts/src/scala/scripts/GeneratedSources.scala
@@ -3,20 +3,11 @@ package scripts
 import typo.*
 
 import java.nio.file.Path
-import java.sql.{Connection, DriverManager}
-import java.util
 import scala.annotation.nowarn
 
 object GeneratedSources {
   def main(args: Array[String]): Unit = {
-    implicit val c: Connection = {
-      val url = "jdbc:postgresql://localhost:6432/postgres"
-      val props = new util.Properties
-      props.setProperty("user", "postgres")
-      props.setProperty("password", "password")
-      props.setProperty("port", "6432")
-      DriverManager.getConnection(url, props)
-    }
+    val ds = TypoDataSource.hikari(server = "localhost", port = 6432, databaseName = "Adventureworks", username = "postgres", password = "password")
 
     val header =
       """|/**
@@ -32,6 +23,7 @@ object GeneratedSources {
     val typoSources = buildDir.resolve("typo/generated-and-checked-in")
 
     val files = generateFromDb(
+      ds,
       Options(
         pkg = "typo.generated",
         jsonLibs = List(JsonLibName.PlayJson),

--- a/typo/src/scala/typo/Options.scala
+++ b/typo/src/scala/typo/Options.scala
@@ -1,5 +1,7 @@
 package typo
 
+import scala.concurrent.ExecutionContext
+
 case class Options(
     pkg: String,
     dbLib: Option[DbLibName],
@@ -21,7 +23,8 @@ case class Options(
     inlineImplicits: Boolean = true,
     fixVerySlowImplicit: Boolean = true,
     keepDependencies: Boolean = false,
-    rewriteDatabase: MetaDb => MetaDb = identity
+    rewriteDatabase: MetaDb => MetaDb = identity,
+    executionContext: ExecutionContext = ExecutionContext.global
 )
 
 object Options {

--- a/typo/src/scala/typo/TypoDataSource.scala
+++ b/typo/src/scala/typo/TypoDataSource.scala
@@ -1,0 +1,29 @@
+package typo
+
+import com.zaxxer.hikari.{HikariConfig, HikariDataSource}
+
+import java.sql.Connection
+import javax.sql.DataSource
+import scala.concurrent.{ExecutionContext, Future, blocking}
+
+case class TypoDataSource(ds: DataSource) {
+  def run[T](f: Connection => T)(implicit ec: ExecutionContext): Future[T] =
+    blocking {
+      Future {
+        val conn = ds.getConnection
+        try f(conn)
+        finally conn.close()
+      }
+    }
+}
+
+object TypoDataSource {
+  def hikari(server: String, port: Int, databaseName: String, username: String, password: String): TypoDataSource = {
+    val config = new HikariConfig
+    config.setJdbcUrl(s"jdbc:postgresql://$server:$port/$databaseName")
+    config.setUsername(username)
+    config.setPassword(password)
+    val ds = new HikariDataSource(config)
+    TypoDataSource(ds)
+  }
+}

--- a/typo/src/scala/typo/TypoLogger.scala
+++ b/typo/src/scala/typo/TypoLogger.scala
@@ -1,8 +1,17 @@
 package typo
 
+import scala.concurrent.{ExecutionContext, Future}
+
 trait TypoLogger {
   def warn(str: String): Unit
   def info(str: String): Unit
+
+  final def timed[T](name: String)(f: Future[T])(implicit ec: ExecutionContext): Future[T] =
+    for {
+      start <- Future.successful(System.currentTimeMillis())
+      res <- f
+      _ <- Future.successful(info(s"finished $name in ${System.currentTimeMillis() - start}ms"))
+    } yield res
 }
 
 object TypoLogger {

--- a/typo/src/scala/typo/generateFromDb.scala
+++ b/typo/src/scala/typo/generateFromDb.scala
@@ -3,7 +3,8 @@ package typo
 import typo.internal.sqlfiles.readSqlFileDirectories
 
 import java.nio.file.Path
-import java.sql.Connection
+import scala.concurrent.duration.Duration
+import scala.concurrent.{Await, ExecutionContext, Future}
 
 /** Main entry-point for generating code from a database.
   */
@@ -12,25 +13,32 @@ object generateFromDb {
   /** Allows you to generate code into *one* folder
     */
   def apply(
+      dataSource: TypoDataSource,
       options: Options,
       targetFolder: Path,
       testTargetFolder: Option[Path],
       selector: Selector = Selector.ExcludePostgresInternal,
       scriptsPaths: List[Path] = Nil
-  )(implicit c: Connection): Generated =
-    apply(options, ProjectGraph(name = "", targetFolder, testTargetFolder, selector, scriptsPaths, Nil)).head
+  ): Generated =
+    apply(dataSource, options, ProjectGraph(name = "", targetFolder, testTargetFolder, selector, scriptsPaths, Nil)).head
 
   /** Allows you to generate code into multiple folders
     */
   def apply(
+      dataSource: TypoDataSource,
       options: Options,
       graph: ProjectGraph[Selector, List[Path]]
-  )(implicit c: Connection): List[Generated] = {
+  ): List[Generated] = {
     Banner.maybePrint(options)
-    internal.generate(
-      options,
-      MetaDb.fromDb(options.logger),
-      graph.mapScripts(paths => paths.flatMap(p => readSqlFileDirectories(options.logger, p)))
-    )
+    implicit val ec: ExecutionContext = options.executionContext
+    val viewSelector = graph.toList.map(_.value).foldLeft(Selector.None)(_.or(_))
+    val eventualMetaDb = MetaDb.fromDb(options.logger, dataSource, viewSelector)
+    val eventualScripts = graph.mapScripts(paths => Future.sequence(paths.map(p => readSqlFileDirectories(options.logger, p, dataSource))).map(_.flatten))
+    val combined = for {
+      metaDb <- eventualMetaDb
+      scripts <- eventualScripts
+    } yield internal.generate(options, metaDb, scripts)
+
+    Await.result(combined, Duration.Inf)
   }
 }

--- a/typo/src/scala/typo/internal/sqlfiles/readSqlFileDirectories.scala
+++ b/typo/src/scala/typo/internal/sqlfiles/readSqlFileDirectories.scala
@@ -10,43 +10,51 @@ import typo.internal.analysis.{DecomposedSql, JdbcMetadata, NullabilityFromExpla
 import java.nio.file.attribute.BasicFileAttributes
 import java.nio.file.{FileVisitResult, Files, Path, SimpleFileVisitor}
 import java.sql.Connection
+import scala.concurrent.{ExecutionContext, Future}
 
 object readSqlFileDirectories {
-  def apply(logger: TypoLogger, scriptsPath: Path)(implicit c: Connection): List[SqlFile] =
-    findSqlFilesUnder(scriptsPath).flatMap { sqlFile =>
-      logger.info(s"Analyzing $sqlFile")
+  def apply(logger: TypoLogger, scriptsPath: Path, ds: TypoDataSource)(implicit ec: ExecutionContext): Future[List[SqlFile]] = {
+    val eventualMaybeFiles: List[Future[Option[SqlFile]]] =
+      findSqlFilesUnder(scriptsPath).map { sqlFile =>
+        logger.timed(s"analyze $sqlFile") {
 
-      val sqlContent = Files.readString(sqlFile)
-      val decomposedSql = DecomposedSql.parse(sqlContent)
+          val sqlContent = Files.readString(sqlFile)
+          val decomposedSql = DecomposedSql.parse(sqlContent)
 
-      val queryType = queryTypeFor(decomposedSql, c)
-      queryType match {
-        case SqlCommandType.BLANK =>
-          logger.info(s"Skipping $sqlFile because it's empty")
-          None
-        case _ =>
-          try {
-            val maybeSqlData = JdbcMetadata.from(decomposedSql.sqlWithQuestionMarks)
-            maybeSqlData match {
-              case Left(msg) =>
-                logger.warn(s"Error while parsing $sqlFile : $msg. Will ignore the file.")
+          ds.run { implicit c =>
+            val queryType = queryTypeFor(decomposedSql, c)
+            queryType match {
+              case SqlCommandType.BLANK =>
+                logger.info(s"Skipping $sqlFile because it's empty")
                 None
-              case Right(jdbcMetadata) =>
-                val nullableColumnsFromJoins =
-                  queryType match {
-                    case SqlCommandType.SELECT => NullabilityFromExplain.from(decomposedSql, jdbcMetadata.params).nullableIndices
-                    case _                     => None
-                  }
+              case _ =>
+                try {
+                  val maybeSqlData = JdbcMetadata.from(decomposedSql.sqlWithQuestionMarks)
+                  maybeSqlData match {
+                    case Left(msg) =>
+                      logger.warn(s"Error while parsing $sqlFile : $msg. Will ignore the file.")
+                      None
+                    case Right(jdbcMetadata) =>
+                      val nullableColumnsFromJoins =
+                        queryType match {
+                          case SqlCommandType.SELECT => NullabilityFromExplain.from(decomposedSql, jdbcMetadata.params).nullableIndices
+                          case _                     => None
+                        }
 
-                Some(SqlFile(RelPath.relativeTo(scriptsPath, sqlFile), decomposedSql, jdbcMetadata, nullableColumnsFromJoins))
+                      Some(SqlFile(RelPath.relativeTo(scriptsPath, sqlFile), decomposedSql, jdbcMetadata, nullableColumnsFromJoins))
+                  }
+                } catch {
+                  case e: PSQLException =>
+                    logger.warn(s"Error while parsing $sqlFile : ${e.getMessage}. Will ignore the file.")
+                    None
+                }
             }
-          } catch {
-            case e: PSQLException =>
-              logger.warn(s"Error while parsing $sqlFile : ${e.getMessage}. Will ignore the file.")
-              None
           }
+        }
       }
-    }
+
+    Future.sequence(eventualMaybeFiles).map(_.flatten)
+  }
 
   def queryTypeFor(decomposedSql: DecomposedSql, c: Connection): SqlCommandType = {
     val pc = c.unwrap(classOf[PgConnection])


### PR DESCRIPTION
- now uses `Future` just to parallelize all calls to postgres
- cleaner separation of input and processing
- now needs a `DataSource` instead of a `Connection`, which breaks API
- adds a dependency upon hikari
- keep it at hikari version 4 to avoid alpha slf4j
- add slf4j-nop to avoid spam