### PR TITLE
Relax constraint on SqlExpr equality operators to just Equiv

### DIFF
--- a/typo-dsl-anorm/src/scala/typo/dsl/SqlExpr.scala
+++ b/typo-dsl-anorm/src/scala/typo/dsl/SqlExpr.scala
@@ -10,16 +10,16 @@ sealed trait SqlExpr[T, N[_]] extends SqlExpr.SqlExprNoHkt[N[T]] {
   final def customBinaryOp[T2, N2[_], NC[_]](op: String, right: SqlExpr[T2, N2])(f: (T, T2) => Boolean)(implicit N: Nullability2[N, N2, NC]): SqlExpr[Boolean, NC] =
     SqlExpr.Binary[T, T2, Boolean, N, N2, NC](this, new SqlOperator(op, f), right, N)
 
-  final def isEqual[N2[_], NC[_]](t: SqlExpr[T, N2])(implicit O: Ordering[T], N: Nullability2[N, N2, NC]): SqlExpr[Boolean, NC] =
+  final def isEqual[N2[_], NC[_]](t: SqlExpr[T, N2])(implicit E: Equiv[T], N: Nullability2[N, N2, NC]): SqlExpr[Boolean, NC] =
     this === t
 
-  final def isNotEqual[N2[_], NC[_]](t: SqlExpr[T, N2])(implicit O: Ordering[T], N: Nullability2[N, N2, NC]): SqlExpr[Boolean, NC] =
+  final def isNotEqual[N2[_], NC[_]](t: SqlExpr[T, N2])(implicit E: Equiv[T], N: Nullability2[N, N2, NC]): SqlExpr[Boolean, NC] =
     this !== t
 
-  final def ===[N2[_], NC[_]](t: SqlExpr[T, N2])(implicit O: Ordering[T], N: Nullability2[N, N2, NC]): SqlExpr[Boolean, NC] =
+  final def ===[N2[_], NC[_]](t: SqlExpr[T, N2])(implicit E: Equiv[T], N: Nullability2[N, N2, NC]): SqlExpr[Boolean, NC] =
     SqlExpr.Binary(this, SqlOperator.eq, t, N)
 
-  final def !==[N2[_], NC[_]](t: SqlExpr[T, N2])(implicit O: Ordering[T], N: Nullability2[N, N2, NC]): SqlExpr[Boolean, NC] =
+  final def !==[N2[_], NC[_]](t: SqlExpr[T, N2])(implicit E: Equiv[T], N: Nullability2[N, N2, NC]): SqlExpr[Boolean, NC] =
     SqlExpr.Binary(this, SqlOperator.neq, t, N)
 
   final def >[N2[_], NC[_]](t: SqlExpr[T, N2])(implicit O: Ordering[T], N: Nullability2[N, N2, NC]): SqlExpr[Boolean, NC] =

--- a/typo-dsl-doobie/src/scala/typo/dsl/SqlExpr.scala
+++ b/typo-dsl-doobie/src/scala/typo/dsl/SqlExpr.scala
@@ -12,16 +12,16 @@ sealed trait SqlExpr[T, N[_]] extends SqlExpr.SqlExprNoHkt[N[T]] {
   final def customBinaryOp[T2, N2[_], NC[_]](op: String, right: SqlExpr[T2, N2])(f: (T, T2) => Boolean)(implicit N: Nullability2[N, N2, NC]): SqlExpr[Boolean, NC] =
     SqlExpr.Binary[T, T2, Boolean, N, N2, NC](this, new SqlOperator(op, f), right, N)
 
-  final def isEqual[N2[_], NC[_]](t: SqlExpr[T, N2])(implicit O: Ordering[T], N: Nullability2[N, N2, NC]): SqlExpr[Boolean, NC] =
+  final def isEqual[N2[_], NC[_]](t: SqlExpr[T, N2])(implicit E: Equiv[T], N: Nullability2[N, N2, NC]): SqlExpr[Boolean, NC] =
     this === t
 
-  final def isNotEqual[N2[_], NC[_]](t: SqlExpr[T, N2])(implicit O: Ordering[T], N: Nullability2[N, N2, NC]): SqlExpr[Boolean, NC] =
+  final def isNotEqual[N2[_], NC[_]](t: SqlExpr[T, N2])(implicit E: Equiv[T], N: Nullability2[N, N2, NC]): SqlExpr[Boolean, NC] =
     this !== t
 
-  final def ===[N2[_], NC[_]](t: SqlExpr[T, N2])(implicit O: Ordering[T], N: Nullability2[N, N2, NC]): SqlExpr[Boolean, NC] =
+  final def ===[N2[_], NC[_]](t: SqlExpr[T, N2])(implicit E: Equiv[T], N: Nullability2[N, N2, NC]): SqlExpr[Boolean, NC] =
     SqlExpr.Binary(this, SqlOperator.eq, t, N)
 
-  final def !==[N2[_], NC[_]](t: SqlExpr[T, N2])(implicit O: Ordering[T], N: Nullability2[N, N2, NC]): SqlExpr[Boolean, NC] =
+  final def !==[N2[_], NC[_]](t: SqlExpr[T, N2])(implicit E: Equiv[T], N: Nullability2[N, N2, NC]): SqlExpr[Boolean, NC] =
     SqlExpr.Binary(this, SqlOperator.neq, t, N)
 
   final def >[N2[_], NC[_]](t: SqlExpr[T, N2])(implicit O: Ordering[T], N: Nullability2[N, N2, NC]): SqlExpr[Boolean, NC] =

--- a/typo-dsl-shared/typo/dsl/SqlOperator.scala
+++ b/typo-dsl-shared/typo/dsl/SqlOperator.scala
@@ -9,10 +9,10 @@ object SqlOperator {
     new SqlOperator[T, T, T]("OR", (i1, i2) => B.map(i1)(b1 => b1 || B.underlying(i2)))
   def and[T](implicit B: Bijection[T, Boolean]) =
     new SqlOperator[T, T, T]("AND", (i1, i2) => B.map(i1)(b1 => b1 && B.underlying(i2)))
-  def eq[T](implicit O: Ordering[T]) =
-    new SqlOperator[T, T, Boolean]("=", O.equiv)
-  def neq[T](implicit O: Ordering[T]) =
-    new SqlOperator[T, T, Boolean]("!=", (i1, i2) => !O.equiv(i1, i2))
+  def eq[T](implicit E: Equiv[T]) =
+    new SqlOperator[T, T, Boolean]("=", E.equiv)
+  def neq[T](implicit E: Equiv[T]) =
+    new SqlOperator[T, T, Boolean]("!=", (i1, i2) => !E.equiv(i1, i2))
   def gt[T](implicit N: Ordering[T]) =
     new SqlOperator[T, T, Boolean](">", N.gt)
   def gte[T](implicit N: Ordering[T]) =


### PR DESCRIPTION
We don't need an Ordering for `===`.

Many types have an `Equiv` instance but not an `Ordering`.

This can save user code from needing to create a bogus ordering.