### PR TITLE
Simple `generateFromDb` overload dropped test scope. (breaking, fixes #118)

### DIFF
--- a/site-in/setup.md
+++ b/site-in/setup.md
@@ -78,7 +78,7 @@ generateFromDb(
   testTargetFolder = Some(testTargetDir),
   selector = selector, 
   scriptsPaths = List(scriptsFolder)
-).overwriteFolder()
+).foreach(_.overwriteFolder())
 
 // add changed files to git, so you can keep them under control
 //scala.sys.process.Process(List("git", "add", targetDir.toString)).!!

--- a/typo-scripts/src/scala/scripts/GeneratedSources.scala
+++ b/typo-scripts/src/scala/scripts/GeneratedSources.scala
@@ -46,7 +46,7 @@ object GeneratedSources {
       List(buildDir.resolve("sql"))
     )
 
-    files.overwriteFolder(): @nowarn
+    files.foreach(_.overwriteFolder())
 
     import scala.sys.process.*
     List("git", "add", "-f", typoSources.toString).!! : @nowarn

--- a/typo/src/scala/typo/generateFromDb.scala
+++ b/typo/src/scala/typo/generateFromDb.scala
@@ -19,8 +19,8 @@ object generateFromDb {
       testTargetFolder: Option[Path],
       selector: Selector = Selector.ExcludePostgresInternal,
       scriptsPaths: List[Path] = Nil
-  ): Generated =
-    apply(dataSource, options, ProjectGraph(name = "", targetFolder, testTargetFolder, selector, scriptsPaths, Nil)).head
+  ): List[Generated] =
+    apply(dataSource, options, ProjectGraph(name = "", targetFolder, testTargetFolder, selector, scriptsPaths, Nil))
 
   /** Allows you to generate code into multiple folders
     */


### PR DESCRIPTION


Must now do `generated.foreach(_.overwriteFolder()) `