### PR TITLE
Fix dark mode: raise specificity of variable-defining dark blocks

### DIFF
--- a/site/docusaurus.config.js
+++ b/site/docusaurus.config.js
@@ -79,11 +79,16 @@ const config = {
   themeConfig:
     /** @type {import('@docusaurus/preset-classic').ThemeConfig} */
     ({
+      colorMode: {
+        defaultMode: 'light',
+        disableSwitch: false,
+        respectPrefersColorScheme: true,
+      },
       announcementBar: {
         id: 'under_development',
         content: '🚧 <strong>Under Development</strong> — This site and product are launching early 2026.',
-        backgroundColor: '#7c3aed',
-        textColor: '#ffffff',
+        backgroundColor: '#0c1a2b',
+        textColor: '#f4f0e6',
         isCloseable: false,
       },
       navbar: {

--- a/site/src/css/custom.css
+++ b/site/src/css/custom.css
@@ -78,7 +78,7 @@
 }
 
 /* Dark mode with elegant contrast */
-[data-theme="dark"] {
+html[data-theme="dark"] {
   /* Primary colors - Lighter purple for dark mode */
   --ifm-color-primary: #a78bfa;
   --ifm-color-primary-dark: #9333ea;
@@ -445,7 +445,7 @@ table thead {
   --ifm-footer-link-hover-color: var(--ifm-color-primary);
 }
 
-[data-theme="dark"] {
+html[data-theme="dark"] {
   --ifm-footer-background-color: #1a1a1a;
   --ifm-footer-color: #9ca3af;
   --ifm-footer-title-color: #f3f4f6;
@@ -607,7 +607,7 @@ table thead {
   --ifm-footer-title-color:            var(--typr-paper);
 }
 
-[data-theme="dark"] {
+html[data-theme="dark"] {
   --typr-paper:           #0c1019;
   --typr-paper-2:         #131829;
   --typr-paper-warm:      #131727;

--- a/typr-scripts/src/scala/scripts/projectsToPublish.scala
+++ b/typr-scripts/src/scala/scripts/projectsToPublish.scala
@@ -7,13 +7,13 @@ object projectsToPublish {
   def include(crossName: model.CrossProjectName): Boolean =
     crossName.name.value match {
       // CLI app
-      case "typr"              => true
+      case "typr" => true
 
       // typr's upstream deps — needed so the published POM resolves
-      case "typr-codegen"      => true
-      case "typr-dsl"          => true
-      case "typr-dsl-scala"    => true
-      case "typr-dsl-kotlin"   => true
+      case "typr-codegen"    => true
+      case "typr-dsl"        => true
+      case "typr-dsl-scala"  => true
+      case "typr-dsl-kotlin" => true
 
       // legacy DSL integrations (still published for backwards-compat consumers)
       case "typr-dsl-anorm"    => true
@@ -25,6 +25,6 @@ object projectsToPublish {
       case "typr-runtime-doobie"   => true
       case "typr-runtime-zio-jdbc" => true
 
-      case _                   => false
+      case _ => false
     }
 }


### PR DESCRIPTION
## Summary
- The CSS minimizer was reordering `:root` and `[data-theme="dark"]` blocks in the production bundle so that `:root` ended up *after* `[data-theme="dark"]`. Both have specificity (0,1,0), so source order wins — the light `--typr-paper` clobbered the dark one even when `data-theme="dark"` was set.
- Result on the deployed site: docs page didn't flip to dark at all, and the landing navbar stayed light.
- Bumping the three variable-defining dark blocks in `custom.css` to `html[data-theme="dark"]` (specificity 0,1,1) makes them beat `:root` regardless of bundler reordering.
- Also commits related theme-config tweaks that were sitting uncommitted: explicit `colorMode` config and announcement bar repainted in editorial ink/cream instead of legacy purple.

## Test plan
- [x] `npm run build` succeeds; new bundle hash confirmed
- [x] Local prod build (`npx serve build`) toggles dark mode on `/` and `/typr/` correctly
- [ ] Verify on deployed site after merge + auto-deploy