### PR TITLE
Fix deprecated GitHub Actions in documentation workflow

### DIFF
--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -2,6 +2,10 @@ name: Deploy Documentation
 on:
   push:
     branches: [ 'main' ]
+    paths:
+      - 'site/**'
+      - 'site-in/**'
+      - '.github/workflows/deploy-docs.yml'
   workflow_dispatch:
 
 permissions:
@@ -50,10 +54,10 @@ jobs:
         working-directory: ./site
 
       - name: Setup Pages
-        uses: actions/configure-pages@v3
+        uses: actions/configure-pages@v4
 
       - name: Upload artifact
-        uses: actions/upload-pages-artifact@v2
+        uses: actions/upload-pages-artifact@v3
         with:
           path: ./site/build
 
@@ -66,4 +70,4 @@ jobs:
     steps:
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v2
+        uses: actions/deploy-pages@v4


### PR DESCRIPTION
## Summary
- Update GitHub Actions to their latest versions to avoid deprecation issues
- Add path filters to only trigger documentation builds when relevant files change

## Changes
1. **Updated GitHub Actions versions**:
   - `actions/configure-pages`: v3 → v4
   - `actions/upload-pages-artifact`: v2 → v3
   - `actions/deploy-pages`: v2 → v4

2. **Added path filters** to trigger documentation builds only when:
   - Files in `site/` directory change
   - Files in `site-in/` directory change  
   - The workflow file itself changes

## Why these changes are needed
The GitHub Actions workflow was failing with the error:
> This request has been automatically failed because it uses a deprecated version of `actions/upload-artifact: v3`

According to the [GitHub changelog](https://github.blog/changelog/2024-12-05-deprecation-notice-github-pages-actions-to-require-artifacts-actions-v4-on-github-com/), starting January 30, 2025, v3 of artifact actions will be deprecated and no longer supported on GitHub.com.

## Test plan
- [x] Updated action versions according to official documentation
- [ ] Workflow should run successfully after merge
- [ ] Documentation should deploy correctly to GitHub Pages

🤖 Generated with [Claude Code](https://claude.ai/code)