### PR TITLE
Exclude frontpage schema from GeneratedAdventureWorks

### DIFF
--- a/typo-scripts/src/scala/scripts/GeneratedAdventureWorks.scala
+++ b/typo-scripts/src/scala/scripts/GeneratedAdventureWorks.scala
@@ -26,7 +26,7 @@ object GeneratedAdventureWorks {
       .use { logger =>
         val ds = TypoDataSource.hikari(server = "localhost", port = 6432, databaseName = "Adventureworks", username = "postgres", password = "password")
         val scriptsPath = buildDir.resolve("adventureworks_sql")
-        val selector = Selector.ExcludePostgresInternal
+        val selector = Selector.ExcludePostgresInternal and !Selector.schemas("frontpage")
         val typoLogger = TypoLogger.Console
         val metadb = Await.result(MetaDb.fromDb(typoLogger, ds, selector, schemaMode = SchemaMode.MultiSchema), Duration.Inf)
         val openEnumSelector = Selector.relationNames("title", "title_domain", "issue142")


### PR DESCRIPTION
## Summary
Exclude the frontpage schema from the main AdventureWorks code generation script to keep it separate from the test suite.

## Why this change?
The frontpage schema was added in PR #151 for website documentation examples. However, it was being included in the main test suite generation, which:
- Added unnecessary code to the test projects (350+ files)
- Required implementing additional methods in DomainInsert objects
- Mixed documentation-specific code with test code

## Changes
Modified the selector in `GeneratedAdventureWorks.scala`:
```scala
// Before
val selector = Selector.ExcludePostgresInternal

// After  
val selector = Selector.ExcludePostgresInternal and \!Selector.schemas("frontpage")
```

This ensures the frontpage schema is excluded from code generation while still being available in the database for separate documentation generation scripts.

## Test Results
✅ All tests pass successfully with this change

## Related
- Supersedes PR #153 which took a different approach
- Related to PR #151 which added the frontpage schema

🤖 Generated with [Claude Code](https://claude.ai/code)